### PR TITLE
feat(cloud): P1.1 — transport and auth

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -108,6 +108,12 @@ status name — "In Progress" is not guaranteed to exist.
 
 ## Rate limiting
 
+| Fact | Consequence |
+|---|---|
+| `Retry-After` is not always a number of seconds — HTTP permits an absolute date, and Atlassian also sends **`X-RateLimit-Reset`** as an RFC 3339 instant | A client that only does `strconv.Atoi` on `Retry-After` silently falls back to its own backoff on both, and waits the wrong amount. Read seconds, then an HTTP-date, then `X-RateLimit-Reset`, and clamp an instant already in the past to zero. |
+| A 429 refuses the request **before it runs**; a 5xx may have got far enough to change something | So a 429 is safe to replay whatever the method, and a 5xx is only safe for a request that was repeatable to begin with. Getting that backwards duplicates issues. |
+| `/search/jql` is a `POST` that only reads | Any blanket "never retry a POST" or "never coalesce a POST" rule has to make an exception for it, or search loses both retries and request coalescing on the hottest path in the application. |
+
 Honour `Retry-After` on 429. Back off exponentially with jitter, cap concurrent requests, and pause
 any poller on the first 429. Cost-based limits mean a burst of narrow requests beats one wide one.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,7 +46,7 @@ contracts every other packet codes against.
 The first batch that produces something usable. Read-only, so it is safe to use against a real
 instance from day one.
 
-- [ ] **P1.1 — Transport and auth** · [#2](https://github.com/varijkapil13/saral/issues/2) · **owns** `pkg/jira/cloud/{client,auth,retry,paginate}.go`
+- [x] **P1.1 — Transport and auth** · [#2](https://github.com/varijkapil13/saral/issues/2) · **owns** `pkg/jira/cloud/{client,auth,retry,paginate}.go`
   Basic auth, `Retry-After` backoff, both paginators, repeated-cursor guard, request coalescing.
 - [ ] **P1.2 — Search and JQL** · [#3](https://github.com/varijkapil13/saral/issues/3) · **owns** `pkg/jira/cloud/search.go`, `internal/app/search.go`
   `POST /search/jql` with explicit field sets, `approximate-count`, saved queries.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/lrstanley/bubblezone/v2 v2.0.0
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/sync v0.22.0
 )
 
 require (
@@ -27,6 +28,5 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/pkg/jira/cloud/auth.go
+++ b/pkg/jira/cloud/auth.go
@@ -1,0 +1,50 @@
+package cloud
+
+import "net/http"
+
+// redacted is what a secret prints as, whatever the verb.
+const redacted = "[redacted]"
+
+// credentials are the site account and its API token. Jira Cloud authenticates
+// an API token as HTTP basic auth, with the account email as the user name.
+type credentials struct {
+	email string
+	token secret
+}
+
+// authorize puts the credentials on a request. It is called last, after every
+// other header, so that nothing a caller set can replace the Authorization one.
+func (c credentials) authorize(req *http.Request) {
+	req.SetBasicAuth(c.email, c.token.value())
+}
+
+// secret holds the API token behind a closure rather than in a string field.
+// fmt reads unexported fields through reflection and cannot call String on
+// them, so a string would be printed verbatim by %#v and by any logger walking
+// the client; a func value prints as an address under every verb there is.
+type secret struct {
+	reveal func() string
+}
+
+func newSecret(token string) secret {
+	if token == "" {
+		return secret{}
+	}
+	return secret{reveal: func() string { return token }}
+}
+
+// String is the redacted form, which is the only form anything printing a
+// secret ever gets.
+func (s secret) String() string {
+	if s.reveal == nil {
+		return ""
+	}
+	return redacted
+}
+
+func (s secret) value() string {
+	if s.reveal == nil {
+		return ""
+	}
+	return s.reveal()
+}

--- a/pkg/jira/cloud/auth_test.go
+++ b/pkg/jira/cloud/auth_test.go
@@ -1,0 +1,78 @@
+package cloud
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestClient_RevealsTheTokenUnderNoFormatVerb(t *testing.T) {
+	t.Parallel()
+
+	c, _ := testClient(t, "example.atlassian.net")
+	encoded := base64.StdEncoding.EncodeToString([]byte(testEmail + ":" + testToken))
+
+	subjects := map[string]any{
+		"the client":       c,
+		"a client value":   *c,
+		"the credentials":  c.creds,
+		"the secret":       c.creds.token,
+		"the retry policy": c.retry,
+	}
+	for _, verb := range []string{"%v", "%+v", "%s", "%q", "%#v"} {
+		for name, subject := range subjects {
+			got := fmt.Sprintf(verb, subject)
+			if strings.Contains(got, testToken) {
+				t.Errorf("%s of %s printed the API token: %s", verb, name, got)
+			}
+			if strings.Contains(got, encoded) {
+				t.Errorf("%s of %s printed the encoded credential, which is the token in one step: %s", verb, name, got)
+			}
+		}
+	}
+
+	if got := c.String(); !strings.Contains(got, "example.atlassian.net") || !strings.Contains(got, testEmail) {
+		t.Errorf("%%v = %s, want it to name the site and the account it is for", got)
+	}
+	if got := c.creds.token.value(); got != testToken {
+		t.Errorf("the token came back as %q through its own accessor, want the one it was built with", got)
+	}
+}
+
+func TestSecret_IsEmptyRatherThanRedactedWhenThereIsNothingToHide(t *testing.T) {
+	t.Parallel()
+
+	var unset secret
+	if unset.String() != "" || unset.value() != "" {
+		t.Errorf("an unset secret prints as %q and reveals %q, want both empty", unset.String(), unset.value())
+	}
+	if got := newSecret("something").String(); got != redacted {
+		t.Errorf("a set secret prints as %q, want %q", got, redacted)
+	}
+}
+
+func TestAuthorize_CannotBeReplacedByAHeaderTheCallerSet(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.atlassian.net/rest/api/3/field", http.NoBody)
+	if err != nil {
+		t.Fatalf("building a request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer somebody-elses-idea")
+
+	creds := credentials{email: testEmail, token: newSecret(testToken)}
+	creds.authorize(req)
+
+	user, pass, ok := req.BasicAuth()
+	if !ok {
+		t.Fatal("the request carries no basic auth")
+	}
+	if user != testEmail || pass != testToken {
+		t.Errorf("basic auth is %q / %q, want the account email and its API token", user, pass)
+	}
+	if got := req.Header.Values("Authorization"); len(got) != 1 {
+		t.Errorf("the request carries %d Authorization headers, want one", len(got))
+	}
+}

--- a/pkg/jira/cloud/client.go
+++ b/pkg/jira/cloud/client.go
@@ -17,14 +17,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/varijkapil13/saral/pkg/jira"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // DefaultMaxConcurrent is how many requests a client keeps in the air at once
@@ -53,7 +55,7 @@ type Client struct {
 
 	concurrency int
 	gate        chan struct{}
-	flight      *singleflight
+	flight      *singleflight.Group
 }
 
 // Option configures a Client at construction.
@@ -86,7 +88,7 @@ func New(site, email, token string, opts ...Option) (*Client, error) {
 		retry:       DefaultRetry(),
 		agent:       defaultUserAgent,
 		concurrency: DefaultMaxConcurrent,
-		flight:      newSingleflight(),
+		flight:      &singleflight.Group{},
 	}
 	for _, o := range opts {
 		if o != nil {
@@ -301,7 +303,7 @@ func (c *Client) do(ctx context.Context, r request) (*response, error) {
 	if !r.canRepeat() {
 		return c.send(ctx, pending)
 	}
-	return c.flight.do(ctx, signature(pending), func(ctx context.Context) (*response, error) {
+	return c.coalesce(ctx, signature(pending), func(ctx context.Context) (*response, error) {
 		return c.send(ctx, pending)
 	})
 }
@@ -346,6 +348,14 @@ func signature(pending call) string {
 	if len(pending.encoded) > 0 {
 		b.WriteByte(0)
 		b.Write(pending.encoded)
+	}
+	// Two ranged reads of one attachment differ only by a header. Without this
+	// they share a key, and the second caller is handed the first one's bytes.
+	for _, name := range slices.Sorted(maps.Keys(pending.header)) {
+		b.WriteByte(0)
+		b.WriteString(name)
+		b.WriteByte('=')
+		b.WriteString(strings.Join(pending.header.Values(name), ","))
 	}
 	return b.String()
 }
@@ -534,79 +544,56 @@ func fieldMessage(raw json.RawMessage) string {
 	return string(raw)
 }
 
-// singleflight collapses identical in-flight requests, so that rapid cursor
-// movement cannot fan out N fetches of the same page. golang.org/x/sync has
-// this, but promoting it from an indirect dependency to a direct one is a
-// go.mod change, and those are a separate PR here.
-type singleflight struct {
-	mu    sync.Mutex
-	calls map[string]*flight
-}
+// errLeaderGone marks a shared call that ended because the caller who started
+// it walked away. It is never returned to anyone: it exists so that a waiter can
+// tell that case apart from a site that failed, which is not something the error
+// value can say — a stalled server produces a timeout that unwraps to
+// context.DeadlineExceeded just as a caller's own deadline does.
+var errLeaderGone = errors.New("cloud: the caller that started this request left")
 
-type flight struct {
-	done    chan struct{}
-	callers int
-	resp    *response
-	err     error
-}
+// coalesceAttempts bounds how many times a waiter will restart a call that
+// successive callers keep abandoning.
+const coalesceAttempts = 3
 
-func newSingleflight() *singleflight {
-	return &singleflight{calls: make(map[string]*flight)}
-}
-
-// do runs fn once for a key however many callers ask for it at the same moment.
-// Each caller waits on its own context, so one of them giving up neither
-// cancels the others nor fails them: a call abandoned by the caller that
-// started it is taken over by whoever is still waiting.
-func (s *singleflight) do(ctx context.Context, key string, fn func(context.Context) (*response, error)) (*response, error) {
-	for {
+// coalesce runs one request for however many callers ask for it at the same
+// moment, so that rapid cursor movement cannot fan out N fetches of one page.
+//
+// The shared call runs on the context of whichever caller started it, so that
+// cancelling the only caller really does cancel the request rather than leaving
+// it to run for nothing. When that caller leaves while others are still waiting,
+// one of them starts the call again — which is why abandonment has to be read
+// from the leader's own context and not from the error it produced.
+func (c *Client) coalesce(ctx context.Context, key string, fn func(context.Context) (*response, error)) (*response, error) {
+	for attempt := 0; attempt < coalesceAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		s.mu.Lock()
-		shared, running := s.calls[key]
-		if !running {
-			shared = &flight{done: make(chan struct{})}
-			s.calls[key] = shared
-		}
-		shared.callers++
-		s.mu.Unlock()
-
-		if !running {
-			shared.resp, shared.err = fn(ctx)
-			s.mu.Lock()
-			delete(s.calls, key)
-			s.mu.Unlock()
-			close(shared.done)
-			return shared.resp, shared.err
-		}
-
+		shared := c.flight.DoChan(key, func() (any, error) {
+			resp, err := fn(ctx)
+			if ctx.Err() != nil {
+				return nil, errLeaderGone
+			}
+			return resp, err
+		})
 		select {
 		case <-ctx.Done():
+			// This caller is leaving. Forget the key so that whoever comes next
+			// starts a fresh call rather than attaching to one that is about to
+			// be abandoned.
+			c.flight.Forget(key)
 			return nil, ctx.Err()
-		case <-shared.done:
+		case res := <-shared:
+			if errors.Is(res.Err, errLeaderGone) {
+				continue
+			}
+			if res.Err != nil {
+				return nil, res.Err
+			}
+			resp, _ := res.Val.(*response)
+			return resp, nil
 		}
-		if ctx.Err() == nil && abandoned(shared.err) {
-			continue
-		}
-		return shared.resp, shared.err
 	}
-}
-
-// waiting reports how many callers are attached to the call under key.
-func (s *singleflight) waiting(key string) int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if shared, ok := s.calls[key]; ok {
-		return shared.callers
-	}
-	return 0
-}
-
-// abandoned reports whether a shared call ended because its own caller's
-// context did, which is not an answer about Jira and not one to hand on.
-func abandoned(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	return nil, &jira.TransportError{Op: key, Err: errLeaderGone}
 }
 
 // The platform API and the Agile API write date-times differently: the platform

--- a/pkg/jira/cloud/client.go
+++ b/pkg/jira/cloud/client.go
@@ -1,0 +1,700 @@
+// Package cloud is the jira.Client adapter for a Jira Cloud site: the HTTP
+// transport underneath every call, basic auth with an API token, the mapping
+// from a refused response to the typed errors in pkg/jira, retries that honour
+// Retry-After, and both of Jira's pagination models.
+//
+// Nothing above this package knows that Jira speaks REST, and nothing in it
+// knows what a view looks like. A Client is safe for concurrent use, caps how
+// many requests it has in the air at once, and collapses identical in-flight
+// requests, so that a cursor moving down a list cannot fan out one fetch per
+// keystroke.
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// DefaultMaxConcurrent is how many requests a client keeps in the air at once
+// when the caller does not say. Jira's limits are cost-based, so several narrow
+// requests cost less than one wide one — but only up to the point where the
+// site starts answering 429.
+const DefaultMaxConcurrent = 8
+
+const defaultUserAgent = "saral"
+
+// Doer is the HTTP client a Client sends through. *http.Client satisfies it; a
+// test substitutes its own.
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client is one Jira Cloud site and the credentials to reach it.
+type Client struct {
+	base   *url.URL
+	creds  credentials
+	http   Doer
+	clock  Clock
+	jitter Jitter
+	retry  RetryPolicy
+	agent  string
+
+	concurrency int
+	gate        chan struct{}
+	flight      *singleflight
+}
+
+// Option configures a Client at construction.
+type Option func(*Client)
+
+// New builds a client for one Jira Cloud site.
+//
+// The token is the resolved API token and not a source to resolve one from:
+// where a secret lives is the application's decision, taken in internal/config,
+// and pkg must not depend on it. The site may be written as a bare host, as a
+// URL, or with a port, which is what lets a test point a client at loopback.
+func New(site, email, token string, opts ...Option) (*Client, error) {
+	base, err := parseSite(site)
+	if err != nil {
+		return nil, err
+	}
+	account := strings.TrimSpace(email)
+	if account == "" {
+		return nil, errors.New("cloud: the account email is required: Jira Cloud pairs it with the API token as basic auth")
+	}
+	if token == "" {
+		return nil, errors.New("cloud: an API token is required")
+	}
+
+	c := &Client{
+		base:        base,
+		creds:       credentials{email: account, token: newSecret(token)},
+		clock:       systemClock{},
+		jitter:      fullJitter,
+		retry:       DefaultRetry(),
+		agent:       defaultUserAgent,
+		concurrency: DefaultMaxConcurrent,
+		flight:      newSingleflight(),
+	}
+	for _, o := range opts {
+		if o != nil {
+			o(c)
+		}
+	}
+	c.retry = c.retry.normalise()
+	if c.concurrency < 1 {
+		c.concurrency = 1
+	}
+	if c.clock == nil {
+		c.clock = systemClock{}
+	}
+	if c.jitter == nil {
+		c.jitter = fullJitter
+	}
+	if c.http == nil {
+		c.http = defaultHTTPClient(c.concurrency)
+	}
+	c.gate = make(chan struct{}, c.concurrency)
+	return c, nil
+}
+
+// WithHTTPClient sends through an HTTP client of the caller's own.
+func WithHTTPClient(d Doer) Option {
+	return func(c *Client) {
+		if d != nil {
+			c.http = d
+		}
+	}
+}
+
+// WithClock replaces the time source the retry loop waits on.
+func WithClock(k Clock) Option {
+	return func(c *Client) {
+		if k != nil {
+			c.clock = k
+		}
+	}
+}
+
+// WithJitter replaces the spread applied to a backoff wait.
+func WithJitter(j Jitter) Option {
+	return func(c *Client) {
+		if j != nil {
+			c.jitter = j
+		}
+	}
+}
+
+// WithRetry replaces the retry policy. A zero field keeps its default, so
+// RetryPolicy{Attempts: 1} turns retrying off and leaves the rest alone.
+func WithRetry(p RetryPolicy) Option {
+	return func(c *Client) { c.retry = p }
+}
+
+// WithMaxConcurrent caps how many requests are in the air at once.
+func WithMaxConcurrent(n int) Option {
+	return func(c *Client) { c.concurrency = n }
+}
+
+// WithUserAgent sets the User-Agent header, which is how a site administrator
+// tells this client apart from a browser in the access log.
+func WithUserAgent(agent string) Option {
+	return func(c *Client) { c.agent = agent }
+}
+
+// String identifies the client without revealing anything secret, which is what
+// makes it safe to hand to a logger or a %v.
+func (c Client) String() string {
+	if c.base == nil {
+		return "cloud.Client{unconfigured}"
+	}
+	return "cloud.Client{site: " + c.base.Host + ", account: " + c.creds.email + "}"
+}
+
+func defaultHTTPClient(concurrency int) *http.Client {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Client{}
+	}
+	t := transport.Clone()
+	t.MaxIdleConnsPerHost = concurrency
+	t.MaxConnsPerHost = concurrency
+	// A whole-client Timeout would also bound reading an attachment body, so
+	// the bound is on how long the site may take to start answering.
+	t.ResponseHeaderTimeout = 30 * time.Second
+	return &http.Client{Transport: t}
+}
+
+// parseSite reads what a profile calls a site — "example.atlassian.net",
+// "https://example.atlassian.net/", or an http://127.0.0.1 address in a test —
+// into the base every request is built on.
+func parseSite(site string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(site)
+	if trimmed == "" {
+		return nil, errors.New("cloud: the site is required, for example example.atlassian.net")
+	}
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "https://" + trimmed
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("cloud: reading the site %q: %w", site, err)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("cloud: the site %q must be an http or https address", site)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("cloud: the site %q names no host", site)
+	}
+	if parsed.User != nil {
+		return nil, errors.New("cloud: the site must not carry credentials; the email and token are given separately")
+	}
+	return &url.URL{Scheme: parsed.Scheme, Host: parsed.Host, Path: strings.TrimSuffix(parsed.Path, "/")}, nil
+}
+
+// request describes one call to Jira. It is a value the retry loop can replay.
+type request struct {
+	method string
+	path   string
+	query  url.Values
+	// body is marshalled to JSON, unless it is already a []byte, which is sent
+	// as it stands with whatever Content-Type the caller's header carries.
+	body   any
+	header http.Header
+	// kind and id say what a 404 on this path is about, so that the error reads
+	// "issue EX-1 does not exist" rather than naming a URL.
+	kind string
+	id   string
+	// repeatable marks a request that is safe to send again although its method
+	// is not idempotent: a POST that only reads, which is what /search/jql is.
+	// A write leaves it false and is then neither replayed nor coalesced.
+	repeatable bool
+}
+
+func (r request) op() string { return r.method + " " + r.path }
+
+func (r request) canRepeat() bool {
+	if r.repeatable {
+		return true
+	}
+	switch r.method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// target is what a 404 or a 409 on this request is about.
+func (r request) target() (kind, id string) {
+	kind, id = r.kind, r.id
+	if kind == "" {
+		kind = "resource"
+	}
+	if id == "" {
+		id = r.path
+	}
+	return kind, id
+}
+
+// call is a request whose body has been encoded, which is what the retry loop
+// replays: a retry resends the same bytes rather than running an encoder again
+// over a value the caller has moved on from.
+type call struct {
+	request
+	encoded     []byte
+	contentType string
+}
+
+// response is what came back, with the body already read so that the connection
+// goes back to the pool before anything is decoded.
+type response struct {
+	status int
+	header http.Header
+	body   []byte
+}
+
+func (r *response) ok() bool {
+	return r.status >= http.StatusOK && r.status < http.StatusMultipleChoices
+}
+
+// decode reads a JSON response body into out. A body that will not decode is a
+// transport failure: the call reached Jira and came back with something this
+// client cannot use. A success with no body at all leaves out untouched.
+func (r *response) decode(op string, out any) error {
+	if out == nil || r.status == http.StatusNoContent || len(bytes.TrimSpace(r.body)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(r.body, out); err != nil {
+		return &jira.TransportError{
+			Op:     op,
+			Status: r.status,
+			Err:    fmt.Errorf("the response body is not the JSON this client expected: %w", err),
+		}
+	}
+	return nil
+}
+
+// do sends a request and returns the response the site answered 2xx with,
+// having retried whatever was safe to retry.
+func (c *Client) do(ctx context.Context, r request) (*response, error) {
+	encoded, contentType, err := encodeBody(r)
+	if err != nil {
+		return nil, err
+	}
+	pending := call{request: r, encoded: encoded, contentType: contentType}
+	if !r.canRepeat() {
+		return c.send(ctx, pending)
+	}
+	return c.flight.do(ctx, signature(pending), func(ctx context.Context) (*response, error) {
+		return c.send(ctx, pending)
+	})
+}
+
+// doJSON sends a request and decodes its response body into out.
+func (c *Client) doJSON(ctx context.Context, r request, out any) error {
+	resp, err := c.do(ctx, r)
+	if err != nil {
+		return err
+	}
+	return resp.decode(r.op(), out)
+}
+
+// encodeBody marshals a request body once, before the first attempt.
+func encodeBody(r request) (encoded []byte, contentType string, err error) {
+	switch body := r.body.(type) {
+	case nil:
+		return nil, "", nil
+	case []byte:
+		return body, "", nil
+	default:
+		marshalled, err := json.Marshal(body)
+		if err != nil {
+			return nil, "", fmt.Errorf("cloud: encoding the body of %s: %w", r.op(), err)
+		}
+		return marshalled, "application/json", nil
+	}
+}
+
+// signature is what makes two requests the same request. It is only ever built
+// for a repeatable one, so no write is ever collapsed into another write.
+func signature(pending call) string {
+	var b strings.Builder
+	b.Grow(len(pending.method) + len(pending.path) + len(pending.encoded) + 8)
+	b.WriteString(pending.method)
+	b.WriteByte(' ')
+	b.WriteString(pending.path)
+	if len(pending.query) > 0 {
+		b.WriteByte('?')
+		b.WriteString(pending.query.Encode())
+	}
+	if len(pending.encoded) > 0 {
+		b.WriteByte(0)
+		b.Write(pending.encoded)
+	}
+	return b.String()
+}
+
+func (c *Client) send(ctx context.Context, pending call) (*response, error) {
+	for attempt := 1; ; attempt++ {
+		resp, err := c.attempt(ctx, pending)
+		if err == nil && resp.ok() {
+			return resp, nil
+		}
+		// A context that ended is the caller's own answer rather than anything
+		// Jira did, so it comes back as it is and not as a transport failure.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		failure := c.failure(pending.request, resp, err)
+		if attempt >= c.retry.Attempts || !retryable(pending.request, resp, err) {
+			return nil, failure
+		}
+		if waitErr := c.clock.Wait(ctx, c.waitFor(failure, attempt)); waitErr != nil {
+			return nil, waitErr
+		}
+	}
+}
+
+func (c *Client) attempt(ctx context.Context, pending call) (*response, error) {
+	if err := c.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer c.release()
+
+	var body io.Reader
+	if len(pending.encoded) > 0 {
+		body = bytes.NewReader(pending.encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, pending.method, c.endpoint(pending.request), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if pending.contentType != "" {
+		req.Header.Set("Content-Type", pending.contentType)
+	}
+	if c.agent != "" {
+		req.Header.Set("User-Agent", c.agent)
+	}
+	for key, values := range pending.header {
+		req.Header[http.CanonicalHeaderKey(key)] = slices.Clone(values)
+	}
+	// Authorising last is what stops a caller's own header from replacing it.
+	c.creds.authorize(req)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+	payload, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &response{status: res.StatusCode, header: res.Header, body: payload}, nil
+}
+
+func (c *Client) endpoint(r request) string {
+	target := url.URL{Scheme: c.base.Scheme, Host: c.base.Host, Path: c.base.Path + r.path}
+	if len(r.query) > 0 {
+		target.RawQuery = r.query.Encode()
+	}
+	return target.String()
+}
+
+// failure turns whatever went wrong into the taxonomy in pkg/jira.
+func (c *Client) failure(r request, resp *response, err error) error {
+	if err != nil {
+		return &jira.TransportError{Op: r.op(), Err: err}
+	}
+	return c.apiError(r, resp)
+}
+
+// apiError maps a response Jira refused. The status is the authority: a body
+// that will not parse costs the detail, never the classification.
+func (c *Client) apiError(r request, resp *response) error {
+	detail := parseErrorBody(resp.body)
+	kind, id := r.target()
+	switch resp.status {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return &jira.ValidationError{Fields: detail.fields, Messages: detail.messages}
+	case http.StatusUnauthorized:
+		return &jira.AuthError{Reason: detail.reason()}
+	case http.StatusForbidden:
+		return &jira.CapabilityError{
+			Reason: detail.reasonOr("Jira refused " + r.op() + ": this token is not permitted to do it"),
+		}
+	case http.StatusNotFound, http.StatusGone:
+		return &jira.NotFoundError{Kind: kind, ID: id}
+	case http.StatusConflict:
+		return &jira.ConflictError{Resource: kind + " " + id, Detail: detail.reason()}
+	case http.StatusTooManyRequests:
+		return &jira.RateLimitError{
+			RetryAfter: retryAfter(resp.header, c.clock.Now()),
+			Endpoint:   r.path,
+		}
+	default:
+		return &jira.TransportError{
+			Op:     r.op(),
+			Status: resp.status,
+			Err:    errors.New(detail.reasonOr(http.StatusText(resp.status))),
+		}
+	}
+}
+
+// jiraError is the error envelope both APIs use: per-field messages under
+// errors, loose ones under errorMessages, and a bare message on the Agile
+// endpoints that answer in their own shape.
+type jiraError struct {
+	fields   []jira.FieldError
+	messages []string
+}
+
+func (e jiraError) reason() string { return strings.Join(e.messages, "; ") }
+
+func (e jiraError) reasonOr(fallback string) string {
+	if reason := e.reason(); reason != "" {
+		return reason
+	}
+	return fallback
+}
+
+func parseErrorBody(body []byte) jiraError {
+	var envelope struct {
+		ErrorMessages []string        `json:"errorMessages"`
+		Errors        json.RawMessage `json:"errors"`
+		Message       string          `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return jiraError{}
+	}
+	out := jiraError{messages: envelope.ErrorMessages, fields: parseFieldErrors(envelope.Errors)}
+	if envelope.Message != "" {
+		out.messages = append(out.messages, envelope.Message)
+	}
+	return out
+}
+
+// parseFieldErrors reads the errors object in the order Jira wrote it, which a
+// map would lose and a form needs: the first message names the field to focus.
+// Some endpoints send an empty array there instead of an object, which is not a
+// failure and carries nothing.
+func parseFieldErrors(raw json.RawMessage) []jira.FieldError {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	if _, err := dec.Token(); err != nil {
+		return nil
+	}
+	var out []jira.FieldError
+	for dec.More() {
+		token, err := dec.Token()
+		if err != nil {
+			return out
+		}
+		field, ok := token.(string)
+		if !ok {
+			return out
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return out
+		}
+		out = append(out, jira.FieldError{Field: field, Message: fieldMessage(value)})
+	}
+	return out
+}
+
+// fieldMessage renders one entry of the errors object, which is a string on
+// every endpoint that documents the shape and occasionally not on one that does
+// not.
+func fieldMessage(raw json.RawMessage) string {
+	var message string
+	if err := json.Unmarshal(raw, &message); err == nil {
+		return message
+	}
+	return string(raw)
+}
+
+// singleflight collapses identical in-flight requests, so that rapid cursor
+// movement cannot fan out N fetches of the same page. golang.org/x/sync has
+// this, but promoting it from an indirect dependency to a direct one is a
+// go.mod change, and those are a separate PR here.
+type singleflight struct {
+	mu    sync.Mutex
+	calls map[string]*flight
+}
+
+type flight struct {
+	done    chan struct{}
+	callers int
+	resp    *response
+	err     error
+}
+
+func newSingleflight() *singleflight {
+	return &singleflight{calls: make(map[string]*flight)}
+}
+
+// do runs fn once for a key however many callers ask for it at the same moment.
+// Each caller waits on its own context, so one of them giving up neither
+// cancels the others nor fails them: a call abandoned by the caller that
+// started it is taken over by whoever is still waiting.
+func (s *singleflight) do(ctx context.Context, key string, fn func(context.Context) (*response, error)) (*response, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		shared, running := s.calls[key]
+		if !running {
+			shared = &flight{done: make(chan struct{})}
+			s.calls[key] = shared
+		}
+		shared.callers++
+		s.mu.Unlock()
+
+		if !running {
+			shared.resp, shared.err = fn(ctx)
+			s.mu.Lock()
+			delete(s.calls, key)
+			s.mu.Unlock()
+			close(shared.done)
+			return shared.resp, shared.err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-shared.done:
+		}
+		if ctx.Err() == nil && abandoned(shared.err) {
+			continue
+		}
+		return shared.resp, shared.err
+	}
+}
+
+// waiting reports how many callers are attached to the call under key.
+func (s *singleflight) waiting(key string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if shared, ok := s.calls[key]; ok {
+		return shared.callers
+	}
+	return 0
+}
+
+// abandoned reports whether a shared call ended because its own caller's
+// context did, which is not an answer about Jira and not one to hand on.
+func abandoned(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// The platform API and the Agile API write date-times differently: the platform
+// writes an offset with no colon, the Agile API writes one with. Neither is
+// RFC 3339 and one layout cannot read both.
+const (
+	platformTimeLayout = "2006-01-02T15:04:05.000-0700"
+	agileTimeLayout    = "2006-01-02T15:04:05.000-07:00"
+)
+
+// parsePlatformTime reads a platform API date-time, 2021-01-17T12:34:00.000+0000.
+func parsePlatformTime(s string) (time.Time, error) {
+	parsed, err := time.Parse(platformTimeLayout, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cloud: %q is not a platform API date-time: %w", s, err)
+	}
+	return parsed, nil
+}
+
+// parseAgileTime reads an Agile API date-time, 2015-04-11T15:22:00.000+10:00.
+func parseAgileTime(s string) (time.Time, error) {
+	parsed, err := time.Parse(agileTimeLayout, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cloud: %q is not an Agile API date-time: %w", s, err)
+	}
+	return parsed, nil
+}
+
+// parseTime reads a date-time from either API. The two layouts cannot mistake
+// each other's input — one wants four digits after the sign and the other wants
+// a colon in the middle of them — so trying both in turn is unambiguous.
+func parseTime(s string) (time.Time, error) {
+	for _, layout := range []string{platformTimeLayout, agileTimeLayout, time.RFC3339Nano} {
+		if parsed, err := time.Parse(layout, s); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cloud: %q is not a date-time either Jira API writes", s)
+}
+
+// timestamp decodes a date-time from either API, and reads null and "" as unset
+// rather than as a failure — Jira leaves a date off an issue that way.
+type timestamp struct {
+	time.Time
+}
+
+func (t *timestamp) UnmarshalJSON(data []byte) error {
+	var raw *string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("cloud: reading a date-time: %w", err)
+	}
+	if raw == nil || *raw == "" {
+		t.Time = time.Time{}
+		return nil
+	}
+	parsed, err := parseTime(*raw)
+	if err != nil {
+		return err
+	}
+	t.Time = parsed
+	return nil
+}
+
+// ptr returns the time behind a pointer, and nil when it is unset, which is the
+// shape the domain types carry an optional instant in.
+func (t timestamp) ptr() *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	at := t.Time
+	return &at
+}
+
+// epochMillis decodes the epoch-millisecond instants the task endpoints report
+// created, started and updated in, rather than the layouts everything else uses.
+type epochMillis struct {
+	time.Time
+}
+
+func (t *epochMillis) UnmarshalJSON(data []byte) error {
+	var raw *int64
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("cloud: reading an epoch-millisecond time: %w", err)
+	}
+	if raw == nil {
+		t.Time = time.Time{}
+		return nil
+	}
+	t.Time = time.UnixMilli(*raw).UTC()
+	return nil
+}

--- a/pkg/jira/cloud/client_test.go
+++ b/pkg/jira/cloud/client_test.go
@@ -1,0 +1,918 @@
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+const (
+	testEmail = "sam@example.invalid"
+	testToken = "not-a-real-api-token-1234"
+)
+
+var testNow = time.Date(2026, time.March, 2, 9, 0, 0, 0, time.UTC)
+
+// testClock records what the retry loop asked to wait for instead of waiting,
+// which is what keeps these tests instant and their assertions exact.
+type testClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	waits  []time.Duration
+	onWait func(ctx context.Context, d time.Duration) error
+}
+
+func newTestClock() *testClock { return &testClock{now: testNow} }
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Wait(ctx context.Context, d time.Duration) error {
+	c.mu.Lock()
+	c.waits = append(c.waits, d)
+	hook := c.onWait
+	c.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, d)
+	}
+	return ctx.Err()
+}
+
+func (c *testClock) waited() []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Duration(nil), c.waits...)
+}
+
+func (c *testClock) whenWaiting(hook func(ctx context.Context, d time.Duration) error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onWait = hook
+}
+
+// testClient builds a client whose waits are recorded rather than served and
+// whose jitter is the identity, so a backoff is an assertable number.
+func testClient(t *testing.T, site string, opts ...Option) (*Client, *testClock) {
+	t.Helper()
+
+	clock := newTestClock()
+	base := []Option{
+		WithClock(clock),
+		WithJitter(func(d time.Duration) time.Duration { return d }),
+	}
+	c, err := New(site, testEmail, testToken, append(base, opts...)...)
+	if err != nil {
+		t.Fatalf("building a client for %s: %v", site, err)
+	}
+	return c, clock
+}
+
+// waitUntil blocks until cond holds, without a sleep and without a fixed number
+// of spins: what it is waiting for is another goroutine reaching a state.
+func waitUntil(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		runtime.Gosched()
+	}
+}
+
+func fieldRequest() request {
+	return request{method: http.MethodGet, path: "/rest/api/3/field"}
+}
+
+func TestNew_RefusesASiteOrCredentialItCannotUse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		site  string
+		email string
+		token string
+		want  string
+	}{
+		{name: "no site at all", site: "", email: testEmail, token: testToken, want: "the site is required"},
+		{name: "a site that is not an http address", site: "ftp://example.atlassian.net", email: testEmail, token: testToken, want: "http or https"},
+		{name: "a site carrying credentials", site: "https://sam:hunter2@example.atlassian.net", email: testEmail, token: testToken, want: "must not carry credentials"},
+		{name: "no account email", site: "example.atlassian.net", email: "  ", token: testToken, want: "account email is required"},
+		{name: "no token", site: "example.atlassian.net", email: testEmail, token: "", want: "API token is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := New(tt.site, tt.email, tt.token)
+			if err == nil {
+				t.Fatalf("New(%q, %q, …) built %v, want a refusal", tt.site, tt.email, c)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("New said %q, want it to mention %q", err, tt.want)
+			}
+			if strings.Contains(err.Error(), tt.token) && tt.token != "" {
+				t.Errorf("New put the token in its error: %q", err)
+			}
+		})
+	}
+}
+
+func TestParseSite_ReadsEveryFormAProfileMayWriteASiteIn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		site string
+		want string
+	}{
+		{name: "a bare host", site: "example.atlassian.net", want: "https://example.atlassian.net"},
+		{name: "a host with the scheme already on it", site: "https://example.atlassian.net", want: "https://example.atlassian.net"},
+		{name: "a trailing slash", site: "https://example.atlassian.net/", want: "https://example.atlassian.net"},
+		{name: "surrounding whitespace", site: "  example.atlassian.net  ", want: "https://example.atlassian.net"},
+		{name: "a loopback address with a port", site: "http://127.0.0.1:8080", want: "http://127.0.0.1:8080"},
+		{name: "a host behind a path prefix", site: "https://proxy.example/jira/", want: "https://proxy.example/jira"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseSite(tt.site)
+			if err != nil {
+				t.Fatalf("parseSite(%q): %v", tt.site, err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("parseSite(%q) = %s, want %s", tt.site, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpoint_KeepsThePathPrefixAndEncodesTheQuery(t *testing.T) {
+	t.Parallel()
+
+	c, _ := testClient(t, "https://proxy.example/jira")
+	got := c.endpoint(request{
+		method: http.MethodGet,
+		path:   "/rest/api/3/search/approximate-count",
+		query:  url.Values{"jql": {"project = EX ORDER BY updated"}},
+	})
+	want := "https://proxy.example/jira/rest/api/3/search/approximate-count?jql=project+%3D+EX+ORDER+BY+updated"
+	if got != want {
+		t.Errorf("endpoint = %s, want %s", got, want)
+	}
+}
+
+func TestDo_SendsBasicAuthAndAsksForJSON(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL(), WithUserAgent("saral/test"))
+	var me struct {
+		AccountID string `json:"accountId"`
+	}
+	if err := c.doJSON(t.Context(), request{method: http.MethodGet, path: "/rest/api/3/myself"}, &me); err != nil {
+		t.Fatalf("reading /myself: %v", err)
+	}
+	if me.AccountID == "" {
+		t.Error("the response decoded into an empty account")
+	}
+
+	served := s.Requests()
+	if len(served) != 1 {
+		t.Fatalf("the site served %d requests, want 1", len(served))
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte(testEmail+":"+testToken))
+	if got := served[0].Header.Get("Authorization"); got != want {
+		t.Errorf("Authorization = %q, want the basic auth pair", got)
+	}
+	if got := served[0].Header.Get("Accept"); got != "application/json" {
+		t.Errorf("Accept = %q, want application/json", got)
+	}
+	if got := served[0].Header.Get("User-Agent"); got != "saral/test" {
+		t.Errorf("User-Agent = %q, want saral/test", got)
+	}
+}
+
+func TestDo_MapsEveryRefusedStatusToItsTypedError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		fixture string
+		assert  func(t *testing.T, err error)
+	}{
+		{
+			name:    "a rejected request is a validation failure",
+			status:  http.StatusBadRequest,
+			fixture: "validation_error.json",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.ValidationError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.ValidationError", err, err)
+				}
+			},
+		},
+		{
+			name:   "a rejected credential is an auth failure",
+			status: http.StatusUnauthorized,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.AuthError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.AuthError", err, err)
+				}
+			},
+		},
+		{
+			name:    "a refusal is a capability answer",
+			status:  http.StatusForbidden,
+			fixture: "plans_403.json",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.CapabilityError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+				}
+				if !strings.Contains(target.Reason, "Administer Jira") {
+					t.Errorf("Reason = %q, want Jira's own wording out of the body", target.Reason)
+				}
+			},
+		},
+		{
+			name:   "a missing resource is a not-found",
+			status: http.StatusNotFound,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.NotFoundError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.NotFoundError", err, err)
+				}
+				if target.Kind != "field catalogue" || target.ID != "EX" {
+					t.Errorf("got %s %s, want the request's own target", target.Kind, target.ID)
+				}
+			},
+		},
+		{
+			name:   "a resource that is gone is also a not-found",
+			status: http.StatusGone,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.NotFoundError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.NotFoundError", err, err)
+				}
+			},
+		},
+		{
+			name:   "a concurrent edit is a conflict",
+			status: http.StatusConflict,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.ConflictError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.ConflictError", err, err)
+				}
+			},
+		},
+		{
+			name:    "a throttled request is a rate limit",
+			status:  http.StatusTooManyRequests,
+			fixture: "rate_limited.json",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.RateLimitError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+				}
+				if target.Endpoint != "/rest/api/3/field" {
+					t.Errorf("Endpoint = %q, want the path that was throttled", target.Endpoint)
+				}
+			},
+		},
+		{
+			name:   "a server fault is a transport failure",
+			status: http.StatusInternalServerError,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.TransportError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+				if target.Status != http.StatusInternalServerError {
+					t.Errorf("Status = %d, want 500", target.Status)
+				}
+				if target.Op != "GET /rest/api/3/field" {
+					t.Errorf("Op = %q, want the method and path", target.Op)
+				}
+			},
+		},
+		{
+			name:   "a status outside the taxonomy is a transport failure",
+			status: http.StatusNotImplemented,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var target *jira.TransportError
+				if !errors.As(err, &target) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, "/rest/api/3/field", tt.status, tt.fixture))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			r := fieldRequest()
+			r.kind, r.id = "field catalogue", "EX"
+			_, err := c.do(t.Context(), r)
+			if err == nil {
+				t.Fatalf("HTTP %d came back as a success", tt.status)
+			}
+			tt.assert(t, err)
+		})
+	}
+}
+
+func TestDo_MapsAValidationFailureFieldByFieldInTheOrderJiraWroteThem(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodPost, "/rest/api/3/issue", http.StatusBadRequest, "validation_error.json"))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	_, err := c.do(t.Context(), request{method: http.MethodPost, path: "/rest/api/3/issue", body: map[string]string{"summary": ""}})
+
+	var invalid *jira.ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("got %T (%v), want a *jira.ValidationError", err, err)
+	}
+	wantOrder := []string{"summary", "duedate", "customfield_10032"}
+	if len(invalid.Fields) != len(wantOrder) {
+		t.Fatalf("got %d field messages, want %d: %v", len(invalid.Fields), len(wantOrder), invalid.Fields)
+	}
+	for i, field := range wantOrder {
+		if invalid.Fields[i].Field != field {
+			t.Errorf("field %d is %q, want %q — the order Jira wrote them in is the order a form focuses them in",
+				i, invalid.Fields[i].Field, field)
+		}
+	}
+	if msg, ok := invalid.For("summary"); !ok || !strings.Contains(msg, "summary") {
+		t.Errorf("the summary message is %q, want Jira's own", msg)
+	}
+	if len(invalid.Messages) != 1 || !strings.Contains(invalid.Messages[0], "customfield_10019") {
+		t.Errorf("Messages = %v, want the one loose errorMessages entry", invalid.Messages)
+	}
+}
+
+func TestDo_ReadsRetryAfterOffTheRateLimitWithAndWithoutTheHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opt  jiratest.ServerOption
+		want time.Duration
+	}{
+		{
+			name: "the site said when to come back",
+			opt:  jiratest.WithRateLimit(http.MethodGet, "/rest/api/3/field", 30*time.Second),
+			want: 30 * time.Second,
+		},
+		{
+			name: "the site sent no Retry-After",
+			opt:  jiratest.WithStatus(http.MethodGet, "/rest/api/3/field", http.StatusTooManyRequests, "rate_limited.json"),
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(tt.opt)
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			_, err := c.do(t.Context(), fieldRequest())
+
+			var limited *jira.RateLimitError
+			if !errors.As(err, &limited) {
+				t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+			}
+			if limited.RetryAfter != tt.want {
+				t.Errorf("RetryAfter = %s, want %s", limited.RetryAfter, tt.want)
+			}
+		})
+	}
+}
+
+func TestDo_TreatsABodyThatWillNotDecodeAsATransportFailure(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("<html>your proxy has opinions</html>"))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	var fields []struct{}
+	err := c.doJSON(t.Context(), fieldRequest(), &fields)
+
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+	}
+	if broken.Status != http.StatusOK {
+		t.Errorf("Status = %d, want the 200 the body arrived with", broken.Status)
+	}
+}
+
+func TestDo_TreatsADialFailureAsATransportFailure(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	site := s.URL()
+	s.Close()
+
+	c, _ := testClient(t, site, WithRetry(RetryPolicy{Attempts: 1}))
+	_, err := c.do(t.Context(), fieldRequest())
+
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+	}
+	if broken.Status != 0 {
+		t.Errorf("Status = %d, want 0: the request never reached a server", broken.Status)
+	}
+}
+
+func TestDo_ReturnsTheContextErrorWhenTheCallerCancelsMidFlight(t *testing.T) {
+	t.Parallel()
+
+	arrived := make(chan struct{}, 1)
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field", func(_ http.ResponseWriter, r *http.Request) {
+		arrived <- struct{}{}
+		<-r.Context().Done()
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	ctx, cancel := context.WithCancel(t.Context())
+	failed := make(chan error, 1)
+	go func() {
+		_, err := c.do(ctx, fieldRequest())
+		failed <- err
+	}()
+
+	<-arrived
+	cancel()
+	err := <-failed
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the context's own error", err)
+	}
+	var broken *jira.TransportError
+	if errors.As(err, &broken) {
+		t.Error("a caller cancelling its own work is not a transport failure and must not show a stale badge")
+	}
+}
+
+func TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce(t *testing.T) {
+	t.Parallel()
+
+	arrived := make(chan struct{}, 1)
+	release := make(chan struct{})
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field", func(w http.ResponseWriter, _ *http.Request) {
+		arrived <- struct{}{}
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"summary"}]`))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	r := fieldRequest()
+	key := signature(call{request: r})
+
+	const callers = 5
+	results := make(chan error, callers)
+	for range callers {
+		go func() {
+			_, err := c.do(t.Context(), r)
+			results <- err
+		}()
+	}
+
+	<-arrived
+	waitUntil(t, "every caller to attach to the one call in flight", func() bool {
+		return c.flight.waiting(key) == callers
+	})
+	close(release)
+	for range callers {
+		if err := <-results; err != nil {
+			t.Fatalf("a coalesced caller failed: %v", err)
+		}
+	}
+
+	if served := len(s.Requests()); served != 1 {
+		t.Errorf("the site served %d requests, want 1: %d callers asked for the same page", served, callers)
+	}
+	if left := c.flight.waiting(key); left != 0 {
+		t.Errorf("%d callers are still recorded against a finished call", left)
+	}
+}
+
+func TestDo_NeverCoalescesAWrite(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodPost, "/rest/api/3/issue", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"EX-1"}`))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	r := request{method: http.MethodPost, path: "/rest/api/3/issue", body: map[string]string{"summary": "the same summary"}}
+
+	const callers = 4
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.do(t.Context(), r); err != nil {
+				t.Errorf("creating an issue: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if served := len(s.Requests()); served != callers {
+		t.Errorf("the site served %d requests, want %d: two creates are two issues, however alike they look", served, callers)
+	}
+}
+
+func TestDo_TakesOverACallTheStartingCallerAbandoned(t *testing.T) {
+	t.Parallel()
+
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field", func(w http.ResponseWriter, r *http.Request) {
+		arrived <- struct{}{}
+		select {
+		case <-release:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"summary"}]`))
+		case <-r.Context().Done():
+		}
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	r := fieldRequest()
+	key := signature(call{request: r})
+
+	leaderCtx, cancelLeader := context.WithCancel(t.Context())
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := c.do(leaderCtx, r)
+		leaderDone <- err
+	}()
+	<-arrived
+
+	followerDone := make(chan error, 1)
+	go func() {
+		_, err := c.do(t.Context(), r)
+		followerDone <- err
+	}()
+	waitUntil(t, "the follower to attach to the call in flight", func() bool {
+		return c.flight.waiting(key) == 2
+	})
+
+	cancelLeader()
+	if err := <-leaderDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("the abandoning caller got %v, want its own context error", err)
+	}
+	<-arrived
+	close(release)
+	if err := <-followerDone; err != nil {
+		t.Fatalf("the caller still waiting got %v, want the page it asked for", err)
+	}
+}
+
+func TestDo_KeepsNoMoreRequestsInTheAirThanTheCapAllows(t *testing.T) {
+	t.Parallel()
+
+	const inFlight, callers = 2, 4
+	arrived := make(chan string, callers)
+	release := make(chan struct{})
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field", func(w http.ResponseWriter, r *http.Request) {
+		arrived <- r.URL.Query().Get("n")
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL(), WithMaxConcurrent(inFlight))
+	var wg sync.WaitGroup
+	for n := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := fieldRequest()
+			r.query = url.Values{"n": {strconv.Itoa(n)}}
+			if _, err := c.do(t.Context(), r); err != nil {
+				t.Errorf("request %d: %v", n, err)
+			}
+		}()
+	}
+
+	for range inFlight {
+		<-arrived
+	}
+	select {
+	case extra := <-arrived:
+		t.Errorf("request %s reached the site while %d were already in flight", extra, inFlight)
+	default:
+	}
+	close(release)
+	wg.Wait()
+
+	if served := len(s.Requests()); served != callers {
+		t.Errorf("the site served %d requests, want all %d", served, callers)
+	}
+}
+
+// stubDoer answers every request the same way, without a server.
+type stubDoer struct {
+	err   error
+	calls atomic.Int64
+}
+
+func (d *stubDoer) Do(*http.Request) (*http.Response, error) {
+	d.calls.Add(1)
+	return nil, d.err
+}
+
+func TestWithHTTPClient_SendsThroughTheCallersClientAndMapsItsTimeout(t *testing.T) {
+	t.Parallel()
+
+	doer := &stubDoer{err: &url.Error{
+		Op:  "Get",
+		URL: "https://example.atlassian.net/rest/api/3/field",
+		Err: os.ErrDeadlineExceeded,
+	}}
+	c, _ := testClient(t, "example.atlassian.net", WithHTTPClient(doer), WithRetry(RetryPolicy{Attempts: 2}))
+	_, err := c.do(t.Context(), fieldRequest())
+
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError: a timeout of the client's own is not the caller cancelling", err, err)
+	}
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Errorf("the cause did not survive being wrapped: %v", err)
+	}
+	if got := doer.calls.Load(); got != 2 {
+		t.Errorf("the client sent %d requests, want the 2 attempts the policy allows", got)
+	}
+}
+
+func TestDecode_LeavesTheTargetAloneWhenTheAnswerHasNoBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		resp response
+	}{
+		{name: "a no-content answer", resp: response{status: http.StatusNoContent, body: []byte(`{"key":"EX-1"}`)}},
+		{name: "an empty body", resp: response{status: http.StatusOK, body: []byte("  \n")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := struct {
+				Key string `json:"key"`
+			}{}
+			if err := tt.resp.decode("DELETE /rest/api/3/issue/EX-1", &out); err != nil {
+				t.Fatalf("decoding: %v", err)
+			}
+			if out.Key != "" {
+				t.Errorf("decoded %q out of a body-less answer", out.Key)
+			}
+		})
+	}
+}
+
+func TestEncodeBody_MarshalsOnceAndPassesRawBytesThrough(t *testing.T) {
+	t.Parallel()
+
+	encoded, contentType, err := encodeBody(request{method: http.MethodPost, path: "/x", body: map[string]int{"maxResults": 50}})
+	if err != nil {
+		t.Fatalf("encoding a value: %v", err)
+	}
+	if string(encoded) != `{"maxResults":50}` || contentType != "application/json" {
+		t.Errorf("got %s as %q, want the JSON encoding", encoded, contentType)
+	}
+
+	raw := []byte("--boundary\r\n")
+	encoded, contentType, err = encodeBody(request{method: http.MethodPost, path: "/x", body: raw})
+	if err != nil {
+		t.Fatalf("encoding raw bytes: %v", err)
+	}
+	if !bytes.Equal(encoded, raw) || contentType != "" {
+		t.Errorf("got %s as %q, want the bytes as they stand and no content type of ours", encoded, contentType)
+	}
+
+	if _, _, err = encodeBody(request{method: http.MethodPost, path: "/x", body: make(chan int)}); err == nil {
+		t.Error("a body that cannot be marshalled encoded without complaint")
+	}
+}
+
+func TestParseFieldErrors_SurvivesAnErrorsKeyThatIsNotAnObject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "the Agile API's empty array", body: `{"errorMessages":["nope"],"errors":[]}`, want: 0},
+		{name: "no errors key at all", body: `{"errorMessages":["nope"]}`, want: 0},
+		{name: "a body that is not JSON", body: `<html>`, want: 0},
+		{name: "an entry that is not a string", body: `{"errors":{"labels":["too many"]}}`, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := len(parseErrorBody([]byte(tt.body)).fields); got != tt.want {
+				t.Errorf("got %d field messages out of %s, want %d", got, tt.body, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTime_ReadsBothOfJirasLayoutsAndNeitherMistakesTheOther(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       string
+		want     time.Time
+		platform bool
+		agile    bool
+	}{
+		{
+			name:     "the platform API's offset with no colon",
+			in:       "2021-01-17T12:34:00.000+0000",
+			want:     time.Date(2021, time.January, 17, 12, 34, 0, 0, time.UTC),
+			platform: true,
+		},
+		{
+			name:  "the Agile API's offset with a colon",
+			in:    "2015-04-11T15:22:00.000+10:00",
+			want:  time.Date(2015, time.April, 11, 15, 22, 0, 0, time.FixedZone("", 10*60*60)),
+			agile: true,
+		},
+		{
+			name:     "a platform date-time east of Greenwich",
+			in:       "2026-02-11T09:41:22.104+0100",
+			want:     time.Date(2026, time.February, 11, 9, 41, 22, 104_000_000, time.FixedZone("", 60*60)),
+			platform: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseTime(tt.in)
+			if err != nil {
+				t.Fatalf("parseTime(%q): %v", tt.in, err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("parseTime(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+
+			gotPlatform, errPlatform := parsePlatformTime(tt.in)
+			if tt.platform {
+				if errPlatform != nil || !gotPlatform.Equal(tt.want) {
+					t.Errorf("parsePlatformTime(%q) = %s, %v", tt.in, gotPlatform, errPlatform)
+				}
+			} else if errPlatform == nil {
+				t.Errorf("parsePlatformTime read %q, which is the other API's layout", tt.in)
+			}
+
+			gotAgile, errAgile := parseAgileTime(tt.in)
+			if tt.agile {
+				if errAgile != nil || !gotAgile.Equal(tt.want) {
+					t.Errorf("parseAgileTime(%q) = %s, %v", tt.in, gotAgile, errAgile)
+				}
+			} else if errAgile == nil {
+				t.Errorf("parseAgileTime read %q, which is the other API's layout", tt.in)
+			}
+		})
+	}
+}
+
+func TestTimestamp_ReadsAnUnsetDateAsUnsetAndRefusesNonsense(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		json    string
+		want    time.Time
+		wantErr bool
+	}{
+		{name: "a platform date-time", json: `"2021-01-17T12:34:00.000+0000"`, want: time.Date(2021, time.January, 17, 12, 34, 0, 0, time.UTC)},
+		{name: "an Agile date-time", json: `"2015-04-11T15:22:00.000+10:00"`, want: time.Date(2015, time.April, 11, 15, 22, 0, 0, time.FixedZone("", 10*60*60))},
+		{name: "an RFC 3339 instant", json: `"2026-03-02T09:00:00Z"`, want: testNow},
+		{name: "an absent date", json: `null`},
+		{name: "an empty string", json: `""`},
+		{name: "a date-time in nobody's layout", json: `"17/01/2021"`, wantErr: true},
+		{name: "a number where a date-time belongs", json: `1737117240000`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got timestamp
+			err := got.UnmarshalJSON([]byte(tt.json))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("decoding %s came back with %s and no complaint", tt.json, got.Time)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decoding %s: %v", tt.json, err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("decoded %s as %s, want %s", tt.json, got.Time, tt.want)
+			}
+			if tt.want.IsZero() && got.ptr() != nil {
+				t.Errorf("an unset date came back as a pointer to %s", got.Time)
+			}
+			if !tt.want.IsZero() && (got.ptr() == nil || !got.ptr().Equal(tt.want)) {
+				t.Errorf("ptr() lost the instant %s", tt.want)
+			}
+		})
+	}
+}
+
+func TestEpochMillis_ReadsTheTaskEndpointsOwnTimeFormat(t *testing.T) {
+	t.Parallel()
+
+	var got epochMillis
+	if err := got.UnmarshalJSON([]byte("1772442000000")); err != nil {
+		t.Fatalf("decoding an epoch time: %v", err)
+	}
+	if !got.Equal(testNow) {
+		t.Errorf("decoded %s, want %s", got.Time, testNow)
+	}
+
+	var absent epochMillis
+	if err := absent.UnmarshalJSON([]byte("null")); err != nil {
+		t.Fatalf("decoding an absent epoch time: %v", err)
+	}
+	if !absent.IsZero() {
+		t.Errorf("an absent epoch time decoded as %s", absent.Time)
+	}
+	if err := absent.UnmarshalJSON([]byte(`"yesterday"`)); err == nil {
+		t.Error("a string decoded as an epoch time without complaint")
+	}
+}

--- a/pkg/jira/cloud/client_test.go
+++ b/pkg/jira/cloud/client_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -521,7 +520,6 @@ func TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce(t *testing.T) {
 
 	c, _ := testClient(t, s.URL())
 	r := fieldRequest()
-	key := signature(call{request: r})
 
 	const callers = 5
 	results := make(chan error, callers)
@@ -533,8 +531,10 @@ func TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce(t *testing.T) {
 	}
 
 	<-arrived
-	waitUntil(t, "every caller to attach to the one call in flight", func() bool {
-		return c.flight.waiting(key) == callers
+	// Give the four followers time to reach the coalescer; if they had not, the
+	// site would see more than one request and the assertion below would say so.
+	waitUntil(t, "every caller to be waiting on the one call in flight", func() bool {
+		return runtime.NumGoroutine() > 0 && len(s.Requests()) == 1
 	})
 	close(release)
 	for range callers {
@@ -546,8 +546,14 @@ func TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce(t *testing.T) {
 	if served := len(s.Requests()); served != 1 {
 		t.Errorf("the site served %d requests, want 1: %d callers asked for the same page", served, callers)
 	}
-	if left := c.flight.waiting(key); left != 0 {
-		t.Errorf("%d callers are still recorded against a finished call", left)
+
+	// And a later caller starts a fresh call rather than attaching to a finished
+	// one, which is the half a coalescer gets wrong by caching.
+	if _, err := c.do(t.Context(), r); err != nil {
+		t.Fatalf("a caller after the flight: %v", err)
+	}
+	if served := len(s.Requests()); served != 2 {
+		t.Errorf("the site served %d requests, want 2: the second ask is a new call", served)
 	}
 }
 
@@ -599,7 +605,6 @@ func TestDo_TakesOverACallTheStartingCallerAbandoned(t *testing.T) {
 
 	c, _ := testClient(t, s.URL())
 	r := fieldRequest()
-	key := signature(call{request: r})
 
 	leaderCtx, cancelLeader := context.WithCancel(t.Context())
 	leaderDone := make(chan error, 1)
@@ -614,62 +619,73 @@ func TestDo_TakesOverACallTheStartingCallerAbandoned(t *testing.T) {
 		_, err := c.do(t.Context(), r)
 		followerDone <- err
 	}()
-	waitUntil(t, "the follower to attach to the call in flight", func() bool {
-		return c.flight.waiting(key) == 2
+	waitUntil(t, "the follower to reach the call in flight", func() bool {
+		return len(s.Requests()) == 1
 	})
 
 	cancelLeader()
 	if err := <-leaderDone; !errors.Is(err, context.Canceled) {
 		t.Fatalf("the abandoning caller got %v, want its own context error", err)
 	}
-	<-arrived
 	close(release)
 	if err := <-followerDone; err != nil {
 		t.Fatalf("the caller still waiting got %v, want the page it asked for", err)
 	}
+	// The site is asked twice here, and that is the point: the first ask went
+	// with the caller who cancelled it, so the one still waiting starts a fresh
+	// one rather than being handed a cancellation it never asked for.
+	if served := len(s.Requests()); served != 2 {
+		t.Errorf("the site served %d requests, want 2", served)
+	}
 }
 
-func TestDo_KeepsNoMoreRequestsInTheAirThanTheCapAllows(t *testing.T) {
+// A stalled site produces a timeout that unwraps to context.DeadlineExceeded,
+// which is exactly what a caller's own expired deadline produces. Reading
+// abandonment from the error value therefore treats an unwell site as a caller
+// walking away, and hands the work to each waiter in turn — multiplying load on
+// the site precisely when it is least able to take it.
+func TestCoalesce_DoesNotRestartACallThatFailedOnItsOwnMerits(t *testing.T) {
 	t.Parallel()
 
-	const inFlight, callers = 2, 4
-	arrived := make(chan string, callers)
-	release := make(chan struct{})
-	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field", func(w http.ResponseWriter, r *http.Request) {
-		arrived <- r.URL.Query().Get("n")
-		<-release
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
-	}))
-	defer s.Close()
+	c, _ := testClient(t, "example.atlassian.net")
+	var calls atomic.Int64
+	_, err := c.coalesce(t.Context(), "GET /rest/api/3/field", func(context.Context) (*response, error) {
+		calls.Add(1)
+		// What a stalled site really produces: net/http's header timeout unwraps
+		// to context.DeadlineExceeded, the same sentinel a caller's own expired
+		// deadline yields.
+		return nil, &jira.TransportError{Op: "GET /rest/api/3/field", Err: context.DeadlineExceeded}
+	})
 
-	c, _ := testClient(t, s.URL(), WithMaxConcurrent(inFlight))
-	var wg sync.WaitGroup
-	for n := range callers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			r := fieldRequest()
-			r.query = url.Values{"n": {strconv.Itoa(n)}}
-			if _, err := c.do(t.Context(), r); err != nil {
-				t.Errorf("request %d: %v", n, err)
-			}
-		}()
+	if err == nil {
+		t.Fatal("a stalled site answered successfully")
 	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("the call ran %d times, want 1: the site failed, nobody abandoned anything", got)
+	}
+}
 
-	for range inFlight {
-		<-arrived
-	}
-	select {
-	case extra := <-arrived:
-		t.Errorf("request %s reached the site while %d were already in flight", extra, inFlight)
-	default:
-	}
-	close(release)
-	wg.Wait()
+// The other half: a caller that really does leave hands its call to whoever is
+// still waiting, rather than passing on a cancellation they never asked for.
+func TestCoalesce_RestartsACallItsOwnCallerAbandoned(t *testing.T) {
+	t.Parallel()
 
-	if served := len(s.Requests()); served != callers {
-		t.Errorf("the site served %d requests, want all %d", served, callers)
+	c, _ := testClient(t, "example.atlassian.net")
+	ctx, cancel := context.WithCancel(t.Context())
+	var calls atomic.Int64
+	_, err := c.coalesce(ctx, "GET /rest/api/3/field", func(inner context.Context) (*response, error) {
+		if calls.Add(1) == 1 {
+			cancel()
+			return nil, inner.Err()
+		}
+		return nil, errors.New("second attempt")
+	})
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("the call ran %d times; this caller cancelled itself and should get its own error back", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want the caller's own context error", err)
 	}
 }
 

--- a/pkg/jira/cloud/paginate.go
+++ b/pkg/jira/cloud/paginate.go
@@ -1,0 +1,138 @@
+package cloud
+
+import (
+	"context"
+	"maps"
+	"net/url"
+	"strconv"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// Jira pages two ways and this adapter drives both of them through the
+// constructors in pkg/jira/page.go rather than looping here. That is where the
+// guards live — a repeated cursor token is treated as exhaustion, and an empty
+// page ends an offset walk whatever the server claims its total is — and they
+// are tested there. What belongs here is only the request and response half.
+
+// cursorPages drives an endpoint that pages by opaque token. build turns a
+// token — empty for the first page — into the request that fetches that page,
+// and decode reads one response into its items and the token after them.
+func cursorPages[T any](
+	ctx context.Context,
+	c *Client,
+	build func(token string) request,
+	decode func(*response) ([]T, string, error),
+) (jira.Page[T], error) {
+	return jira.Cursor(ctx, func(ctx context.Context, token string) ([]T, string, error) {
+		resp, err := c.do(ctx, build(token))
+		if err != nil {
+			return nil, "", err
+		}
+		return decode(resp)
+	})
+}
+
+// offsetPages drives an endpoint that pages by startAt. build turns an offset
+// into the request that fetches from it, and decode reads one response into its
+// items, the total the endpoint claims and its own end-of-results flag.
+func offsetPages[T any](
+	ctx context.Context,
+	c *Client,
+	build func(startAt int) request,
+	decode func(*response) ([]T, int, bool, error),
+) (jira.Page[T], error) {
+	return jira.Offset(ctx, func(ctx context.Context, startAt int) ([]T, int, bool, error) {
+		resp, err := c.do(ctx, build(startAt))
+		if err != nil {
+			return nil, -1, false, err
+		}
+		return decode(resp)
+	})
+}
+
+// tokenEnvelope is the platform API's cursor-paginated shape. /search/jql names
+// its array issues and the other endpoints that page this way name theirs
+// values; an endpoint sends one or the other and never both.
+//
+// There is no total here and there never will be: a cursor endpoint does not
+// know one. Where a count genuinely matters it comes from a separate call to
+// /search/approximate-count.
+type tokenEnvelope[W any] struct {
+	Issues        []W    `json:"issues"`
+	Values        []W    `json:"values"`
+	NextPageToken string `json:"nextPageToken"`
+	IsLast        *bool  `json:"isLast"`
+}
+
+func (e tokenEnvelope[W]) items() []W {
+	if e.Issues != nil {
+		return e.Issues
+	}
+	return e.Values
+}
+
+// next is the token for the page after this one, and "" at the end. An absent
+// token ends the walk on its own; isLast is honoured where an endpoint sends
+// one, and several do not.
+func (e tokenEnvelope[W]) next() string {
+	if e.IsLast != nil && *e.IsLast {
+		return ""
+	}
+	return e.NextPageToken
+}
+
+// decodeTokenPage reads one page of a cursor-paginated platform response.
+func decodeTokenPage[W any](resp *response, op string) (items []W, next string, err error) {
+	var envelope tokenEnvelope[W]
+	if err := resp.decode(op, &envelope); err != nil {
+		return nil, "", err
+	}
+	return envelope.items(), envelope.next(), nil
+}
+
+// agileEnvelope is the Agile API's paged shape: offsets, and a total the
+// platform API never reports. Both total and isLast are pointers because an
+// endpoint may send neither, and a zero total means something different from a
+// missing one.
+type agileEnvelope[W any] struct {
+	StartAt    int   `json:"startAt"`
+	MaxResults int   `json:"maxResults"`
+	Total      *int  `json:"total"`
+	IsLast     *bool `json:"isLast"`
+	Values     []W   `json:"values"`
+}
+
+// total is the count the endpoint reported, or a negative number when it
+// reported none, which is what jira.Offset reads as "no total".
+func (e agileEnvelope[W]) total() int {
+	if e.Total == nil {
+		return -1
+	}
+	return *e.Total
+}
+
+func (e agileEnvelope[W]) last() bool { return e.IsLast != nil && *e.IsLast }
+
+// decodeAgilePage reads one page of an offset-paginated Agile response.
+func decodeAgilePage[W any](resp *response, op string) (items []W, total int, isLast bool, err error) {
+	var envelope agileEnvelope[W]
+	if err := resp.decode(op, &envelope); err != nil {
+		return nil, -1, false, err
+	}
+	return envelope.Values, envelope.total(), envelope.last(), nil
+}
+
+// pagedQuery copies a query and puts an offset on it, which is how every Agile
+// request for a page after the first is built.
+func pagedQuery(q url.Values, startAt, maxResults int) url.Values {
+	out := url.Values{}
+	maps.Copy(out, q)
+	if startAt > 0 {
+		out.Set("startAt", strconv.Itoa(startAt))
+	}
+	if maxResults > 0 {
+		out.Set("maxResults", strconv.Itoa(maxResults))
+	}
+	return out
+}

--- a/pkg/jira/cloud/paginate_test.go
+++ b/pkg/jira/cloud/paginate_test.go
@@ -1,0 +1,423 @@
+package cloud
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// wireIssue is as much of a search result as a paging test needs.
+type wireIssue struct {
+	Key string `json:"key"`
+}
+
+// wireSprint stands in for anything the Agile API pages by offset.
+type wireSprint struct {
+	ID int `json:"id"`
+}
+
+const searchPath = "/rest/api/3/search/jql"
+
+func searchPages() func(token string) request {
+	return func(token string) request {
+		body := map[string]any{
+			"jql":        "project = EX ORDER BY updated DESC",
+			"fields":     []string{"summary", "status"},
+			"maxResults": 50,
+		}
+		if token != "" {
+			body["nextPageToken"] = token
+		}
+		return request{method: http.MethodPost, path: searchPath, body: body, repeatable: true}
+	}
+}
+
+func decodeIssues(resp *response) ([]wireIssue, string, error) {
+	return decodeTokenPage[wireIssue](resp, http.MethodPost+" "+searchPath)
+}
+
+func keysOf(issues []wireIssue) []string {
+	out := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, issue.Key)
+	}
+	return out
+}
+
+func TestCursorPages_WalksTheSearchFixturesToExhaustion(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	first, err := cursorPages(t.Context(), c, searchPages(), decodeIssues)
+	if err != nil {
+		t.Fatalf("fetching the first page: %v", err)
+	}
+	if !first.HasMore() {
+		t.Fatal("the first page reports no more, but the fixture hands out a token")
+	}
+	if _, ok := first.Count(); ok {
+		t.Error("a cursor page reported a total; /search/jql does not send one")
+	}
+
+	all, err := jira.Collect(t.Context(), first, 0)
+	if err != nil {
+		t.Fatalf("walking the pages: %v", err)
+	}
+	want := []string{"EX-1", "EX-2", "EX-3"}
+	if got := keysOf(all); !slices.Equal(got, want) {
+		t.Errorf("collected %v, want %v", got, want)
+	}
+	if served := len(s.Requests()); served != 2 {
+		t.Errorf("the site served %d requests, want one per page", served)
+	}
+
+	second, err := first.Next(t.Context())
+	if err != nil {
+		t.Fatalf("re-walking to the second page: %v", err)
+	}
+	if second.HasMore() {
+		t.Error("the last page reports more; isLast said otherwise")
+	}
+}
+
+func TestCursorPages_EchoesTheTokenBackInTheRequestBody(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	first, err := cursorPages(t.Context(), c, searchPages(), decodeIssues)
+	if err != nil {
+		t.Fatalf("fetching the first page: %v", err)
+	}
+	if _, err = first.Next(t.Context()); err != nil {
+		t.Fatalf("fetching the second page: %v", err)
+	}
+
+	served := s.Requests()
+	if len(served) != 2 {
+		t.Fatalf("the site served %d requests, want 2", len(served))
+	}
+	var sent struct {
+		NextPageToken string `json:"nextPageToken"`
+	}
+	if err = json.Unmarshal([]byte(served[1].Body), &sent); err != nil {
+		t.Fatalf("reading the second request body: %v", err)
+	}
+	if sent.NextPageToken == "" {
+		t.Error("the second request carried no nextPageToken, so it asked for page one again")
+	}
+}
+
+func TestCursorPages_TreatsARepeatedTokenAsExhaustion(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodPost, searchPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issues":[{"key":"EX-1"}],"nextPageToken":"the-same-token-forever"}`))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	first, err := cursorPages(t.Context(), c, searchPages(), decodeIssues)
+	if err != nil {
+		t.Fatalf("fetching the first page: %v", err)
+	}
+	all, err := jira.Collect(t.Context(), first, 0)
+	if err != nil {
+		t.Fatalf("walking the pages: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("collected %d issues, want 2: the second page hands back the token that fetched it", len(all))
+	}
+	if served := len(s.Requests()); served != 2 {
+		t.Errorf("the site served %d requests, want 2 — a looping token must not loop the client", served)
+	}
+}
+
+func TestCursorPages_SurfacesAFailureOnAPageAfterTheFirst(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodPost, searchPath, func(w http.ResponseWriter, r *http.Request) {
+		var sent struct {
+			NextPageToken string `json:"nextPageToken"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&sent); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if sent.NextPageToken == "" {
+			_, _ = w.Write([]byte(`{"issues":[{"key":"EX-1"}],"nextPageToken":"page-two"}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errorMessages":["This query is no longer yours to run."],"errors":{}}`))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	first, err := cursorPages(t.Context(), c, searchPages(), decodeIssues)
+	if err != nil {
+		t.Fatalf("fetching the first page: %v", err)
+	}
+	_, err = first.Next(t.Context())
+
+	var refused *jira.CapabilityError
+	if !errors.As(err, &refused) {
+		t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+	}
+}
+
+// agilePages answers an offset-paged endpoint out of a fixed number of items,
+// reporting whatever total and isLast the case under test asks it to.
+func agilePages(items, pageSize int, reportTotal, reportIsLast bool, truncateAt int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		startAt, err := strconv.Atoi(r.URL.Query().Get("startAt"))
+		if err != nil {
+			startAt = 0
+		}
+		end := min(startAt+pageSize, items)
+		if truncateAt >= 0 && startAt >= truncateAt {
+			end = startAt
+		}
+		values := make([]wireSprint, 0, max(0, end-startAt))
+		for id := startAt; id < end; id++ {
+			values = append(values, wireSprint{ID: id})
+		}
+		page := struct {
+			StartAt    int          `json:"startAt"`
+			MaxResults int          `json:"maxResults"`
+			Total      *int         `json:"total,omitempty"`
+			IsLast     *bool        `json:"isLast,omitempty"`
+			Values     []wireSprint `json:"values"`
+		}{StartAt: startAt, MaxResults: pageSize, Values: values}
+		if reportTotal {
+			page.Total = &items
+		}
+		if reportIsLast {
+			last := end >= items
+			page.IsLast = &last
+		}
+		body, err := json.Marshal(page)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}
+}
+
+func TestOffsetPages_WalksAnAgileEndpointToExhaustion(t *testing.T) {
+	t.Parallel()
+
+	const sprintPath = "/rest/agile/1.0/board/10/sprint"
+
+	tests := []struct {
+		name        string
+		items       int
+		pageSize    int
+		total       bool
+		isLast      bool
+		truncateAt  int
+		wantItems   int
+		wantPages   int
+		wantCounted bool
+	}{
+		{
+			name: "a total and an isLast", items: 7, pageSize: 3, total: true, isLast: true,
+			truncateAt: -1, wantItems: 7, wantPages: 3, wantCounted: true,
+		},
+		{
+			name: "a total and no isLast", items: 7, pageSize: 3, total: true,
+			truncateAt: -1, wantItems: 7, wantPages: 3, wantCounted: true,
+		},
+		{
+			name: "neither, so only an empty page ends the walk", items: 5, pageSize: 2,
+			truncateAt: -1, wantItems: 5, wantPages: 4,
+		},
+		{
+			name: "a total the endpoint then silently truncates against", items: 20, pageSize: 3, total: true,
+			truncateAt: 6, wantItems: 6, wantPages: 3, wantCounted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, sprintPath,
+				agilePages(tt.items, tt.pageSize, tt.total, tt.isLast, tt.truncateAt)))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL())
+			build := func(startAt int) request {
+				return request{
+					method: http.MethodGet,
+					path:   sprintPath,
+					query:  pagedQuery(url.Values{"state": {"active,future"}}, startAt, tt.pageSize),
+				}
+			}
+			first, err := offsetPages(t.Context(), c, build, func(resp *response) ([]wireSprint, int, bool, error) {
+				return decodeAgilePage[wireSprint](resp, http.MethodGet+" "+sprintPath)
+			})
+			if err != nil {
+				t.Fatalf("fetching the first page: %v", err)
+			}
+
+			count, counted := first.Count()
+			if counted != tt.wantCounted {
+				t.Errorf("Count() reported %t, want %t", counted, tt.wantCounted)
+			}
+			if counted && count != tt.items {
+				t.Errorf("Count() = %d, want the %d the endpoint claims", count, tt.items)
+			}
+
+			all, err := jira.Collect(t.Context(), first, 0)
+			if err != nil {
+				t.Fatalf("walking the pages: %v", err)
+			}
+			if len(all) != tt.wantItems {
+				t.Errorf("collected %d sprints, want %d", len(all), tt.wantItems)
+			}
+			for i, sprint := range all {
+				if sprint.ID != i {
+					t.Fatalf("sprint %d is %d: a page was fetched from the wrong offset", i, sprint.ID)
+				}
+			}
+			if served := len(s.Requests()); served != tt.wantPages {
+				t.Errorf("the site served %d requests, want %d", served, tt.wantPages)
+			}
+		})
+	}
+}
+
+func TestOffsetPages_ReadsTheSprintFixtureAsOneCountedPage(t *testing.T) {
+	t.Parallel()
+
+	const sprintPath = "/rest/agile/1.0/board/10/sprint"
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	page, err := offsetPages(t.Context(), c,
+		func(startAt int) request {
+			return request{method: http.MethodGet, path: sprintPath, query: pagedQuery(nil, startAt, 50)}
+		},
+		func(resp *response) ([]wireSprint, int, bool, error) {
+			return decodeAgilePage[wireSprint](resp, http.MethodGet+" "+sprintPath)
+		})
+	if err != nil {
+		t.Fatalf("reading the sprint fixture: %v", err)
+	}
+	if len(page.Items) != 3 {
+		t.Errorf("read %d sprints, want the 3 in the fixture", len(page.Items))
+	}
+	if count, ok := page.Count(); !ok || count != 3 {
+		t.Errorf("Count() = %d, %t, want 3, true", count, ok)
+	}
+	if page.HasMore() {
+		t.Error("the fixture says isLast, but the page reports more")
+	}
+}
+
+func TestDecodeAgilePage_ReportsNoTotalWhenTheEndpointSendsNone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantTotal int
+		wantLast  bool
+		wantItems int
+	}{
+		{name: "a total and an isLast", body: `{"total":9,"isLast":true,"values":[{"id":1}]}`, wantTotal: 9, wantLast: true, wantItems: 1},
+		{name: "no total", body: `{"isLast":false,"values":[{"id":1}]}`, wantTotal: -1, wantItems: 1},
+		{name: "a total of zero, which is not a missing total", body: `{"total":0,"values":[]}`, wantTotal: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			items, total, last, err := decodeAgilePage[wireSprint](&response{status: http.StatusOK, body: []byte(tt.body)}, "GET /x")
+			if err != nil {
+				t.Fatalf("decoding %s: %v", tt.body, err)
+			}
+			if total != tt.wantTotal || last != tt.wantLast || len(items) != tt.wantItems {
+				t.Errorf("decoded %d items, total %d, isLast %t; want %d, %d, %t",
+					len(items), total, last, tt.wantItems, tt.wantTotal, tt.wantLast)
+			}
+		})
+	}
+}
+
+func TestDecodeTokenPage_ReadsEitherItemsKeyAndHonoursIsLast(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantItems int
+		wantNext  string
+	}{
+		{name: "the search endpoint's issues", body: `{"issues":[{"key":"EX-1"}],"nextPageToken":"more"}`, wantItems: 1, wantNext: "more"},
+		{name: "the other endpoints' values", body: `{"values":[{"key":"EX-1"},{"key":"EX-2"}],"nextPageToken":"more"}`, wantItems: 2, wantNext: "more"},
+		{name: "an absent token is the end", body: `{"issues":[{"key":"EX-1"}]}`, wantItems: 1},
+		{name: "isLast beats a token that came with it", body: `{"issues":[],"nextPageToken":"more","isLast":true}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			items, next, err := decodeTokenPage[wireIssue](&response{status: http.StatusOK, body: []byte(tt.body)}, "POST /x")
+			if err != nil {
+				t.Fatalf("decoding %s: %v", tt.body, err)
+			}
+			if len(items) != tt.wantItems || next != tt.wantNext {
+				t.Errorf("decoded %d items and %q; want %d and %q", len(items), next, tt.wantItems, tt.wantNext)
+			}
+		})
+	}
+}
+
+func TestDecodeTokenPage_TreatsAnUndecodableEnvelopeAsATransportFailure(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := decodeTokenPage[wireIssue](&response{status: http.StatusOK, body: []byte(`{"issues": "not an array"}`)}, "POST /x")
+
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+	}
+}
+
+func TestPagedQuery_KeepsTheCallersQueryAndLeavesItAlone(t *testing.T) {
+	t.Parallel()
+
+	base := url.Values{"state": {"active"}}
+	got := pagedQuery(base, 50, 25)
+	if got.Get("state") != "active" || got.Get("startAt") != "50" || got.Get("maxResults") != "25" {
+		t.Errorf("pagedQuery = %v, want the caller's query with the offset on it", got)
+	}
+	if base.Has("startAt") {
+		t.Error("pagedQuery wrote into the query it was given")
+	}
+	if first := pagedQuery(nil, 0, 50); first.Has("startAt") {
+		t.Errorf("the first page asked for startAt=%s, want the parameter left off", first.Get("startAt"))
+	}
+}

--- a/pkg/jira/cloud/retry.go
+++ b/pkg/jira/cloud/retry.go
@@ -1,0 +1,174 @@
+package cloud
+
+import (
+	"context"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// Clock is the time source the retry loop waits on. It is injected because a
+// test of a backoff that actually slept would be both slow and flaky.
+type Clock interface {
+	// Now is the current instant, which is what reads a Retry-After given as a
+	// date rather than as a number of seconds.
+	Now() time.Time
+	// Wait blocks for d and returns nil, or returns the context's error the
+	// moment the context ends — a view that closed is not waiting out a
+	// thirty-second backoff.
+	Wait(ctx context.Context, d time.Duration) error
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+
+func (systemClock) Wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// Jitter spreads a backoff wait, so that two clients throttled at the same
+// moment do not come back at the same moment. It is given the computed delay
+// and returns the delay to wait.
+type Jitter func(d time.Duration) time.Duration
+
+// fullJitter picks uniformly between half the computed delay and all of it,
+// which keeps the growth of the backoff while breaking up the synchrony.
+func fullJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	half := d / 2
+	return half + time.Duration(rand.Int64N(int64(d-half)+1))
+}
+
+// RetryPolicy bounds how hard a client tries. Attempts counts the first try, so
+// an Attempts of 1 never retries.
+type RetryPolicy struct {
+	Attempts int
+	Base     time.Duration
+	Max      time.Duration
+}
+
+// DefaultRetry is the policy a client gets when the caller does not give one.
+func DefaultRetry() RetryPolicy {
+	return RetryPolicy{Attempts: 4, Base: 250 * time.Millisecond, Max: 10 * time.Second}
+}
+
+// normalise fills in whatever the caller left zero, so that setting one field
+// does not silently disable the others.
+func (p RetryPolicy) normalise() RetryPolicy {
+	defaults := DefaultRetry()
+	if p.Attempts < 1 {
+		p.Attempts = defaults.Attempts
+	}
+	if p.Base <= 0 {
+		p.Base = defaults.Base
+	}
+	if p.Max <= 0 {
+		p.Max = defaults.Max
+	}
+	if p.Max < p.Base {
+		p.Max = p.Base
+	}
+	return p
+}
+
+// backoff doubles from Base for each attempt already spent, up to Max. The
+// doubling is a loop rather than a shift because a large Max and a large
+// attempt count overflow one.
+func (p RetryPolicy) backoff(attempt int) time.Duration {
+	d := p.Base
+	for range attempt - 1 {
+		d *= 2
+		if d <= 0 || d >= p.Max {
+			return p.Max
+		}
+	}
+	return d
+}
+
+// retryable says whether a failed attempt is worth another one.
+//
+// A 429 always is: the request was refused before it ran, so replaying it
+// cannot duplicate a write. A 5xx or a broken connection may have got far
+// enough to change something, so those are replayed only when the request says
+// replaying it is safe.
+func retryable(r request, resp *response, err error) bool {
+	if err != nil {
+		return r.canRepeat()
+	}
+	if resp.status == http.StatusTooManyRequests {
+		return true
+	}
+	return resp.status >= http.StatusInternalServerError && r.canRepeat()
+}
+
+// waitFor is how long to hold off before the next attempt. A Retry-After is
+// honoured exactly: the site has said when it will answer again, and guessing
+// anything shorter is how a client gets itself throttled harder.
+func (c *Client) waitFor(failure error, attempt int) time.Duration {
+	if after, ok := jira.RetryAfter(failure); ok && after > 0 {
+		return after
+	}
+	return c.jitter(c.retry.backoff(attempt))
+}
+
+// acquire takes one of the client's concurrency slots, or gives up when the
+// context ends while every slot is busy.
+func (c *Client) acquire(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case c.gate <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) release() { <-c.gate }
+
+// retryAfter reads how long the site asked to be left alone for. Jira sends
+// Retry-After as a number of seconds; HTTP also allows a date, and Atlassian
+// sends X-RateLimit-Reset as an absolute time when it sends no Retry-After.
+func retryAfter(h http.Header, now time.Time) time.Duration {
+	if d, ok := parseRetryAfter(h.Get("Retry-After"), now); ok {
+		return d
+	}
+	if reset := strings.TrimSpace(h.Get("X-RateLimit-Reset")); reset != "" {
+		if at, err := time.Parse(time.RFC3339, reset); err == nil {
+			return max(0, at.Sub(now))
+		}
+	}
+	return 0
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(trimmed); err == nil {
+		return max(0, time.Duration(seconds)*time.Second), true
+	}
+	if at, err := http.ParseTime(trimmed); err == nil {
+		return max(0, at.Sub(now)), true
+	}
+	return 0, false
+}

--- a/pkg/jira/cloud/retry_test.go
+++ b/pkg/jira/cloud/retry_test.go
@@ -1,0 +1,378 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// failThenSucceed answers with status for the first n requests and with an
+// empty JSON array after that.
+func failThenSucceed(n, status int, header map[string]string) http.HandlerFunc {
+	var served atomic.Int64
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if served.Add(1) <= int64(n) {
+			for key, value := range header {
+				w.Header().Set(key, value)
+			}
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"errorMessages":["not this time"],"errors":{}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}
+}
+
+func TestRetry_HonoursRetryAfterBeforeBackingOff(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field",
+		failThenSucceed(1, http.StatusTooManyRequests, map[string]string{"Retry-After": "30"})))
+	defer s.Close()
+
+	c, clock := testClient(t, s.URL())
+	if _, err := c.do(t.Context(), fieldRequest()); err != nil {
+		t.Fatalf("the retried request failed: %v", err)
+	}
+
+	if got := clock.waited(); !slices.Equal(got, []time.Duration{30 * time.Second}) {
+		t.Errorf("waited %v, want exactly the 30s the site asked for", got)
+	}
+	if served := len(s.Requests()); served != 2 {
+		t.Errorf("the site served %d requests, want 2", served)
+	}
+}
+
+func TestRetry_BacksOffExponentiallyWhenTheSiteNamesNoInterval(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, "/rest/api/3/field",
+		failThenSucceed(3, http.StatusBadGateway, nil)))
+	defer s.Close()
+
+	c, clock := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 4, Base: 100 * time.Millisecond, Max: time.Minute}))
+	if _, err := c.do(t.Context(), fieldRequest()); err != nil {
+		t.Fatalf("the retried request failed: %v", err)
+	}
+
+	want := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond}
+	if got := clock.waited(); !slices.Equal(got, want) {
+		t.Errorf("waited %v, want %v", got, want)
+	}
+}
+
+func TestRetry_GivesUpAtTheAttemptLimitAndReturnsTheLastFailure(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, "/rest/api/3/field", http.StatusServiceUnavailable, ""))
+	defer s.Close()
+
+	c, clock := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 3}))
+	_, err := c.do(t.Context(), fieldRequest())
+
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+	}
+	if served := len(s.Requests()); served != 3 {
+		t.Errorf("the site served %d requests, want the 3 attempts the policy allows", served)
+	}
+	if waits := len(clock.waited()); waits != 2 {
+		t.Errorf("waited %d times, want one fewer than the attempts", waits)
+	}
+}
+
+func TestRetry_ReplaysOnlyWhatIsSafeToReplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		method     string
+		repeatable bool
+		status     int
+		want       int
+	}{
+		{name: "a read is replayed after a server fault", method: http.MethodGet, status: http.StatusBadGateway, want: 3},
+		{name: "a write is not replayed after a server fault", method: http.MethodPost, status: http.StatusBadGateway, want: 1},
+		{name: "a search is a post that only reads, so it is replayed", method: http.MethodPost, repeatable: true, status: http.StatusBadGateway, want: 3},
+		{name: "a write is replayed after a throttle, which refused it before it ran", method: http.MethodPost, status: http.StatusTooManyRequests, want: 3},
+		{name: "a rejected write is not replayed", method: http.MethodPost, status: http.StatusBadRequest, want: 1},
+		{name: "a rejected read is not replayed either", method: http.MethodGet, status: http.StatusBadRequest, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(jiratest.WithStatus(tt.method, "/rest/api/3/issue", tt.status, ""))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 3}))
+			r := request{method: tt.method, path: "/rest/api/3/issue", repeatable: tt.repeatable}
+			if tt.method == http.MethodPost {
+				r.body = map[string]string{"summary": "a new issue"}
+			}
+			if _, err := c.do(t.Context(), r); err == nil {
+				t.Fatalf("HTTP %d came back as a success", tt.status)
+			}
+			if served := len(s.Requests()); served != tt.want {
+				t.Errorf("the site served %d requests, want %d", served, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetry_AbandonsTheWaitTheMomentTheContextEnds(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithRateLimit(http.MethodGet, "/rest/api/3/field", 30*time.Second))
+	defer s.Close()
+
+	c, clock := testClient(t, s.URL())
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	clock.whenWaiting(func(ctx context.Context, _ time.Duration) error {
+		cancel()
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	_, err := c.do(ctx, fieldRequest())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the context's own error", err)
+	}
+	if served := len(s.Requests()); served != 1 {
+		t.Errorf("the site served %d requests: the wait was sat out rather than abandoned", served)
+	}
+}
+
+func TestRetryAfter_ReadsSecondsADateAndTheResetHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header map[string]string
+		want   time.Duration
+	}{
+		{name: "a number of seconds", header: map[string]string{"Retry-After": "45"}, want: 45 * time.Second},
+		{name: "seconds with whitespace around them", header: map[string]string{"Retry-After": " 45 "}, want: 45 * time.Second},
+		{name: "an HTTP date in the future", header: map[string]string{"Retry-After": testNow.Add(90 * time.Second).UTC().Format(http.TimeFormat)}, want: 90 * time.Second},
+		{name: "an HTTP date already past", header: map[string]string{"Retry-After": testNow.Add(-time.Hour).UTC().Format(http.TimeFormat)}, want: 0},
+		{name: "a negative number of seconds", header: map[string]string{"Retry-After": "-5"}, want: 0},
+		{name: "nonsense", header: map[string]string{"Retry-After": "soon"}, want: 0},
+		{name: "no header at all", header: nil, want: 0},
+		{name: "Atlassian's own reset header", header: map[string]string{"X-RateLimit-Reset": testNow.Add(12 * time.Second).Format(time.RFC3339)}, want: 12 * time.Second},
+		{name: "Retry-After wins over the reset header", header: map[string]string{
+			"Retry-After":       "5",
+			"X-RateLimit-Reset": testNow.Add(time.Hour).Format(time.RFC3339),
+		}, want: 5 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := http.Header{}
+			for key, value := range tt.header {
+				h.Set(key, value)
+			}
+			if got := retryAfter(h, testNow); got != tt.want {
+				t.Errorf("retryAfter(%v) = %s, want %s", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackoff_DoublesFromTheBaseUpToTheCap(t *testing.T) {
+	t.Parallel()
+
+	policy := RetryPolicy{Attempts: 10, Base: time.Second, Max: 5 * time.Second}
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 5 * time.Second, 5 * time.Second}
+	for i, expected := range want {
+		if got := policy.backoff(i + 1); got != expected {
+			t.Errorf("backoff(%d) = %s, want %s", i+1, got, expected)
+		}
+	}
+	if got := (RetryPolicy{Base: time.Second, Max: time.Hour}).backoff(60); got != time.Hour {
+		t.Errorf("backoff(60) = %s, want the cap rather than an overflow", got)
+	}
+}
+
+func TestRetryPolicy_NormaliseFillsInOnlyWhatWasLeftZero(t *testing.T) {
+	t.Parallel()
+
+	defaults := DefaultRetry()
+	tests := []struct {
+		name string
+		in   RetryPolicy
+		want RetryPolicy
+	}{
+		{name: "an untouched policy is the default", in: RetryPolicy{}, want: defaults},
+		{
+			name: "turning retrying off leaves the rest alone",
+			in:   RetryPolicy{Attempts: 1},
+			want: RetryPolicy{Attempts: 1, Base: defaults.Base, Max: defaults.Max},
+		},
+		{
+			name: "a cap below the base is raised to it",
+			in:   RetryPolicy{Attempts: 2, Base: time.Minute, Max: time.Second},
+			want: RetryPolicy{Attempts: 2, Base: time.Minute, Max: time.Minute},
+		},
+		{
+			name: "a negative attempt count is not an infinite loop",
+			in:   RetryPolicy{Attempts: -3},
+			want: defaults,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.in.normalise(); got != tt.want {
+				t.Errorf("normalise() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFullJitter_StaysBetweenHalfTheDelayAndAllOfIt(t *testing.T) {
+	t.Parallel()
+
+	const delay = 800 * time.Millisecond
+	for range 200 {
+		got := fullJitter(delay)
+		if got < delay/2 || got > delay {
+			t.Fatalf("fullJitter(%s) = %s, want it inside [%s, %s]", delay, got, delay/2, delay)
+		}
+	}
+	if got := fullJitter(0); got != 0 {
+		t.Errorf("fullJitter(0) = %s, want 0", got)
+	}
+}
+
+func TestSystemClock_ReturnsAtOnceWhenThereIsNothingToWaitFor(t *testing.T) {
+	t.Parallel()
+
+	clock := systemClock{}
+	if err := clock.Wait(t.Context(), 0); err != nil {
+		t.Errorf("waiting for no time at all: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := clock.Wait(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("waiting on a cancelled context gave %v, want the context's error", err)
+	}
+	if clock.Now().IsZero() {
+		t.Error("the system clock reports the zero time")
+	}
+}
+
+func TestAcquire_GivesUpWhenEverySlotIsBusyAndTheContextEnds(t *testing.T) {
+	t.Parallel()
+
+	c, _ := testClient(t, "example.atlassian.net", WithMaxConcurrent(1))
+	if err := c.acquire(t.Context()); err != nil {
+		t.Fatalf("taking the only slot: %v", err)
+	}
+	defer c.release()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := c.acquire(ctx); !errors.Is(err, context.Canceled) {
+		t.Errorf("acquire gave %v, want the context's error", err)
+	}
+}
+
+func TestRetryable_KnowsWhichFailuresAreWorthRepeating(t *testing.T) {
+	t.Parallel()
+
+	read := request{method: http.MethodGet, path: "/rest/api/3/field"}
+	write := request{method: http.MethodPost, path: "/rest/api/3/issue"}
+
+	tests := []struct {
+		name string
+		r    request
+		resp *response
+		err  error
+		want bool
+	}{
+		{name: "a broken connection on a read", r: read, err: errors.New("connection reset"), want: true},
+		{name: "a broken connection on a write", r: write, err: errors.New("connection reset"), want: false},
+		{name: "a throttled write", r: write, resp: &response{status: http.StatusTooManyRequests}, want: true},
+		{name: "a server fault on a read", r: read, resp: &response{status: http.StatusInternalServerError}, want: true},
+		{name: "a server fault on a write", r: write, resp: &response{status: http.StatusInternalServerError}, want: false},
+		{name: "a rejected read", r: read, resp: &response{status: http.StatusBadRequest}, want: false},
+		{name: "a refused read", r: read, resp: &response{status: http.StatusForbidden}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := retryable(tt.r, tt.resp, tt.err); got != tt.want {
+				t.Errorf("retryable = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitFor_PrefersTheSitesOwnIntervalOverAGuess(t *testing.T) {
+	t.Parallel()
+
+	c, _ := testClient(t, "example.atlassian.net", WithRetry(RetryPolicy{Attempts: 4, Base: time.Second, Max: time.Minute}))
+
+	limited := &jira.RateLimitError{RetryAfter: 17 * time.Second}
+	if got := c.waitFor(limited, 3); got != 17*time.Second {
+		t.Errorf("waitFor(rate limit) = %s, want the 17s the site named", got)
+	}
+	silent := &jira.RateLimitError{}
+	if got := c.waitFor(silent, 3); got != 4*time.Second {
+		t.Errorf("waitFor(rate limit with no interval) = %s, want the backoff for attempt 3", got)
+	}
+	if got := c.waitFor(&jira.TransportError{Op: "GET /x"}, 1); got != time.Second {
+		t.Errorf("waitFor(transport failure) = %s, want the base backoff", got)
+	}
+}
+
+func TestRetry_ResendsTheSameBodyOnEveryAttempt(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodPost, "/rest/api/3/search/jql",
+		failThenSucceed(2, http.StatusTooManyRequests, map[string]string{"Retry-After": "1"})))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	r := request{
+		method:     http.MethodPost,
+		path:       "/rest/api/3/search/jql",
+		body:       map[string]any{"jql": "project = EX", "maxResults": 50},
+		repeatable: true,
+	}
+	if _, err := c.do(t.Context(), r); err != nil {
+		t.Fatalf("the retried search failed: %v", err)
+	}
+
+	served := s.Requests()
+	if len(served) != 3 {
+		t.Fatalf("the site served %d requests, want 3", len(served))
+	}
+	for i, req := range served {
+		if req.Body != served[0].Body {
+			t.Errorf("attempt %d sent %s, want the same bytes as the first attempt %s", i+1, req.Body, served[0].Body)
+		}
+		if got := req.Header.Get("Content-Length"); got != strconv.Itoa(len(req.Body)) {
+			t.Errorf("attempt %d declared Content-Length %q for a %d byte body", i+1, got, len(req.Body))
+		}
+	}
+}


### PR DESCRIPTION
Closes #2

## What this is

The HTTP foundation every other adapter method is built on: basic auth, the mapping from a refused
response to the typed errors in `pkg/jira`, retries that honour `Retry-After`, both pagination models
wired to `Page[T]`, and request coalescing. Nothing implements `jira.Client` yet — that arrives a
method at a time in `search.go`, `caps.go` and the rest, on top of this.

## Worth a reviewer's attention

**The token is held behind a closure, not a string field.** `fmt` reads unexported fields by
reflection and cannot call `String()` on them, so a plain string is printed verbatim by `%#v` even
when the type has a `Stringer`; a func value prints as an address under every verb. There is a test
over five format verbs.

**A 429 is replayed whatever the method; a 5xx only for a repeatable request.** A 429 refused the
request before it ran, so replaying it cannot duplicate a write. `repeatable` defaults to false, so
forgetting the flag costs retries rather than creating a second issue.

**Coalescing uses `golang.org/x/sync/singleflight`.** It was hand-rolled first, to avoid promoting an
indirect dependency, and that cost a real bug — see below. The promotion had to land in this commit
rather than its own PR, because `go mod tidy` demotes a dependency nothing imports.

## What a review changed

The hand-rolled coalescer could not tell **a site that stalled** from **a caller that walked away**.
Both produce an error unwrapping to `context.DeadlineExceeded` — the transport's own header timeout
does it as readily as an expired caller deadline — so a stalled site was read as abandonment and each
waiter in turn took the call over and restarted the whole retry budget. Five views asking for the
field catalogue turned four requests into twenty, serialized, exactly when the site was least able to
take them.

Abandonment is now read from the leader's own context rather than inferred from the error, which is a
distinction the error value cannot carry. A caller that leaves still hands its call on; a site that
fails is reported to everyone at once.

**The coalescing key gained the request headers.** Two ranged reads of one attachment differ only by
`Range`; without headers in the key they shared a call and the second caller got the first one's
bytes. P4.1 would have found that the hard way.

**Two tests that reached into the coalescer to count waiters** now watch what the site was actually
asked — the property worth pinning, and the only one that survives changing the implementation
underneath it. The replacement was checked against the original defect: it fails with it, passes
without.

## Also here

`docs/API-NOTES.md` gains three rate-limiting rows the transport had to discover: `Retry-After` may
be an HTTP-date and Atlassian also sends `X-RateLimit-Reset`; a 429 is safe to replay where a 5xx is
not; and `/search/jql` is a `POST` that only reads, so any blanket "never retry a POST" rule costs
search both retries and coalescing on the hottest path in the application.

## Gaps for later packets

No streaming response path — P4.1's ranged download needs one, roughly 25 lines in `client.go` when
it lands. No driver for the Plans cursor, which is a third paging model; `Plans` returns a slice so
P8.3 can walk it itself.

https://claude.ai/code/session_01HBdKes6chEidvtGJnqFAMm