### PR TITLE
feat(cloud): P1.3 — probe what this token can do, and say why not

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -53,6 +53,17 @@ here cost time to find out; read this before writing an adapter method.
 | Permissions | `GET /rest/api/3/mypermissions?permissions=…` |
 | The user's timezone | `GET /rest/api/3/myself` |
 
+## Permissions, which is what the capability probe reads
+
+| Fact | Consequence |
+|---|---|
+| In the **global context** `mypermissions` reports a project permission as held if the token holds it in *any* project | An unscoped probe answers a different question from the one being asked, and answers it optimistically: it reports Move as available to a token that cannot move an issue in the project on screen. Always send `projectKey`. |
+| The `permissions` parameter is required, and an empty or unrecognised key is a **400** rather than a silently dropped one | Ask for a fixed, narrow list. Widening it speculatively is how a probe starts failing outright on a site that does not know the new key. |
+| A key that *was* asked for can still be missing from the answer, and a **404 means either "no such project" or "you may not see it"** — the endpoint does not distinguish them | Absent, `havePermission: false`, and "the call failed" are three different answers. Word all three differently; a view keyed off the wrong one is either hidden for no reason or lying about why. |
+| `BULK_CHANGE` is a `GLOBAL` permission while `MOVE_ISSUES`, `CREATE_ISSUES` and `DELETE_ISSUES` are `PROJECT` ones — each entry's `type` says which | A cross-project move needs the global one, Move in the source **and** Create in the target, so a probe scoped to one project can only half-answer it. The move flow has to re-check Create once a target is chosen. |
+| Every entry carries a localised `name` and `description` | The `name` is what the site's own administrator sees, in the site's own language, so it is the right wording for a capability's reason — and, being translated, it is never something to match on. |
+| `GET /rest/api/3/attachment/meta` answers the same question as `/configuration` with `enabled`, and adds `uploadLimit` | Narrower than reading the whole site configuration, and the only place the maximum attachment size comes from. |
+
 ## ADF
 
 | Fact | Consequence |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,7 +50,7 @@ instance from day one.
   Basic auth, `Retry-After` backoff, both paginators, repeated-cursor guard, request coalescing.
 - [ ] **P1.2 — Search and JQL** · [#3](https://github.com/varijkapil13/saral/issues/3) · **owns** `pkg/jira/cloud/search.go`, `internal/app/search.go`
   `POST /search/jql` with explicit field sets, `approximate-count`, saved queries.
-- [ ] **P1.3 — Capability probe** · [#4](https://github.com/varijkapil13/saral/issues/4) · **owns** `pkg/jira/cloud/caps.go`
+- [x] **P1.3 — Capability probe** · [#4](https://github.com/varijkapil13/saral/issues/4) · **owns** `pkg/jira/cloud/caps.go`
   `/mypermissions`, `/configuration`, `/myself`, `/plans` probe, board presence, terminal graphics
   detection. Populates `Capabilities` with a human-readable `Reason` for every negative.
 - [x] **P1.4 — ADF to markdown** · [#5](https://github.com/varijkapil13/saral/issues/5) · **owns** `pkg/adf/render*.go`

--- a/pkg/jira/cloud/caps.go
+++ b/pkg/jira/cloud/caps.go
@@ -1,0 +1,461 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const (
+	capsPermissionsPath   = "/rest/api/3/mypermissions"
+	capsConfigurationPath = "/rest/api/3/configuration"
+	capsMyselfPath        = "/rest/api/3/myself"
+	// The doubled segment is correct: /rest/api/3/plans does not exist.
+	capsPlansPath  = "/rest/api/3/plans/plan"
+	capsBoardsPath = "/rest/agile/1.0/board"
+)
+
+// capsApply writes one probe's answer into the result. A probe hands one back
+// instead of writing the struct itself, so that the writing happens after the
+// goroutines have joined rather than while they are still running.
+type capsApply func(*jira.Capabilities)
+
+// capsProbe is one independent question about this site, token and project.
+type capsProbe func(context.Context) (capsApply, error)
+
+// Capabilities probes what this site, token and project allow, and gives every
+// negative a sentence the UI can show as it stands.
+//
+// The probes run concurrently and independently. A site that will not answer
+// for attachments still reports its boards, because a refusal, a failure and a
+// silence are three different answers and only the caller can tell which of
+// them matters. Nothing here returns an error for a capability being absent:
+// that is the result. The error is reserved for what makes every answer
+// meaningless — a cancelled context, a credential Jira rejected, and a rate
+// limit, which says to ask again rather than anything about the token.
+//
+// An empty projectKey probes only what is site-wide. Boards, BulkMove and
+// DeleteIssues then come back unavailable with a reason saying that no project
+// was named, which is deliberately not the same answer as "this token may not":
+// Jira reports a project permission held in any project at all as held in the
+// global context, so an unscoped probe would report Move as available to a
+// token that cannot move an issue in the project actually being looked at.
+func (c *Client) Capabilities(ctx context.Context, projectKey string) (jira.Capabilities, error) {
+	project := strings.TrimSpace(projectKey)
+	caps := jira.Capabilities{Graphics: capsDetectGraphics(os.Getenv)}
+
+	probes := []capsProbe{c.capsAttachments, c.capsTimeZone, c.capsPlans}
+	if project == "" {
+		capsWithoutProject(&caps)
+	} else {
+		probes = append(probes,
+			func(ctx context.Context) (capsApply, error) { return c.capsPermissions(ctx, project) },
+			func(ctx context.Context) (capsApply, error) { return c.capsBoards(ctx, project) },
+		)
+	}
+
+	applies := make([]capsApply, len(probes))
+	errs := make([]error, len(probes))
+	var wg sync.WaitGroup
+	for i, probe := range probes {
+		wg.Go(func() { applies[i], errs[i] = probe(ctx) })
+	}
+	wg.Wait()
+
+	if err := capsVoid(ctx, errs); err != nil {
+		return jira.Capabilities{}, err
+	}
+	for _, apply := range applies {
+		apply(&caps)
+	}
+	return caps, nil
+}
+
+// capsVoid reports the failure that makes the whole probe meaningless rather
+// than one capability absent. A rejected credential and a rate limit are both
+// answers about the next attempt, so recording either as an absent capability
+// would tell someone with a mistyped token that they lack Bulk Change — and the
+// result is cached, so that would outlive the minute that caused it.
+func capsVoid(ctx context.Context, errs []error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, err := range errs {
+		var rejected *jira.AuthError
+		if errors.As(err, &rejected) {
+			return rejected
+		}
+	}
+	for _, err := range errs {
+		var limited *jira.RateLimitError
+		if errors.As(err, &limited) {
+			return limited
+		}
+	}
+	return nil
+}
+
+// capsWithoutProject answers the three per-project capabilities when there is
+// no project to ask about. Saying so is the whole point: leaving them absent
+// with no reason reads as "this token may not", which is a different answer.
+func capsWithoutProject(caps *jira.Capabilities) {
+	caps.Boards = jira.Capability{
+		Reason: "No project is selected, and a board belongs to a project",
+	}
+	caps.BulkMove = jira.Capability{
+		Reason: "No project is selected, and Jira grants Move Issues and Create Issues per project",
+	}
+	caps.DeleteIssues = jira.Capability{
+		Reason: "No project is selected, and Jira grants Delete Issues per project",
+	}
+}
+
+// capsFailed is the Reason for a probe that did not come back with an answer. A
+// 403 is an answer, and Jira's own sentence for it is what the user reads: the
+// site knows which permission scheme refused and this client does not. Anything
+// else says what could not be checked, because "no" and "not known" must not
+// read the same in the footer.
+func capsFailed(subject string, err error) string {
+	var refused *jira.CapabilityError
+	if errors.As(err, &refused) {
+		return refused.Error()
+	}
+	return "Jira did not answer " + subject + ": " + err.Error()
+}
+
+// capsAttachments asks whether the site has attachments switched on at all. It
+// is deliberately not also a permission check: reading one needs nothing beyond
+// seeing the issue, so folding Create Attachments in here would hide the whole
+// view from someone who may perfectly well read it.
+func (c *Client) capsAttachments(ctx context.Context) (capsApply, error) {
+	var body struct {
+		AttachmentsEnabled bool `json:"attachmentsEnabled"`
+	}
+	err := c.doJSON(ctx, request{
+		method: http.MethodGet,
+		path:   capsConfigurationPath,
+		kind:   "the site configuration",
+		id:     c.base.Host,
+	}, &body)
+
+	var got jira.Capability
+	switch {
+	case err != nil:
+		got.Reason = capsFailed("whether attachments are enabled on this site", err)
+	case body.AttachmentsEnabled:
+		got.OK = true
+	default:
+		got.Reason = "Attachments are switched off for this site, which only a Jira administrator can change"
+	}
+	return func(caps *jira.Capabilities) { caps.Attachments = got }, err
+}
+
+// capsTimeZone reads the account's timezone, which is the one Jira renders its
+// own dates in and the one this client must render them in too. The machine's
+// zone is not it: an issue due "today" is due today where the account lives.
+func (c *Client) capsTimeZone(ctx context.Context) (capsApply, error) {
+	var body struct {
+		TimeZone string `json:"timeZone"`
+	}
+	err := c.doJSON(ctx, request{
+		method: http.MethodGet,
+		path:   capsMyselfPath,
+		kind:   "account",
+		id:     "the authenticated account",
+	}, &body)
+
+	var zone *time.Location
+	if err == nil && body.TimeZone != "" {
+		// A machine carrying no zoneinfo database, or a zone name Go does not
+		// know, is not a Jira failure and must not read as one: dates then
+		// render in UTC, which is what Capabilities.Location falls back to.
+		if loaded, loadErr := time.LoadLocation(body.TimeZone); loadErr == nil {
+			zone = loaded
+		}
+	}
+	return func(caps *jira.Capabilities) { caps.TimeZone = zone }, err
+}
+
+// capsPlans asks whether the Plans API answers this token at all. A 403 is the
+// ordinary reply — every one of its endpoints wants Administer Jira, and the
+// per-plan rights the web UI hands out do not grant it — so it is a capability
+// result here rather than a failure.
+func (c *Client) capsPlans(ctx context.Context) (capsApply, error) {
+	_, err := c.do(ctx, request{
+		method: http.MethodGet,
+		path:   capsPlansPath,
+		query:  url.Values{"maxResults": []string{"1"}},
+		kind:   "the plan list",
+		id:     capsPlansPath,
+	})
+
+	var got jira.Capability
+	var missing *jira.NotFoundError
+	switch {
+	case err == nil:
+		got.OK = true
+	case errors.As(err, &missing):
+		got.Reason = "This site has no Plans API, which arrives with a Jira Premium subscription"
+	default:
+		got.Reason = capsFailed("whether this token can read plans", err)
+	}
+	return func(caps *jira.Capabilities) { caps.Plans = got }, err
+}
+
+// capsBoards asks whether the project has a board. Absence is an ordinary
+// answer — a project can be run entirely from the issue list — and it is not
+// the same answer as the Agile API refusing to say.
+func (c *Client) capsBoards(ctx context.Context, projectKey string) (capsApply, error) {
+	req := request{
+		method: http.MethodGet,
+		path:   capsBoardsPath,
+		query: url.Values{
+			"projectKeyOrId": []string{projectKey},
+			"maxResults":     []string{"1"},
+		},
+		kind: "project",
+		id:   projectKey,
+	}
+	resp, err := c.do(ctx, req)
+	// Only how many came back matters here; what is in a board is not this
+	// probe's business.
+	var boards []json.RawMessage
+	if err == nil {
+		boards, _, _, err = decodeAgilePage[json.RawMessage](resp, req.op())
+	}
+
+	var got jira.Capability
+	switch {
+	case err != nil:
+		got.Reason = capsFailed("whether "+projectKey+" has a board", err)
+	case len(boards) == 0:
+		got.Reason = projectKey + " has no board"
+	default:
+		got.OK = true
+	}
+	return func(caps *jira.Capabilities) { caps.Boards = got }, err
+}
+
+// capsPermission is one entry of the mypermissions response. Name is the site's
+// own wording for the permission, in the site's own language, which is what the
+// user's administrator sees and therefore what to put in front of the user.
+type capsPermission struct {
+	Name           string `json:"name"`
+	HavePermission bool   `json:"havePermission"`
+}
+
+func (p capsPermission) label(fallback string) string {
+	if name := strings.TrimSpace(p.Name); name != "" {
+		return name
+	}
+	return fallback
+}
+
+// capsRequirement is one permission a capability needs. The label is only used
+// where the site sent no name of its own for it, which is every permission the
+// site left out of its answer.
+type capsRequirement struct {
+	key   string
+	label string
+}
+
+var (
+	// Moving an issue to another project needs the global Bulk Change
+	// permission, Move in the project it leaves and Create in the one it
+	// arrives in. Only the project being probed is known here, so this answers
+	// for a move out of it; the move itself has to re-check Create against
+	// whichever project the user picks as the target.
+	capsBulkMoveNeeds = []capsRequirement{
+		{key: "BULK_CHANGE", label: "Bulk Change"},
+		{key: "MOVE_ISSUES", label: "Move Issues"},
+		{key: "CREATE_ISSUES", label: "Create Issues"},
+	}
+	capsDeleteIssuesNeeds = []capsRequirement{
+		{key: "DELETE_ISSUES", label: "Delete Issues"},
+	}
+)
+
+// capsWanted is the permissions parameter, which is required and decides the
+// whole of the answer: Jira replies with the keys asked for and nothing else.
+func capsWanted() string {
+	keys := make([]string, 0, len(capsBulkMoveNeeds)+len(capsDeleteIssuesNeeds))
+	for _, need := range slices.Concat(capsBulkMoveNeeds, capsDeleteIssuesNeeds) {
+		keys = append(keys, need.key)
+	}
+	slices.Sort(keys)
+	return strings.Join(slices.Compact(keys), ",")
+}
+
+// capsPermissions asks what this token may do in one project.
+func (c *Client) capsPermissions(ctx context.Context, projectKey string) (capsApply, error) {
+	var body struct {
+		Permissions map[string]capsPermission `json:"permissions"`
+	}
+	err := c.doJSON(ctx, request{
+		method: http.MethodGet,
+		path:   capsPermissionsPath,
+		query: url.Values{
+			"projectKey":  []string{projectKey},
+			"permissions": []string{capsWanted()},
+		},
+		kind: "project",
+		id:   projectKey,
+	}, &body)
+
+	var bulkMove, deleteIssues jira.Capability
+	if err != nil {
+		unknown := jira.Capability{Reason: capsFailed("what this token may do in "+projectKey, err)}
+		bulkMove, deleteIssues = unknown, unknown
+	} else {
+		bulkMove = capsAllow(body.Permissions, capsBulkMoveNeeds, "move issues between projects")
+		deleteIssues = capsAllow(body.Permissions, capsDeleteIssuesNeeds, "delete issues")
+	}
+	return func(caps *jira.Capabilities) {
+		caps.BulkMove, caps.DeleteIssues = bulkMove, deleteIssues
+	}, err
+}
+
+// capsAllow turns what Jira said about a set of permissions into one capability
+// and the sentence explaining it.
+//
+// A permission the answer does not mention is not a permission denied. Jira
+// sends back the keys it was asked for, so a missing one means the site did not
+// answer for it — an unknown key on this site, or one the endpoint dropped —
+// and reporting that as a refusal invents a denial the site never made.
+func capsAllow(answers map[string]capsPermission, needs []capsRequirement, action string) jira.Capability {
+	var refused, unanswered []string
+	for _, need := range needs {
+		answer, mentioned := answers[need.key]
+		switch {
+		case !mentioned:
+			unanswered = append(unanswered, need.label)
+		case !answer.HavePermission:
+			refused = append(refused, answer.label(need.label))
+		}
+	}
+
+	switch {
+	case len(refused) == 0 && len(unanswered) == 0:
+		return jira.Capability{OK: true}
+	case len(unanswered) == 0:
+		return jira.Capability{Reason: fmt.Sprintf("You need the %s %s to %s",
+			capsList(refused), capsNoun(len(refused)), action)}
+	case len(refused) == 0:
+		return jira.Capability{Reason: fmt.Sprintf("Jira did not answer for the %s %s, which is needed to %s",
+			capsList(unanswered), capsNoun(len(unanswered)), action)}
+	default:
+		return jira.Capability{Reason: fmt.Sprintf("You need the %s %s to %s, and Jira did not answer for the %s %s",
+			capsList(refused), capsNoun(len(refused)), action,
+			capsList(unanswered), capsNoun(len(unanswered)))}
+	}
+}
+
+func capsNoun(n int) string {
+	if n == 1 {
+		return "permission"
+	}
+	return "permissions"
+}
+
+// capsList writes a list the way a sentence does, because this one is read by a
+// person rather than parsed.
+func capsList(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + " and " + items[len(items)-1]
+	}
+}
+
+// capsEnv reads one environment variable. os.Getenv is the real one; a test
+// passes its own so that detection can be exercised without a terminal and
+// without touching the process.
+type capsEnv func(string) string
+
+// capsDetectGraphics works out how, if at all, this terminal can show an image.
+// It reads the environment rather than writing a query escape sequence and
+// waiting for a reply: stdout may be a pipe, and a query nobody answers either
+// blocks or leaves its own bytes on somebody's screen. Being wrong costs more
+// upwards than downwards — claiming a protocol the terminal lacks prints
+// garbage over the frame, missing one prints blocks — so each rule below fires
+// only on a terminal known to speak it.
+func capsDetectGraphics(env capsEnv) jira.GraphicsMode {
+	term := strings.ToLower(strings.TrimSpace(env("TERM")))
+	program := strings.ToLower(strings.TrimSpace(env("TERM_PROGRAM")))
+	if term == "" || term == "dumb" {
+		return jira.GraphicsNone
+	}
+	if !capsMultiplexed(env, term) {
+		switch {
+		case capsSpeaksKitty(env, term, program):
+			return jira.GraphicsKitty
+		case capsSpeaksITerm2(env, term, program):
+			return jira.GraphicsITerm2
+		}
+	}
+	if capsHasColor(env, term) {
+		return jira.GraphicsHalfBlocks
+	}
+	return jira.GraphicsNone
+}
+
+// capsMultiplexed reports a terminal with tmux or screen in the middle, where
+// an image protocol does not survive the trip whatever the outer terminal is.
+func capsMultiplexed(env capsEnv, term string) bool {
+	return env("TMUX") != "" || strings.HasPrefix(term, "screen") || strings.HasPrefix(term, "tmux")
+}
+
+func capsSpeaksKitty(env capsEnv, term, program string) bool {
+	switch {
+	case env("KITTY_WINDOW_ID") != "", strings.Contains(term, "kitty"):
+		return true
+	case program == "ghostty", env("GHOSTTY_RESOURCES_DIR") != "":
+		return true
+	case program == "wezterm", env("WEZTERM_PANE") != "":
+		return true
+	default:
+		return false
+	}
+}
+
+func capsSpeaksITerm2(env capsEnv, term, program string) bool {
+	switch {
+	case program == "iterm.app", env("ITERM_SESSION_ID") != "":
+		return true
+	// iTerm sets LC_TERMINAL and forwards it, which is how the protocol is
+	// still there after an ssh into somewhere with a plain TERM.
+	case strings.EqualFold(strings.TrimSpace(env("LC_TERMINAL")), "iTerm2"):
+		return true
+	case program == "mintty", strings.Contains(term, "mintty"):
+		return true
+	default:
+		return false
+	}
+}
+
+// capsHasColor reports whether half blocks are worth drawing: they are two
+// coloured cells stacked in one character, so with no colour there is no
+// picture — and NO_COLOR is a request not to send any.
+func capsHasColor(env capsEnv, term string) bool {
+	if env("NO_COLOR") != "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(env("COLORTERM"))) {
+	case "truecolor", "24bit":
+		return true
+	}
+	return strings.Contains(term, "256color") || strings.Contains(term, "direct")
+}

--- a/pkg/jira/cloud/caps.go
+++ b/pkg/jira/cloud/caps.go
@@ -102,6 +102,27 @@ func capsVoid(ctx context.Context, errs []error) error {
 			return limited
 		}
 	}
+	// A host that never answered makes every answer as meaningless as a rejected
+	// credential does. Reporting five confident denials instead would be cached
+	// as "this token may do nothing", and the caller has no typed signal to tell
+	// a locked-down token from a mistyped site or one dropped packet —
+	// docs/ARCHITECTURE.md wants a transport failure to leave the cached answer
+	// standing behind a stale badge, which it cannot do if the probe says it
+	// succeeded.
+	var unreachable *jira.TransportError
+	for _, err := range errs {
+		if err == nil {
+			return nil
+		}
+		var broken *jira.TransportError
+		if !errors.As(err, &broken) {
+			return nil
+		}
+		unreachable = broken
+	}
+	if unreachable != nil {
+		return unreachable
+	}
 	return nil
 }
 

--- a/pkg/jira/cloud/caps_test.go
+++ b/pkg/jira/cloud/caps_test.go
@@ -1,0 +1,645 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+const capsProject = "EX"
+
+// capsPlansReason is what plans_403.json says, which is the sentence the probe
+// has to put in front of the user rather than the status code.
+const capsPlansReason = "The Plans API requires the Administer Jira global permission, and a Jira Premium subscription."
+
+// capsJSON answers a route with a body written here rather than in a fixture,
+// for the two shapes no fixture carries: a project with no board, and a
+// timezone no zoneinfo database knows.
+func capsJSON(method, pattern string, status int, body string) jiratest.ServerOption {
+	return jiratest.WithHandler(method, pattern, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+func capsFakeEnv(vars map[string]string) capsEnv {
+	return func(name string) string { return vars[name] }
+}
+
+// capsAssert checks one probe result, reason included: the reason is UI text,
+// so a change to it is a change to what the user reads.
+func capsAssert(t *testing.T, name string, got jira.Capability, wantOK bool, wantReason string) {
+	t.Helper()
+
+	if got.OK != wantOK {
+		t.Errorf("%s.OK = %v, want %v (reason %q)", name, got.OK, wantOK, got.Reason)
+	}
+	if got.Reason != wantReason {
+		t.Errorf("%s.Reason = %q, want %q", name, got.Reason, wantReason)
+	}
+}
+
+func capsServed(t *testing.T, s *jiratest.Server, path string) jiratest.Request {
+	t.Helper()
+
+	for _, req := range s.Requests() {
+		if req.Path == path {
+			return req
+		}
+	}
+	t.Fatalf("no request was served for %s", path)
+	return jiratest.Request{}
+}
+
+func capsCount(s *jiratest.Server, path string) int {
+	n := 0
+	for _, req := range s.Requests() {
+		if req.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCapabilities_AnswersEveryCapabilityForATokenThatMayDoEverything(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+
+	tests := []struct {
+		name   string
+		got    jira.Capability
+		wantOK bool
+		reason string
+	}{
+		{name: "Attachments", got: got.Attachments, wantOK: true},
+		{name: "Boards", got: got.Boards, wantOK: true},
+		{name: "BulkMove", got: got.BulkMove, wantOK: true},
+		{name: "DeleteIssues", got: got.DeleteIssues, wantOK: true},
+		{name: "Plans", got: got.Plans, reason: capsPlansReason},
+	}
+	for _, tt := range tests {
+		capsAssert(t, tt.name, tt.got, tt.wantOK, tt.reason)
+	}
+
+	if served := len(s.Requests()); served != 5 {
+		t.Errorf("the site served %d requests, want one per probe", served)
+	}
+}
+
+func TestCapabilities_ExplainsWhatABasicTokenMayNotDo(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithFixture(http.MethodGet, capsPermissionsPath, "mypermissions_basic.json"))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+
+	// The basic fixture refuses Move Issues and never mentions Bulk Change at
+	// all, and the two are different answers: one is a denial the site made and
+	// the other is a question it did not answer.
+	capsAssert(t, "BulkMove", got.BulkMove, false,
+		"You need the Move Issues permission to move issues between projects, and Jira did not answer for the Bulk Change permission")
+	capsAssert(t, "DeleteIssues", got.DeleteIssues, false,
+		"You need the Delete Issues permission to delete issues")
+}
+
+func TestCapabilities_NamesEveryPermissionAnActionNeeds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		answers map[string]capsPermission
+		needs   []capsRequirement
+		wantOK  bool
+		reason  string
+	}{
+		{
+			name: "every permission granted",
+			answers: map[string]capsPermission{
+				"BULK_CHANGE":   {Name: "Make bulk changes", HavePermission: true},
+				"MOVE_ISSUES":   {Name: "Move Issues", HavePermission: true},
+				"CREATE_ISSUES": {Name: "Create Issues", HavePermission: true},
+			},
+			needs:  capsBulkMoveNeeds,
+			wantOK: true,
+		},
+		{
+			name: "two of the three refused, in the site's own words",
+			answers: map[string]capsPermission{
+				"BULK_CHANGE":   {Name: "Massenänderungen", HavePermission: false},
+				"MOVE_ISSUES":   {Name: "Vorgänge verschieben", HavePermission: false},
+				"CREATE_ISSUES": {Name: "Vorgänge erstellen", HavePermission: true},
+			},
+			needs:  capsBulkMoveNeeds,
+			reason: "You need the Massenänderungen and Vorgänge verschieben permissions to move issues between projects",
+		},
+		{
+			name: "all three refused reads as a list",
+			answers: map[string]capsPermission{
+				"BULK_CHANGE":   {Name: "Make bulk changes"},
+				"MOVE_ISSUES":   {Name: "Move Issues"},
+				"CREATE_ISSUES": {Name: "Create Issues"},
+			},
+			needs:  capsBulkMoveNeeds,
+			reason: "You need the Make bulk changes, Move Issues and Create Issues permissions to move issues between projects",
+		},
+		{
+			name:    "a site that answered for none of them",
+			answers: map[string]capsPermission{},
+			needs:   capsDeleteIssuesNeeds,
+			reason:  "Jira did not answer for the Delete Issues permission, which is needed to delete issues",
+		},
+		{
+			name: "a permission with no name of its own falls back to ours",
+			answers: map[string]capsPermission{
+				"DELETE_ISSUES": {HavePermission: false},
+			},
+			needs:  capsDeleteIssuesNeeds,
+			reason: "You need the Delete Issues permission to delete issues",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			action := "delete issues"
+			if len(tt.needs) > 1 {
+				action = "move issues between projects"
+			}
+			capsAssert(t, "capsAllow", capsAllow(tt.answers, tt.needs, action), tt.wantOK, tt.reason)
+		})
+	}
+}
+
+func TestCapabilities_RepeatsJirasOwnWordsWhenItRefusesAProbe(t *testing.T) {
+	t.Parallel()
+
+	const refusal = "You do not have permission to view this project, or it does not exist."
+	s := jiratest.NewServer(capsJSON(http.MethodGet, capsPermissionsPath, http.StatusForbidden,
+		`{"errorMessages":["`+refusal+`"],"errors":{}}`))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+
+	capsAssert(t, "BulkMove", got.BulkMove, false, refusal)
+	capsAssert(t, "DeleteIssues", got.DeleteIssues, false, refusal)
+	capsAssert(t, "Boards", got.Boards, true, "")
+}
+
+func TestCapabilities_ReportsAPlansApiThisTokenCanReach(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithFixture(http.MethodGet, capsPlansPath, "plans_ok.json"))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+	capsAssert(t, "Plans", got.Plans, true, "")
+}
+
+func TestCapabilities_SaysWhenTheSiteHasNoPlansApiAtAll(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, capsPlansPath, http.StatusNotFound, ""))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+	capsAssert(t, "Plans", got.Plans, false,
+		"This site has no Plans API, which arrives with a Jira Premium subscription")
+}
+
+func TestCapabilities_SaysWhenAProjectHasNoBoard(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(capsJSON(http.MethodGet, capsBoardsPath, http.StatusOK,
+		`{"maxResults":1,"startAt":0,"total":0,"isLast":true,"values":[]}`))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+	capsAssert(t, "Boards", got.Boards, false, capsProject+" has no board")
+}
+
+func TestCapabilities_SaysWhenTheSiteHasAttachmentsSwitchedOff(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(capsJSON(http.MethodGet, capsConfigurationPath, http.StatusOK,
+		`{"attachmentsEnabled":false,"votingEnabled":true,"timeTrackingEnabled":true}`))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+	capsAssert(t, "Attachments", got.Attachments, false,
+		"Attachments are switched off for this site, which only a Jira administrator can change")
+}
+
+func TestCapabilities_KeepsTheOtherAnswersWhenOneProbeFails(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, capsConfigurationPath, http.StatusInternalServerError, ""))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("a failed probe sank the whole capability probe: %v", err)
+	}
+
+	capsAssert(t, "Attachments", got.Attachments, false,
+		"Jira did not answer whether attachments are enabled on this site: GET /rest/api/3/configuration failed with HTTP 500: Internal Server Error")
+	capsAssert(t, "Boards", got.Boards, true, "")
+	capsAssert(t, "BulkMove", got.BulkMove, true, "")
+	if got.TimeZone == nil {
+		t.Error("the timezone probe was lost with the configuration one")
+	}
+}
+
+func TestCapabilities_SaysWhichAnswersNeedAProjectWhenThereIsNone(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), "   ")
+	if err != nil {
+		t.Fatalf("probing with no project: %v", err)
+	}
+
+	capsAssert(t, "Boards", got.Boards, false,
+		"No project is selected, and a board belongs to a project")
+	capsAssert(t, "BulkMove", got.BulkMove, false,
+		"No project is selected, and Jira grants Move Issues and Create Issues per project")
+	capsAssert(t, "DeleteIssues", got.DeleteIssues, false,
+		"No project is selected, and Jira grants Delete Issues per project")
+	capsAssert(t, "Attachments", got.Attachments, true, "")
+	capsAssert(t, "Plans", got.Plans, false, capsPlansReason)
+
+	// Asking Jira for a project permission without naming a project is worse
+	// than not asking: it answers yes when the token holds it in any project at
+	// all, which is a different question from the one being put.
+	for _, path := range []string{capsPermissionsPath, capsBoardsPath} {
+		if n := capsCount(s, path); n != 0 {
+			t.Errorf("%s was requested %d times with no project to scope it to", path, n)
+		}
+	}
+}
+
+func TestCapabilities_ReadsTheAccountTimezoneRatherThanTheMachines(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+
+	if got.TimeZone == nil {
+		t.Fatal("the account timezone came back nil")
+	}
+	if name := got.TimeZone.String(); name != "Europe/Berlin" {
+		t.Errorf("timezone = %s, want the one myself.json reports", name)
+	}
+	if got.Location() != got.TimeZone {
+		t.Error("Location did not return the probed zone")
+	}
+}
+
+func TestCapabilities_FallsBackToUTCWhenTheZoneNameIsUnknownHere(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(capsJSON(http.MethodGet, capsMyselfPath, http.StatusOK,
+		`{"accountId":"5b10a2844c20165700ede21g","timeZone":"Mars/Olympus"}`))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("a zone this machine cannot load sank the probe: %v", err)
+	}
+	if got.TimeZone != nil {
+		t.Errorf("timezone = %v, want none for a zone no zoneinfo database has", got.TimeZone)
+	}
+	if got.Location() != time.UTC {
+		t.Errorf("Location = %v, want UTC", got.Location())
+	}
+}
+
+func TestCapabilities_ReturnsTheRejectedCredentialRatherThanAbsentCapabilities(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(capsJSON(http.MethodGet, capsMyselfPath, http.StatusUnauthorized,
+		`{"errorMessages":["Client must be authenticated to access this resource."],"errors":{}}`))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+
+	var rejected *jira.AuthError
+	if !errors.As(err, &rejected) {
+		t.Fatalf("got %T (%v), want a *jira.AuthError", err, err)
+	}
+	if got != (jira.Capabilities{}) {
+		t.Errorf("capabilities = %+v, want none alongside a rejected credential", got)
+	}
+}
+
+func TestCapabilities_ReturnsTheRateLimitRatherThanAbsentCapabilities(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithRateLimit(http.MethodGet, capsPermissionsPath, 30*time.Second))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+	got, err := c.Capabilities(t.Context(), capsProject)
+
+	var limited *jira.RateLimitError
+	if !errors.As(err, &limited) {
+		t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+	}
+	if limited.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %s, want the 30s the site asked for", limited.RetryAfter)
+	}
+	if got != (jira.Capabilities{}) {
+		t.Errorf("capabilities = %+v, want none while the site is refusing to answer", got)
+	}
+}
+
+func TestCapabilities_StopsWhenTheCallerCancels(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(ctx, capsProject)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the caller's own cancellation", err)
+	}
+	if got != (jira.Capabilities{}) {
+		t.Errorf("capabilities = %+v, want none from a cancelled probe", got)
+	}
+	if served := len(s.Requests()); served != 0 {
+		t.Errorf("the site served %d requests after the caller left", served)
+	}
+}
+
+func TestCapabilities_AsksOnlyForThePermissionsItNeeds(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.Capabilities(t.Context(), capsProject); err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+
+	permissions, err := url.ParseQuery(capsServed(t, s, capsPermissionsPath).Query)
+	if err != nil {
+		t.Fatalf("reading the permissions query: %v", err)
+	}
+	if got := permissions.Get("projectKey"); got != capsProject {
+		t.Errorf("projectKey = %q, want the project being probed", got)
+	}
+	if got := permissions.Get("permissions"); got != "BULK_CHANGE,CREATE_ISSUES,DELETE_ISSUES,MOVE_ISSUES" {
+		t.Errorf("permissions = %q, want the four the capabilities need and no more", got)
+	}
+
+	boards, err := url.ParseQuery(capsServed(t, s, capsBoardsPath).Query)
+	if err != nil {
+		t.Fatalf("reading the board query: %v", err)
+	}
+	if got := boards.Get("projectKeyOrId"); got != capsProject {
+		t.Errorf("projectKeyOrId = %q, want the project being probed", got)
+	}
+	if got := boards.Get("maxResults"); got != "1" {
+		t.Errorf("maxResults = %q, want the one board that answers the question", got)
+	}
+}
+
+func TestCapabilities_ProbesEachEndpointOnce(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.Capabilities(t.Context(), capsProject); err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+
+	for _, path := range []string{
+		capsPermissionsPath, capsConfigurationPath, capsMyselfPath, capsPlansPath, capsBoardsPath,
+	} {
+		if n := capsCount(s, path); n != 1 {
+			t.Errorf("%s was requested %d times, want once", path, n)
+		}
+	}
+}
+
+func TestDetectGraphics_ReadsTheTerminalOutOfTheEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want jira.GraphicsMode
+	}{
+		{
+			name: "nothing in the environment is not a terminal",
+			env:  map[string]string{},
+			want: jira.GraphicsNone,
+		},
+		{
+			name: "a dumb terminal gets text",
+			env:  map[string]string{"TERM": "dumb", "COLORTERM": "truecolor"},
+			want: jira.GraphicsNone,
+		},
+		{
+			name: "kitty by its TERM",
+			env:  map[string]string{"TERM": "xterm-kitty"},
+			want: jira.GraphicsKitty,
+		},
+		{
+			name: "kitty by its window id under a borrowed TERM",
+			env:  map[string]string{"TERM": "xterm-256color", "KITTY_WINDOW_ID": "1"},
+			want: jira.GraphicsKitty,
+		},
+		{
+			name: "ghostty speaks the kitty protocol",
+			env:  map[string]string{"TERM": "xterm-256color", "TERM_PROGRAM": "ghostty"},
+			want: jira.GraphicsKitty,
+		},
+		{
+			name: "wezterm speaks it too",
+			env:  map[string]string{"TERM": "xterm-256color", "WEZTERM_PANE": "0"},
+			want: jira.GraphicsKitty,
+		},
+		{
+			name: "iTerm2 by its program name",
+			env:  map[string]string{"TERM": "xterm-256color", "TERM_PROGRAM": "iTerm.app"},
+			want: jira.GraphicsITerm2,
+		},
+		{
+			name: "iTerm2 forwarded through ssh by LC_TERMINAL",
+			env:  map[string]string{"TERM": "xterm-256color", "LC_TERMINAL": "iTerm2"},
+			want: jira.GraphicsITerm2,
+		},
+		{
+			name: "mintty speaks the iTerm2 protocol on Windows",
+			env:  map[string]string{"TERM": "mintty", "TERM_PROGRAM": "mintty"},
+			want: jira.GraphicsITerm2,
+		},
+		{
+			name: "an image protocol does not survive tmux",
+			env:  map[string]string{"TERM": "screen-256color", "TMUX": "/tmp/tmux-501/default,1,0", "KITTY_WINDOW_ID": "1"},
+			want: jira.GraphicsHalfBlocks,
+		},
+		{
+			name: "a 256 colour terminal draws half blocks",
+			env:  map[string]string{"TERM": "xterm-256color"},
+			want: jira.GraphicsHalfBlocks,
+		},
+		{
+			name: "true colour with a plain TERM draws them as well",
+			env:  map[string]string{"TERM": "xterm", "COLORTERM": "truecolor"},
+			want: jira.GraphicsHalfBlocks,
+		},
+		{
+			name: "sixteen colours are not enough to be worth it",
+			env:  map[string]string{"TERM": "xterm"},
+			want: jira.GraphicsNone,
+		},
+		{
+			name: "NO_COLOR takes the colour away and with it the blocks",
+			env:  map[string]string{"TERM": "xterm-256color", "NO_COLOR": "1"},
+			want: jira.GraphicsNone,
+		},
+		{
+			name: "NO_COLOR is not a request to stop showing images",
+			env:  map[string]string{"TERM": "xterm-kitty", "NO_COLOR": "1"},
+			want: jira.GraphicsKitty,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := capsDetectGraphics(capsFakeEnv(tt.env)); got != tt.want {
+				t.Errorf("graphics = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// The environment is process-wide, so this one cannot run in parallel with
+// anything: t.Setenv says so and the testing package enforces it.
+func TestCapabilities_ReportsTheTerminalItWasStartedIn(t *testing.T) {
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	for _, unset := range []string{"KITTY_WINDOW_ID", "TERM_PROGRAM", "LC_TERMINAL", "WEZTERM_PANE", "TMUX", "NO_COLOR"} {
+		t.Setenv(unset, "")
+	}
+	t.Setenv("TERM", "xterm-kitty")
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+	if got.Graphics != jira.GraphicsKitty {
+		t.Errorf("graphics = %s, want kitty from TERM", got.Graphics)
+	}
+}
+
+func TestCapsList_WritesAListTheWayASentenceDoes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		items []string
+		want  string
+	}{
+		{name: "nothing at all", items: nil, want: ""},
+		{name: "one", items: []string{"Move Issues"}, want: "Move Issues"},
+		{name: "two", items: []string{"Move Issues", "Create Issues"}, want: "Move Issues and Create Issues"},
+		{
+			name:  "three",
+			items: []string{"Bulk Change", "Move Issues", "Create Issues"},
+			want:  "Bulk Change, Move Issues and Create Issues",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := capsList(tt.items); got != tt.want {
+				t.Errorf("capsList = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapsFailed_PrefersJirasOwnSentenceToOurs(t *testing.T) {
+	t.Parallel()
+
+	refused := capsFailed("whether this token can read plans",
+		&jira.CapabilityError{Capability: jira.CapPlans, Reason: capsPlansReason})
+	if refused != capsPlansReason {
+		t.Errorf("reason = %q, want Jira's own sentence", refused)
+	}
+
+	broken := capsFailed("whether this token can read plans", errors.New("the connection was reset"))
+	const want = "Jira did not answer whether this token can read plans: the connection was reset"
+	if broken != want {
+		t.Errorf("reason = %q, want %q", broken, want)
+	}
+	if !strings.HasPrefix(broken, "Jira did not answer") {
+		t.Error("a failure to reach Jira reads as a refusal by Jira")
+	}
+}

--- a/pkg/jira/cloud/caps_test.go
+++ b/pkg/jira/cloud/caps_test.go
@@ -643,3 +643,27 @@ func TestCapsFailed_PrefersJirasOwnSentenceToOurs(t *testing.T) {
 		t.Error("a failure to reach Jira reads as a refusal by Jira")
 	}
 }
+
+func TestCapabilities_ReportsAnUnreachableSiteRatherThanFiveDenials(t *testing.T) {
+	t.Parallel()
+
+	// A mistyped site, a DNS failure, captive wifi. Every probe fails at the
+	// transport, and answering "you may do nothing" would be cached — and worse,
+	// the kernel replaces a good capability set with it on a refresh.
+	refused := &stubDoer{err: &url.Error{
+		Op:  "Get",
+		URL: "https://example.atlassian.net/rest/api/3/configuration",
+		Err: errors.New("dial tcp 127.0.0.1:9: connect: connection refused"),
+	}}
+	c, _ := testClient(t, "example.atlassian.net",
+		WithHTTPClient(refused), WithRetry(RetryPolicy{Attempts: 1}))
+
+	caps, err := c.Capabilities(t.Context(), "EX")
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got caps=%+v err=%v; want a *jira.TransportError: a host that never answered has told us nothing", caps, err)
+	}
+	if caps.Attachments.OK || caps.BulkMove.OK {
+		t.Error("a voided probe should not also hand back capabilities")
+	}
+}


### PR DESCRIPTION
Closes #4

## What this is

`Capabilities(ctx, projectKey)` on the cloud client: `/mypermissions`, `/configuration`, `/myself`,
`/plans/plan` and board presence, run concurrently, each negative carrying a reason the UI shows
verbatim.

## Decisions worth arguing with

**An empty project key sends no per-project request at all.** Not to save a round trip: in the global
context Jira reports a project permission as held if it is held in **any** project, so an unscoped
`/mypermissions` answers a more flattering question than the one asked. The three per-project
capabilities come back unavailable with reasons naming the missing project.

**Absent and `havePermission: false` are different answers, and get different wording.**
`/mypermissions` returns only the keys you asked for. Absent → "Jira did not answer for the Bulk
Change permission, which is needed to move issues between projects". False → "You need the Move
Issues permission to…". The permission label is the site's own localised `name` from the response —
the words the user's admin sees — and a built-in English label appears only when Jira sent none.

**No `errgroup`, deliberately.** Its value is cancelling siblings on the first error, and here a
failed probe is a *result*, not an error. A `WaitGroup` runs the probes, each returning a closure
applied after the barrier, so nothing mutates shared state while goroutines run.

**Attachments is instance-only**, not `AND CREATE_ATTACHMENTS` — reading an attachment needs no
permission, and folding upload rights in would hide the whole view from someone who can read it. P4.2
checks `CREATE_ATTACHMENTS` itself.

**Graphics detection is in the wrong package and is here anyway.** It is a terminal property, but the
frozen port carries `GraphicsMode` on `Capabilities` and the import-boundary test stops `internal/ui`
importing this package. It is unexported, pure, and takes an injectable environment; it should move
to the kernel in the packet that first draws an image, with the adapter's answer as the fallback. It
reads the environment rather than writing a query escape sequence, because stdout may be a pipe.

## What a review changed

A site that could not be reached at all — a mistyped URL, DNS failure, captive wifi — returned a
**nil error beside five confident denials**, and that result is cached. The live consequence is worse
than the wording: `kernel.go` takes a successful probe and replaces its capability set
unconditionally, so pressing `R` during a blip swapped a good set for an all-negative one.
`docs/ARCHITECTURE.md` asks for the opposite from a transport failure — keep the cached answer, badge
it stale, retry — and a caller can only do that if it gets the typed error instead of matching on
reason text. A transport failure from *every* probe now voids the probe; one failing among others
still becomes that capability's reason.

## Gaps

`jira.Capabilities` has no slot for a timezone failure, so a `/myself` that fails leaves no reason
anywhere and dates silently render in UTC. That needs a port change and therefore its own issue.

https://claude.ai/code/session_01HBdKes6chEidvtGJnqFAMm