### PR TITLE
chore(capture): make the fixture script runnable, and fix three endpoints it got wrong

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -11,6 +11,8 @@ here cost time to find out; read this before writing an adapter method.
 | `/search/jql` pages by opaque `nextPageToken` and returns **no `total`** | The UI must work without a count. Use `POST /rest/api/3/search/approximate-count` — no `/jql` segment — where a number is genuinely needed. Guard against a token that repeats. |
 | `/search/jql` returns almost nothing without `fields` | Always send an explicit, narrow field list. |
 | The Agile API still uses `startAt`/`maxResults`/`total` | Two pagination models in one client, unified behind `Page[T]`. It also silently truncates against an unreadable instance limit. |
+| There is a **third** paging style: `/rest/api/3/plans/plan` uses `cursor`/`nextPageCursor` and *does* report a `total` and an `isLast` | It is neither of the other two. `Plans` returns a plain slice for that reason. A fourth shape — no paging at all — covers `/field`, `/project/{key}/versions` and attachment upload. |
+| The Plans API lives at `/rest/api/3/plans/plan` — the doubled segment is correct | `GET /rest/api/3/plans` does not exist. |
 | v3 requires **ADF** for description, environment, comments, worklog comments and multi-line custom fields | Single-line fields take plain strings. `pkg/adf` is not optional. |
 | `PUT /rest/agile/1.0/sprint/{id}` is a **full replace** — omitted fields become null | Never expose it. Use `POST /rest/agile/1.0/sprint/{id}` for partial updates. |
 | Sprint state machine: `future → active → closed` only, start needs both dates set, `completeDate` is never writable, a closed sprint only accepts `name` and `goal` | Validate locally and return a real error instead of a 400. |

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -19,8 +19,10 @@ export SARAL_TOKEN=...   # https://id.atlassian.com/manage-profile/security/api-
 what the locally-defined-plan fallback exists for. Either way it is a valid capability answer, not a
 failure.
 
+The path has a doubled segment and that is not a typo — `/rest/api/3/plans` alone does not exist.
+
 ```sh
-curl -su "$SARAL_EMAIL:$SARAL_TOKEN" "https://$SARAL_SITE/rest/api/3/plans?maxResults=5"
+curl -su "$SARAL_EMAIL:$SARAL_TOKEN" "https://$SARAL_SITE/rest/api/3/plans/plan?maxResults=5"
 ```
 
 **b. What can this token do?** Look for `havePermission: true` on `BULK_CHANGE`, `MOVE_ISSUES` and
@@ -56,13 +58,19 @@ Once the calls above look sane, capture them properly. This is what makes every 
 with no Jira, no credentials and no shared sandbox.
 
 ```sh
-export SARAL_PROJECT=PROJ
-export SARAL_ISSUE=PROJ-1        # pick one with lists, code blocks, panels and links
 ./scripts/capture.sh
 ```
 
-Then do the two manual follow-ups the script prints (second search page, board configuration) and
-**read the diff** — the scrubber is best-effort and you are the last line of defence. See
+It asks for the site, email, token, a project key and an issue key, so nothing has to be exported
+first; set any of `SARAL_SITE`, `SARAL_EMAIL`, `SARAL_TOKEN`, `SARAL_PROJECT` or `SARAL_ISSUE`
+beforehand to skip that prompt. Pick an issue with lists, code blocks, panels, links and an image —
+that one description decides what `pkg/adf` has to render properly.
+
+The script follows the search page token and walks the boards itself, so there is nothing left to
+capture by hand. What it cannot capture it names at the end, along with the four places a real
+capture has to be reconciled with the tests: the fixture inventory, the create-meta issue type the
+fixture server dispatches on, and the ADF node census. **Read the diff** — the scrubber handles
+account ids, names, emails and mentions, but not the prose in a summary or a comment. See
 [`pkg/jira/jiratest/fixtures/README.md`](../pkg/jira/jiratest/fixtures/README.md).
 
 ## 3. Start P0.1

--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -153,7 +153,7 @@ if [ -n "$NEXT" ]; then
 else
   echo "  !! page one reported no nextPageToken — pick a project with more than 5 issues"
 fi
-capture POST "/rest/api/3/search/jql/approximate-count" approximate_count.json \
+capture POST "/rest/api/3/search/approximate-count" approximate_count.json \
   "{\"jql\":\"project = $SARAL_PROJECT\"}"
 
 echo

--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -3,143 +3,212 @@
 #
 # Run by a human against a real site. Never in CI. Requires: curl, python3.
 #
-#   export SARAL_SITE=your-site.atlassian.net
-#   export SARAL_EMAIL=you@example.com
-#   export SARAL_TOKEN=...            # https://id.atlassian.com/manage-profile/security/api-tokens
-#   export SARAL_PROJECT=PROJ         # a project you can read
-#   export SARAL_ISSUE=PROJ-1         # an issue with a RICH description (lists, code, panels, links)
 #   ./scripts/capture.sh
 #
-# Writes scrubbed JSON to pkg/jira/jiratest/fixtures/. Read the diff before committing:
-# the scrubber is best-effort, and you are the last line of defence.
+# It asks for what it needs. Set any of these first to skip the prompt:
+#
+#   SARAL_SITE=your-site.atlassian.net
+#   SARAL_EMAIL=you@example.com
+#   SARAL_TOKEN=...          # https://id.atlassian.com/manage-profile/security/api-tokens
+#   SARAL_PROJECT=PROJ       # a project you can read
+#   SARAL_ISSUE=PROJ-1       # an issue with a RICH description: lists, code, panels, links, an image
+#
+# Writes scrubbed JSON to pkg/jira/jiratest/fixtures/, replacing what is there. Read the diff before
+# committing: the scrubber is best-effort and you are the last line of defence.
 set -euo pipefail
 
-: "${SARAL_SITE:?set SARAL_SITE}"
-: "${SARAL_EMAIL:?set SARAL_EMAIL}"
-: "${SARAL_TOKEN:?set SARAL_TOKEN}"
-: "${SARAL_PROJECT:?set SARAL_PROJECT}"
-: "${SARAL_ISSUE:?set SARAL_ISSUE}"
-
-OUT="$(cd "$(dirname "$0")/.." && pwd)/pkg/jira/jiratest/fixtures"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$ROOT/pkg/jira/jiratest/fixtures"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$OUT"
 
-get() { # get <path> <fixture-name>
-  local path="$1" name="$2" code
-  code=$(curl -sS -u "$SARAL_EMAIL:$SARAL_TOKEN" -H 'Accept: application/json' \
-    -o "$OUT/$name.raw" -w '%{http_code}' "https://$SARAL_SITE$path") || true
-  scrub "$name" "$code" "GET $path"
+for tool in curl python3; do
+  command -v "$tool" >/dev/null || { echo "capture: $tool is required" >&2; exit 1; }
+done
+
+ask() { # ask <var> <prompt> [secret]
+  local var="$1" prompt="$2" secret="${3:-}" value="${!1:-}"
+  if [ -n "$value" ]; then return; fi
+  if [ ! -t 0 ]; then
+    echo "capture: $var is not set and there is no terminal to ask on; export it and re-run" >&2
+    exit 1
+  fi
+  if [ -n "$secret" ]; then
+    read -rsp "$prompt: " value; echo
+  else
+    read -rp "$prompt: " value
+  fi
+  [ -n "$value" ] || { echo "capture: $var cannot be empty" >&2; exit 1; }
+  printf -v "$var" '%s' "$value"
+  export "${var?}"
 }
 
-post() { # post <path> <fixture-name> <json>
-  local path="$1" name="$2" body="$3" code
-  code=$(curl -sS -u "$SARAL_EMAIL:$SARAL_TOKEN" -X POST \
-    -H 'Accept: application/json' -H 'Content-Type: application/json' -d "$body" \
-    -o "$OUT/$name.raw" -w '%{http_code}' "https://$SARAL_SITE$path") || true
-  scrub "$name" "$code" "POST $path"
+ask SARAL_SITE    "Jira site (host only, e.g. example.atlassian.net)"
+ask SARAL_EMAIL   "Atlassian account email"
+ask SARAL_TOKEN   "API token (not echoed)" secret
+ask SARAL_PROJECT "Project key to capture (e.g. PROJ)"
+ask SARAL_ISSUE   "Issue key with a rich description (e.g. PROJ-1)"
+
+SARAL_SITE="${SARAL_SITE#https://}"
+SARAL_SITE="${SARAL_SITE%/}"
+
+# The token goes through a curl config on a pipe, never through argv, so it does not show up in ps.
+creds() { printf 'user = "%s:%s"\n' "$SARAL_EMAIL" "$SARAL_TOKEN"; }
+
+CODE=0
+fetch() { # fetch <method> <path> <slot> [body]
+  local method="$1" path="$2" slot="$3" body="${4:-}"
+  if [ "$method" = GET ]; then
+    CODE=$(curl -sS --config <(creds) -H 'Accept: application/json' \
+      -o "$TMP/$slot" -w '%{http_code}' "https://$SARAL_SITE$path") || CODE=000
+  else
+    CODE=$(curl -sS --config <(creds) -X "$method" \
+      -H 'Accept: application/json' -H 'Content-Type: application/json' -d "$body" \
+      -o "$TMP/$slot" -w '%{http_code}' "https://$SARAL_SITE$path") || CODE=000
+  fi
 }
 
-scrub() {
-  local name="$1" code="$2" what="$3"
-  SARAL_SITE="$SARAL_SITE" SARAL_EMAIL="$SARAL_EMAIL" python3 - "$OUT/$name.raw" "$OUT/$name.json" <<'PY'
-import json, os, re, sys, hashlib
-
-src, dst = sys.argv[1], sys.argv[2]
-raw = open(src, encoding="utf-8").read()
-site, email = os.environ["SARAL_SITE"], os.environ["SARAL_EMAIL"]
-
-def fake_id(v):
-    return "acct" + hashlib.sha256(v.encode()).hexdigest()[:20]
-
-SENSITIVE = {"emailAddress": "user@example.com", "displayName": "Test User",
-             "name": None, "avatarUrls": "DROP", "timeZone": "Etc/UTC"}
-
-def walk(o):
-    if isinstance(o, dict):
-        out = {}
-        for k, v in o.items():
-            if k == "avatarUrls":
-                continue
-            if k == "accountId" and isinstance(v, str):
-                out[k] = fake_id(v); continue
-            if k == "emailAddress":
-                out[k] = "user@example.com"; continue
-            if k == "displayName":
-                out[k] = "Test User"; continue
-            if k == "leadAccountId" and isinstance(v, str):
-                out[k] = fake_id(v); continue
-            out[k] = walk(v)
-        return out
-    if isinstance(o, list):
-        return [walk(v) for v in o]
-    if isinstance(o, str):
-        s = o.replace(site, "example.atlassian.net").replace(email, "user@example.com")
-        s = re.sub(r"[\w.+-]+@[\w-]+\.[\w.]+", "user@example.com", s)
-        return s
-    return o
-
-try:
-    data = walk(json.loads(raw))
-except json.JSONDecodeError:
-    sys.stderr.write(f"  !! {dst}: response was not JSON, not written\n")
-    sys.exit(0)
-
-json.dump(data, open(dst, "w", encoding="utf-8"), indent=2, ensure_ascii=False, sort_keys=True)
-open(dst, "a").write("\n")
-PY
-  rm -f "$OUT/$name.raw"
-  printf '  %-38s %s  %s\n' "$name" "$code" "$what"
+scrub() { # scrub <slot> <fixture> <what>
+  local slot="$1" fixture="$2" what="$3"
+  if ! SARAL_SITE="$SARAL_SITE" SARAL_EMAIL="$SARAL_EMAIL" \
+    python3 "$ROOT/scripts/scrub.py" "$TMP/$slot" "$OUT/$fixture"; then
+    cp "$TMP/$slot" "$OUT/${fixture%.json}.raw"
+    printf '  %-34s %s  %s  !! not JSON, kept as %s\n' "$fixture" "$CODE" "$what" "${fixture%.json}.raw"
+    return
+  fi
+  printf '  %-34s %s  %s\n' "$fixture" "$CODE" "$what"
 }
 
-echo "capturing from $SARAL_SITE -> $OUT"
+capture() { # capture <method> <path> <fixture> [body]
+  local method="$1" path="$2" fixture="$3" body="${4:-}"
+  fetch "$method" "$path" slot "$body"
+  scrub slot "$fixture" "$method $path"
+}
 
-# --- capability probe surface (P1.3) -----------------------------------------
-get "/rest/api/3/myself" myself
-get "/rest/api/3/configuration" configuration
-get "/rest/api/3/mypermissions?permissions=BULK_CHANGE,MOVE_ISSUES,CREATE_ISSUES,DELETE_ISSUES,EDIT_ISSUES,DELETE_ALL_COMMENTS,ADMINISTER" mypermissions
-get "/rest/api/3/plans?maxResults=5" plans          # expect 403 without Administer Jira — capture either way
+# pick <file> <what> — pull one value out of a captured response, or print nothing
+pick() {
+  python3 "$ROOT/scripts/pick.py" "$1" "$2" 2>/dev/null || true
+}
 
-# --- field and schema resolution (P2.2) --------------------------------------
-get "/rest/api/3/field" fields
-get "/rest/api/3/project/search?maxResults=50" projects
-get "/rest/api/3/issue/createmeta?projectKeys=$SARAL_PROJECT&expand=projects.issuetypes.fields" createmeta
+echo "capturing from $SARAL_SITE into $OUT"
+echo
 
-# --- issues, ADF and pagination (P1.2, P1.4) --------------------------------
-get "/rest/api/3/issue/$SARAL_ISSUE" issue_rich
-get "/rest/api/3/issue/$SARAL_ISSUE/transitions?expand=transitions.fields" transitions
-get "/rest/api/3/issue/$SARAL_ISSUE/comment" comments
-post "/rest/api/3/search/jql" search_page1 \
-  "{\"jql\":\"project = $SARAL_PROJECT ORDER BY created DESC\",\"maxResults\":5,\"fields\":[\"summary\",\"status\",\"assignee\",\"issuetype\",\"priority\",\"updated\"]}"
-post "/rest/api/3/search/jql/approximate-count" search_count \
+echo "capability probe (P1.3)"
+capture GET "/rest/api/3/myself" myself.json
+capture GET "/rest/api/3/configuration" configuration.json
+
+# One token cannot produce both permission fixtures. Name the file for what this token actually is,
+# and leave the other one as it stands.
+fetch GET "/rest/api/3/mypermissions?permissions=BULK_CHANGE,MOVE_ISSUES,CREATE_ISSUES,DELETE_ISSUES,EDIT_ISSUES,DELETE_ALL_COMMENTS,ADMINISTER" perms
+scrub perms mypermissions_capture.json "GET /rest/api/3/mypermissions"
+if [ "$(pick "$OUT/mypermissions_capture.json" administers)" = "yes" ]; then
+  PERMS_AS=mypermissions_admin.json
+else
+  PERMS_AS=mypermissions_basic.json
+fi
+mv "$OUT/mypermissions_capture.json" "$OUT/$PERMS_AS"
+echo "  -> saved as $PERMS_AS (this token's own permissions)"
+
+# The Plans API lives at /plans/plan — the doubled segment is correct, /rest/api/3/plans does not
+# exist. 403 is the normal answer and is a capability result, not a failure.
+fetch GET "/rest/api/3/plans/plan?maxResults=5" plans
+if [ "$CODE" = "403" ]; then
+  scrub plans plans_403.json "GET /rest/api/3/plans/plan"
+else
+  scrub plans plans_ok.json "GET /rest/api/3/plans/plan"
+  echo "  -> this token reaches the Plans API; plans_403.json is unchanged and still hand-authored"
+fi
+
+echo
+echo "fields and create schema (P2.2)"
+capture GET "/rest/api/3/field" field.json
+
+# The old /issue/createmeta?projectKeys=&expand= is deprecated; the replacement is a pair.
+capture GET "/rest/api/3/issue/createmeta/$SARAL_PROJECT/issuetypes" createmeta_issuetypes.json
+FIRST_TYPE=$(pick "$OUT/createmeta_issuetypes.json" first-issue-type)
+BUG_TYPE=$(pick "$OUT/createmeta_issuetypes.json" bug-issue-type)
+[ -n "$FIRST_TYPE" ] && capture GET "/rest/api/3/issue/createmeta/$SARAL_PROJECT/issuetypes/$FIRST_TYPE" createmeta_task.json
+if [ -n "$BUG_TYPE" ] && [ "$BUG_TYPE" != "$FIRST_TYPE" ]; then
+  capture GET "/rest/api/3/issue/createmeta/$SARAL_PROJECT/issuetypes/$BUG_TYPE" createmeta_bug.json
+else
+  echo "  !! no second issue type to capture; createmeta_bug.json is unchanged"
+fi
+
+echo
+echo "issues, ADF and paging (P1.2, P1.4)"
+capture GET "/rest/api/3/issue/$SARAL_ISSUE" issue_rich_adf.json
+capture GET "/rest/api/3/issue/$SARAL_ISSUE/transitions?expand=transitions.fields" transitions.json
+capture GET "/rest/api/3/issue/$SARAL_ISSUE/comment" comments.json
+
+SEARCH_FIELDS='["summary","status","assignee","issuetype","priority","updated"]'
+capture POST "/rest/api/3/search/jql" search_page1.json \
+  "{\"jql\":\"project = $SARAL_PROJECT ORDER BY created DESC\",\"maxResults\":5,\"fields\":$SEARCH_FIELDS}"
+
+# The paginator tests need a real second page, so follow the token rather than asking a human to.
+NEXT=$(pick "$OUT/search_page1.json" next-page-token)
+if [ -n "$NEXT" ]; then
+  capture POST "/rest/api/3/search/jql" search_page2.json \
+    "{\"jql\":\"project = $SARAL_PROJECT ORDER BY created DESC\",\"maxResults\":5,\"fields\":$SEARCH_FIELDS,\"nextPageToken\":\"$NEXT\"}"
+else
+  echo "  !! page one reported no nextPageToken — pick a project with more than 5 issues"
+fi
+capture POST "/rest/api/3/search/jql/approximate-count" approximate_count.json \
   "{\"jql\":\"project = $SARAL_PROJECT\"}"
 
-# --- versions (P5.1) ---------------------------------------------------------
-get "/rest/api/3/project/$SARAL_PROJECT/version?maxResults=50" versions
+echo
+echo "versions (P5.1)"
+capture GET "/rest/api/3/project/$SARAL_PROJECT/version?maxResults=50" versions.json
 
-# --- boards and sprints (P6.1, P6.2) ----------------------------------------
-get "/rest/agile/1.0/board?projectKeyOrId=$SARAL_PROJECT" boards
+echo
+echo "boards and sprints (P6.1, P6.2)"
+capture GET "/rest/agile/1.0/board?projectKeyOrId=$SARAL_PROJECT" board.json
+
+# Both board-configuration shapes matter, and which board has which is per-site — so look.
+BOARDS=$(pick "$OUT/board.json" board-ids)
+GOT_EST="" GOT_NONE="" SCRUM_BOARD=""
+for id in $BOARDS; do
+  fetch GET "/rest/agile/1.0/board/$id/configuration" cfg
+  KIND=$(pick "$TMP/cfg" estimation-type)
+  if [ "$KIND" = "none" ] && [ -z "$GOT_NONE" ]; then
+    scrub cfg board_config_no_estimation.json "GET /rest/agile/1.0/board/$id/configuration"
+    GOT_NONE=$id
+  elif [ "$KIND" != "none" ] && [ -z "$GOT_EST" ]; then
+    scrub cfg board_config_estimation.json "GET /rest/agile/1.0/board/$id/configuration"
+    GOT_EST=$id
+  fi
+  [ -z "$SCRUM_BOARD" ] && SCRUM_BOARD=$id
+  [ -n "$GOT_EST" ] && [ -n "$GOT_NONE" ] && break
+done
+[ -z "$GOT_EST" ] && echo "  !! no board with estimation; board_config_estimation.json is unchanged"
+[ -z "$GOT_NONE" ] && echo "  !! no board with estimation type none; board_config_no_estimation.json is unchanged"
+if [ -n "$SCRUM_BOARD" ]; then
+  capture GET "/rest/agile/1.0/board/$SCRUM_BOARD/sprint?maxResults=10" sprint_page.json
+else
+  echo "  !! no board on $SARAL_PROJECT; sprint_page.json is unchanged"
+fi
 
 cat <<'NOTE'
 
-Done. Two follow-ups you must do by hand:
+Done. These fixtures cannot be captured and stay hand-authored:
 
-  1. search_page2 — take nextPageToken from search_page1.json and re-run the search with it,
-     saving as search_page2.json. The paginator tests need a real second page.
-  2. board_config / sprints — pick a board id from boards.json, then:
-       ./scripts/capture.sh   # after: export SARAL_BOARD=<id>
-     or capture directly:
-       /rest/agile/1.0/board/<id>/configuration  -> board_config.json
-       /rest/agile/1.0/board/<id>/sprint         -> sprints.json
-     Capture one board WITH estimation and one with type "none" if you have both.
+  rate_limited.json        429 with Retry-After
+  validation_error.json    400 with per-field errors
+  bulkmove_submit.json     and bulkmove_task_{enqueued,running,complete,failed}.json
+  the mypermissions variant this token is not
 
-Fixtures that cannot be captured and are hand-authored instead:
-  rate_limited.json (429 + Retry-After), bulkmove_task_*.json (each task state),
-  validation_error.json (400 with per-field errors).
+Now reconcile and read the diff:
 
-NOW READ THE DIFF. Check for real names, emails, account ids, and your site host before committing.
+  1. git diff pkg/jira/jiratest/fixtures/ — check for real names, emails, account ids, your site
+     host, and anything in a summary or comment body you would not publish. The scrubber handles
+     structure, not prose.
+  2. pkg/jira/jiratest/fixtures_test.go pins the fixture inventory in
+     TestFixtures_CoverEveryResponseTheServerReplays. Add createmeta_issuetypes.json (and plans_ok.json
+     if you captured one) to that list, or delete the files.
+  3. pkg/jira/jiratest/server.go dispatches createmeta on srvBugIssueTypeID and reads the page-one
+     token out of search_page1.json. Point the const at the issue type you actually captured.
+  4. TestFixtures_RichDescriptionExercisesTheNodesARendererMustHandle asserts which ADF node types
+     the description contains. Run the census and update it to what your issue really has:
+       go test ./pkg/jira/jiratest/ -run RichDescription -v
+  5. go test ./... — green before you commit.
 NOTE
-
-if [ -n "${SARAL_BOARD:-}" ]; then
-  get "/rest/agile/1.0/board/$SARAL_BOARD/configuration" board_config
-  get "/rest/agile/1.0/board/$SARAL_BOARD/sprint?maxResults=10" sprints
-  get "/rest/agile/1.0/board/$SARAL_BOARD/backlog?maxResults=5" backlog
-fi

--- a/scripts/pick.py
+++ b/scripts/pick.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Pull one value out of a captured Jira response, for scripts/capture.sh.
+
+Prints nothing and exits 0 when the file is missing, is not JSON, or does not carry the value, so
+the caller can treat an empty string as "not there".
+"""
+
+import json
+import sys
+
+
+def load(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def issue_types(doc):
+    return doc.get("issueTypes", []) if isinstance(doc, dict) else []
+
+
+def main() -> int:
+    path, what = sys.argv[1], sys.argv[2]
+    doc = load(path)
+    if doc is None:
+        return 0
+
+    if what == "administers":
+        perms = doc.get("permissions", {}) if isinstance(doc, dict) else {}
+        if perms.get("ADMINISTER", {}).get("havePermission"):
+            print("yes")
+    elif what == "first-issue-type":
+        for t in issue_types(doc):
+            if not t.get("subtask"):
+                print(t.get("id", ""))
+                break
+    elif what == "bug-issue-type":
+        for t in issue_types(doc):
+            if str(t.get("name", "")).lower() in ("bug", "defect"):
+                print(t.get("id", ""))
+                break
+    elif what == "next-page-token":
+        if isinstance(doc, dict) and doc.get("nextPageToken"):
+            print(doc["nextPageToken"])
+    elif what == "board-ids":
+        values = doc.get("values", []) if isinstance(doc, dict) else []
+        print(" ".join(str(b["id"]) for b in values[:8] if "id" in b))
+    elif what == "estimation-type":
+        estimation = (doc.get("estimation") or {}) if isinstance(doc, dict) else {}
+        print(estimation.get("type", "none"))
+    else:
+        sys.stderr.write(f"pick: unknown value {what!r}\n")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Scrub a captured Jira response so it is safe to commit as a fixture.
+
+Reads one JSON file and writes a scrubbed copy. Exits non-zero without writing if the input is not
+JSON, so the caller can keep the raw body for inspection.
+
+It handles structure: account ids, display names, email addresses, avatar URLs, the site host, and
+the names inside ADF mention nodes. It cannot handle prose — a summary or a comment body that names
+a customer stays exactly as it was, which is why the capture script tells you to read the diff.
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+
+EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
+
+# Anything that identifies a person, mapped to a stable stand-in so that two comments by the same
+# author still look like the same author in the fixture.
+ACCOUNT_KEYS = {"accountId", "leadAccountId", "authorAccountId", "updateAuthorAccountId"}
+DROP_KEYS = {"avatarUrls", "profilePicture"}
+
+
+def fake_account(value: str) -> str:
+    return "5b10a2844c20165700" + hashlib.sha256(value.encode()).hexdigest()[:6]
+
+
+def fake_name(value: str) -> str:
+    return "User " + hashlib.sha256(value.encode()).hexdigest()[:4].upper()
+
+
+def scrub(node, site: str, email: str):
+    if isinstance(node, dict):
+        # An ADF mention carries the person's real name in attrs.text, which no generic rule catches.
+        if node.get("type") == "mention" and isinstance(node.get("attrs"), dict):
+            attrs = dict(node["attrs"])
+            if isinstance(attrs.get("id"), str):
+                attrs["id"] = fake_account(attrs["id"])
+            if isinstance(attrs.get("text"), str) and attrs["text"].startswith("@"):
+                attrs["text"] = "@" + fake_name(attrs["text"][1:])
+            node = {**node, "attrs": attrs}
+
+        out = {}
+        for key, value in node.items():
+            if key in DROP_KEYS:
+                continue
+            if key in ACCOUNT_KEYS and isinstance(value, str):
+                out[key] = fake_account(value)
+            elif key == "emailAddress":
+                out[key] = "user@example.com"
+            elif key == "displayName" and isinstance(value, str):
+                out[key] = fake_name(value)
+            else:
+                out[key] = scrub(value, site, email)
+        return out
+
+    if isinstance(node, list):
+        return [scrub(v, site, email) for v in node]
+
+    if isinstance(node, str):
+        text = node.replace(site, "example.atlassian.net").replace(email, "user@example.com")
+        return EMAIL.sub("user@example.com", text)
+
+    return node
+
+
+def main() -> int:
+    src, dst = sys.argv[1], sys.argv[2]
+    site, email = os.environ["SARAL_SITE"], os.environ["SARAL_EMAIL"]
+    try:
+        with open(src, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return 1
+
+    # Key order is preserved on purpose: the point of a captured fixture is that it looks like what
+    # the wire actually sent, and pkg/adf's round-trip guarantee is about exact bytes.
+    with open(dst, "w", encoding="utf-8") as f:
+        json.dump(scrub(data, site, email), f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Packet

None — this is the fixture-capture tooling that `docs/BOOTSTRAP.md` step 2 depends on. Stacked on
#32; review that first.

## Why

Trying to actually run `scripts/capture.sh` against a real site turned up three bugs and one design
problem, all of which would have cost whoever ran it first an afternoon.

**It wrote filenames the fixture server does not know about.** `fields.json`, `issue_rich.json`,
`boards.json`, `sprints.json`, `board_config.json`, `search_count.json`, `plans.json`,
`mypermissions.json`, `createmeta.json` — nine of them. A capture would have *added* a parallel set
rather than replacing anything, and `TestFixtures_CoverEveryResponseTheServerReplays` compares the
directory with `slices.Equal`, so the tree goes red.

**Three endpoints were wrong.**

- `GET /issue/createmeta?projectKeys=…&expand=…` is the deprecated form. The replacement is the
  paginated pair, `…/createmeta/{project}/issuetypes` then `…/issuetypes/{id}`.
- `GET /rest/api/3/plans` does not exist. The path has a doubled segment: `/rest/api/3/plans/plan`.
  `docs/BOOTSTRAP.md` had the same mistake and is fixed here too.
- The board list was captured but never used, so `board_config` and `sprints` only happened if you
  had already exported `SARAL_BOARD` — which the instructions told you to do *after* reading the
  board list, in a second run.

**The manual follow-ups were the design problem.** The second search page and the board
configurations were left for a human to fetch by hand. That is exactly how a fixture set goes stale:
the tedious half quietly stops being done.

## What it does now

- **Asks for what it needs.** No exports required; set any of `SARAL_SITE`, `SARAL_EMAIL`,
  `SARAL_TOKEN`, `SARAL_PROJECT`, `SARAL_ISSUE` beforehand to skip that prompt. With no terminal it
  says which variable is missing and exits rather than hanging.
- **Follows the page token itself** to get a real second page, and **walks the boards**, picking one
  with estimation and one without — both shapes matter and which board is which is per-site.
- **Names the permission fixture for what the token can actually do** (`mypermissions_admin.json` vs
  `_basic.json`), because one token cannot produce both.
- **Keeps the token out of `argv`** — it goes through a `curl` config on a pipe, so it is not visible
  in `ps`.
- **Ends with the reconciliation checklist**, naming the four places a real capture has to be
  squared with the tests: the fixture inventory, the create-meta issue type the server dispatches on,
  the ADF node census, and the diff itself.

## The scrubber

Moved to `scripts/scrub.py` — it had grown past what belongs in a heredoc.

- **Key order is preserved.** It used to re-serialize with `sort_keys=True`. The point of a captured
  fixture is that it looks like what the wire sent, and `pkg/adf`'s guarantee is about exact bytes.
- **It knows about ADF mentions.** A mention node carries a colleague's real name in `attrs.text`,
  where no generic rule catches it. That is a live leak in anything captured from a real ticket.
- **Names hash to a stable stand-in** instead of all becoming "Test User", so two comments by the
  same author still read as the same author.

It still cannot scrub prose. A summary or comment body that names a customer comes through
untouched, which is why reading the diff is step one of the checklist and not a footnote.

## Verified

Driven end to end against a stubbed `curl`: every route, the token chase producing a genuinely
different page two, both board-configuration shapes classified correctly, the permission fixture
named from the response, and no trace of the site host, the email, the display name, the account id
or the token in any output. `make check` green.

Not run against a real instance — that is `docs/BOOTSTRAP.md` step 2 and needs a human with a token.

https://claude.ai/code/session_01HBdKes6chEidvtGJnqFAMm
