### PR TITLE
feat(adf): P1.4 — render a document as markdown a terminal can show

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,7 @@ instance from day one.
 - [ ] **P1.3 — Capability probe** · [#4](https://github.com/varijkapil13/saral/issues/4) · **owns** `pkg/jira/cloud/caps.go`
   `/mypermissions`, `/configuration`, `/myself`, `/plans` probe, board presence, terminal graphics
   detection. Populates `Capabilities` with a human-readable `Reason` for every negative.
-- [ ] **P1.4 — ADF to markdown** · [#5](https://github.com/varijkapil13/saral/issues/5) · **owns** `pkg/adf/render*.go`
+- [x] **P1.4 — ADF to markdown** · [#5](https://github.com/varijkapil13/saral/issues/5) · **owns** `pkg/adf/render*.go`
   Paragraphs, headings, lists, code, links, marks, panels, mentions, status lozenges. Unknown nodes
   preserved verbatim. Golden-file tests over real captured ADF.
 - [ ] **P1.5 — Issue list and detail views** · [#6](https://github.com/varijkapil13/saral/issues/6) · **owns** `internal/ui/{list,issue}/**`

--- a/pkg/adf/render.go
+++ b/pkg/adf/render.go
@@ -1,0 +1,451 @@
+package adf
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Options tunes how a document is rendered.
+type Options struct {
+	// TableWidth bounds the total width of a table, in terminal cells. It is
+	// the only thing a width is needed for here: prose is never wrapped, so
+	// that the viewport showing it can reflow on a resize without first having
+	// to undo the wrapping this package chose. Zero lets a table be as wide as
+	// its widest row.
+	TableWidth int
+
+	// ASCII swaps the Unicode markers for ASCII ones, for the terminals and
+	// fonts docs/UX.md says never to assume anything about.
+	ASCII bool
+
+	// Location renders the instant carried by a date node. Nil means UTC. No
+	// clock is read, so a document always renders to the same bytes.
+	Location *time.Location
+}
+
+// Markdown renders a document as markdown a terminal can show.
+//
+// The output is plain text: no ANSI, no wrapping, and no trailing newline, so
+// that a caller can wrap it, style it, or split it into lines without having
+// to undo anything first. It is markdown by shape rather than by standard —
+// tables are padded to align in a monospaced pager, a panel becomes a marked
+// blockquote and a status lozenge becomes bracketed text, none of which have a
+// markdown spelling that survives a pager. Prose is not backslash-escaped
+// either, because a reader should see the characters the author typed.
+//
+// A node type this package does not know is rendered rather than dropped: its
+// type is shown and its text content is rendered below it. ADF gains node
+// types faster than any client follows them, and a reader who cannot see that
+// something is there cannot go and look at it in a browser.
+func Markdown(d Doc) string { return MarkdownWith(d, Options{}) }
+
+// MarkdownWith renders a document as markdown with explicit options.
+func MarkdownWith(d Doc, opt Options) string {
+	return string(AppendMarkdown(make([]byte, 0, estimate(d.Content)), d, opt))
+}
+
+// AppendMarkdown appends the rendered document to dst and returns the extended
+// buffer, so that a caller rendering many documents can reuse one allocation.
+func AppendMarkdown(dst []byte, d Doc, opt Options) []byte {
+	w := writer{buf: dst, opt: opt, gl: glyphsFor(opt.ASCII)}
+	w.blocks(d.Content, false)
+	w.endLine()
+	return w.buf
+}
+
+// estimate sizes the output buffer from the text the document carries, which
+// costs one walk and saves the growth copies on anything but a tiny document.
+func estimate(nodes []Node) int {
+	n := 0
+	for i := range nodes {
+		n += len(nodes[i].Text) + 8 + estimate(nodes[i].Content)
+	}
+	return n
+}
+
+// spaces is sliced to build an indent, so that indenting a list item does not
+// allocate.
+const spaces = "                                "
+
+var headingMarks = [7]string{"", "# ", "## ", "### ", "#### ", "##### ", "###### "}
+
+// writer renders into one buffer, tracking the prefix every line of the
+// current block carries — "> " inside a quote, two spaces inside a list item —
+// so that nesting costs a string concatenation per block rather than a nested
+// buffer per block.
+type writer struct {
+	buf    []byte
+	opt    Options
+	gl     glyphs
+	prefix string // carried by every line of the current block
+	marker string // carried by the next line only, in place of prefix
+
+	lineAt   int  // where the current line starts in buf
+	open     bool // a line is being written
+	written  bool // a line has been written
+	blank    bool // a blank line is owed before the next line
+	verbatim bool // keep trailing whitespace, for code
+
+	// blankPrefix is the prefix that was in force when the blank line was
+	// owed, which is the one it must carry: a blank line between two blocks of
+	// a quote belongs to the quote, not to the block that follows it.
+	blankPrefix string
+}
+
+func (w *writer) separate(on bool) {
+	w.blank, w.blankPrefix = on, w.prefix
+}
+
+func (w *writer) startLine() {
+	if w.open {
+		return
+	}
+	if w.written {
+		w.buf = append(w.buf, '\n')
+		if w.blank {
+			w.buf = append(w.buf, strings.TrimRight(w.blankPrefix, " ")...)
+			w.buf = append(w.buf, '\n')
+		}
+	}
+	w.written, w.open, w.blank = true, true, false
+	w.lineAt = len(w.buf)
+	if w.marker != "" {
+		w.buf = append(w.buf, w.marker...)
+		w.marker = ""
+		return
+	}
+	w.buf = append(w.buf, w.prefix...)
+}
+
+func (w *writer) endLine() {
+	if !w.open {
+		return
+	}
+	if !w.verbatim {
+		for len(w.buf) > w.lineAt {
+			if c := w.buf[len(w.buf)-1]; c != ' ' && c != '\t' {
+				break
+			}
+			w.buf = w.buf[:len(w.buf)-1]
+		}
+	}
+	w.open = false
+}
+
+// emit writes text into the current line, starting one if none is open and
+// breaking wherever the text does.
+func (w *writer) emit(s string) {
+	for {
+		i := strings.IndexByte(s, '\n')
+		if i < 0 {
+			break
+		}
+		w.startLine()
+		w.buf = append(w.buf, s[:i]...)
+		w.endLine()
+		s = s[i+1:]
+	}
+	w.startLine()
+	w.buf = append(w.buf, s...)
+}
+
+func (w *writer) line(s string) {
+	w.emit(s)
+	w.endLine()
+}
+
+// push sets the prefix for the next line and for the ones after it, and
+// returns the function that restores both. A marker that is still pending when
+// the block ends is handed back to the caller, so that an outer list bullet
+// whose item rendered nothing is not lost.
+func (w *writer) push(first, cont string) func() {
+	prefix, marker := w.prefix, w.marker
+	base := marker
+	if base == "" {
+		base = prefix
+	}
+	pushed := base + first
+	w.marker, w.prefix = pushed, prefix+cont
+	return func() {
+		if w.marker == pushed {
+			w.marker = marker
+		} else {
+			w.marker = ""
+		}
+		w.prefix = prefix
+	}
+}
+
+// indentFor returns an indent as wide on screen as the marker it continues.
+func indentFor(marker string) string {
+	n := ansi.StringWidth(marker)
+	if n > len(spaces) {
+		n = len(spaces)
+	}
+	return spaces[:n]
+}
+
+func (w *writer) blocks(nodes []Node, tight bool) {
+	for i := range nodes {
+		if i > 0 {
+			w.separate(!tight || !isList(nodes[i].Type))
+		}
+		w.block(nodes[i])
+	}
+}
+
+func (w *writer) block(n Node) {
+	switch n.Type {
+	case "paragraph":
+		w.inline(n.Content)
+		w.endLine()
+	case "heading":
+		w.heading(n)
+	case "bulletList", "orderedList":
+		w.list(n)
+	case "taskList", "decisionList":
+		w.checklist(n)
+	case "blockquote":
+		pop := w.push("> ", "> ")
+		w.blocks(n.Content, false)
+		pop()
+	case "codeBlock":
+		w.codeBlock(n)
+	case "rule":
+		w.line("---")
+	case "panel":
+		w.panel(n)
+	case "table":
+		w.table(n)
+	case "mediaSingle", "mediaGroup":
+		w.mediaBlock(n)
+	case "expand", "nestedExpand":
+		w.expand(n)
+	case "layoutSection", "layoutColumn", "caption":
+		w.blocks(n.Content, false)
+	case "blockCard", "embedCard":
+		w.line(w.cardText(n))
+	default:
+		if isInline(n.Type) {
+			w.inlineNode(n)
+			w.endLine()
+			return
+		}
+		w.unknownBlock(n)
+	}
+}
+
+func (w *writer) heading(n Node) {
+	level, ok := attrInt(n.Attrs, "level")
+	switch {
+	case !ok || level < 1:
+		level = 1
+	case level > 6:
+		level = 6
+	}
+	pop := w.push(headingMarks[level], "")
+	w.inline(n.Content)
+	w.endLine()
+	pop()
+}
+
+func (w *writer) list(n Node) {
+	ordered := n.Type == "orderedList"
+	number := 1
+	if ordered {
+		if start, ok := attrInt(n.Attrs, "order"); ok && start > 0 {
+			number = start
+		}
+	}
+	for i := range n.Content {
+		if i > 0 {
+			w.separate(false)
+		}
+		marker := "- "
+		if ordered {
+			marker = strconv.Itoa(number) + ". "
+			number++
+		}
+		w.item(n.Content[i], marker)
+	}
+}
+
+func (w *writer) checklist(n Node) {
+	for i := range n.Content {
+		if i > 0 {
+			w.separate(false)
+		}
+		child := n.Content[i]
+		marker := "- " + w.gl.decision + " "
+		if child.Type == "taskItem" {
+			marker = "- [ ] "
+			if state, _ := attrString(child.Attrs, "state"); strings.EqualFold(state, "DONE") {
+				marker = "- [x] "
+			}
+		}
+		w.item(child, marker)
+	}
+}
+
+// item renders one list, task or decision item under its marker, indenting
+// everything below the first line to the width of that marker.
+func (w *writer) item(n Node, marker string) {
+	pop := w.push(marker, indentFor(marker))
+	switch {
+	case len(n.Content) == 0:
+		w.line("")
+	case inlineOnly(n.Content):
+		w.inline(n.Content)
+		w.endLine()
+	default:
+		w.blocks(n.Content, true)
+	}
+	if w.marker != "" {
+		w.line("")
+	}
+	pop()
+}
+
+func (w *writer) codeBlock(n Node) {
+	code := textOf(n.Content)
+	fence := "```"
+	if n := fenceLen(code); n > 3 {
+		fence = strings.Repeat("`", n)
+	}
+	language, _ := attrString(n.Attrs, "language")
+	w.line(fence + sanitize(language))
+	w.verbatim = true
+	w.line(strings.TrimRight(code, "\n"))
+	w.verbatim = false
+	w.line(fence)
+}
+
+// fenceLen returns a fence long enough to hold code that contains backticks.
+func fenceLen(code string) int {
+	longest, run := 0, 0
+	for i := range len(code) {
+		if code[i] != '`' {
+			run = 0
+			continue
+		}
+		run++
+		if run > longest {
+			longest = run
+		}
+	}
+	if longest < 3 {
+		return 3
+	}
+	return longest + 1
+}
+
+func (w *writer) panel(n Node) {
+	pop := w.push("> ", "> ")
+	marker, label := w.panelParts(n.Attrs)
+	w.line(marker + " " + label)
+	w.blocks(n.Content, false)
+	pop()
+}
+
+// panelParts picks the marker and label for a panel. panelType is an enum
+// rather than anything the site names, but an unknown one is still shown.
+func (w *writer) panelParts(a Attrs) (marker, label string) {
+	kind, _ := attrString(a, "panelType")
+	switch kind {
+	case "info":
+		return w.gl.info, "INFO"
+	case "note":
+		return w.gl.note, "NOTE"
+	case "tip", "success":
+		return w.gl.success, strings.ToUpper(kind)
+	case "warning":
+		return w.gl.warning, "WARNING"
+	case "error":
+		return w.gl.failure, "ERROR"
+	case "custom":
+		if icon, ok := attrString(a, "panelIconText"); ok && icon != "" {
+			return sanitize(icon), "PANEL"
+		}
+		return w.gl.custom, "PANEL"
+	case "":
+		return w.gl.custom, "PANEL"
+	default:
+		return w.gl.custom, strings.ToUpper(sanitize(kind))
+	}
+}
+
+func (w *writer) mediaBlock(n Node) {
+	for i := range n.Content {
+		if i > 0 {
+			w.separate(false)
+		}
+		if child := n.Content[i]; child.Type == "media" {
+			w.line(w.mediaText(child))
+			continue
+		}
+		w.block(n.Content[i])
+	}
+	if len(n.Content) == 0 {
+		w.unknownBlock(n)
+	}
+}
+
+func (w *writer) expand(n Node) {
+	title, _ := attrString(n.Attrs, "title")
+	if title != "" {
+		title = " " + sanitize(title)
+	}
+	w.line(w.gl.expand + title)
+	pop := w.push("  ", "  ")
+	w.blocks(n.Content, false)
+	pop()
+}
+
+// unknownBlock shows that a node is there, and what it holds, without
+// pretending to know how it should look.
+func (w *writer) unknownBlock(n Node) {
+	pop := w.push("> ", "> ")
+	w.line("[unsupported: " + originalType(n) + "]")
+	switch {
+	case len(n.Content) > 0 && inlineOnly(n.Content):
+		w.inline(n.Content)
+		w.endLine()
+	case len(n.Content) > 0:
+		w.blocks(n.Content, false)
+	case n.Text != "":
+		w.line(sanitize(n.Text))
+	default:
+		if text, ok := attrString(n.Attrs, "text"); ok && text != "" {
+			w.line(sanitize(text))
+		}
+	}
+	pop()
+}
+
+// originalType names an unsupportedBlock or unsupportedInline by the node it
+// stands in for, which is the only interesting thing about it.
+func originalType(n Node) string {
+	if n.Type != "unsupportedBlock" && n.Type != "unsupportedInline" {
+		return sanitize(n.Type)
+	}
+	original, ok := n.Attrs["originalValue"].(map[string]any)
+	if !ok {
+		return sanitize(n.Type)
+	}
+	if typ, ok := original["type"].(string); ok && typ != "" {
+		return sanitize(typ)
+	}
+	return sanitize(n.Type)
+}
+
+func isList(typ string) bool {
+	switch typ {
+	case "bulletList", "orderedList", "taskList", "decisionList":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/adf/render.go
+++ b/pkg/adf/render.go
@@ -279,6 +279,15 @@ func (w *writer) checklist(n Node) {
 			w.separate(false)
 		}
 		child := n.Content[i]
+		// ADF's content model for these lists is (item | list)+: indenting an
+		// action item in the editor stores a sibling list inside its parent, and
+		// treating that as an item renders every child as unsupported.
+		if child.Type == "taskList" || child.Type == "decisionList" {
+			done := w.push("  ", "  ")
+			w.checklist(child)
+			done()
+			continue
+		}
 		marker := "- " + w.gl.decision + " "
 		if child.Type == "taskItem" {
 			marker = "- [ ] "

--- a/pkg/adf/render_inline.go
+++ b/pkg/adf/render_inline.go
@@ -1,0 +1,393 @@
+package adf
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// glyphs are the markers the renderer puts in front of things markdown has no
+// spelling for. Nothing here may assume a Nerd Font.
+type glyphs struct {
+	info     string
+	note     string
+	success  string
+	warning  string
+	failure  string
+	custom   string
+	decision string
+	expand   string
+	ellipsis string
+}
+
+func glyphsFor(ascii bool) glyphs {
+	if ascii {
+		return glyphs{
+			info: "i", note: "#", success: "+", warning: "!", failure: "x",
+			custom: "<>", decision: "<>", expand: "v", ellipsis: "...",
+		}
+	}
+	return glyphs{
+		info: "ℹ", note: "✎", success: "✓", warning: "⚠", failure: "✗",
+		custom: "◆", decision: "◇", expand: "▾", ellipsis: "…",
+	}
+}
+
+func (w *writer) inline(nodes []Node) {
+	for i := range nodes {
+		w.inlineNode(nodes[i])
+	}
+}
+
+func (w *writer) inlineNode(n Node) {
+	switch n.Type {
+	case "text":
+		w.emit(marked(sanitize(n.Text), n.Marks))
+	case "hardBreak":
+		w.startLine()
+		w.endLine()
+	case "mention":
+		w.emit(mentionText(n.Attrs))
+	case "status":
+		w.emit(statusText(n.Attrs))
+	case "emoji":
+		w.emit(emojiText(n.Attrs))
+	case "date":
+		w.emit(w.dateText(n.Attrs))
+	case "inlineCard", "inlineEmbedCard":
+		w.emit(w.cardText(n))
+	case "media", "mediaInline":
+		w.emit(w.mediaText(n))
+	case "placeholder":
+		if text, ok := attrString(n.Attrs, "text"); ok {
+			w.emit(sanitize(text))
+		}
+	default:
+		w.unknownInline(n)
+	}
+}
+
+func (w *writer) unknownInline(n Node) {
+	w.emit("[unsupported: " + originalType(n))
+	switch {
+	case len(n.Content) > 0:
+		w.emit(": ")
+		w.inline(n.Content)
+	case n.Text != "":
+		w.emit(": " + sanitize(n.Text))
+	}
+	w.emit("]")
+}
+
+// mentionText renders a mention from the display text the editor stored with
+// it. The account id behind it means nothing to a reader.
+func mentionText(a Attrs) string {
+	text, _ := attrString(a, "text")
+	text = sanitize(strings.TrimSpace(text))
+	if text == "" {
+		if id, ok := attrString(a, "id"); ok {
+			text = sanitize(id)
+		}
+	}
+	if text == "" {
+		return "@?"
+	}
+	if strings.HasPrefix(text, "@") {
+		return text
+	}
+	return "@" + text
+}
+
+// statusText renders a lozenge as bracketed text. Its colour is styling, which
+// this package does not do, and its wording is whatever the author typed —
+// never a status this client resolved, so it is not localised here either.
+func statusText(a Attrs) string {
+	text, _ := attrString(a, "text")
+	text = sanitize(strings.TrimSpace(text))
+	if text == "" {
+		return "[status]"
+	}
+	return "[" + text + "]"
+}
+
+func emojiText(a Attrs) string {
+	if text, ok := attrString(a, "text"); ok && text != "" {
+		return sanitize(text)
+	}
+	if short, ok := attrString(a, "shortName"); ok && short != "" {
+		return sanitize(short)
+	}
+	if id, ok := attrString(a, "id"); ok && id != "" {
+		return ":" + sanitize(id) + ":"
+	}
+	return ""
+}
+
+// dateText renders the instant a date node carries, which arrives as epoch
+// milliseconds in a string.
+func (w *writer) dateText(a Attrs) string {
+	stamp, _ := attrString(a, "timestamp")
+	ms, err := strconv.ParseInt(strings.TrimSpace(stamp), 10, 64)
+	if err != nil {
+		if stamp == "" {
+			return ""
+		}
+		return sanitize(stamp)
+	}
+	loc := w.opt.Location
+	if loc == nil {
+		loc = time.UTC
+	}
+	return time.UnixMilli(ms).In(loc).Format(time.DateOnly)
+}
+
+// cardText renders a smart link. Jira resolves these server-side for the
+// browser; over the API only the URL comes back, so the URL is what a reader
+// gets.
+func (w *writer) cardText(n Node) string {
+	url, _ := attrString(n.Attrs, "url")
+	name := ""
+	if data, ok := n.Attrs["data"].(map[string]any); ok {
+		if url == "" {
+			url, _ = data["url"].(string)
+		}
+		name, _ = data["name"].(string)
+	}
+	url = sanitize(strings.TrimSpace(url))
+	name = sanitize(strings.TrimSpace(name))
+	switch {
+	case url == "" && name == "":
+		return "[unsupported: " + originalType(n) + "]"
+	case url == "":
+		return name
+	case name == "" || name == url:
+		return "<" + url + ">"
+	default:
+		return link(name, url)
+	}
+}
+
+// mediaText renders an attachment reference. A media node carries an id and a
+// collection rather than a filename, so the id is kept: it is what a later
+// packet resolves against the attachment list.
+func (w *writer) mediaText(n Node) string {
+	alt, _ := attrString(n.Attrs, "alt")
+	alt = sanitize(strings.TrimSpace(alt))
+	if alt == "" {
+		alt = "media"
+	}
+	target, _ := attrString(n.Attrs, "url")
+	if target == "" {
+		if id, ok := attrString(n.Attrs, "id"); ok && id != "" {
+			target = "media:" + id
+		}
+	}
+	if target == "" {
+		return "[unsupported: " + originalType(n) + "]"
+	}
+	return "!" + link(alt, sanitize(strings.TrimSpace(target)))
+}
+
+// angles is what an address has to have escaped before it can be wrapped in
+// angle brackets, which is what holds a link together when the address itself
+// contains a bracket or a space.
+var angles = strings.NewReplacer("<", "%3C", ">", "%3E")
+
+func link(text, url string) string {
+	if strings.ContainsAny(url, " ()<>") {
+		return "[" + text + "](<" + angles.Replace(url) + ">)"
+	}
+	return "[" + text + "](" + url + ")"
+}
+
+// marked wraps text in its marks in a fixed order, innermost first. Marks come
+// off the wire in ProseMirror rank order, which is byte-significant and means
+// nothing, so strong inside em has to render as em inside strong does.
+func marked(s string, marks []Mark) string {
+	if s == "" || len(marks) == 0 {
+		return s
+	}
+	var code, underline, strike, em, strong bool
+	href := ""
+	for i := range marks {
+		switch marks[i].Type {
+		case "code":
+			code = true
+		case "underline":
+			underline = true
+		case "strike":
+			strike = true
+		case "em":
+			em = true
+		case "strong":
+			strong = true
+		case "link":
+			if href == "" {
+				href, _ = attrString(marks[i].Attrs, "href")
+				href = strings.TrimSpace(href)
+			}
+		}
+	}
+	if !code && !underline && !strike && !em && !strong && href == "" {
+		return s
+	}
+
+	// Emphasis around leading or trailing spaces is not emphasis; keep the
+	// spaces outside the markers.
+	core := strings.TrimRight(strings.TrimLeft(s, " \t"), " \t")
+	if core == "" {
+		return s
+	}
+	lead, trail := s[:len(s)-len(strings.TrimLeft(s, " \t"))], s[len(strings.TrimRight(s, " \t")):]
+
+	if code {
+		core = codeSpan(core)
+	}
+	for _, m := range [...]struct {
+		on   bool
+		wrap string
+	}{
+		{underline, "_"},
+		{strike, "~~"},
+		{em, "*"},
+		{strong, "**"},
+	} {
+		if m.on {
+			core = m.wrap + core + m.wrap
+		}
+	}
+	if href != "" {
+		href = sanitize(href)
+		if core == href {
+			core = "<" + href + ">"
+		} else {
+			core = link(core, href)
+		}
+	}
+	return lead + core + trail
+}
+
+// codeSpan fences inline code in enough backticks to hold whatever is inside
+// it, padding when the content would otherwise touch a fence.
+func codeSpan(s string) string {
+	fence := strings.Repeat("`", fenceRun(s)+1)
+	if strings.HasPrefix(s, "`") || strings.HasSuffix(s, "`") {
+		return fence + " " + s + " " + fence
+	}
+	return fence + s + fence
+}
+
+func fenceRun(s string) int {
+	longest, run := 0, 0
+	for i := range len(s) {
+		if s[i] != '`' {
+			run = 0
+			continue
+		}
+		run++
+		if run > longest {
+			longest = run
+		}
+	}
+	return longest
+}
+
+// sanitize drops the control characters a terminal would act on. Issue text is
+// written by anyone with a Jira login, and an escape sequence in a description
+// must not be able to repaint the screen it is displayed in.
+func sanitize(s string) string {
+	if !hasControl(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func hasControl(s string) bool {
+	for _, r := range s {
+		if isControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isControl(r rune) bool {
+	switch {
+	case r == '\n' || r == '\t':
+		return false
+	case r < 0x20 || r == 0x7f:
+		return true
+	case r >= 0x80 && r <= 0x9f:
+		return true
+	default:
+		return false
+	}
+}
+
+// textOf concatenates the text of a run of nodes, which is how a code block
+// carries its lines.
+func textOf(nodes []Node) string {
+	if len(nodes) == 1 {
+		return sanitize(nodes[0].Text)
+	}
+	var b strings.Builder
+	for i := range nodes {
+		b.WriteString(nodes[i].Text)
+	}
+	return sanitize(b.String())
+}
+
+func isInline(typ string) bool {
+	switch typ {
+	case "text", "hardBreak", "mention", "status", "emoji", "date",
+		"inlineCard", "inlineEmbedCard", "media", "mediaInline",
+		"placeholder", "inlineExtension", "unsupportedInline":
+		return true
+	default:
+		return false
+	}
+}
+
+func inlineOnly(nodes []Node) bool {
+	for i := range nodes {
+		if !isInline(nodes[i].Type) {
+			return false
+		}
+	}
+	return len(nodes) > 0
+}
+
+// attrString reads a string attribute, reporting whether it was there and of
+// that type — an attribute this package models can still arrive as something
+// else, and a document that does that must still render.
+func attrString(a Attrs, key string) (string, bool) {
+	v, ok := a[key].(string)
+	return v, ok
+}
+
+// attrInt reads a numeric attribute. JSON numbers decode to float64, but a
+// document built in Go carries whatever the caller put there.
+func attrInt(a Attrs, key string) (int, bool) {
+	switch v := a[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case json.Number:
+		n, err := v.Int64()
+		return int(n), err == nil
+	default:
+		return 0, false
+	}
+}

--- a/pkg/adf/render_table.go
+++ b/pkg/adf/render_table.go
@@ -1,0 +1,203 @@
+package adf
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// minCell is the narrowest a column is squeezed to before the table is allowed
+// to overflow the width it was given.
+const minCell = 3
+
+// table lays a table out as a padded pipe grid. Markdown's table syntax only
+// reads as a table once the columns line up, so the columns are measured in
+// terminal cells rather than in bytes or runes: a cell holding CJK or an emoji
+// is two cells wide per character, and counting either of the other two puts
+// every row after it out by a column.
+//
+// A cell's blocks are folded onto one line, because a pipe row cannot hold a
+// second one. A table whose first row is not a header row gets no delimiter
+// row, which is not GitHub-flavoured markdown but is the only honest thing a
+// pager can show.
+func (w *writer) table(n Node) {
+	rows, header := w.tableCells(n)
+	if len(rows) == 0 {
+		return
+	}
+	widths := columnWidths(rows, w.opt.TableWidth)
+
+	for i := range rows {
+		if i > 0 {
+			w.separate(false)
+		}
+		w.startLine()
+		w.writeRow(rows[i], widths)
+		w.endLine()
+		if i == 0 && header {
+			w.separate(false)
+			w.startLine()
+			w.writeRow(nil, widths)
+			w.endLine()
+		}
+	}
+}
+
+// tableCells folds the table into rectangular rows of rendered cells, and
+// reports whether the first row is a header row.
+func (w *writer) tableCells(n Node) (rows [][]string, header bool) {
+	rows = make([][]string, 0, len(n.Content))
+	scratch := writer{opt: w.opt, gl: w.gl}
+	columns := 0
+	for i := range n.Content {
+		row := n.Content[i]
+		if row.Type != "tableRow" {
+			continue
+		}
+		cells := make([]string, 0, len(row.Content))
+		headers := 0
+		for j := range row.Content {
+			if row.Content[j].Type == "tableHeader" {
+				headers++
+			}
+			cells = append(cells, scratch.cellText(row.Content[j]))
+		}
+		if len(rows) == 0 {
+			header = headers > 0 && headers == len(cells)
+		}
+		if len(cells) > columns {
+			columns = len(cells)
+		}
+		rows = append(rows, cells)
+	}
+	if columns == 0 {
+		return nil, false
+	}
+	for i := range rows {
+		for len(rows[i]) < columns {
+			rows[i] = append(rows[i], "")
+		}
+	}
+	return rows, header
+}
+
+// cellText renders one cell into the scratch writer it is called on, which is
+// reused for every cell of the table.
+func (w *writer) cellText(n Node) string {
+	buf := w.buf[:0]
+	*w = writer{buf: buf, opt: w.opt, gl: w.gl}
+	w.blocks(n.Content, false)
+	w.endLine()
+	return foldCell(w.buf)
+}
+
+// foldCell puts a cell's lines on one line and escapes the character the grid
+// is drawn with.
+func foldCell(b []byte) string {
+	var out strings.Builder
+	out.Grow(len(b))
+	for len(b) > 0 {
+		line := b
+		if i := bytes.IndexByte(b, '\n'); i >= 0 {
+			line, b = b[:i], b[i+1:]
+		} else {
+			b = nil
+		}
+		line = bytes.Trim(line, " \t")
+		if len(line) == 0 {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteByte(' ')
+		}
+		if bytes.IndexByte(line, '|') < 0 {
+			out.Write(line)
+			continue
+		}
+		for _, c := range line {
+			if c == '|' {
+				out.WriteByte('\\')
+			}
+			out.WriteByte(c)
+		}
+	}
+	return out.String()
+}
+
+// columnWidths measures every column and, when a width was given, squeezes the
+// widest ones until the grid fits inside it.
+func columnWidths(rows [][]string, limit int) []int {
+	widths := make([]int, len(rows[0]))
+	for j := range widths {
+		widths[j] = minCell
+	}
+	for i := range rows {
+		for j := range rows[i] {
+			if n := ansi.StringWidth(rows[i][j]); n > widths[j] {
+				widths[j] = n
+			}
+		}
+	}
+	if limit <= 0 {
+		return widths
+	}
+	for gridWidth(widths) > limit {
+		widest := 0
+		for j := range widths {
+			if widths[j] > widths[widest] {
+				widest = j
+			}
+		}
+		if widths[widest] <= minCell {
+			break
+		}
+		widths[widest]--
+	}
+	return widths
+}
+
+// gridWidth is what a row costs on screen: a bar at each end and between every
+// pair of columns, and a space either side of every cell.
+func gridWidth(widths []int) int {
+	total := 1
+	for _, width := range widths {
+		total += width + 3
+	}
+	return total
+}
+
+// writeRow appends one row of the grid, padding or truncating every cell to
+// its column. A nil cells is the delimiter row under a header.
+func (w *writer) writeRow(cells []string, widths []int) {
+	w.buf = append(w.buf, '|')
+	for j := range widths {
+		w.buf = append(w.buf, ' ')
+		filled := widths[j]
+		if cells == nil {
+			w.buf = appendRepeat(w.buf, '-', widths[j])
+		} else {
+			filled = w.appendCell(cells[j], widths[j])
+		}
+		w.buf = appendRepeat(w.buf, ' ', widths[j]-filled)
+		w.buf = append(w.buf, ' ', '|')
+	}
+}
+
+// appendCell writes one cell and returns how many terminal cells it took.
+func (w *writer) appendCell(s string, width int) int {
+	n := ansi.StringWidth(s)
+	if n > width {
+		s = ansi.Truncate(s, width, w.gl.ellipsis)
+		n = ansi.StringWidth(s)
+	}
+	w.buf = append(w.buf, s...)
+	return n
+}
+
+func appendRepeat(dst []byte, c byte, n int) []byte {
+	for range n {
+		dst = append(dst, c)
+	}
+	return dst
+}

--- a/pkg/adf/render_table.go
+++ b/pkg/adf/render_table.go
@@ -8,8 +8,12 @@ import (
 )
 
 // minCell is the narrowest a column is squeezed to before the table is allowed
-// to overflow the width it was given.
-const minCell = 3
+// to overflow the width it was given. It has to leave room for the ellipsis
+// itself and something either side of it, or squeezing a column erases it: the
+// ASCII ellipsis is three cells wide where the Unicode one is one.
+func minCell(ellipsis string) int {
+	return ansi.StringWidth(ellipsis) + 2
+}
 
 // table lays a table out as a padded pipe grid. Markdown's table syntax only
 // reads as a table once the columns line up, so the columns are measured in
@@ -26,7 +30,11 @@ func (w *writer) table(n Node) {
 	if len(rows) == 0 {
 		return
 	}
-	widths := columnWidths(rows, w.opt.TableWidth)
+	limit := w.opt.TableWidth
+	if limit > 0 {
+		limit -= ansi.StringWidth(w.prefix)
+	}
+	widths := columnWidths(rows, limit, minCell(w.gl.ellipsis))
 
 	for i := range rows {
 		if i > 0 {
@@ -58,10 +66,19 @@ func (w *writer) tableCells(n Node) (rows [][]string, header bool) {
 		cells := make([]string, 0, len(row.Content))
 		headers := 0
 		for j := range row.Content {
-			if row.Content[j].Type == "tableHeader" {
+			cell := row.Content[j]
+			if cell.Type == "tableHeader" {
 				headers++
 			}
-			cells = append(cells, scratch.cellText(row.Content[j]))
+			text := scratch.cellText(cell)
+			// A merged cell holds the grid positions it spans. Emitting one
+			// column for it puts every value after it under the wrong header,
+			// which is not a cosmetic problem — it is the wrong answer.
+			span, _ := attrInt(cell.Attrs, "colspan")
+			for span = max(1, span); span > 0; span-- {
+				cells = append(cells, text)
+				text = ""
+			}
 		}
 		if len(rows) == 0 {
 			header = headers > 0 && headers == len(cells)
@@ -105,6 +122,10 @@ func foldCell(b []byte) string {
 			b = nil
 		}
 		line = bytes.Trim(line, " \t")
+		// A tab reaches here from a code block. ansi.StringWidth counts it as
+		// nothing while a terminal jumps to the next stop, so the padding is
+		// self-consistent and the grid still comes out ragged.
+		line = bytes.ReplaceAll(line, []byte{'\t'}, []byte{' '})
 		if len(line) == 0 {
 			continue
 		}
@@ -127,10 +148,10 @@ func foldCell(b []byte) string {
 
 // columnWidths measures every column and, when a width was given, squeezes the
 // widest ones until the grid fits inside it.
-func columnWidths(rows [][]string, limit int) []int {
+func columnWidths(rows [][]string, limit, floor int) []int {
 	widths := make([]int, len(rows[0]))
 	for j := range widths {
-		widths[j] = minCell
+		widths[j] = floor
 	}
 	for i := range rows {
 		for j := range rows[i] {
@@ -149,7 +170,7 @@ func columnWidths(rows [][]string, limit int) []int {
 				widest = j
 			}
 		}
-		if widths[widest] <= minCell {
+		if widths[widest] <= floor {
 			break
 		}
 		widths[widest]--

--- a/pkg/adf/render_test.go
+++ b/pkg/adf/render_test.go
@@ -805,3 +805,74 @@ func marksJSON(types []string) []string {
 	}
 	return out
 }
+
+func TestMarkdown_NestedTaskListKeepsItsCheckboxes(t *testing.T) {
+	t.Parallel()
+
+	// Indenting an action item in the Jira editor stores a sibling taskList
+	// inside its parent, which is what ADF's (taskItem | taskList)+ content
+	// model allows. Treating that child as an item renders every one of its
+	// entries as unsupported and loses the DONE state.
+	const in = `{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"a"},"content":[
+		{"type":"taskItem","attrs":{"localId":"b","state":"TODO"},"content":[{"type":"text","text":"ship the fix"}]},
+		{"type":"taskList","attrs":{"localId":"c"},"content":[
+			{"type":"taskItem","attrs":{"localId":"d","state":"DONE"},"content":[{"type":"text","text":"write the test"}]},
+			{"type":"taskItem","attrs":{"localId":"e","state":"TODO"},"content":[{"type":"text","text":"update the docs"}]}]},
+		{"type":"taskItem","attrs":{"localId":"f","state":"TODO"},"content":[{"type":"text","text":"tell the reporter"}]}]}]}`
+
+	got := adf.Markdown(parse(t, in))
+	for _, want := range []string{"- [ ] ship the fix", "- [x] write the test", "- [ ] update the docs", "- [ ] tell the reporter"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "unsupported") {
+		t.Errorf("a nested task list rendered as unsupported:\n%s", got)
+	}
+}
+
+func TestMarkdown_MergedCellsKeepLaterValuesUnderTheirOwnHeading(t *testing.T) {
+	t.Parallel()
+
+	// A cell with colspan holds the grid positions it spans. Emitting one column
+	// for it slides every value after it left, so the answer under a heading is
+	// simply wrong rather than merely misaligned.
+	const in = `{"version":1,"type":"doc","content":[{"type":"table","content":[
+		{"type":"tableRow","content":[
+			{"type":"tableHeader","content":[{"type":"paragraph","content":[{"type":"text","text":"Env"}]}]},
+			{"type":"tableHeader","content":[{"type":"paragraph","content":[{"type":"text","text":"Runs"}]}]},
+			{"type":"tableHeader","content":[{"type":"paragraph","content":[{"type":"text","text":"Owner"}]}]}]},
+		{"type":"tableRow","content":[
+			{"type":"tableCell","attrs":{"colspan":2},"content":[{"type":"paragraph","content":[{"type":"text","text":"both"}]}]},
+			{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"nobody"}]}]}]}]}]}`
+
+	lines := strings.Split(strings.TrimRight(adf.Markdown(parse(t, in)), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want a header, a delimiter and one row, got:\n%s", strings.Join(lines, "\n"))
+	}
+	cells := strings.Split(strings.Trim(lines[2], "| "), "|")
+	if len(cells) != 3 {
+		t.Fatalf("the merged row has %d columns, want 3: %q", len(cells), lines[2])
+	}
+	if got := strings.TrimSpace(cells[2]); got != "nobody" {
+		t.Errorf("the Owner column holds %q, want \"nobody\": a merged cell shifted it", got)
+	}
+}
+
+func TestMarkdown_ASCIIEllipsisDoesNotEraseASqueezedColumn(t *testing.T) {
+	t.Parallel()
+
+	// The ASCII ellipsis is three cells wide against the Unicode one's one, so a
+	// floor of three leaves a squeezed column holding nothing but "...".
+	const in = `{"version":1,"type":"doc","content":[{"type":"table","content":[
+		{"type":"tableRow","content":[
+			{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"alpha bravo charlie"}]}]},
+			{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"delta echo foxtrot"}]}]}]}]}]}`
+
+	got := adf.MarkdownWith(parse(t, in), adf.Options{ASCII: true, TableWidth: 24})
+	for _, cell := range strings.Split(strings.Trim(strings.TrimSpace(got), "| "), "|") {
+		if strings.TrimSpace(cell) == "..." {
+			t.Errorf("a squeezed column shows only the ellipsis:\n%s", got)
+		}
+	}
+}

--- a/pkg/adf/render_test.go
+++ b/pkg/adf/render_test.go
@@ -1,0 +1,807 @@
+package adf_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files")
+
+// bt is a backtick, which a raw string literal cannot hold.
+const bt = "`"
+
+// richFixture is the description of the issue the fixture server serves. It is
+// read rather than copied so that a change to what Jira really sends shows up
+// here as a golden-file diff.
+const richFixture = "../jira/jiratest/fixtures/issue_rich_adf.json"
+
+func TestMarkdown_RendersTheRichFixtureDescription(t *testing.T) {
+	t.Parallel()
+	d := fixtureDescription(t)
+
+	for name, opt := range map[string]adf.Options{
+		"rich_unicode.golden": {},
+		"rich_ascii_20.golden": {
+			TableWidth: 20,
+			ASCII:      true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			golden(t, name, adf.MarkdownWith(d, opt))
+		})
+	}
+}
+
+func TestMarkdown_RendersEveryNodeTypeItKnows(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a paragraph",
+			in:   para(text("The basket is empty.")),
+			want: "The basket is empty.",
+		},
+		{
+			name: "a heading at every level it has",
+			in: node("heading", `"attrs":{"level":1},"content":[`+text("one")+`]`) + "," +
+				node("heading", `"attrs":{"level":6},"content":[`+text("six")+`]`),
+			want: "# one\n\n###### six",
+		},
+		{
+			name: "a heading deeper than markdown goes",
+			in:   node("heading", `"attrs":{"level":9},"content":[`+text("clamped")+`]`),
+			want: "###### clamped",
+		},
+		{
+			name: "a heading with no level",
+			in:   node("heading", `"content":[`+text("unlevelled")+`]`),
+			want: "# unlevelled",
+		},
+		{
+			name: "a heading with nothing in it, which is nothing to show",
+			in:   node("heading", `"attrs":{"level":2}`),
+			want: "",
+		},
+		{
+			name: "bold, italic, struck through and underlined text",
+			in: para(marked("bold", "strong") + "," + marked("italic", "em") + "," +
+				marked("gone", "strike") + "," + marked("under", "underline")),
+			want: "**bold***italic*~~gone~~_under_",
+		},
+		{
+			name: "inline code",
+			in:   para(marked("basketTotal()", "code")),
+			want: bt + "basketTotal()" + bt,
+		},
+		{
+			name: "inline code containing a backtick",
+			in:   para(marked("a "+bt+" b", "code")),
+			want: bt + bt + "a " + bt + " b" + bt + bt,
+		},
+		{
+			name: "a link",
+			in:   para(`{"type":"text","text":"the runbook","marks":[{"type":"link","attrs":{"href":"https://example.com/x"}}]}`),
+			want: "[the runbook](https://example.com/x)",
+		},
+		{
+			name: "a link whose text is its own address",
+			in:   para(`{"type":"text","text":"https://example.com/x","marks":[{"type":"link","attrs":{"href":"https://example.com/x"}}]}`),
+			want: "<https://example.com/x>",
+		},
+		{
+			name: "a link to an address holding a bracket",
+			in:   para(`{"type":"text","text":"wiki","marks":[{"type":"link","attrs":{"href":"https://example.com/a(b)"}}]}`),
+			want: "[wiki](<https://example.com/a(b)>)",
+		},
+		{
+			name: "emphasis around a trailing space, which is not emphasis",
+			in:   para(marked("bold ", "strong") + "," + text("and on")),
+			want: "**bold** and on",
+		},
+		{
+			name: "a mark this package does not render",
+			in:   para(`{"type":"text","text":"coloured","marks":[{"type":"textColor","attrs":{"color":"#ff0000"}}]}`),
+			want: "coloured",
+		},
+		{
+			name: "a hard break inside a paragraph",
+			in:   para(text("first") + `,{"type":"hardBreak"},` + text("second")),
+			want: "first\nsecond",
+		},
+		{
+			name: "a mention",
+			in:   para(text("Ask ") + `,{"type":"mention","attrs":{"id":"5b10ac8d","text":"@Someone"}},` + text(" about it")),
+			want: "Ask @Someone about it",
+		},
+		{
+			name: "a mention the editor stored without its text",
+			in:   para(`{"type":"mention","attrs":{"id":"5b10ac8d"}}`),
+			want: "@5b10ac8d",
+		},
+		{
+			name: "a status lozenge",
+			in:   para(`{"type":"status","attrs":{"text":"Wartet auf Freigabe","color":"yellow"}}`),
+			want: "[Wartet auf Freigabe]",
+		},
+		{
+			name: "an emoji",
+			in:   para(`{"type":"emoji","attrs":{"shortName":":smile:","id":"1f604","text":"😄"}}`),
+			want: "😄",
+		},
+		{
+			name: "an emoji with no character to show",
+			in:   para(`{"type":"emoji","attrs":{"shortName":":ship_it:","id":"atlassian-ship_it"}}`),
+			want: ":ship_it:",
+		},
+		{
+			name: "a date",
+			in:   para(`{"type":"date","attrs":{"timestamp":"1772409600000"}}`),
+			want: "2026-03-02",
+		},
+		{
+			name: "a date whose timestamp is not a number",
+			in:   para(`{"type":"date","attrs":{"timestamp":"soon"}}`),
+			want: "soon",
+		},
+		{
+			name: "an inline card",
+			in:   para(`{"type":"inlineCard","attrs":{"url":"https://example.atlassian.net/browse/EX-2"}}`),
+			want: "<https://example.atlassian.net/browse/EX-2>",
+		},
+		{
+			name: "an inline card that resolved to a title",
+			in:   para(`{"type":"inlineCard","attrs":{"data":{"url":"https://example.com/p","name":"The page"}}}`),
+			want: "[The page](https://example.com/p)",
+		},
+		{
+			name: "an inline image",
+			in:   para(`{"type":"mediaInline","attrs":{"id":"3f6b1c72","type":"file","alt":"the trace"}}`),
+			want: "![the trace](media:3f6b1c72)",
+		},
+		{
+			name: "an image with no alt text",
+			in:   node("mediaSingle", `"content":[{"type":"media","attrs":{"id":"3f6b1c72","type":"file"}}]`),
+			want: "![media](media:3f6b1c72)",
+		},
+		{
+			name: "an externally hosted image",
+			in:   node("mediaSingle", `"content":[{"type":"media","attrs":{"type":"external","url":"https://example.com/a.png","alt":"a"}}]`),
+			want: "![a](https://example.com/a.png)",
+		},
+		{
+			name: "an image with a caption",
+			in: node("mediaSingle", `"content":[{"type":"media","attrs":{"id":"3f","type":"file"}},`+
+				node("caption", `"content":[`+text("Figure 1")+`]`)+`]`),
+			want: "![media](media:3f)\nFigure 1",
+		},
+		{
+			name: "prose whose characters are not one cell wide",
+			in:   para(text("日本語 🙂 e\u0301cole — ok")),
+			want: "日本語 🙂 e\u0301cole — ok",
+		},
+		{
+			name: "a horizontal rule",
+			in:   para(text("above")) + "," + node("rule", "") + "," + para(text("below")),
+			want: "above\n\n---\n\nbelow",
+		},
+		{
+			name: "a code block with a language",
+			in:   node("codeBlock", `"attrs":{"language":"go"},"content":[`+text("x := 1\\ny := 2")+`]`),
+			want: bt + bt + bt + "go\nx := 1\ny := 2\n" + bt + bt + bt,
+		},
+		{
+			name: "a code block with no language",
+			in:   node("codeBlock", `"content":[`+text("plain")+`]`),
+			want: bt + bt + bt + "\nplain\n" + bt + bt + bt,
+		},
+		{
+			name: "a code block holding a fence",
+			in:   node("codeBlock", `"content":[`+text("a\\n"+bt+bt+bt+"\\nb")+`]`),
+			want: bt + bt + bt + bt + "\na\n" + bt + bt + bt + "\nb\n" + bt + bt + bt + bt,
+		},
+		{
+			name: "a blockquote",
+			in:   node("blockquote", `"content":[`+para(text("one"))+`,`+para(text("two"))+`]`),
+			want: "> one\n>\n> two",
+		},
+		{
+			name: "an information panel",
+			in:   node("panel", `"attrs":{"panelType":"info"},"content":[`+para(text("Read this."))+`]`),
+			want: "> ℹ INFO\n> Read this.",
+		},
+		{
+			name: "every other panel type",
+			in: node("panel", `"attrs":{"panelType":"note"},"content":[`+para(text("n"))+`]`) + "," +
+				node("panel", `"attrs":{"panelType":"success"},"content":[`+para(text("s"))+`]`) + "," +
+				node("panel", `"attrs":{"panelType":"warning"},"content":[`+para(text("w"))+`]`) + "," +
+				node("panel", `"attrs":{"panelType":"error"},"content":[`+para(text("e"))+`]`),
+			want: "> ✎ NOTE\n> n\n\n> ✓ SUCCESS\n> s\n\n> ⚠ WARNING\n> w\n\n> ✗ ERROR\n> e",
+		},
+		{
+			name: "a custom panel with its own icon",
+			in:   node("panel", `"attrs":{"panelType":"custom","panelIconText":"🛠"},"content":[`+para(text("c"))+`]`),
+			want: "> 🛠 PANEL\n> c",
+		},
+		{
+			name: "a panel of a type nobody has published yet",
+			in:   node("panel", `"attrs":{"panelType":"surprise"},"content":[`+para(text("p"))+`]`),
+			want: "> ◆ SURPRISE\n> p",
+		},
+		{
+			name: "a task list",
+			in: node("taskList", `"content":[`+
+				node("taskItem", `"attrs":{"state":"DONE"},"content":[`+text("done")+`]`)+`,`+
+				node("taskItem", `"attrs":{"state":"TODO"},"content":[`+text("todo")+`]`)+`]`),
+			want: "- [x] done\n- [ ] todo",
+		},
+		{
+			name: "a decision list",
+			in:   node("decisionList", `"content":[`+node("decisionItem", `"content":[`+text("ship it")+`]`)+`]`),
+			want: "- ◇ ship it",
+		},
+		{
+			name: "an expand",
+			in:   node("expand", `"attrs":{"title":"The long version"},"content":[`+para(text("detail"))+`]`),
+			want: "▾ The long version\n  detail",
+		},
+		{
+			name: "an expand with no title",
+			in:   node("expand", `"content":[`+para(text("detail"))+`]`),
+			want: "▾\n  detail",
+		},
+		{
+			name: "a placeholder",
+			in:   para(`{"type":"placeholder","attrs":{"text":"Type something"}}`),
+			want: "Type something",
+		},
+		{
+			name: "a block card",
+			in:   node("blockCard", `"attrs":{"url":"https://example.com/board"}`),
+			want: "<https://example.com/board>",
+		},
+		{
+			name: "a layout, whose columns stack",
+			in: node("layoutSection", `"content":[`+
+				node("layoutColumn", `"attrs":{"width":50},"content":[`+para(text("left"))+`]`)+`,`+
+				node("layoutColumn", `"attrs":{"width":50},"content":[`+para(text("right"))+`]`)+`]`),
+			want: "left\n\nright",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := adf.Markdown(parse(t, wrap(tc.in))); got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMarkdown_ShowsANodeTypeItHasNeverHeardOf(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a block node with block content",
+			in:   node("futureBlock", `"attrs":{"variant":"callout"},"content":[`+para(text("kept"))+`]`),
+			want: "> [unsupported: futureBlock]\n> kept",
+		},
+		{
+			name: "a block node with nothing in it",
+			in:   node("futureBlock", `"attrs":{"variant":"callout"}`),
+			want: "> [unsupported: futureBlock]",
+		},
+		{
+			name: "a block node carrying its text in an attribute",
+			in:   node("futureBlock", `"attrs":{"text":"a caption"}`),
+			want: "> [unsupported: futureBlock]\n> a caption",
+		},
+		{
+			name: "an inline node inside a paragraph",
+			in:   para(text("before ") + `,{"type":"futureInline","attrs":{"x":1}},` + text(" after")),
+			want: "before [unsupported: futureInline] after",
+		},
+		{
+			name: "an inline node with text in it",
+			in:   para(`{"type":"futureInline","content":[` + text("its words") + `]}`),
+			want: "[unsupported: futureInline: its words]",
+		},
+		{
+			name: "the node Jira itself stores for something it could not parse",
+			in:   node("unsupportedBlock", `"attrs":{"originalValue":{"type":"someMacro","attrs":{"k":1}}}`),
+			want: "> [unsupported: someMacro]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := adf.Markdown(parse(t, wrap(tc.in))); got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMarkdown_RendersADocumentThatIsOnlyAnUnknownNode(t *testing.T) {
+	t.Parallel()
+	const in = `{"version":1,"type":"doc","content":[{"type":"multiBodiedExtension","attrs":{"extensionKey":"chart"},` +
+		`"content":[{"type":"extensionFrame","content":[{"type":"paragraph","content":[{"type":"text","text":"a chart lives here"}]}]}]}]}`
+	golden(t, "unknown_only.golden", adf.Markdown(parse(t, in)))
+}
+
+func TestMarkdown_IsEmptyForADocumentWithNoContent(t *testing.T) {
+	t.Parallel()
+	for name, in := range map[string]string{
+		"an empty document":       `{"version":1,"type":"doc","content":[]}`,
+		"a document with no key":  `{"version":1,"type":"doc"}`,
+		"a null document":         `null`,
+		"an empty paragraph":      wrap(node("paragraph", "")),
+		"two empty paragraphs":    wrap(node("paragraph", "") + "," + node("paragraph", "")),
+		"an empty table":          wrap(node("table", `"attrs":{"layout":"default"}`)),
+		"a table with empty rows": wrap(node("table", `"content":[`+node("tableRow", "")+`]`)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := adf.Markdown(parse(t, in)); got != "" {
+				t.Errorf("want no output, got %q", got)
+			}
+		})
+	}
+}
+
+func TestMarkdown_RendersTheSameBytesEveryTime(t *testing.T) {
+	t.Parallel()
+	d := fixtureDescription(t)
+	first := adf.Markdown(d)
+	for range 8 {
+		if got := adf.Markdown(d); got != first {
+			t.Fatalf("two renders of one document differ\n--- first ---\n%s\n--- then ---\n%s", first, got)
+		}
+	}
+}
+
+func TestMarkdown_IsEmptyForTheZeroDocument(t *testing.T) {
+	t.Parallel()
+	if got := adf.Markdown(adf.Doc{}); got != "" {
+		t.Errorf("want no output, got %q", got)
+	}
+}
+
+func TestMarkdown_NestsListsAndQuotesToAnyDepth(t *testing.T) {
+	t.Parallel()
+	golden(t, "nested_lists.golden", adf.Markdown(parse(t, nestedLists)))
+}
+
+func TestMarkdown_NumbersAnOrderedListFromItsStart(t *testing.T) {
+	t.Parallel()
+	in := wrap(node("orderedList", `"attrs":{"order":9},"content":[`+
+		item("nine")+`,`+item("ten")+`,`+item("eleven")+`]`))
+	const want = "9. nine\n10. ten\n11. eleven"
+	if got := adf.Markdown(parse(t, in)); got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMarkdown_KeepsTheBulletOfAnEmptyListItem(t *testing.T) {
+	t.Parallel()
+	in := wrap(node("bulletList", `"content":[`+node("listItem", "")+`,`+item("second")+`]`))
+	const want = "-\n- second"
+	if got := adf.Markdown(parse(t, in)); got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMarkdown_RendersATableWithAndWithoutAHeaderRow(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		in    string
+		width int
+	}{
+		"table_header.golden":    {wrap(headedTable), 0},
+		"table_no_header.golden": {wrap(headlessTable), 0},
+		"table_ragged.golden":    {wrap(raggedTable), 0},
+		"table_squeezed.golden":  {wrap(headedTable), 30},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			golden(t, name, adf.MarkdownWith(parse(t, tc.in), adf.Options{TableWidth: tc.width}))
+		})
+	}
+}
+
+func TestMarkdown_BoundsATableToTheWidthItWasGiven(t *testing.T) {
+	t.Parallel()
+	for _, width := range []int{80, 40, 20} {
+		out := adf.MarkdownWith(parse(t, wrap(headedTable)), adf.Options{TableWidth: width})
+		for line := range strings.SplitSeq(out, "\n") {
+			if got := ansi.StringWidth(line); got > width {
+				t.Errorf("at width %d a line came back %d cells wide: %q", width, got, line)
+			}
+		}
+	}
+}
+
+func TestMarkdown_LinesUpAColumnOfCharactersThatAreNotOneCellWide(t *testing.T) {
+	t.Parallel()
+	out := adf.Markdown(parse(t, wrap(wideTable)))
+	golden(t, "table_wide_runes.golden", out)
+
+	lines := strings.Split(out, "\n")
+	want := ansi.StringWidth(lines[0])
+	for _, line := range lines[1:] {
+		if got := ansi.StringWidth(line); got != want {
+			t.Errorf("the grid is %d cells wide but this row is %d: %q", want, got, line)
+		}
+	}
+	if want == len(lines[0]) {
+		t.Fatal("the test data has to contain something wider than one byte per cell, or it proves nothing")
+	}
+}
+
+func TestMarkdown_OrderingTheSameMarksDifferentlyRendersTheSame(t *testing.T) {
+	t.Parallel()
+	for name, orders := range map[string][][]string{
+		"bold and italic": {{"strong", "em"}, {"em", "strong"}},
+		"a link carrying emphasis": {
+			{"link", "em", "strong"},
+			{"strong", "em", "link"},
+			{"em", "link", "strong"},
+		},
+		"every mark at once": {
+			{"link", "em", "strong", "strike", "underline", "code"},
+			{"code", "underline", "strike", "strong", "em", "link"},
+			{"strike", "link", "code", "strong", "underline", "em"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			first := ""
+			for i, order := range orders {
+				in := wrap(para(`{"type":"text","text":"emphasis","marks":[` +
+					strings.Join(marksJSON(order), ",") + `]}`))
+				got := adf.Markdown(parse(t, in))
+				switch {
+				case i == 0:
+					first = got
+				case got != first:
+					t.Errorf("%v rendered %q but %v rendered %q", orders[0], first, order, got)
+				}
+			}
+			if !strings.Contains(first, "emphasis") {
+				t.Fatalf("the marked text itself went missing: %q", first)
+			}
+		})
+	}
+}
+
+func TestMarkdown_DropsTheControlCharactersATerminalWouldActOn(t *testing.T) {
+	t.Parallel()
+	const escape = `{"version":1,"type":"doc","content":[{"type":"paragraph","content":[` +
+		`{"type":"text","text":"safe \u001b[31mred\u001b[0m and a bell\u0007"}]}]}`
+	got := adf.Markdown(parse(t, escape))
+	if strings.ContainsAny(got, "\x1b\x07") {
+		t.Fatalf("an escape sequence survived into the output: %q", got)
+	}
+	if want := "safe [31mred[0m and a bell"; got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMarkdown_KeepsTabsAndNewlinesInCode(t *testing.T) {
+	t.Parallel()
+	in := wrap(node("codeBlock", `"content":[`+text("if x {\\n\\tdo()\\n}")+`]`))
+	if got := adf.Markdown(parse(t, in)); !strings.Contains(got, "\n\tdo()\n") {
+		t.Errorf("the indentation did not survive: %q", got)
+	}
+}
+
+func TestMarkdown_RendersADateInTheLocationItWasGiven(t *testing.T) {
+	t.Parallel()
+	in := parse(t, wrap(para(`{"type":"date","attrs":{"timestamp":"1772409600000"}}`)))
+	auckland, err := time.LoadLocation("Pacific/Auckland")
+	if err != nil {
+		t.Skipf("no timezone database here: %v", err)
+	}
+	if got := adf.MarkdownWith(in, adf.Options{Location: auckland}); got != "2026-03-02" {
+		t.Errorf("got %q", got)
+	}
+	if got := adf.MarkdownWith(in, adf.Options{Location: time.FixedZone("west", -12*60*60)}); got != "2026-03-01" {
+		t.Errorf("a date twelve hours behind UTC should fall on the day before, got %q", got)
+	}
+}
+
+func TestMarkdown_SwapsInASCIIMarkersWhenAskedTo(t *testing.T) {
+	t.Parallel()
+	in := parse(t, wrap(
+		node("panel", `"attrs":{"panelType":"warning"},"content":[`+para(text("careful"))+`]`)+","+
+			node("decisionList", `"content":[`+node("decisionItem", `"content":[`+text("ship")+`]`)+`]`)+","+
+			node("expand", `"attrs":{"title":"more"},"content":[`+para(text("detail"))+`]`)))
+
+	got := adf.MarkdownWith(in, adf.Options{ASCII: true})
+	for _, r := range got {
+		if r > 127 {
+			t.Fatalf("%q is not ascii, in:\n%s", r, got)
+		}
+	}
+	const want = "> ! WARNING\n> careful\n\n- <> ship\n\nv more\n  detail"
+	if got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMarkdown_EndsWithoutATrailingNewline(t *testing.T) {
+	t.Parallel()
+	got := adf.Markdown(fixtureDescription(t))
+	if strings.HasSuffix(got, "\n") {
+		t.Error("the output ends with a newline, so splitting it into lines yields an empty last line")
+	}
+	if strings.Contains(got, "\n\n\n") {
+		t.Error("the output holds a run of blank lines")
+	}
+	for line := range strings.SplitSeq(got, "\n") {
+		if strings.HasSuffix(line, " ") {
+			t.Errorf("a line ends in a space: %q", line)
+		}
+	}
+}
+
+func TestAppendMarkdown_AppendsToTheBufferItWasGiven(t *testing.T) {
+	t.Parallel()
+	d := parse(t, wrap(para(text("second"))))
+	got := string(adf.AppendMarkdown([]byte("first\n"), d, adf.Options{}))
+	if want := "first\nsecond"; got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestAppendMarkdown_ReusesOneBufferAcrossDocuments(t *testing.T) {
+	t.Parallel()
+	first := parse(t, wrap(para(text("one"))))
+	second := parse(t, wrap(para(text("a much longer second document"))))
+
+	buf := adf.AppendMarkdown(nil, first, adf.Options{})
+	if got := string(buf); got != "one" {
+		t.Fatalf("got %q", got)
+	}
+	buf = adf.AppendMarkdown(buf[:0], second, adf.Options{})
+	if got, want := string(buf), "a much longer second document"; got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestMarkdown_AllocatesPerNodeAndNotPerCharacter guards the property that
+// makes this renderer safe to put in front of a viewport: doubling the text
+// must not double the allocations. A renderer that builds a string per
+// character passes every other test in this file and then falls over on a
+// description somebody pasted a log into.
+func TestMarkdown_AllocatesPerNodeAndNotPerCharacter(t *testing.T) {
+	short := parse(t, paragraphs(50, 4))
+	long := parse(t, paragraphs(50, 4000))
+
+	shortRuns := testing.AllocsPerRun(20, func() { sink = adf.Markdown(short) })
+	longRuns := testing.AllocsPerRun(20, func() { sink = adf.Markdown(long) })
+	if longRuns > shortRuns+2 {
+		t.Errorf("the same %d nodes cost %.0f allocations with four characters each and %.0f with four thousand",
+			50, shortRuns, longRuns)
+	}
+}
+
+// paragraphs builds a document of count paragraphs of size characters each.
+func paragraphs(count, size int) string {
+	blocks := make([]string, 0, count)
+	for range count {
+		blocks = append(blocks, para(text(strings.Repeat("word ", size/5))))
+	}
+	return wrap(strings.Join(blocks, ","))
+}
+
+func BenchmarkMarkdown_RichFixture(b *testing.B) {
+	d := fixtureDescription(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		sink = adf.Markdown(d)
+	}
+}
+
+func BenchmarkMarkdown_LargeDocument(b *testing.B) {
+	d := largeDoc(b, 500)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		sink = adf.Markdown(d)
+	}
+}
+
+func BenchmarkAppendMarkdown_ReusedBuffer(b *testing.B) {
+	d := largeDoc(b, 500)
+	buf := make([]byte, 0, 1<<16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf = adf.AppendMarkdown(buf[:0], d, adf.Options{})
+	}
+	byteSink = buf
+}
+
+var (
+	sink     string
+	byteSink []byte
+)
+
+// largeDoc repeats the fixture description until it is a document nobody would
+// write by hand but a long-running issue eventually becomes.
+func largeDoc(tb testing.TB, times int) adf.Doc {
+	tb.Helper()
+	one := fixtureDescription(tb)
+	content := make([]adf.Node, 0, len(one.Content)*times)
+	for range times {
+		content = append(content, one.Clone().Content...)
+	}
+	return adf.NewDoc(content...)
+}
+
+func fixtureDescription(tb testing.TB) adf.Doc {
+	tb.Helper()
+	raw, err := os.ReadFile(richFixture)
+	if err != nil {
+		tb.Fatalf("reading %s: %v", richFixture, err)
+	}
+	var envelope struct {
+		Fields struct {
+			Description adf.Doc `json:"description"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		tb.Fatalf("parsing %s: %v", richFixture, err)
+	}
+	if envelope.Fields.Description.IsEmpty() {
+		tb.Fatalf("%s carries no description", richFixture)
+	}
+	return envelope.Fields.Description
+}
+
+func parse(tb testing.TB, in string) adf.Doc {
+	tb.Helper()
+	d, err := adf.Unmarshal([]byte(in))
+	if err != nil {
+		tb.Fatalf("unmarshal %s: %v", in, err)
+	}
+	return d
+}
+
+func golden(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("%v — run: go test ./pkg/adf -update", err)
+	}
+	if string(want) != got {
+		t.Errorf("output differs from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}
+
+func wrap(content string) string {
+	return `{"version":1,"type":"doc","content":[` + content + `]}`
+}
+
+func node(typ, rest string) string {
+	if rest == "" {
+		return `{"type":"` + typ + `"}`
+	}
+	return `{"type":"` + typ + `",` + rest + `}`
+}
+
+func text(s string) string { return `{"type":"text","text":"` + s + `"}` }
+
+func marked(s, mark string) string {
+	return `{"type":"text","text":"` + s + `","marks":[{"type":"` + mark + `"}]}`
+}
+
+func para(content string) string {
+	if content == "" {
+		return node("paragraph", "")
+	}
+	return node("paragraph", `"content":[`+content+`]`)
+}
+
+func item(s string) string { return node("listItem", `"content":[`+para(text(s))+`]`) }
+
+func cell(typ, s string) string { return node(typ, `"content":[`+para(text(s))+`]`) }
+
+func row(cells ...string) string {
+	return node("tableRow", `"content":[`+strings.Join(cells, ",")+`]`)
+}
+
+// nestedLists puts a list inside a list inside a list, and a list inside a
+// quote, because indentation is where a line-prefix renderer goes wrong.
+var nestedLists = wrap(
+	node("bulletList", `"content":[`+
+		node("listItem", `"content":[`+para(text("one"))+`,`+
+			node("bulletList", `"content":[`+
+				node("listItem", `"content":[`+para(text("one a"))+`,`+
+					node("orderedList", `"attrs":{"order":3},"content":[`+
+						item("deep")+`,`+
+						node("listItem", `"content":[`+para(text("deeper"))+`,`+
+							node("codeBlock", `"attrs":{"language":"sh"},"content":[`+text("make check")+`]`)+`]`)+
+						`]`)+`]`)+
+				`]`)+`]`)+`,`+
+		node("listItem", `"content":[`+para(text("two"))+`,`+para(text("still two"))+`]`)+
+		`]`) + `,` +
+		node("blockquote", `"content":[`+para(text("quoted"))+`,`+
+			node("bulletList", `"content":[`+item("in a quote")+`,`+
+				node("listItem", `"content":[`+para(text("with a panel"))+`,`+
+					node("panel", `"attrs":{"panelType":"info"},"content":[`+para(text("nested deep"))+`]`)+`]`)+
+				`]`)+`]`),
+)
+
+var headedTable = node("table", `"attrs":{"isNumberColumnEnabled":false,"layout":"default"},"content":[`+
+	row(cell("tableHeader", "Environment"), cell("tableHeader", "Reproduced"), cell("tableHeader", "Owner"))+`,`+
+	row(cell("tableCell", "staging"), cell("tableCell", "twice"), cell("tableCell", "the checkout team"))+`,`+
+	row(cell("tableCell", "production"), cell("tableCell", "never"), cell("tableCell", "nobody yet"))+
+	`]`)
+
+var headlessTable = node("table", `"content":[`+
+	row(cell("tableCell", "left"), cell("tableCell", "right"))+`,`+
+	row(cell("tableCell", "bottom left"), cell("tableCell", "bottom right"))+
+	`]`)
+
+// raggedTable is what an editor produces rather than what a schema promises: a
+// merged cell leaving a row short, a cell holding more than one block, and a
+// cell holding the character the grid is drawn with.
+var raggedTable = node("table", `"content":[`+
+	row(cell("tableHeader", "One"), cell("tableHeader", "Two"), cell("tableHeader", "Three"))+`,`+
+	row(node("tableCell", `"attrs":{"colspan":2},"content":[`+para(text("spans two"))+`]`), cell("tableCell", "last"))+`,`+
+	row(
+		node("tableCell", `"content":[`+para(text("first paragraph"))+`,`+para(text("second paragraph"))+`]`),
+		node("tableCell", `"content":[`+node("bulletList", `"content":[`+item("a")+`,`+item("b")+`]`)+`]`),
+		cell("tableCell", "a | b"))+
+	`]`)
+
+// wideTable holds a column of characters that are two cells wide, a column of
+// emoji, and a column with a combining acute, none of which a byte count or a
+// rune count measures correctly.
+var wideTable = node("table", `"content":[`+
+	row(cell("tableHeader", "言語"), cell("tableHeader", "Emoji"), cell("tableHeader", "Combining"))+`,`+
+	row(cell("tableCell", "日本語"), cell("tableCell", "🙂🙂"), cell("tableCell", "école"))+`,`+
+	row(cell("tableCell", "ascii"), cell("tableCell", "🚀"), cell("tableCell", "e\u0301cole"))+
+	`]`)
+
+func marksJSON(types []string) []string {
+	out := make([]string, 0, len(types))
+	for _, m := range types {
+		if m == "link" {
+			out = append(out, `{"type":"link","attrs":{"href":"https://example.com"}}`)
+			continue
+		}
+		out = append(out, `{"type":"`+m+`"}`)
+	}
+	return out
+}

--- a/pkg/adf/testdata/nested_lists.golden
+++ b/pkg/adf/testdata/nested_lists.golden
@@ -1,0 +1,19 @@
+- one
+  - one a
+    3. deep
+    4. deeper
+
+       ```sh
+       make check
+       ```
+- two
+
+  still two
+
+> quoted
+>
+> - in a quote
+> - with a panel
+>
+>   > ℹ INFO
+>   > nested deep

--- a/pkg/adf/testdata/rich_ascii_20.golden
+++ b/pkg/adf/testdata/rich_ascii_20.golden
@@ -1,0 +1,29 @@
+The basket total is **recalculated** before the line items are read, so an empty basket divides by zero. See [**the checkout runbook**](https://example.atlassian.net/wiki/spaces/EX/pages/98304) and the `basketTotal()` helper.
+
+## Steps to reproduce
+
+- Sign in as a customer with no saved basket.
+- Open <https://example.atlassian.net/browse/EX-2> and follow the linked route.
+- Ask @user to confirm the account state.
+
+> ! WARNING
+> Do not retry the request: each attempt writes an orphaned order row.
+
+```go
+func basketTotal(items []Item) Money {
+	var sum Money
+	for _, it := range items {
+		sum = sum.Add(it.Price)
+	}
+	return sum.Div(len(items))
+}
+```
+
+| Env... | Repr... |
+| ------ | ------- |
+| sta... | twice   |
+
+![media](media:3f6b1c72-9d0e-4a55-b1b7-6c6b0a9f2e41)
+
+> [unsupported: futureBlock]
+> This node type is not in any published ADF schema. It must survive the round trip untouched.

--- a/pkg/adf/testdata/rich_unicode.golden
+++ b/pkg/adf/testdata/rich_unicode.golden
@@ -1,0 +1,29 @@
+The basket total is **recalculated** before the line items are read, so an empty basket divides by zero. See [**the checkout runbook**](https://example.atlassian.net/wiki/spaces/EX/pages/98304) and the `basketTotal()` helper.
+
+## Steps to reproduce
+
+- Sign in as a customer with no saved basket.
+- Open <https://example.atlassian.net/browse/EX-2> and follow the linked route.
+- Ask @user to confirm the account state.
+
+> ⚠ WARNING
+> Do not retry the request: each attempt writes an orphaned order row.
+
+```go
+func basketTotal(items []Item) Money {
+	var sum Money
+	for _, it := range items {
+		sum = sum.Add(it.Price)
+	}
+	return sum.Div(len(items))
+}
+```
+
+| Environment | Reproduced |
+| ----------- | ---------- |
+| staging     | twice      |
+
+![media](media:3f6b1c72-9d0e-4a55-b1b7-6c6b0a9f2e41)
+
+> [unsupported: futureBlock]
+> This node type is not in any published ADF schema. It must survive the round trip untouched.

--- a/pkg/adf/testdata/table_header.golden
+++ b/pkg/adf/testdata/table_header.golden
@@ -1,0 +1,4 @@
+| Environment | Reproduced | Owner             |
+| ----------- | ---------- | ----------------- |
+| staging     | twice      | the checkout team |
+| production  | never      | nobody yet        |

--- a/pkg/adf/testdata/table_no_header.golden
+++ b/pkg/adf/testdata/table_no_header.golden
@@ -1,0 +1,2 @@
+| left        | right        |
+| bottom left | bottom right |

--- a/pkg/adf/testdata/table_ragged.golden
+++ b/pkg/adf/testdata/table_ragged.golden
@@ -1,4 +1,4 @@
 | One                              | Two     | Three  |
 | -------------------------------- | ------- | ------ |
-| spans two                        | last    |        |
+| spans two                        |         | last   |
 | first paragraph second paragraph | - a - b | a \| b |

--- a/pkg/adf/testdata/table_ragged.golden
+++ b/pkg/adf/testdata/table_ragged.golden
@@ -1,0 +1,4 @@
+| One                              | Two     | Three  |
+| -------------------------------- | ------- | ------ |
+| spans two                        | last    |        |
+| first paragraph second paragraph | - a - b | a \| b |

--- a/pkg/adf/testdata/table_squeezed.golden
+++ b/pkg/adf/testdata/table_squeezed.golden
@@ -1,0 +1,4 @@
+| Envir… | Reprod… | Owner   |
+| ------ | ------- | ------- |
+| stagi… | twice   | the ch… |
+| produ… | never   | nobody… |

--- a/pkg/adf/testdata/table_wide_runes.golden
+++ b/pkg/adf/testdata/table_wide_runes.golden
@@ -1,0 +1,4 @@
+| 言語   | Emoji | Combining |
+| ------ | ----- | --------- |
+| 日本語 | 🙂🙂  | école     |
+| ascii  | 🚀    | école     |

--- a/pkg/adf/testdata/unknown_only.golden
+++ b/pkg/adf/testdata/unknown_only.golden
@@ -1,0 +1,3 @@
+> [unsupported: multiBodiedExtension]
+> > [unsupported: extensionFrame]
+> > a chart lives here


### PR DESCRIPTION
Closes #5

## What this is

`pkg/adf/render*.go`: an ADF document rendered as markdown for a pager. Paragraphs, headings, nested
lists, code blocks with a language, blockquotes, rules, panels, tables, task and decision lists, and
the inline nodes that make a Jira ticket look like one — mentions, status lozenges, emoji, dates,
inline cards and media. Marks are order-insensitive, as `docs/API-NOTES.md` requires, because the
editor reorders them and the order carries no meaning.

An unknown node renders as `> [unsupported: <type>]` with its text beneath, rather than vanishing.
ADF grows node types faster than any client follows and `pkg/adf` already preserves them; the
renderer's job is to tell the reader something is there.

## A golden file changed, and it was wrong before

`table_ragged.golden` is the visible change in the second commit. A cell with `colspan` holds the
grid positions it spans, and emitting one column for it slid every later value left — so the table
said the wrong thing under a heading rather than merely looking untidy. The old golden had locked
that in, which is the argument for reading a golden diff instead of accepting it.

## What a review changed

- **Merged cells** as above: `colspan` is expanded, so a value stays under its own heading.
- **Nested task lists.** ADF's content model is `(taskItem | taskList)+`, so indenting an action item
  in the editor stores a sibling list inside its parent. Treating that child as an item rendered
  every entry as `[unsupported: taskItem]` and threw away the `DONE` state — a supported node type
  reported as an error.
- **The ASCII ellipsis.** The floor a column is squeezed to was a flat three cells, exactly the width
  of `...`, so a squeezed column in ASCII mode showed the ellipsis and nothing else. The floor is
  measured from the ellipsis in use now, which is one cell in Unicode and three in ASCII.
- **A tab in a cell** is folded to a space: `ansi.StringWidth` counts it as nothing while a terminal
  jumps to the next stop, so the padding was self-consistent and the grid still came out ragged.
- **The table's width budget** has the block prefix taken out of it, so a table inside a list or a
  quote fits the width it was given rather than overflowing by the indent.

Each of the three new tests was checked against the defect it covers: they fail with it and pass
without.

## Choices a reviewer might want to argue with

Width is the caller's to give (`Options.TableWidth`); the renderer does not guess at a terminal.
Output is plain text rather than styled, so P1.5 can put it in a viewport and style it there. Tables
get a delimiter row only when the first row is genuinely a header row — not GitHub-flavoured
markdown, but the honest thing for a pager to show.

Grapheme correctness is `github.com/charmbracelet/x/ansi` throughout; `len()` appears on no display
string.

https://claude.ai/code/session_01HBdKes6chEidvtGJnqFAMm