### PR TITLE
feat(onboarding): P1.6 — verify a site, an email and a token before writing anything

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -55,6 +55,7 @@ here cost time to find out; read this before writing an adapter method.
 | Whether attachments are enabled | `GET /rest/api/3/configuration` |
 | Permissions | `GET /rest/api/3/mypermissions?permissions=…` |
 | The user's timezone | `GET /rest/api/3/myself` |
+| Which projects exist, and which this token can see | `GET /rest/api/3/project/search` — paginated, and the only endpoint that answers it. The port has no method for it, so the onboarding picker derives the keys from the projects on a `/search/jql` page instead, which is a shorter answer: it lists what the account has touched, not what it could reach. |
 
 ## Permissions, which is what the capability probe reads
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,7 +58,7 @@ instance from day one.
   preserved verbatim. Golden-file tests over real captured ADF.
 - [x] **P1.5 — Issue list and detail views** · [#6](https://github.com/varijkapil13/saral/issues/6) · **owns** `internal/ui/{list,issue}/**`
   Virtualized table, incremental cursor paging, `142+` counts, detail pane, comment thread read-only.
-- [ ] **P1.6 — First-run onboarding** · [#7](https://github.com/varijkapil13/saral/issues/7) · **owns** `internal/ui/onboarding/**`
+- [x] **P1.6 — First-run onboarding** · [#7](https://github.com/varijkapil13/saral/issues/7) · **owns** `internal/ui/onboarding/**`
   Site, email, token, project picker; writes the profile; explains what the probe found.
 
 ## Batch 2 — Change your work · parallel ×4

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/BurntSushi/toml"
 )
@@ -42,9 +43,13 @@ type Config struct {
 
 // Profile is one Jira account on one site.
 type Profile struct {
-	Name     string
-	Site     string
-	Email    string
+	Name  string
+	Site  string
+	Email string
+	// Project is the project a session opens in. Jira grants Move, Create and
+	// Delete per project and a board belongs to one, so the capability probe
+	// answers differently in two projects on one site and has to be told which.
+	Project  string
 	Token    TokenSource
 	Timeline Timeline
 	Theme    string
@@ -143,6 +148,7 @@ type fileConfig struct {
 type fileProfile struct {
 	Site     string         `toml:"site"`
 	Email    string         `toml:"email"`
+	Project  string         `toml:"project"`
 	Token    toml.Primitive `toml:"token"`
 	Timeline Timeline       `toml:"timeline"`
 	Theme    string         `toml:"theme"`
@@ -222,6 +228,7 @@ func decodeProfile(md *toml.MetaData, name string, fp fileProfile) (Profile, err
 		Name:     name,
 		Site:     site,
 		Email:    strings.TrimSpace(fp.Email),
+		Project:  strings.TrimSpace(fp.Project),
 		Token:    token,
 		Timeline: fp.Timeline,
 		Theme:    strings.TrimSpace(fp.Theme),
@@ -361,6 +368,9 @@ func (p Profile) Validate() error {
 	}
 	if strings.TrimSpace(p.Email) == "" {
 		return fmt.Errorf(`profile %q: email is required, it is the account the API token belongs to`, p.Name)
+	}
+	if strings.ContainsFunc(p.Project, unicode.IsSpace) {
+		return fmt.Errorf("profile %q: project %q is not a project key", p.Name, p.Project)
 	}
 	if n := p.Token.count(); n != 1 {
 		return tokenSourceErr(p.Name, countPhrase(n))
@@ -506,6 +516,9 @@ func (c Config) encode() ([]byte, error) {
 		}
 		fmt.Fprintf(&b, "\n[profiles.%s]\n", tomlKey(name))
 		pairs := [][2]string{{"site", quote(p.Site)}, {"email", quote(p.Email)}}
+		if p.Project != "" {
+			pairs = append(pairs, [2]string{"project", quote(p.Project)})
+		}
 		if p.Theme != "" {
 			pairs = append(pairs, [2]string{"theme", quote(p.Theme)})
 		}

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProfileProject_RoundTripsAndIsOmittedWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		project string
+		want    string
+	}{
+		"a scoped profile writes the key":   {project: "PROJ", want: "project = \"PROJ\"\n"},
+		"an unscoped profile writes no key": {project: "", want: ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{
+				Active: "work",
+				Mouse:  true,
+				Profiles: map[string]Profile{"work": {
+					Name:    "work",
+					Site:    "example.atlassian.net",
+					Email:   "you@example.com",
+					Project: tc.project,
+					Token:   TokenSource{Keychain: "saral:work"},
+				}},
+			}
+
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := cfg.Save(path); err != nil {
+				t.Fatalf("Save: %v", err)
+			}
+			written, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading back: %v", err)
+			}
+			if tc.want == "" {
+				if strings.Contains(string(written), "project") {
+					t.Errorf("an unscoped profile still wrote a project key:\n%s", written)
+				}
+			} else if !strings.Contains(string(written), tc.want) {
+				t.Errorf("wrote\n%s\nwant a line %q", written, strings.TrimSpace(tc.want))
+			}
+
+			got, err := LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile: %v", err)
+			}
+			if got.Profiles["work"].Project != tc.project {
+				t.Errorf("project round-tripped as %q, want %q", got.Profiles["work"].Project, tc.project)
+			}
+		})
+	}
+}
+
+func TestValidate_RefusesAProjectThatIsNotAKey(t *testing.T) {
+	t.Parallel()
+
+	p := Profile{
+		Name:    "work",
+		Site:    "example.atlassian.net",
+		Email:   "you@example.com",
+		Project: "two words",
+		Token:   TokenSource{Env: "JIRA_TOKEN"},
+	}
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("a project key with a space was accepted")
+	}
+	if !strings.Contains(err.Error(), "two words") {
+		t.Errorf("error %q does not quote the offending value", err)
+	}
+}

--- a/internal/ui/onboarding/bench_test.go
+++ b/internal/ui/onboarding/bench_test.go
@@ -1,0 +1,78 @@
+package onboarding
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// benchView builds the view at a step without going near a test's helpers, so
+// that the benchmark measures the render and nothing around it.
+func benchView(b *testing.B, w, h int, to step) kernel.View {
+	b.Helper()
+	deps := kernel.Deps{Theme: kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs())}
+	fake := jiratest.New(
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithIssues(jiratest.Gen(6)),
+		jiratest.WithCapabilities(jiratest.NoBulkMove, jiratest.NoPlans),
+	)
+	v := NewWith(deps, connectorFor(fake))
+	v, _ = v.Update(kernel.SizeMsg{Width: w, Height: h})
+
+	m, ok := v.(Model)
+	if !ok {
+		b.Fatalf("the view is a %T", v)
+	}
+	m.setValue(fieldSite, "example.atlassian.net")
+	m.setValue(fieldEmail, "you@example.com")
+	m.setValue(fieldToken, "9d8f7a6b5c4d3e2f1a0b")
+	m.setValue(fieldProject, "PROJ")
+	m.suggested = []string{"PROJ", "OTHER", "THIRD"}
+	m.probed, m.project = true, "PROJ"
+	caps, err := fake.Capabilities(b.Context(), "PROJ")
+	if err != nil {
+		b.Fatalf("probing the fake: %v", err)
+	}
+	m.caps = caps
+	_ = m.goTo(to)
+	return m
+}
+
+func BenchmarkView(b *testing.B) {
+	for name, tc := range map[string]struct {
+		w, h int
+		step step
+	}{
+		"site at 200x60":    {200, 60, stepSite},
+		"store at 200x60":   {200, 60, stepStorage},
+		"project at 200x60": {200, 60, stepProject},
+		"review at 200x60":  {200, 60, stepReview},
+		"review at 80x20":   {80, 20, stepReview},
+	} {
+		b.Run(name, func(b *testing.B) {
+			v := benchView(b, tc.w, tc.h, tc.step)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				_ = v.View()
+			}
+		})
+	}
+}
+
+// BenchmarkKeyToFrame is the budgeted path: one keystroke into a field, then
+// the frame that comes out of it.
+func BenchmarkKeyToFrame(b *testing.B) {
+	v := benchView(b, 200, 60, stepSite)
+	key := tea.KeyPressMsg{Code: 'x', Text: "x"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		next, _ := v.Update(key)
+		_ = next.View()
+	}
+}

--- a/internal/ui/onboarding/commands.go
+++ b/internal/ui/onboarding/commands.go
@@ -1,0 +1,366 @@
+package onboarding
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// busy is which call is in the air. Only one blocking call runs at a time; the
+// project suggestions are the one thing fetched in the background.
+type busy int
+
+const (
+	busyNone busy = iota
+	busyConnect
+	busyProbe
+	busySave
+)
+
+func (b busy) String() string {
+	switch b {
+	case busyConnect:
+		return "Checking the site, the email and the token"
+	case busyProbe:
+		return "Asking what this token can do"
+	case busySave:
+		return "Writing the profile"
+	default:
+		return ""
+	}
+}
+
+type configLoadedMsg struct {
+	cfg  config.Config
+	path string
+	err  error
+}
+
+type connectedMsg struct {
+	seq     int
+	client  jira.Client
+	account jira.User
+}
+
+type connectFailedMsg struct {
+	seq int
+	err error
+}
+
+type projectsFoundMsg struct {
+	seq  int
+	keys []string
+}
+
+type projectsUnknownMsg struct {
+	seq int
+	err error
+}
+
+type probedMsg struct {
+	seq     int
+	project string
+	caps    jira.Capabilities
+}
+
+type probeFailedMsg struct {
+	seq int
+	err error
+}
+
+type savedMsg struct {
+	seq     int
+	path    string
+	stored  string
+	warning string
+}
+
+type saveFailedMsg struct {
+	seq int
+	err error
+}
+
+// loadConfig reads whatever config file is already there. A missing one is the
+// first run and not a failure; one that cannot be parsed is, because writing
+// over it would lose the profiles in it.
+func loadConfig() tea.Msg {
+	path, err := config.Path()
+	if err != nil {
+		return configLoadedMsg{cfg: config.Config{Mouse: true}, err: err}
+	}
+	cfg, err := config.LoadFile(path)
+	if errors.Is(err, config.ErrNoConfig) {
+		return configLoadedMsg{cfg: config.Config{Mouse: true}, path: path}
+	}
+	return configLoadedMsg{cfg: cfg, path: path, err: err}
+}
+
+func (m *Model) configLoaded(msg configLoadedMsg) tea.Cmd {
+	m.cfgPath, m.cfgErr = msg.path, msg.err
+	if msg.err == nil {
+		m.cfg = msg.cfg
+	}
+	m.cache.reset()
+	return nil
+}
+
+// stop cancels whatever is in the air, which is what closing or looking away
+// from this view has to do: a verification the user has walked away from must
+// not still be running.
+func (m *Model) stop() {
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
+	if m.cancelBg != nil {
+		m.cancelBg()
+		m.cancelBg = nil
+	}
+	m.busy = busyNone
+}
+
+func (m Model) stale(seq int) bool { return seq != m.seq }
+
+// start runs one blocking call under its own context and bumps the sequence
+// number, so that an answer to a question the user has moved past is dropped.
+func (m *Model) start(kind busy, run func(context.Context, int) tea.Msg) tea.Cmd {
+	m.stop()
+	m.seq++
+	seq := m.seq
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	m.cancel, m.busy, m.last = cancel, kind, kind
+	m.problem, m.note = "", ""
+	return tea.Batch(m.spin.Tick, func() tea.Msg {
+		defer cancel()
+		return run(ctx, seq)
+	})
+}
+
+func (m *Model) verify() tea.Cmd {
+	site, email := m.value(fieldSite), m.value(fieldEmail)
+	token := m.input[fieldToken].Value()
+	connect := m.connect
+	return m.start(busyConnect, func(ctx context.Context, seq int) tea.Msg {
+		client, err := connect(site, email, token)
+		if err != nil {
+			return connectFailedMsg{seq: seq, err: err}
+		}
+		account, err := client.Me(ctx)
+		if err != nil {
+			return connectFailedMsg{seq: seq, err: err}
+		}
+		return connectedMsg{seq: seq, client: client, account: account}
+	})
+}
+
+func (m *Model) connected(msg connectedMsg) tea.Cmd {
+	if m.stale(msg.seq) {
+		return nil
+	}
+	m.busy, m.last = busyNone, busyNone
+	m.client, m.account = msg.client, msg.account
+	m.search = app.NewSearch(msg.client)
+	m.probed, m.caps = false, jira.Capabilities{}
+	return tea.Batch(m.goTo(stepStorage), m.suggest())
+}
+
+// connectFailed sends the user back to the field that can fix it. A rejected
+// credential and an unreachable host are different problems with different
+// answers, and landing on the wrong field is how someone retypes a token that
+// was right all along.
+func (m *Model) connectFailed(msg connectFailedMsg) tea.Cmd {
+	if m.stale(msg.seq) {
+		return nil
+	}
+	m.busy = busyNone
+	m.problem = reason(msg.err)
+
+	var rejected *jira.AuthError
+	var unreachable *jira.TransportError
+	switch {
+	case errors.As(msg.err, &rejected):
+		return m.stay(stepToken)
+	case errors.As(msg.err, &unreachable):
+		m.note = "Nothing was written. The site, the email and the token are all still here."
+		return m.stay(stepSite)
+	}
+	return m.stay(stepToken)
+}
+
+// stay puts the user on the step that can fix the problem without clearing the
+// message that says what it is.
+func (m *Model) stay(on step) tea.Cmd {
+	problem, note := m.problem, m.note
+	cmd := m.goTo(on)
+	m.problem, m.note = problem, note
+	return cmd
+}
+
+// suggest looks for the projects this account has been working in, so that the
+// picker offers something rather than demanding a key from memory. It is a
+// convenience: a failure is a note, never a refusal.
+func (m *Model) suggest() tea.Cmd {
+	if m.search == nil {
+		return nil
+	}
+	if m.cancelBg != nil {
+		m.cancelBg()
+	}
+	search, seq := m.search, m.seq
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	m.cancelBg = cancel
+	m.looking, m.suggested, m.lookup = true, nil, ""
+	return func() tea.Msg {
+		defer cancel()
+		keys, err := recentProjects(ctx, search)
+		if err != nil {
+			return projectsUnknownMsg{seq: seq, err: err}
+		}
+		return projectsFoundMsg{seq: seq, keys: keys}
+	}
+}
+
+// suggestionLimit is how many issues the picker reads to find project keys. It
+// is a page, not a walk: the answer is a handful of keys and paging further
+// only finds projects the account has not touched recently.
+const suggestionLimit = 50
+
+// recentProjects reads the projects behind the account's own recent issues,
+// then anything it can see at all. Both queries ask for one field.
+func recentProjects(ctx context.Context, search *app.Search) ([]string, error) {
+	projection := app.Projection{Name: "project picker", IDs: []string{"project"}}
+	for _, jql := range []string{"assignee = currentUser() ORDER BY updated DESC", "ORDER BY updated DESC"} {
+		result, err := search.Run(ctx, app.Request{JQL: jql, Projection: projection, MaxResults: suggestionLimit})
+		if err != nil {
+			return nil, err
+		}
+		if keys := distinctProjects(result.Page.Items); len(keys) > 0 {
+			return keys, nil
+		}
+	}
+	return nil, nil
+}
+
+// distinctProjects keeps the order the issues came back in, which is the order
+// the query sorted them by and therefore the order worth offering.
+func distinctProjects(issues []jira.Issue) []string {
+	seen := make(map[string]bool, len(issues))
+	keys := make([]string, 0, 4)
+	for i := range issues {
+		key := issues[i].Project.Key
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (m *Model) probe() tea.Cmd {
+	if m.client == nil {
+		m.problem = "the site has not been checked yet"
+		return m.stay(stepToken)
+	}
+	client, project := m.client, m.value(fieldProject)
+	return m.start(busyProbe, func(ctx context.Context, seq int) tea.Msg {
+		caps, err := client.Capabilities(ctx, project)
+		if err != nil {
+			return probeFailedMsg{seq: seq, err: err}
+		}
+		return probedMsg{seq: seq, project: project, caps: caps}
+	})
+}
+
+func (m *Model) probeLanded(msg probedMsg) tea.Cmd {
+	if m.stale(msg.seq) {
+		return nil
+	}
+	m.busy, m.last = busyNone, busyNone
+	m.caps, m.project, m.probed = msg.caps, msg.project, true
+	return m.goTo(stepReview)
+}
+
+func (m *Model) probeFailed(msg probeFailedMsg) tea.Cmd {
+	if m.stale(msg.seq) {
+		return nil
+	}
+	m.busy = busyNone
+	m.problem = reason(msg.err)
+
+	var rejected *jira.AuthError
+	if errors.As(msg.err, &rejected) {
+		return m.stay(stepToken)
+	}
+	return nil
+}
+
+func (m *Model) save() tea.Cmd {
+	profile, err := m.profile()
+	if err != nil {
+		m.problem = err.Error()
+		return nil
+	}
+	switch {
+	case m.cfgErr != nil:
+		m.problem = "refusing to write over a config file Saral cannot read: " + m.cfgErr.Error()
+		return nil
+	case m.cfgPath == "":
+		m.problem = "Saral cannot work out where its config file goes; set SARAL_CONFIG_DIR"
+		return nil
+	}
+	path := m.cfgPath
+	token := m.input[fieldToken].Value()
+	cfg := config.Config{Active: profile.Name, Mouse: m.cfg.Mouse, Profiles: map[string]config.Profile{}}
+	maps.Copy(cfg.Profiles, m.cfg.Profiles)
+	cfg.Profiles[profile.Name] = profile
+
+	return m.start(busySave, func(ctx context.Context, seq int) tea.Msg {
+		// The keychain goes first: a config file naming an entry that was never
+		// written is a profile that fails on every screen, which is the whole
+		// thing this view exists to prevent.
+		if profile.Token.Keychain != "" {
+			if err := profile.StoreToken(token); err != nil {
+				return saveFailedMsg{seq: seq, err: err}
+			}
+		}
+		if err := cfg.Save(path); err != nil {
+			return saveFailedMsg{seq: seq, err: err}
+		}
+		return savedMsg{seq: seq, path: path, stored: profile.Token.String(), warning: checkResolves(ctx, profile, token)}
+	})
+}
+
+// checkResolves reads the token back the way the next start will, so that a
+// variable nobody exported or a command nobody has is reported now rather than
+// at the next start, when the wording would be about a broken profile.
+func checkResolves(ctx context.Context, profile config.Profile, token string) string {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	got, err := profile.ResolveToken(ctx)
+	switch {
+	case err != nil:
+		return err.Error()
+	case got != token:
+		return "the " + profile.Token.String() + " answers with a different token than the one just verified"
+	}
+	return ""
+}
+
+func (m *Model) saveLanded(msg savedMsg) tea.Cmd {
+	if m.stale(msg.seq) {
+		return nil
+	}
+	m.busy, m.last = busyNone, busyNone
+	m.savedTo, m.name, m.stored = msg.path, m.profileName(), msg.stored
+	cmd := m.goTo(stepDone)
+	m.problem = msg.warning
+	return cmd
+}

--- a/internal/ui/onboarding/extra_test.go
+++ b/internal/ui/onboarding/extra_test.go
@@ -1,0 +1,98 @@
+package onboarding
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+func TestProfileName_IsDerivedFromTheSiteAndAlwaysABareKey(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"example.atlassian.net":     "example",
+		"ACME-Corp.atlassian.net":   "acme-corp",
+		"jira.internal.example.com": "jira",
+		"...":                       "default",
+	}
+
+	for site, want := range tests {
+		t.Run(site, func(t *testing.T) {
+			t.Parallel()
+
+			if got := profileNameFor(site); got != want {
+				t.Errorf("profileNameFor(%q) = %q, want %q", site, got, want)
+			}
+		})
+	}
+}
+
+func TestHostOf_DropsThePathPeopleActuallyCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"https://example.atlassian.net/jira/software/projects/PROJ/boards/1": "https://example.atlassian.net",
+		"example.atlassian.net/browse/PROJ-1":                                "example.atlassian.net",
+		"https://example.atlassian.net":                                      "https://example.atlassian.net",
+		"example.atlassian.net":                                              "example.atlassian.net",
+		"example.atlassian.net?a=b":                                          "example.atlassian.net",
+	}
+
+	for raw, want := range tests {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			if got := hostOf(raw); got != want {
+				t.Errorf("hostOf(%q) = %q, want %q", raw, got, want)
+			}
+		})
+	}
+}
+
+// TestStaleAnswersAreDropped covers the case a slow site produces: the user
+// went back and started again, and the first answer lands afterwards.
+func TestStaleAnswersAreDropped(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.atStep(stepStorage)
+
+	d.send(connectFailedMsg{seq: d.model().seq - 1, err: errNotReached})
+	d.atStep(stepStorage)
+	if got := d.model().problem; got != "" {
+		t.Errorf("an answer to an older question was shown: %q", got)
+	}
+}
+
+var errNotReached = &staleError{}
+
+type staleError struct{}
+
+func (*staleError) Error() string { return "this should never be shown" }
+
+func TestStoreKind_EveryChoiceExplainsItselfAndNamesItsField(t *testing.T) {
+	t.Parallel()
+
+	for kind := storeKind(0); kind < storeCount; kind++ {
+		if kind.title() == "" || kind.label() == "" || kind.explain() == "" {
+			t.Errorf("%v is missing a title, a label or an explanation", kind)
+		}
+		if !strings.Contains(kind.explain(), "Saral") {
+			t.Errorf("%v does not say what Saral itself does: %q", kind, kind.explain())
+		}
+	}
+}
+
+func TestResize_KeepsTheFieldsInsideTheBox(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	for _, w := range []int{80, 120, 200, 40} {
+		d.send(kernel.SizeMsg{Width: w, Height: 30})
+		if got := d.model().input[fieldSite].Width(); got < 8 || got > w {
+			t.Errorf("at width %d the site field is %d wide", w, got)
+		}
+	}
+}

--- a/internal/ui/onboarding/harness_test.go
+++ b/internal/ui/onboarding/harness_test.go
@@ -1,0 +1,277 @@
+package onboarding
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files")
+
+const (
+	testSite  = "example.atlassian.net"
+	testEmail = "you@example.com"
+	// testToken is what must never appear in a frame or on disk.
+	testToken = "9d8f7a6b5c4d3e2f1a0b"
+)
+
+func testTheme() *kernel.Theme {
+	return kernel.NewTheme(kernel.ThemeNoColor, true, kernel.ASCIIGlyphs())
+}
+
+func testDeps() kernel.Deps {
+	return kernel.Deps{
+		Theme: testTheme(),
+		Site:  testSite,
+		Now:   func() time.Time { return time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC) },
+	}
+}
+
+func testFake(opts ...jiratest.Option) *jiratest.Fake {
+	base := make([]jiratest.Option, 0, 3+len(opts))
+	base = append(base,
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithIssues(jiratest.Gen(6)),
+		jiratest.WithMe(jira.User{AccountID: "acct-me", DisplayName: "Sam Tester", Active: true, TimeZone: time.UTC}),
+	)
+	return jiratest.New(append(base, opts...)...)
+}
+
+// driver runs the view the way the kernel would: it delivers a message, keeps
+// the frame that came out of it, and runs whatever command came back.
+type driver struct {
+	t      *testing.T
+	view   kernel.View
+	frames []string
+	quit   bool
+	dir    string
+	path   string
+}
+
+func newDriver(t *testing.T, client jira.Client, opts ...func(*kernel.Deps)) *driver {
+	t.Helper()
+	return newDriverWith(t, connectorFor(client), opts...)
+}
+
+func connectorFor(client jira.Client) Connector {
+	return func(string, string, string) (jira.Client, error) { return client, nil }
+}
+
+func newDriverWith(t *testing.T, connect Connector, opts ...func(*kernel.Deps)) *driver {
+	t.Helper()
+	deps := testDeps()
+	for _, o := range opts {
+		o(&deps)
+	}
+	d := &driver{t: t, dir: t.TempDir()}
+	d.path = filepath.Join(d.dir, "config.toml")
+	d.view = NewWith(deps, connect)
+	d.send(kernel.SizeMsg{Width: 100, Height: 30})
+	// The real Init reads the config file from its XDG location; the tests point
+	// it at a temporary one so that they can run in parallel and read it back.
+	d.send(configLoadedMsg{cfg: config.Config{Mouse: true}, path: d.path})
+	return d
+}
+
+func (d *driver) send(msg tea.Msg) {
+	d.t.Helper()
+	view, cmd := d.view.Update(msg)
+	d.view = view
+	d.frames = append(d.frames, view.View())
+	d.run(cmd)
+}
+
+// run executes a command tree the way Bubble Tea would, minus the two commands
+// that are timers: a spinner tick and a cursor blink would each turn a test
+// into a wait.
+func (d *driver) run(cmd tea.Cmd) {
+	d.t.Helper()
+	if cmd == nil {
+		return
+	}
+	switch msg := cmd().(type) {
+	case nil:
+	case tea.BatchMsg:
+		for _, c := range msg {
+			d.run(c)
+		}
+	case spinner.TickMsg:
+	case tea.QuitMsg:
+		d.quit = true
+	default:
+		d.send(msg)
+	}
+}
+
+func (d *driver) typeIn(s string) {
+	d.t.Helper()
+	for _, r := range s {
+		d.send(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+}
+
+func (d *driver) press(keys ...string) {
+	d.t.Helper()
+	for _, k := range keys {
+		d.send(keyPress(k))
+	}
+}
+
+func keyPress(s string) tea.KeyPressMsg {
+	switch s {
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "tab":
+		return tea.KeyPressMsg{Code: tea.KeyTab}
+	case "shift+tab":
+		return tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "ctrl+r":
+		return tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}
+	case "backspace":
+		return tea.KeyPressMsg{Code: tea.KeyBackspace}
+	default:
+		r, _ := utf8.DecodeRuneInString(s)
+		return tea.KeyPressMsg{Code: r, Text: s}
+	}
+}
+
+// clearField empties whatever the current step is asking for, which is what a
+// user does to a field that came with a default in it.
+func (d *driver) clearField() {
+	d.t.Helper()
+	for range len(d.model().input[d.model().step.field()].Value()) {
+		d.press("backspace")
+	}
+}
+
+// refusesToSearch is the fake with one method broken, because FailNext queues
+// an error for the next call whichever it is, and the picker's search is never
+// the next call.
+type refusesToSearch struct {
+	*jiratest.Fake
+	err error
+}
+
+func (r refusesToSearch) Search(context.Context, jira.Query) (jira.Page[jira.Issue], error) {
+	return jira.Page[jira.Issue]{}, r.err
+}
+
+func (d *driver) model() Model {
+	d.t.Helper()
+	m, ok := d.view.(Model)
+	if !ok {
+		d.t.Fatalf("the view is a %T, not a Model", d.view)
+	}
+	return m
+}
+
+func (d *driver) frame() string { return ansi.Strip(d.view.View()) }
+
+// forget drops the frames drawn so far, which is what a test that has just
+// resized wants before it starts looking at every frame.
+func (d *driver) forget() { d.frames = nil }
+
+// credentials walks the three fields every path starts with.
+func (d *driver) credentials() {
+	d.t.Helper()
+	d.typeIn(testSite)
+	d.press("enter")
+	d.typeIn(testEmail)
+	d.press("enter")
+	d.typeIn(testToken)
+	d.press("enter")
+}
+
+func (d *driver) atStep(want step) {
+	d.t.Helper()
+	if got := d.model().step; got != want {
+		d.t.Fatalf("on step %v, want %v — last frame:\n%s", got, want, d.frame())
+	}
+}
+
+func (d *driver) mustContain(want string) {
+	d.t.Helper()
+	if !strings.Contains(d.frame(), want) {
+		d.t.Errorf("the frame does not mention %q:\n%s", want, d.frame())
+	}
+}
+
+// noTokenAnywhere is the assertion that matters most here: the token may not be
+// in any frame the flow drew, nor in anything it wrote.
+func (d *driver) noTokenAnywhere() {
+	d.t.Helper()
+	for i, frame := range d.frames {
+		if strings.Contains(ansi.Strip(frame), testToken) {
+			d.t.Fatalf("frame %d shows the token:\n%s", i, ansi.Strip(frame))
+		}
+	}
+	entries, err := os.ReadDir(d.dir)
+	if err != nil {
+		d.t.Fatalf("reading %s: %v", d.dir, err)
+	}
+	for _, entry := range entries {
+		body, err := os.ReadFile(filepath.Join(d.dir, entry.Name()))
+		if err != nil {
+			d.t.Fatalf("reading %s: %v", entry.Name(), err)
+		}
+		if strings.Contains(string(body), testToken) {
+			d.t.Fatalf("%s holds the token:\n%s", entry.Name(), body)
+		}
+	}
+}
+
+func (d *driver) written() string {
+	d.t.Helper()
+	body, err := os.ReadFile(d.path)
+	if err != nil {
+		d.t.Fatalf("reading the config back: %v", err)
+	}
+	return string(body)
+}
+
+func (d *driver) nothingWritten() {
+	d.t.Helper()
+	if _, err := os.Stat(d.path); !errors.Is(err, os.ErrNotExist) {
+		d.t.Errorf("a config file was written at %s (%v)", d.path, err)
+	}
+}
+
+func golden(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("%v — run: go test ./internal/ui/onboarding -update", err)
+	}
+	if string(want) != got {
+		t.Errorf("frame differs from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}

--- a/internal/ui/onboarding/kernel_test.go
+++ b/internal/ui/onboarding/kernel_test.go
@@ -1,0 +1,223 @@
+package onboarding
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	zone "github.com/lrstanley/bubblezone/v2"
+	"github.com/zalando/go-keyring"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// TestKernel_RunsTheWholeFlowThroughTheRegisteredView drives the view the way
+// the program does: through the registry, the kernel's key routing and its
+// frame, with the fake underneath. It is not parallel because both the kernel
+// registry and the connector are process-wide.
+func TestKernel_RunsTheWholeFlowThroughTheRegisteredView(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(keyring.MockInit)
+
+	dir := t.TempDir()
+	t.Setenv("SARAL_CONFIG_DIR", dir)
+
+	fake := testFake()
+	SetConnector(func(string, string, string) (jira.Client, error) { return fake, nil })
+	t.Cleanup(func() { SetConnector(nil) })
+
+	if errs := kernel.RegistrationErrors(); len(errs) > 0 {
+		t.Fatalf("the view did not register cleanly: %v", errs)
+	}
+	spec, ok := kernel.LookupView(ViewID)
+	if !ok {
+		t.Fatal("the view is not in the registry, so no build can open it")
+	}
+	if spec.Slot != 0 {
+		t.Errorf("the view claims footer slot %d; setup is not a place to navigate to", spec.Slot)
+	}
+	if kernel.KeysFor(ViewID).IsZero() {
+		t.Error("no keys are registered, so the footer can say nothing about this view")
+	}
+
+	root, err := kernel.New(testDeps(), kernel.WithSize(100, 30), kernel.WithInitialView(ViewID), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	k := &kernelDriver{t: t, model: root}
+	k.send(tea.WindowSizeMsg{Width: 100, Height: 30})
+	k.run(root.Init())
+
+	k.typeIn(testSite)
+	k.press("enter")
+	k.typeIn(testEmail)
+	k.press("enter")
+	k.typeIn(testToken)
+	k.press("enter")
+	k.press("enter")
+	// The project is picked from the suggestions rather than typed: the kernel
+	// matches R before it forwards a key, so PROJ arrives as POJ. See
+	// TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem.
+	k.press("down", "enter")
+
+	if !strings.Contains(k.frame(), "What this token can do in PROJ") {
+		t.Fatalf("the probe result never reached the frame:\n%s", k.frame())
+	}
+	k.press("enter")
+	if !strings.Contains(k.frame(), "The profile is written") {
+		t.Fatalf("the flow did not finish:\n%s", k.frame())
+	}
+	for i, frame := range k.frames {
+		if strings.Contains(frame, testToken) {
+			t.Fatalf("kernel frame %d shows the token:\n%s", i, frame)
+		}
+	}
+}
+
+// TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem records a real
+// limitation rather than a wish: the kernel matches q, r, R, ? and 1-9 before
+// it forwards a key, so a root view cannot spell them. Onboarding blocks the
+// close so that q does not quit mid-setup, but the character is still lost.
+// Delete this test when the kernel grows a way for a view to claim text input.
+func TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem(t *testing.T) {
+	SetConnector(func(string, string, string) (jira.Client, error) { return testFake(), nil })
+	t.Cleanup(func() { SetConnector(nil) })
+
+	root, err := kernel.New(testDeps(), kernel.WithSize(100, 30), kernel.WithInitialView(ViewID), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	k := &kernelDriver{t: t, model: root}
+	k.send(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	k.typeIn("acme")
+	k.press("q")
+	if !strings.Contains(k.frame(), "nothing has been saved") {
+		t.Errorf("q did not reach the blocker, so a half-typed setup can be quit away:\n%s", k.frame())
+	}
+	if strings.Contains(k.frame(), "acmeq") {
+		t.Error("the kernel has started forwarding q; this test and its workaround can go")
+	}
+}
+
+func TestKernel_ClickingASuggestionAndACompletedStepWorks(t *testing.T) {
+	zones := zone.New()
+	t.Cleanup(zones.Close)
+
+	deps := testDeps()
+	deps.Zones = zones
+	d := newDriver(t, testFake(), func(x *kernel.Deps) { x.Zones = zones })
+	d.credentials()
+	d.press("enter")
+	d.atStep(stepProject)
+
+	prefix := d.model().zone
+	scan(t, zones, d.view.View())
+	eventually(t, func() bool { return !zones.Get(prefix + "project:PROJ").IsZero() })
+
+	info := zones.Get(prefix + "project:PROJ")
+	d.send(tea.MouseClickMsg{X: info.StartX + 2, Y: info.StartY, Button: tea.MouseLeft})
+	if got := d.model().value(fieldProject); got != "PROJ" {
+		t.Errorf("clicking a suggestion left the field at %q", got)
+	}
+
+	scan(t, zones, d.view.View())
+	eventually(t, func() bool { return !zones.Get(prefix + "step:email").IsZero() })
+	info = zones.Get(prefix + "step:email")
+	d.send(tea.MouseClickMsg{X: info.StartX + 4, Y: info.StartY, Button: tea.MouseLeft})
+	d.atStep(stepEmail)
+	if got := d.model().value(fieldEmail); got != testEmail {
+		t.Errorf("clicking back to a finished step lost what was in it: %q", got)
+	}
+}
+
+func TestKernel_ClickingATokenStoreChoosesIt(t *testing.T) {
+	zones := zone.New()
+	t.Cleanup(zones.Close)
+
+	d := newDriver(t, testFake(), func(x *kernel.Deps) { x.Zones = zones })
+	d.credentials()
+	d.atStep(stepStorage)
+
+	prefix := d.model().zone
+	scan(t, zones, d.view.View())
+	eventually(t, func() bool { return !zones.Get(prefix + "store:command").IsZero() })
+
+	info := zones.Get(prefix + "store:command")
+	d.send(tea.MouseClickMsg{X: info.StartX + 2, Y: info.StartY, Button: tea.MouseLeft})
+	if got := d.model().store; got != storeCommand {
+		t.Errorf("the store is %v after clicking the command row", got)
+	}
+}
+
+// scan hands a frame to the zone manager the way the kernel does when the mouse
+// is on, which is what turns a marked string into coordinates.
+func scan(t *testing.T, zones *zone.Manager, frame string) {
+	t.Helper()
+	_ = zones.Scan(frame)
+}
+
+func eventually(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatal("the zone never turned up; the scan is asynchronous but not this slow")
+		}
+		runtime.Gosched()
+	}
+}
+
+type kernelDriver struct {
+	t      *testing.T
+	model  tea.Model
+	frames []string
+}
+
+func (k *kernelDriver) send(msg tea.Msg) {
+	k.t.Helper()
+	next, cmd := k.model.Update(msg)
+	k.model = next
+	k.frames = append(k.frames, k.frame())
+	k.run(cmd)
+}
+
+func (k *kernelDriver) run(cmd tea.Cmd) {
+	k.t.Helper()
+	if cmd == nil {
+		return
+	}
+	switch msg := cmd().(type) {
+	case nil, tea.QuitMsg:
+	case tea.BatchMsg:
+		for _, c := range msg {
+			k.run(c)
+		}
+	case spinner.TickMsg:
+	default:
+		k.send(msg)
+	}
+}
+
+func (k *kernelDriver) typeIn(s string) {
+	k.t.Helper()
+	for _, r := range s {
+		k.send(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+}
+
+func (k *kernelDriver) press(keys ...string) {
+	k.t.Helper()
+	for _, s := range keys {
+		k.send(keyPress(s))
+	}
+}
+
+func (k *kernelDriver) frame() string {
+	return ansi.Strip(k.model.(kernel.Model).Frame())
+}

--- a/internal/ui/onboarding/kernel_test.go
+++ b/internal/ui/onboarding/kernel_test.go
@@ -60,10 +60,10 @@ func TestKernel_RunsTheWholeFlowThroughTheRegisteredView(t *testing.T) {
 	k.typeIn(testToken)
 	k.press("enter")
 	k.press("enter")
-	// The project is picked from the suggestions rather than typed: the kernel
-	// matches R before it forwards a key, so PROJ arrives as POJ. See
-	// TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem.
-	k.press("down", "enter")
+	// Typed, not clicked: PROJ contains an R, which the kernel would have
+	// matched as its own refresh binding before the field ever saw it.
+	k.typeIn("PROJ")
+	k.press("enter")
 
 	if !strings.Contains(k.frame(), "What this token can do in PROJ") {
 		t.Fatalf("the probe result never reached the frame:\n%s", k.frame())
@@ -79,12 +79,55 @@ func TestKernel_RunsTheWholeFlowThroughTheRegisteredView(t *testing.T) {
 	}
 }
 
-// TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem records a real
-// limitation rather than a wish: the kernel matches q, r, R, ? and 1-9 before
-// it forwards a key, so a root view cannot spell them. Onboarding blocks the
-// close so that q does not quit mid-setup, but the character is still lost.
-// Delete this test when the kernel grows a way for a view to claim text input.
-func TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem(t *testing.T) {
+// A credential is typed, not pasted, and every Atlassian token contains digits.
+// If the kernel's own bindings reach the form first, the token that gets
+// verified is not the token that was typed — and the user is sent back to
+// re-enter one that was already correct.
+func TestKernel_TheFormReceivesEveryCharacterOfACredential(t *testing.T) {
+	var got struct{ site, email, token string }
+	SetConnector(func(site, email, token string) (jira.Client, error) {
+		got.site, got.email, got.token = site, email, token
+		return testFake(), nil
+	})
+	t.Cleanup(func() { SetConnector(nil) })
+
+	root, err := kernel.New(testDeps(), kernel.WithSize(100, 30), kernel.WithInitialView(ViewID), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	k := &kernelDriver{t: t, model: root}
+	k.send(tea.WindowSizeMsg{Width: 100, Height: 30})
+	k.run(root.Init())
+
+	// Every one of these carries a character the kernel binds globally: the
+	// digits are slot keys, r and R are refresh, q is quit, ? is help.
+	const (
+		site  = "acme1.atlassian.net"
+		email = "rita.quinn+jira2@acme.com"
+		token = "ATATT3xFfGF0Rq9Quick27?"
+	)
+	k.typeIn(site)
+	k.press("enter")
+	k.typeIn(email)
+	k.press("enter")
+	k.typeIn(token)
+	k.press("enter")
+	k.press("enter")
+
+	if got.site != site {
+		t.Errorf("the site arrived as %q, want %q", got.site, site)
+	}
+	if got.email != email {
+		t.Errorf("the email arrived as %q, want %q", got.email, email)
+	}
+	if got.token != token {
+		t.Errorf("the token arrived as %q, want %q", got.token, token)
+	}
+}
+
+// A view holding the keyboard must still be quittable by the one key that always
+// means it.
+func TestKernel_CtrlCStillQuitsWhileTheFormHasTheKeyboard(t *testing.T) {
 	SetConnector(func(string, string, string) (jira.Client, error) { return testFake(), nil })
 	t.Cleanup(func() { SetConnector(nil) })
 
@@ -94,14 +137,10 @@ func TestKernel_TheGlobalKeysReachTheKernelBeforeAFormCanSeeThem(t *testing.T) {
 	}
 	k := &kernelDriver{t: t, model: root}
 	k.send(tea.WindowSizeMsg{Width: 100, Height: 30})
-
 	k.typeIn("acme")
-	k.press("q")
-	if !strings.Contains(k.frame(), "nothing has been saved") {
-		t.Errorf("q did not reach the blocker, so a half-typed setup can be quit away:\n%s", k.frame())
-	}
-	if strings.Contains(k.frame(), "acmeq") {
-		t.Error("the kernel has started forwarding q; this test and its workaround can go")
+
+	if _, cmd := k.model.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}); cmd == nil {
+		t.Error("ctrl+c produced no command while the form had the keyboard")
 	}
 }
 

--- a/internal/ui/onboarding/onboarding.go
+++ b/internal/ui/onboarding/onboarding.go
@@ -97,6 +97,8 @@ var _ kernel.View = Model{}
 
 var _ kernel.Blocker = Model{}
 
+var _ kernel.KeyCapturer = Model{}
+
 // Model is the onboarding view: a state machine over five text inputs and one
 // choice, with a verification between the steps that need one.
 type Model struct {
@@ -143,6 +145,14 @@ type Model struct {
 
 	styles styles
 	cache  *renderCache
+}
+
+// WantsRawKeys is true whenever a field is on screen. Every Atlassian API token
+// contains digits, and without this the kernel's slot keys eat them before the
+// field sees them — the credential that gets verified is then not the one that
+// was typed, and the user is sent back to re-paste a token that was correct.
+func (m Model) WantsRawKeys() bool {
+	return m.step.field() != fieldNone
 }
 
 // Init loads the config file that may already exist, because onboarding also

--- a/internal/ui/onboarding/onboarding.go
+++ b/internal/ui/onboarding/onboarding.go
@@ -1,0 +1,680 @@
+// Package onboarding is the first-run view: it collects a site, an account
+// email and an API token, checks them against Jira before anything is written,
+// asks where the token should live, picks a project, and then reports what the
+// capability probe found in the probe's own words.
+//
+// Nothing is saved until it has been verified, and the token itself never
+// reaches the config file: the file names a keychain entry, an environment
+// variable or a command, and internal/config resolves it at each start.
+package onboarding
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// ViewID is the name this view is registered and opened under.
+const ViewID = "onboarding"
+
+// opTimeout bounds one verification, probe or save. It is generous because the
+// user is watching a spinner they can cancel by going back, not a frame budget.
+const opTimeout = 30 * time.Second
+
+// Connector opens a client for credentials that have not been saved yet.
+//
+// The view cannot build one itself: internal/ui takes the jira.Client port and
+// never an adapter, so the composition root registers the adapter this build
+// uses with SetConnector.
+type Connector func(site, email, token string) (jira.Client, error)
+
+var registered struct {
+	mu sync.RWMutex
+	fn Connector
+}
+
+// SetConnector records how this build opens a connection to a site the user has
+// just typed in. It is called once, from the composition root.
+func SetConnector(fn Connector) {
+	registered.mu.Lock()
+	defer registered.mu.Unlock()
+	registered.fn = fn
+}
+
+func connector() Connector {
+	registered.mu.RLock()
+	defer registered.mu.RUnlock()
+	return registered.fn
+}
+
+// New builds the view with whatever connector this build registered.
+func New(d kernel.Deps) kernel.View { return NewWith(d, connector()) }
+
+// NewWith builds the view over a connector of the caller's own, which is how a
+// test drives the whole flow against pkg/jira/jiratest.
+func NewWith(d kernel.Deps, connect Connector) kernel.View {
+	if d.Theme == nil {
+		d.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
+	}
+	m := Model{
+		deps:    d,
+		connect: connect,
+		cfg:     config.Config{Mouse: true},
+		cache:   &renderCache{},
+	}
+	if d.Zones != nil {
+		m.zone = d.Zones.NewPrefix()
+	}
+	m.restyle()
+	m.spin = spinner.New(spinner.WithSpinner(spinner.Spinner{
+		Frames: d.Theme.Glyphs.Spinner,
+		FPS:    time.Second / 12,
+	}))
+	m.spin.Style = d.Theme.Accent
+	m.pane = viewport.New()
+	for i := range m.input {
+		m.input[i] = m.newInput(field(i))
+	}
+	_ = m.input[fieldSite].Focus()
+	return m
+}
+
+var _ kernel.View = Model{}
+
+var _ kernel.Blocker = Model{}
+
+// Model is the onboarding view: a state machine over five text inputs and one
+// choice, with a verification between the steps that need one.
+type Model struct {
+	deps    kernel.Deps
+	connect Connector
+	zone    string
+
+	width, height int
+
+	step   step
+	input  [fieldCount]textinput.Model
+	store  storeKind
+	secret [storeCount]string
+
+	spin spinner.Model
+	pane viewport.Model
+	busy busy
+	last busy
+	seq  int
+
+	cancel   context.CancelFunc
+	cancelBg context.CancelFunc
+
+	problem string
+	note    string
+
+	client  jira.Client
+	search  *app.Search
+	account jira.User
+	caps    jira.Capabilities
+	probed  bool
+	project string
+
+	suggested []string
+	looking   bool
+	lookup    string
+
+	cfg     config.Config
+	cfgPath string
+	cfgErr  error
+	name    string
+	savedTo string
+	stored  string
+
+	styles styles
+	cache  *renderCache
+}
+
+// Init loads the config file that may already exist, because onboarding also
+// adds a profile to one, and because writing over a file this build cannot
+// parse would lose whatever is in it.
+func (m Model) Init() tea.Cmd { return loadConfig }
+
+// Update routes one message. Every outcome has its own message type, and each
+// carries the sequence number of the operation that produced it so that a
+// result the user has already moved past is dropped rather than applied.
+func (m Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
+	switch msg := msg.(type) {
+	case kernel.SizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		m.resize()
+		return m, nil
+
+	case kernel.FocusMsg:
+		if !msg.Focused {
+			m.stop()
+			m.blurField()
+			return m, nil
+		}
+		cmd := m.focusField()
+		return m, cmd
+
+	case kernel.ThemeMsg:
+		m.deps.Theme = msg.Theme
+		m.restyle()
+		m.spin.Spinner = spinner.Spinner{Frames: msg.Theme.Glyphs.Spinner, FPS: time.Second / 12}
+		m.spin.Style = msg.Theme.Accent
+		for i := range m.input {
+			m.styleInput(&m.input[i], field(i))
+		}
+		m.resize()
+		m.cache.reset()
+		return m, nil
+
+	case kernel.RefreshMsg:
+		cmd := m.retry()
+		return m, cmd
+
+	case configLoadedMsg:
+		cmd := m.configLoaded(msg)
+		return m, cmd
+
+	case connectedMsg:
+		cmd := m.connected(msg)
+		return m, cmd
+
+	case connectFailedMsg:
+		cmd := m.connectFailed(msg)
+		return m, cmd
+
+	case projectsFoundMsg:
+		if m.stale(msg.seq) {
+			return m, nil
+		}
+		m.looking, m.suggested, m.lookup = false, msg.keys, ""
+		return m, nil
+
+	case projectsUnknownMsg:
+		if m.stale(msg.seq) {
+			return m, nil
+		}
+		m.looking = false
+		m.lookup = "Saral could not list your recent projects, so type the key: " + reason(msg.err)
+		return m, nil
+
+	case probedMsg:
+		cmd := m.probeLanded(msg)
+		return m, cmd
+
+	case probeFailedMsg:
+		cmd := m.probeFailed(msg)
+		return m, cmd
+
+	case savedMsg:
+		cmd := m.saveLanded(msg)
+		return m, cmd
+
+	case saveFailedMsg:
+		if m.stale(msg.seq) {
+			return m, nil
+		}
+		m.busy = busyNone
+		m.problem = reason(msg.err)
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.busy == busyNone {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		return m, cmd
+
+	case tea.KeyPressMsg:
+		return m.key(msg)
+
+	case tea.PasteMsg:
+		return m.toInput(msg)
+
+	case tea.MouseClickMsg:
+		return m.click(msg)
+
+	case tea.MouseWheelMsg:
+		if m.step.field() != fieldNone {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.pane, cmd = m.pane.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+// BlocksClose keeps a half-finished profile from being thrown away by the key
+// that quits. Nothing typed here is recoverable — the token especially — and
+// the kernel shows this reason instead of leaving.
+func (m Model) BlocksClose() (string, bool) {
+	if m.step == stepDone || !m.dirty() {
+		return "", false
+	}
+	return "Saral is still being set up and nothing has been saved; ctrl+c leaves without saving", true
+}
+
+func (m Model) dirty() bool {
+	for i := range m.input {
+		if m.input[i].Value() != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) key(msg tea.KeyPressMsg) (kernel.View, tea.Cmd) {
+	switch msg.String() {
+	case "enter", "tab":
+		if m.busy != busyNone {
+			return m, nil
+		}
+		cmd := m.advance()
+		return m, cmd
+	case "shift+tab":
+		if m.busy != busyNone {
+			return m, nil
+		}
+		cmd := m.back()
+		return m, cmd
+	case "ctrl+r":
+		cmd := m.retry()
+		return m, cmd
+	case "up", "down":
+		if cmd, handled := m.choose(msg.String() == "down"); handled {
+			return m, cmd
+		}
+	}
+	if m.busy != busyNone {
+		return m, nil
+	}
+	if m.step.field() == fieldNone {
+		var cmd tea.Cmd
+		m.pane, cmd = m.pane.Update(msg)
+		return m, cmd
+	}
+	return m.toInput(msg)
+}
+
+// toInput hands a key or a paste to the field the current step owns. A step
+// with no field — the review and the summary — swallows it rather than letting
+// a stray keystroke look like it did something.
+func (m Model) toInput(msg tea.Msg) (kernel.View, tea.Cmd) {
+	f := m.step.field()
+	if f == fieldNone {
+		return m, nil
+	}
+	m.problem, m.note = "", ""
+	var cmd tea.Cmd
+	m.input[f], cmd = m.input[f].Update(msg)
+	if f == fieldSecret {
+		m.secret[m.store] = m.input[f].Value()
+	}
+	return m, cmd
+}
+
+// choose moves the selection on the two steps that have one: the token store
+// and the project suggestions. Both are also clickable, and neither can use
+// j/k, which the field below them is spelling.
+func (m *Model) choose(down bool) (tea.Cmd, bool) {
+	switch m.step {
+	case stepStorage:
+		next := m.store + 1
+		if !down {
+			next = m.store - 1
+		}
+		if next < 0 || next >= storeCount {
+			return nil, true
+		}
+		return m.setStore(next), true
+	case stepProject:
+		if len(m.suggested) == 0 {
+			return nil, false
+		}
+		return m.cycleSuggestion(down), true
+	case stepSite, stepEmail, stepToken, stepReview, stepDone:
+	}
+	return nil, false
+}
+
+func (m *Model) cycleSuggestion(down bool) tea.Cmd {
+	at := -1
+	for i, key := range m.suggested {
+		if key == m.input[fieldProject].Value() {
+			at = i
+			break
+		}
+	}
+	switch {
+	case down:
+		at++
+	case at < 0:
+		at = len(m.suggested) - 1
+	default:
+		at--
+	}
+	if at < 0 || at >= len(m.suggested) {
+		return nil
+	}
+	m.setValue(fieldProject, m.suggested[at])
+	return nil
+}
+
+func (m Model) click(msg tea.MouseClickMsg) (kernel.View, tea.Cmd) {
+	if m.zone == "" || m.deps.Zones == nil || msg.Button != tea.MouseLeft {
+		return m, nil
+	}
+	switch m.step {
+	case stepStorage:
+		for kind := storeKind(0); kind < storeCount; kind++ {
+			if m.deps.Zones.Get(m.zone + "store:" + kind.String()).InBounds(msg) {
+				cmd := m.setStore(kind)
+				return m, cmd
+			}
+		}
+	case stepProject:
+		for _, key := range m.suggested {
+			if m.deps.Zones.Get(m.zone + "project:" + key).InBounds(msg) {
+				m.setValue(fieldProject, key)
+				return m, nil
+			}
+		}
+	case stepSite, stepEmail, stepToken, stepReview, stepDone:
+	}
+	for s := stepSite; s < m.step; s++ {
+		if m.deps.Zones.Get(m.zone + "step:" + s.String()).InBounds(msg) {
+			cmd := m.goTo(s)
+			return m, cmd
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) setStore(kind storeKind) tea.Cmd {
+	if kind == m.store {
+		return nil
+	}
+	m.store = kind
+	m.problem = ""
+	m.setValue(fieldSecret, m.storeValue())
+	m.cache.reset()
+	return nil
+}
+
+// storeValue is what the entry field shows for the current store: whatever the
+// user typed for it before, or the default that most people want. Only what was
+// typed is remembered, so a default follows a site that has since changed.
+func (m Model) storeValue() string {
+	if v := m.secret[m.store]; v != "" {
+		return v
+	}
+	switch m.store {
+	case storeKeychain:
+		return "saral:" + m.profileName()
+	case storeEnv:
+		return "JIRA_TOKEN"
+	default:
+		return ""
+	}
+}
+
+func (m *Model) setValue(f field, v string) {
+	m.input[f].SetValue(v)
+	m.input[f].CursorEnd()
+}
+
+func (m Model) value(f field) string { return strings.TrimSpace(m.input[f].Value()) }
+
+// advance validates the current step and moves on, or starts the call that
+// decides whether it can. Nothing typed is ever cleared by a refusal.
+func (m *Model) advance() tea.Cmd {
+	switch m.step {
+	case stepSite:
+		site, err := config.NormalizeSite(hostOf(m.value(fieldSite)))
+		if err != nil {
+			m.problem = err.Error()
+			return nil
+		}
+		m.setValue(fieldSite, site)
+		return m.goTo(stepEmail)
+
+	case stepEmail:
+		email := m.value(fieldEmail)
+		if !strings.Contains(email, "@") || strings.ContainsFunc(email, unicode.IsSpace) {
+			m.problem = "Jira Cloud pairs the account email with the API token as basic auth, so it has to be the address the token belongs to"
+			return nil
+		}
+		m.setValue(fieldEmail, email)
+		return m.goTo(stepToken)
+
+	case stepToken:
+		switch {
+		case strings.TrimSpace(m.input[fieldToken].Value()) == "":
+			m.problem = "an API token is required; create one at id.atlassian.com/manage-profile/security/api-tokens"
+			return nil
+		case m.connect == nil:
+			m.problem = "this build cannot open a connection: nothing wired an adapter into onboarding.SetConnector"
+			return nil
+		}
+		return m.verify()
+
+	case stepStorage:
+		if _, err := m.tokenSource(); err != nil {
+			m.problem = err.Error()
+			return nil
+		}
+		return m.goTo(stepProject)
+
+	case stepProject:
+		return m.probe()
+
+	case stepReview:
+		return m.save()
+
+	case stepDone:
+		return m.finish()
+	}
+	return nil
+}
+
+func (m *Model) back() tea.Cmd {
+	if m.step == stepSite {
+		return nil
+	}
+	return m.goTo(m.step - 1)
+}
+
+func (m *Model) goTo(to step) tea.Cmd {
+	m.blurField()
+	m.step = to
+	m.problem, m.note = "", ""
+	if to < stepStorage {
+		m.name = ""
+	}
+	if to == stepStorage {
+		m.name = m.profileName()
+		m.setValue(fieldSecret, m.storeValue())
+	}
+	m.pane.SetYOffset(0)
+	m.resize()
+	m.cache.reset()
+	return m.focusField()
+}
+
+func (m *Model) blurField() {
+	if f := m.step.field(); f != fieldNone {
+		m.input[f].Blur()
+	}
+}
+
+func (m *Model) focusField() tea.Cmd {
+	if f := m.step.field(); f != fieldNone {
+		return m.input[f].Focus()
+	}
+	return nil
+}
+
+func (m *Model) finish() tea.Cmd {
+	// A session that started without a client cannot use the profile it has just
+	// written: nothing hands a kernel that is already running a new one.
+	if m.deps.Jira == nil {
+		return tea.Quit
+	}
+	return kernel.Status("profile " + m.name + " saved to " + m.savedTo)
+}
+
+// retry re-runs whatever last failed, which is what r means here. A transport
+// failure is the ordinary reason to be looking at this screen twice.
+func (m *Model) retry() tea.Cmd {
+	if m.busy != busyNone {
+		return nil
+	}
+	switch m.last {
+	case busyConnect:
+		return m.verify()
+	case busyProbe:
+		return m.probe()
+	case busySave:
+		return m.save()
+	case busyNone:
+	}
+	if m.step == stepProject && m.client != nil {
+		return m.suggest()
+	}
+	return nil
+}
+
+func (m Model) profileName() string {
+	if m.name != "" {
+		return m.name
+	}
+	base := profileNameFor(m.value(fieldSite))
+	name := base
+	for n := 2; ; n++ {
+		if _, taken := m.cfg.Profiles[name]; !taken {
+			return name
+		}
+		name = base + "-" + strconv.Itoa(n)
+	}
+}
+
+// profileNameFor turns a host into a bare TOML key: the first label, lowercased,
+// with anything that would have to be quoted dropped.
+func profileNameFor(site string) string {
+	label, _, _ := strings.Cut(site, ".")
+	var b strings.Builder
+	for _, r := range strings.ToLower(label) {
+		if r == '-' || r == '_' || (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "default"
+	}
+	return b.String()
+}
+
+// resize sizes the fields to what is left of the row after the indent, the
+// label column, the prompt arrow and the cell the cursor sits in.
+func (m *Model) resize() {
+	w := m.width - inputIndent - labelWidth - 6 - lipgloss.Width(m.deps.Theme.Glyphs.Arrow) - 2
+	if w < 8 {
+		w = 8
+	}
+	for i := range m.input {
+		m.input[i].SetWidth(w)
+	}
+	m.pane.SetWidth(max(m.width, 1))
+	m.pane.SetHeight(m.paneHeight())
+	m.refreshPane()
+}
+
+// refreshPane loads the block the summary steps show. It is the one part of
+// this view that can be taller than the box it is in — a probe answers with as
+// many sentences as it has refusals — so it is the one part that scrolls.
+func (m *Model) refreshPane() {
+	switch m.step {
+	case stepReview:
+		m.pane.SetContentLines(m.summary())
+	case stepDone:
+		m.pane.SetContentLines(m.finished())
+	case stepSite, stepEmail, stepToken, stepStorage, stepProject:
+	}
+}
+
+func (m Model) newInput(f field) textinput.Model {
+	in := textinput.New()
+	in.Prompt = ""
+	in.Placeholder = f.placeholder()
+	if f == fieldToken {
+		in.EchoMode = textinput.EchoPassword
+		in.EchoCharacter = firstRune(m.deps.Theme.Glyphs.Bullet, '*')
+	}
+	m.styleInput(&in, f)
+	return in
+}
+
+// styleInput dresses one field in the theme. The cursor does not blink: the
+// kernel owns the frame and renders a string, so a blink is a full redraw of
+// the form twice a second to move one reversed cell.
+func (m Model) styleInput(in *textinput.Model, f field) {
+	t := m.deps.Theme
+	state := textinput.StyleState{Text: t.Base, Placeholder: t.Muted, Suggestion: t.Muted, Prompt: t.Muted}
+	in.SetStyles(textinput.Styles{
+		Focused: state,
+		Blurred: state,
+		Cursor:  textinput.CursorStyle{Color: t.Accent.GetForeground(), Blink: false},
+	})
+	if f == fieldToken {
+		in.EchoCharacter = firstRune(t.Glyphs.Bullet, '*')
+	}
+}
+
+func firstRune(s string, fallback rune) rune {
+	for _, r := range s {
+		return r
+	}
+	return fallback
+}
+
+// hostOf drops the path off what was pasted. What people have in the clipboard
+// is the URL of a board or a ticket, and internal/config quite rightly refuses
+// to keep a path in a profile — but refusing the paste is not the same as
+// refusing the site it names.
+func hostOf(raw string) string {
+	site := strings.TrimSpace(raw)
+	rest := site
+	if i := strings.Index(site, "://"); i >= 0 {
+		rest = site[i+len("://"):]
+	}
+	if j := strings.IndexAny(rest, "/?#"); j >= 0 {
+		return site[:len(site)-len(rest)+j]
+	}
+	return site
+}
+
+// reason is the sentence to put in front of the user for an error, which for a
+// typed Jira error is the wording the error already carries.
+func reason(err error) string {
+	if err == nil {
+		return ""
+	}
+	text, _ := jira.Reason(err)
+	return text
+}

--- a/internal/ui/onboarding/onboarding_test.go
+++ b/internal/ui/onboarding/onboarding_test.go
@@ -1,0 +1,613 @@
+package onboarding
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/zalando/go-keyring"
+
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// TestFlow_WritesTheProfileOnlyAfterEverythingHasBeenChecked is the happy path,
+// and the assertion that matters is where the write happens: at the end, once.
+func TestFlow_WritesTheProfileOnlyAfterEverythingHasBeenChecked(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(keyring.MockInit)
+
+	fake := testFake()
+	d := newDriver(t, fake)
+
+	d.credentials()
+	d.atStep(stepStorage)
+	d.nothingWritten()
+
+	d.press("enter")
+	d.atStep(stepProject)
+	d.typeIn("PROJ")
+	d.press("enter")
+
+	d.atStep(stepReview)
+	d.mustContain("What this token can do in PROJ")
+	d.nothingWritten()
+
+	d.press("enter")
+	d.atStep(stepDone)
+
+	written := d.written()
+	for _, want := range []string{
+		`active = "example"`,
+		`site    = "example.atlassian.net"`,
+		`email   = "you@example.com"`,
+		`project = "PROJ"`,
+		`token   = { keychain = "saral:example" }`,
+	} {
+		if !strings.Contains(written, want) {
+			t.Errorf("the config does not hold %q:\n%s", want, written)
+		}
+	}
+	d.noTokenAnywhere()
+
+	stored, err := keyring.Get("saral", "example")
+	if err != nil {
+		t.Fatalf("reading the keychain back: %v", err)
+	}
+	if stored != testToken {
+		t.Errorf("the keychain holds %q, want the token that was verified", stored)
+	}
+
+	cfg, err := config.LoadFile(d.path)
+	if err != nil {
+		t.Fatalf("loading back what onboarding wrote: %v", err)
+	}
+	profile, err := cfg.Current()
+	if err != nil {
+		t.Fatalf("the written config has no usable profile: %v", err)
+	}
+	if profile.Project != "PROJ" {
+		t.Errorf("the profile remembers project %q, want PROJ", profile.Project)
+	}
+	if got, _ := profile.ResolveToken(t.Context()); got != testToken {
+		t.Errorf("the written profile resolves to %q, so the next start would fail", got)
+	}
+}
+
+func TestFlow_ARejectedTokenReturnsToTheTokenFieldWithEverythingStillThere(t *testing.T) {
+	t.Parallel()
+
+	fake := testFake()
+	fake.FailNext(&jira.AuthError{Reason: "the token is not valid for you@example.com"})
+	d := newDriver(t, fake)
+
+	d.credentials()
+
+	d.atStep(stepToken)
+	d.mustContain("the token is not valid for you@example.com")
+	if got := d.model().value(fieldSite); got != testSite {
+		t.Errorf("the site was lost: %q", got)
+	}
+	if got := d.model().value(fieldEmail); got != testEmail {
+		t.Errorf("the email was lost: %q", got)
+	}
+	if got := d.model().input[fieldToken].Value(); got != testToken {
+		t.Error("the token field was emptied by the refusal")
+	}
+	d.nothingWritten()
+	d.noTokenAnywhere()
+
+	// The second attempt goes through, which is what makes the first one a
+	// refusal rather than a dead end.
+	d.press("enter")
+	d.atStep(stepStorage)
+}
+
+func TestFlow_AnUnreachableSiteReturnsToTheSiteFieldAndSaysWhichProblemItIs(t *testing.T) {
+	t.Parallel()
+
+	fake := testFake()
+	fake.FailNext(&jira.TransportError{
+		Op:  "GET /rest/api/3/myself",
+		Err: errors.New("dial tcp: lookup exmaple.atlassian.net: no such host"),
+	})
+	d := newDriver(t, fake)
+
+	d.credentials()
+
+	d.atStep(stepSite)
+	d.mustContain("no such host")
+	d.mustContain("Nothing was written")
+	if got := d.model().input[fieldToken].Value(); got != testToken {
+		t.Error("going back to the site field emptied the token")
+	}
+	d.nothingWritten()
+	d.noTokenAnywhere()
+}
+
+func TestFlow_AConnectorThatCannotBuildAClientIsReportedOnTheTokenStep(t *testing.T) {
+	t.Parallel()
+
+	d := newDriverWith(t, func(string, string, string) (jira.Client, error) {
+		return nil, errors.New("cloud: an API token is required")
+	})
+	d.credentials()
+
+	d.atStep(stepToken)
+	d.mustContain("an API token is required")
+}
+
+func TestFlow_AProjectTheTokenCannotSeeIsRefusedWithoutLeavingTheStep(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("enter")
+
+	d.typeIn("NOPE")
+	d.press("enter")
+
+	d.atStep(stepProject)
+	d.mustContain("does not exist, or you cannot see it")
+	d.nothingWritten()
+
+	d.clearField()
+	d.typeIn("PROJ")
+	d.press("enter")
+	d.atStep(stepReview)
+}
+
+func TestFlow_NoProjectIsAnAnswerAndTheProbeSaysWhatItCostsYou(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("enter", "enter")
+
+	d.atStep(stepReview)
+	d.mustContain("What this token can do on this site")
+	d.mustContain("no project is selected, so per-project permissions are unknown")
+}
+
+func TestFlow_TheProbeReasonsAreShownInTheProbesOwnWords(t *testing.T) {
+	t.Parallel()
+
+	fake := testFake(jiratest.WithCapabilities(jiratest.NoBulkMove, jiratest.NoPlans))
+	d := newDriver(t, fake)
+	d.credentials()
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter")
+
+	d.atStep(stepReview)
+	d.mustContain("needs Bulk Change permission")
+	d.mustContain("the Plans API needs Administer Jira")
+}
+
+func TestFlow_AKeychainThatRefusesTheWriteLeavesNothingBehind(t *testing.T) {
+	keyring.MockInitWithError(errors.New("the keychain is locked"))
+	t.Cleanup(keyring.MockInit)
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter")
+	d.press("enter")
+
+	d.atStep(stepReview)
+	d.mustContain("the keychain is locked")
+	d.nothingWritten()
+	d.noTokenAnywhere()
+}
+
+// TestFlow_AnEnvironmentSourceIsReportedWhenTheVariableIsNotSet is the other
+// half of "saved and then broken on every screen": the file is right, and the
+// place it points at is empty.
+func TestFlow_AnEnvironmentSourceIsReportedWhenTheVariableIsNotSet(t *testing.T) {
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("down")
+	d.clearField()
+	d.typeIn("SARAL_TEST_TOKEN_UNSET")
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter")
+	d.press("enter")
+
+	d.atStep(stepDone)
+	d.mustContain("SARAL_TEST_TOKEN_UNSET is empty or not set")
+	if !strings.Contains(d.written(), `token   = { env = "SARAL_TEST_TOKEN_UNSET" }`) {
+		t.Errorf("the config does not name the environment variable:\n%s", d.written())
+	}
+	d.noTokenAnywhere()
+}
+
+func TestFlow_AnEnvironmentSourceThatResolvesIsNotComplainedAbout(t *testing.T) {
+	t.Setenv("SARAL_TEST_TOKEN", testToken)
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("down")
+	d.clearField()
+	d.typeIn("SARAL_TEST_TOKEN")
+	d.press("enter")
+	d.press("enter")
+	d.press("enter")
+
+	d.atStep(stepDone)
+	if got := d.model().problem; got != "" {
+		t.Errorf("a working environment source was reported as a problem: %q", got)
+	}
+	d.noTokenAnywhere()
+}
+
+func TestStorage_EverySourceIsOfferedAndValidatedInItsOwnWords(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		down  int
+		value string
+		want  string
+	}{
+		"an unnamed keychain entry": {down: 0, value: "", want: "name the keychain entry"},
+		"a variable with a space":   {down: 1, value: "JIRA TOKEN", want: "name the environment variable"},
+		"a pipeline as a command":   {down: 2, value: "pass jira | head -1", want: "never run through a shell"},
+		"an empty command":          {down: 2, value: "", want: "name the command"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := newDriver(t, testFake())
+			d.credentials()
+			for range tc.down {
+				d.press("down")
+			}
+			d.clearField()
+			d.typeIn(tc.value)
+			d.press("enter")
+
+			d.atStep(stepStorage)
+			d.mustContain(tc.want)
+		})
+	}
+}
+
+func TestStorage_SwitchingSourceKeepsWhatWasTypedForEachOne(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.atStep(stepStorage)
+
+	d.clearField()
+	d.typeIn("saral:mine")
+	d.press("down")
+	if got := d.model().input[fieldSecret].Value(); got != "JIRA_TOKEN" {
+		t.Errorf("the environment source starts at %q, want the usual default", got)
+	}
+	d.press("up")
+	if got := d.model().input[fieldSecret].Value(); got != "saral:mine" {
+		t.Errorf("switching back lost the entry name: %q", got)
+	}
+}
+
+func TestProjects_AreOfferedFromTheAccountsOwnRecentWorkFirst(t *testing.T) {
+	t.Parallel()
+
+	fake := jiratest.New(
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithIssues(jiratest.Gen(6)),
+		jiratest.WithIssues(jiratest.GenFor("OTHER", 3)),
+		jiratest.WithMe(jira.User{AccountID: "acct-ada", DisplayName: "Ada Lovelace", TimeZone: time.UTC, Active: true}),
+	)
+	d := newDriver(t, fake)
+	d.credentials()
+	d.press("enter")
+
+	d.atStep(stepProject)
+	if got := d.model().suggested; len(got) == 0 {
+		t.Fatal("no project was suggested from the account's own issues")
+	}
+	d.mustContain("Recently worked in")
+
+	d.press("down")
+	if got := d.model().value(fieldProject); got == "" {
+		t.Error("choosing a suggestion did not fill the field")
+	}
+}
+
+func TestProjects_FallBackToWhatTheAccountCanSeeWhenNothingIsAssignedToIt(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("enter")
+
+	if got := d.model().suggested; len(got) != 1 || got[0] != "PROJ" {
+		t.Errorf("suggestions are %v, want the one project the account can see", got)
+	}
+}
+
+func TestProjects_AFailedLookupIsANoteAndNotARefusal(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, refusesToSearch{
+		Fake: testFake(),
+		err:  &jira.RateLimitError{RetryAfter: 30 * time.Second, Endpoint: "/search/jql"},
+	})
+	d.credentials()
+
+	d.atStep(stepStorage)
+	d.press("enter")
+	d.atStep(stepProject)
+	d.mustContain("rate limited by Jira")
+
+	d.typeIn("PROJ")
+	d.press("enter")
+	d.atStep(stepReview)
+}
+
+func TestBack_KeepsEverythingThatWasTyped(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.atStep(stepStorage)
+
+	d.press("shift+tab")
+	d.atStep(stepToken)
+	if got := d.model().input[fieldToken].Value(); got != testToken {
+		t.Error("going back emptied the token field")
+	}
+	d.press("shift+tab", "shift+tab")
+	d.atStep(stepSite)
+	if got := d.model().value(fieldSite); got != testSite {
+		t.Errorf("going back to the start lost the site: %q", got)
+	}
+	d.press("shift+tab")
+	d.atStep(stepSite)
+}
+
+func TestSite_AcceptsWhatPeopleActuallyPasteAndRefusesWhatCannotBeASite(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		typed string
+		want  string
+		stay  bool
+	}{
+		"a pasted url":       {typed: "https://example.atlassian.net/jira/software", want: "", stay: true},
+		"a bare host":        {typed: "Example.Atlassian.NET", want: ""},
+		"an empty site":      {typed: "", want: "site is required", stay: true},
+		"an insecure scheme": {typed: "http://example.atlassian.net", want: "must be reached over https", stay: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := newDriver(t, testFake())
+			d.typeIn(tc.typed)
+			d.press("enter")
+
+			if tc.want != "" {
+				d.atStep(stepSite)
+				d.mustContain(tc.want)
+				return
+			}
+			d.atStep(stepEmail)
+			if got := d.model().value(fieldSite); got != testSite {
+				t.Errorf("the site was normalised to %q, want %q", got, testSite)
+			}
+		})
+	}
+}
+
+func TestEmail_MustBeAnAddressBecauseJiraPairsItWithTheToken(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.typeIn(testSite)
+	d.press("enter")
+	d.typeIn("you")
+	d.press("enter")
+
+	d.atStep(stepEmail)
+	d.mustContain("pairs the account email with the API token")
+}
+
+func TestBlocksClose_RefusesToThrowAwayAHalfFinishedSetup(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	if _, blocked := d.model().BlocksClose(); blocked {
+		t.Error("an untouched form blocks quitting")
+	}
+
+	d.typeIn(testSite)
+	reason, blocked := d.model().BlocksClose()
+	if !blocked {
+		t.Fatal("a form with something typed in it does not block quitting")
+	}
+	if !strings.Contains(reason, "ctrl+c") {
+		t.Errorf("the reason %q does not say how to leave anyway", reason)
+	}
+}
+
+func TestBlocksClose_StopsBlockingOnceTheProfileIsWritten(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(keyring.MockInit)
+
+	d := newDriver(t, testFake())
+	d.credentials()
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter", "enter")
+
+	d.atStep(stepDone)
+	if _, blocked := d.model().BlocksClose(); blocked {
+		t.Error("a finished setup still blocks quitting")
+	}
+	d.press("enter")
+	if !d.quit {
+		t.Error("enter on the summary did not leave, so nothing tells the user to restart")
+	}
+}
+
+func TestSave_RefusesToWriteOverAConfigFileItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.send(configLoadedMsg{path: d.path, err: errors.New("unknown key profiles.work.colour")})
+
+	d.credentials()
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter", "enter")
+
+	d.atStep(stepReview)
+	d.mustContain("refusing to write over a config file")
+	d.nothingWritten()
+}
+
+func TestSave_AddsToTheProfilesThatAreAlreadyThereAndBecomesTheActiveOne(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(keyring.MockInit)
+
+	d := newDriver(t, testFake())
+	d.send(configLoadedMsg{path: d.path, cfg: config.Config{
+		Active: "work",
+		Mouse:  true,
+		Profiles: map[string]config.Profile{"work": {
+			Name:  "work",
+			Site:  "other.atlassian.net",
+			Email: "you@example.com",
+			Token: config.TokenSource{Env: "JIRA_TOKEN"},
+		}},
+	}})
+
+	d.credentials()
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter", "enter")
+
+	d.atStep(stepDone)
+	cfg, err := config.LoadFile(d.path)
+	if err != nil {
+		t.Fatalf("loading back: %v", err)
+	}
+	if len(cfg.Profiles) != 2 {
+		t.Errorf("the file holds %d profiles, want the old one and the new one", len(cfg.Profiles))
+	}
+	if cfg.Active != "example" {
+		t.Errorf("active is %q, want the profile that was just set up", cfg.Active)
+	}
+}
+
+func TestSave_NamesASecondProfileForTheSameSiteWithoutOverwritingTheFirst(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.send(configLoadedMsg{path: d.path, cfg: config.Config{
+		Mouse:    true,
+		Profiles: map[string]config.Profile{"example": {Name: "example", Site: testSite, Email: "old@example.com", Token: config.TokenSource{Env: "JIRA_TOKEN"}}},
+	}})
+	d.credentials()
+
+	d.atStep(stepStorage)
+	if got := d.model().profileName(); got != "example-2" {
+		t.Errorf("the new profile is called %q, which would replace the one already there", got)
+	}
+}
+
+func TestFocus_CancelsWhatIsInTheAirWhenTheViewStopsBeingLookedAt(t *testing.T) {
+	t.Parallel()
+
+	fake := testFake()
+	fake.Delay(time.Hour)
+	d := newDriver(t, testFake())
+
+	d.typeIn(testSite)
+	d.press("enter")
+	d.typeIn(testEmail)
+	d.press("enter")
+	d.typeIn(testToken)
+
+	m := d.model()
+	m.client = fake
+	m.busy, m.seq = busyProbe, 7
+	cancelled := false
+	m.cancel = func() { cancelled = true }
+	m.stop()
+
+	if !cancelled {
+		t.Error("the in-flight call was not cancelled")
+	}
+	if m.busy != busyNone {
+		t.Error("the view still thinks something is in the air")
+	}
+}
+
+func TestRefresh_RunsTheLastThingThatFailedAgain(t *testing.T) {
+	t.Parallel()
+
+	fake := testFake()
+	fake.FailNext(&jira.TransportError{Op: "GET /rest/api/3/myself", Err: errors.New("connection reset by peer")})
+	d := newDriver(t, fake)
+	d.credentials()
+
+	d.atStep(stepSite)
+	d.send(kernel.RefreshMsg{})
+	d.atStep(stepStorage)
+}
+
+func TestTheme_IsRebuiltWithoutLosingAnythingTyped(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.typeIn(testSite)
+	d.send(kernel.ThemeMsg{Theme: kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs())})
+
+	if got := d.model().value(fieldSite); got != testSite {
+		t.Errorf("a theme change lost the site: %q", got)
+	}
+	if !strings.Contains(d.frame(), testSite) {
+		t.Errorf("the retheme dropped the field:\n%s", d.frame())
+	}
+}
+
+func TestPaste_ReachesTheField(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.send(tea.PasteMsg{Content: testSite})
+	if got := d.model().value(fieldSite); got != testSite {
+		t.Errorf("a pasted site landed as %q", got)
+	}
+}
+
+func TestInit_ReadsTheConfigDirectoryFromTheEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SARAL_CONFIG_DIR", dir)
+
+	msg, ok := loadConfig().(configLoadedMsg)
+	if !ok {
+		t.Fatalf("loadConfig returned a %T", msg)
+	}
+	if msg.err != nil {
+		t.Errorf("a first run reported an error: %v", msg.err)
+	}
+	if !strings.HasPrefix(msg.path, dir) {
+		t.Errorf("the config path is %q, which is not under %q", msg.path, dir)
+	}
+	if !msg.cfg.Mouse {
+		t.Error("a first run turned the mouse off")
+	}
+}

--- a/internal/ui/onboarding/register.go
+++ b/internal/ui/onboarding/register.go
@@ -1,0 +1,38 @@
+package onboarding
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// The view claims no footer slot: it is where the program starts when there is
+// no profile, and after that it is something reached by name or by the palette,
+// not a place anyone navigates to daily.
+func init() {
+	kernel.RegisterView(kernel.ViewSpec{
+		ID:    ViewID,
+		Title: "Setup",
+		New:   New,
+	})
+
+	kernel.RegisterKeys(ViewID, kernel.KeySet{
+		Short: []kernel.Binding{
+			kernel.Bind([]string{"enter"}, "enter", "continue"),
+			kernel.Bind([]string{"shift+tab"}, "shift+tab", "back a step"),
+		},
+		Full: [][]kernel.Binding{{
+			kernel.Bind([]string{"enter", "tab"}, "enter", "continue"),
+			kernel.Bind([]string{"shift+tab"}, "shift+tab", "back a step"),
+			kernel.Bind([]string{"up", "down"}, "up/down", "choose"),
+			kernel.Bind([]string{"ctrl+r"}, "ctrl+r", "try that again"),
+		}},
+	})
+
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "onboarding.run",
+		Title: "Set up a Jira profile",
+		Group: "Profile",
+		Run:   func(kernel.Deps) tea.Cmd { return kernel.Open(ViewID) },
+	})
+}

--- a/internal/ui/onboarding/render.go
+++ b/internal/ui/onboarding/render.go
@@ -1,0 +1,492 @@
+package onboarding
+
+import (
+	"strconv"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const (
+	inputIndent = 4
+	labelWidth  = 10
+	// railMinHeight is the shortest box the list of steps is drawn in. Below it
+	// the step being worked on gets the rows instead.
+	railMinHeight = 24
+)
+
+// styles are built once per theme generation. Constructing a lipgloss.Style is
+// the expensive half of rendering, and none of these may be built in a loop.
+type styles struct {
+	title    lipgloss.Style
+	subtitle lipgloss.Style
+	label    lipgloss.Style
+	value    lipgloss.Style
+	muted    lipgloss.Style
+	prompt   lipgloss.Style
+	problem  lipgloss.Style
+	yes      lipgloss.Style
+	no       lipgloss.Style
+	chosen   lipgloss.Style
+	done     lipgloss.Style
+	here     lipgloss.Style
+	pending  lipgloss.Style
+}
+
+func (m *Model) restyle() {
+	t := m.deps.Theme
+	m.styles = styles{
+		title:    t.Title,
+		subtitle: t.Muted,
+		label:    t.Muted,
+		value:    t.Base,
+		muted:    t.Muted,
+		prompt:   t.Accent,
+		problem:  t.Danger,
+		yes:      t.Success,
+		no:       t.Warning,
+		chosen:   t.Selected,
+		done:     t.Success,
+		here:     t.Accent,
+		pending:  t.Muted,
+	}
+}
+
+// renderCache holds the parts of the frame that do not change per keystroke:
+// the heading and the block of prose under the field. They are rebuilt when the
+// step, the width or the theme changes and not otherwise.
+type renderCache struct {
+	key     cacheKey
+	heading []string
+	explain []string
+	pane    []string
+	valid   bool
+}
+
+type cacheKey struct {
+	step   step
+	store  storeKind
+	width  int
+	height int
+	theme  int
+	offset int
+}
+
+func (c *renderCache) reset() {
+	if c != nil {
+		c.valid = false
+	}
+}
+
+// View draws the whole body the kernel gave this view, in exactly the number of
+// rows it was given.
+func (m Model) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+	heading, explain, pane := m.chrome()
+	body := m.section(pane)
+	rail := []string(nil)
+	if m.showRail() {
+		rail = m.rail()
+	}
+
+	out := make([]string, 0, m.height)
+	out = append(out, heading...)
+	if m.showRail() {
+		out = append(out, rail...)
+		out = append(out, "")
+	}
+	out = append(out, body...)
+	if len(explain) > 0 && len(out)+1+len(explain) <= m.height {
+		out = append(out, "")
+		out = append(out, explain...)
+	}
+	return m.frame(out)
+}
+
+// showRail decides whether there is room for the list of steps beside the one
+// being worked on. It answers from the height alone rather than from whether
+// the rest happens to fit, so that the layout does not move as a step grows.
+func (m Model) showRail() bool { return m.height >= railMinHeight }
+
+// paneHeight is what is left for the scrolling summary once the heading, the
+// rail, the prompt and two rows for messages are taken out.
+func (m Model) paneHeight() int {
+	used := len(m.heading()) + 2 + 2
+	if m.showRail() {
+		used += steps + 1
+	}
+	return max(m.height-used, 3)
+}
+
+// chrome returns the heading and the prose, rebuilt only when the step, the
+// width or the theme has changed. Everything else on the screen answers to a
+// keystroke and is built fresh.
+func (m Model) chrome() (heading, explain, pane []string) {
+	if m.cache == nil {
+		return m.heading(), m.explain(), m.paneLines()
+	}
+	key := cacheKey{
+		step: m.step, store: m.store, theme: m.deps.Theme.Gen,
+		width: m.width, height: m.height, offset: m.pane.YOffset(),
+	}
+	if !m.cache.valid || m.cache.key != key {
+		*m.cache = renderCache{
+			key: key, valid: true,
+			heading: m.heading(), explain: m.explain(), pane: m.paneLines(),
+		}
+	}
+	return m.cache.heading, m.cache.explain, m.cache.pane
+}
+
+// paneLines renders the scrolling summary. It is in the cache because the
+// widget re-wraps and re-pads its whole content on every call, and the screen
+// it draws answers to nothing but a scroll.
+func (m Model) paneLines() []string {
+	switch m.step {
+	case stepReview, stepDone:
+		return strings.Split(m.pane.View(), "\n")
+	default:
+		return nil
+	}
+}
+
+// frame clamps every row to the width and the whole thing to the height. A row
+// that wraps costs the footer its line, and the long rows here are the ones
+// carrying an error message.
+func (m Model) frame(rows []string) string {
+	ellipsis := m.deps.Theme.Glyphs.Ellipsis
+	var b strings.Builder
+	b.Grow(m.width * min(len(rows), m.height))
+	for i, row := range rows {
+		if i >= m.height {
+			break
+		}
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if lipgloss.Width(row) > m.width {
+			row = ansi.Truncate(row, m.width, ellipsis)
+		}
+		b.WriteString(strings.TrimRight(row, " "))
+	}
+	return b.String()
+}
+
+func (m Model) heading() []string {
+	title := "Set up Saral"
+	if m.step == stepDone {
+		title = "Saral is set up"
+	}
+	if m.step >= stepDone {
+		return []string{m.styles.title.Render(title), ""}
+	}
+	counter := "step " + strconv.Itoa(int(m.step)+1) + " of " + strconv.Itoa(steps)
+	return []string{m.spread(m.styles.title.Render(title), m.styles.muted.Render(counter)), ""}
+}
+
+// spread puts left at the margin and right at the far edge, dropping the right
+// half rather than letting the row wrap.
+func (m Model) spread(left, right string) string {
+	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		return left
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+// rail is the list of steps down the side, with what has been entered beside
+// the ones that are behind. Each one behind is clickable.
+func (m Model) rail() []string {
+	out := make([]string, 0, steps)
+	for s := stepSite; s < stepDone; s++ {
+		var mark, label string
+		switch {
+		case s < m.step:
+			mark, label = m.deps.Theme.Glyphs.Check, m.styles.done.Render(s.title())
+		case s == m.step:
+			mark, label = m.deps.Theme.Glyphs.Arrow, m.styles.here.Render(s.title())
+		default:
+			mark, label = " ", m.styles.pending.Render(s.title())
+		}
+		row := "  " + cell(mark, 3) + label
+		if entered := m.entered(s); entered != "" {
+			row = "  " + cell(mark, 3) + pad(label, labelWidth+5) + m.styles.muted.Render(entered)
+		}
+		if s < m.step {
+			row = m.mark("step:"+s.String(), row)
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// entered is what the user put into a step, echoed beside it. The token is the
+// one that never is.
+func (m Model) entered(s step) string {
+	if s >= m.step {
+		return ""
+	}
+	switch s {
+	case stepSite:
+		return m.value(fieldSite)
+	case stepEmail:
+		return m.value(fieldEmail)
+	case stepToken:
+		if m.account.DisplayName != "" {
+			return "verified as " + m.account.DisplayName
+		}
+		return "verified"
+	case stepStorage:
+		return m.store.title()
+	case stepProject:
+		if key := m.value(fieldProject); key != "" {
+			return key
+		}
+		return "none"
+	case stepReview, stepDone:
+	}
+	return ""
+}
+
+// section is the step's own content: the prompt, whatever it is asking for, and
+// the line that says what went wrong.
+func (m Model) section(pane []string) []string {
+	out := make([]string, 0, 8)
+	out = append(out, indent(m.styles.subtitle.Render(m.step.prompt())))
+
+	switch m.step {
+	case stepStorage:
+		out = append(out, "")
+		out = append(out, m.choices()...)
+		out = append(out, "", m.fieldRow(m.store.label()))
+	case stepProject:
+		out = append(out, "", m.fieldRow("Project key"))
+		out = append(out, m.suggestions()...)
+	case stepReview, stepDone:
+		out = append(out, "")
+		out = append(out, pane...)
+	case stepSite, stepEmail, stepToken:
+		out = append(out, "", m.fieldRow(""))
+	}
+	return append(out, m.messages()...)
+}
+
+func (m Model) fieldRow(label string) string {
+	f := m.step.field()
+	if f == fieldNone {
+		return ""
+	}
+	column := ""
+	if label != "" {
+		column = m.styles.label.Render(pad(label, labelWidth+4))
+	}
+	return indent(column + m.styles.prompt.Render(m.deps.Theme.Glyphs.Arrow+" ") + m.input[f].View())
+}
+
+// messages is what sits under the field: what went wrong, what is in flight, or
+// what is worth knowing. There is always a row for it, so that the prose below
+// does not move as messages come and go.
+func (m Model) messages() []string {
+	rows := make([]string, 0, 2)
+	switch {
+	case m.problem != "":
+		rows = append(rows, indent(m.styles.problem.Render(m.deps.Theme.Glyphs.Cross+" "+m.problem)))
+	case m.busy != busyNone:
+		rows = append(rows, indent(m.spin.View()+" "+m.styles.muted.Render(m.busy.String()+m.deps.Theme.Glyphs.Ellipsis)))
+	case m.step != stepProject:
+	case m.looking:
+		rows = append(rows, indent(m.styles.muted.Render("Looking for the projects you have been working in"+m.deps.Theme.Glyphs.Ellipsis)))
+	case m.lookup != "":
+		rows = append(rows, indent(m.styles.muted.Render(m.lookup)))
+	}
+	if m.note != "" {
+		rows = append(rows, indent(m.styles.muted.Render(m.note)))
+	}
+	if len(rows) == 0 {
+		rows = append(rows, "")
+	}
+	return rows
+}
+
+func (m Model) choices() []string {
+	out := make([]string, 0, storeCount)
+	for kind := storeKind(0); kind < storeCount; kind++ {
+		mark, style := " ", m.styles.value
+		if kind == m.store {
+			mark, style = m.deps.Theme.Glyphs.Diamond, m.styles.chosen
+		}
+		row := indent(style.Render(cell(mark, 2) + " " + kind.title()))
+		out = append(out, m.mark("store:"+kind.String(), row))
+	}
+	return out
+}
+
+func (m Model) suggestions() []string {
+	if len(m.suggested) == 0 {
+		return nil
+	}
+	rows := make([]string, 0, len(m.suggested)+1)
+	rows = append(rows, "", indent(m.styles.muted.Render("Recently worked in")))
+	picked := m.value(fieldProject)
+	for _, key := range m.suggested {
+		mark, style := " ", m.styles.value
+		if key == picked {
+			mark, style = m.deps.Theme.Glyphs.Diamond, m.styles.chosen
+		}
+		rows = append(rows, m.mark("project:"+key, indent(style.Render(cell(mark, 2)+" "+key))))
+	}
+	return rows
+}
+
+// summary is the review screen: everything that will be written, then what the
+// probe found, in the probe's own words.
+func (m Model) summary() []string {
+	rows := make([]string, 0, 16)
+	rows = append(rows,
+		m.pair("Site", m.value(fieldSite)),
+		m.pair("Account", m.accountLine()),
+		m.pair("Profile", m.profileName()+m.styles.muted.Render(" in "+m.cfgPath)),
+		m.pair("Token", m.tokenLine()),
+		m.pair("Project", m.projectLine()),
+	)
+	if !m.probed {
+		return rows
+	}
+	rows = append(rows, "", indent(m.styles.subtitle.Render(m.capsHeading())))
+	for _, c := range capabilityList {
+		rows = append(rows, m.capabilityRow(c.key, c.label))
+	}
+	return append(rows, "",
+		m.pair("Dates in", m.caps.Location().String()),
+		m.pair("Images", m.caps.Graphics.String()))
+}
+
+func (m Model) capsHeading() string {
+	if m.project == "" {
+		return "What this token can do on this site"
+	}
+	return "What this token can do in " + m.project
+}
+
+var capabilityList = []struct {
+	key   jira.CapabilityKey
+	label string
+}{
+	{jira.CapBoards, "Boards"},
+	{jira.CapBulkMove, "Move between projects"},
+	{jira.CapDeleteIssues, "Delete issues"},
+	{jira.CapAttachments, "Attachments"},
+	{jira.CapPlans, "Plans"},
+}
+
+func (m Model) capabilityRow(key jira.CapabilityKey, label string) string {
+	got := m.caps.Capability(key)
+	if got.OK {
+		return indent(m.styles.yes.Render(cell(m.deps.Theme.Glyphs.Check, 2)) + m.styles.value.Render(label))
+	}
+	return indent(m.styles.no.Render(cell(m.deps.Theme.Glyphs.Cross, 2)) +
+		m.styles.value.Render(pad(label, labelWidth+12)) + m.styles.muted.Render(got.Reason))
+}
+
+func (m Model) accountLine() string {
+	if m.account.DisplayName == "" {
+		return m.value(fieldEmail)
+	}
+	return m.account.DisplayName + m.styles.muted.Render(" · "+m.value(fieldEmail))
+}
+
+func (m Model) tokenLine() string {
+	source, err := m.tokenSource()
+	if err != nil {
+		return m.styles.problem.Render(err.Error())
+	}
+	return source.String()
+}
+
+func (m Model) projectLine() string {
+	if key := m.value(fieldProject); key != "" {
+		return key
+	}
+	return m.styles.muted.Render("none, so Jira's per-project answers stay unknown")
+}
+
+func (m Model) finished() []string {
+	rows := []string{
+		m.pair("Profile", m.name),
+		m.pair("Written to", m.savedTo),
+		m.pair("Token", m.stored),
+	}
+	if m.deps.Jira == nil {
+		return append(rows, "", indent(m.styles.value.Render("Press enter to leave, then run saral again to open "+m.value(fieldSite)+".")))
+	}
+	return append(rows, "", indent(m.styles.value.Render("Press enter to carry on.")))
+}
+
+func (m Model) pair(label, value string) string {
+	return indent(m.styles.label.Render(pad(label, labelWidth+4)) + value)
+}
+
+// explain is the prose under the field. It is cached because wrapping it is the
+// most expensive thing on this screen and it changes only with the step.
+func (m Model) explain() []string {
+	text := ""
+	switch m.step {
+	case stepSite:
+		text = "The host you open in a browser, with or without the https:// in front. " +
+			"Saral talks to it over https and nothing else."
+	case stepEmail:
+		text = "Jira Cloud sends the email and the API token together as basic auth, so a token " +
+			"paired with the wrong address is refused exactly the way a wrong token is."
+	case stepToken:
+		text = "Create one at id.atlassian.com/manage-profile/security/api-tokens. It is checked " +
+			"against the site before anything at all is written, and it never goes into the config file."
+	case stepStorage:
+		text = m.store.explain() + " The config file only ever names the source, so it stays safe to read, " +
+			"copy between machines and keep in a dotfiles repository."
+	case stepProject:
+		text = "Jira grants Move, Create and Delete per project, and a board belongs to one, so the " +
+			"same token answers differently in two projects on one site. Saral remembers the one you " +
+			"pick, and naming a project on the command line overrides it for that run."
+	case stepReview, stepDone:
+		return nil
+	}
+	if text == "" {
+		return nil
+	}
+	width := m.width - 2*inputIndent
+	if width < 20 {
+		return nil
+	}
+	wrapped := strings.Split(ansi.Wordwrap(text, width, ""), "\n")
+	out := make([]string, 0, len(wrapped))
+	for _, line := range wrapped {
+		out = append(out, indent(m.styles.muted.Render(line)))
+	}
+	return out
+}
+
+func (m Model) mark(id, row string) string {
+	if m.zone == "" || m.deps.Zones == nil {
+		return row
+	}
+	return m.deps.Zones.Mark(m.zone+id, row)
+}
+
+func indent(s string) string { return strings.Repeat(" ", inputIndent) + s }
+
+// pad widens a label to a column, always leaving at least one space after it.
+func pad(s string, width int) string { return cell(s, width) + " " }
+
+// cell widens a string to exactly width columns, measuring what will be on the
+// screen rather than the styling around it.
+func cell(s string, width int) string {
+	if gap := width - lipgloss.Width(s); gap > 0 {
+		return s + strings.Repeat(" ", gap)
+	}
+	return s
+}

--- a/internal/ui/onboarding/render_test.go
+++ b/internal/ui/onboarding/render_test.go
@@ -1,0 +1,166 @@
+package onboarding
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// goldenPath stands in for the XDG path so that a golden file does not carry a
+// temporary directory in it.
+const goldenPath = "/home/you/.config/saral/config.toml"
+
+func goldenDriver(t *testing.T) *driver {
+	t.Helper()
+	d := newDriver(t, testFake(jiratest.WithCapabilities(jiratest.NoBulkMove, jiratest.NoPlans)))
+	d.send(configLoadedMsg{path: goldenPath})
+	return d
+}
+
+func TestView_Golden(t *testing.T) {
+	t.Parallel()
+
+	screens := map[string]func(*driver){
+		"site":  func(*driver) {},
+		"email": func(d *driver) { d.typeIn(testSite); d.press("enter") },
+		"token": func(d *driver) {
+			d.typeIn(testSite)
+			d.press("enter")
+			d.typeIn(testEmail)
+			d.press("enter")
+			d.typeIn(testToken)
+		},
+		"store": func(d *driver) { d.credentials() },
+		"store-command": func(d *driver) {
+			d.credentials()
+			d.press("down", "down")
+			d.typeIn("pass show jira")
+		},
+		"project": func(d *driver) { d.credentials(); d.press("enter") },
+		"review": func(d *driver) {
+			d.credentials()
+			d.press("enter")
+			d.typeIn("PROJ")
+			d.press("enter")
+		},
+		"done": func(d *driver) {
+			d.credentials()
+			d.press("enter")
+			d.typeIn("PROJ")
+			d.press("enter")
+			d.send(savedMsg{seq: d.model().seq, path: goldenPath, stored: "keychain entry saral:example"})
+		},
+		"rejected": func(d *driver) {
+			d.model()
+			d.typeIn(testSite)
+			d.press("enter")
+			d.typeIn(testEmail)
+			d.press("enter")
+			d.typeIn(testToken)
+			d.send(connectFailedMsg{seq: d.model().seq, err: &jira.AuthError{Reason: "the token has been revoked"}})
+		},
+	}
+
+	sizes := map[string][2]int{"120x40": {120, 40}, "80x20": {80, 20}}
+
+	for name, build := range screens {
+		for size, wh := range sizes {
+			t.Run(name+"_"+size, func(t *testing.T) {
+				t.Parallel()
+
+				d := goldenDriver(t)
+				d.send(kernel.SizeMsg{Width: wh[0], Height: wh[1]})
+				build(d)
+				golden(t, name+"_"+size+".golden", d.frame())
+			})
+		}
+	}
+}
+
+func TestView_FitsTheBoxItIsGiven(t *testing.T) {
+	t.Parallel()
+
+	for _, wh := range [][2]int{{80, 20}, {100, 24}, {120, 40}, {200, 60}} {
+		d := goldenDriver(t)
+		d.send(kernel.SizeMsg{Width: wh[0], Height: wh[1]})
+		d.forget()
+		d.credentials()
+		d.press("enter")
+		d.typeIn("PROJ")
+		d.press("enter")
+		d.send(savedMsg{seq: d.model().seq, path: goldenPath, warning: strings.Repeat("a very long warning ", 12)})
+
+		for _, frame := range d.frames {
+			lines := strings.Split(frame, "\n")
+			if len(lines) > wh[1] {
+				t.Errorf("at %dx%d a frame is %d rows:\n%s", wh[0], wh[1], len(lines), frame)
+			}
+			for i, line := range lines {
+				if w := lipgloss.Width(line); w > wh[0] {
+					t.Errorf("at %dx%d row %d is %d columns wide:\n%s", wh[0], wh[1], i, w, line)
+				}
+			}
+		}
+	}
+}
+
+// TestView_TheSummaryScrollsWhenItDoesNotFit covers the one screen that can be
+// taller than the terminal: a probe answers with as many sentences as it has
+// refusals, and none of them may be unreachable.
+func TestView_TheSummaryScrollsWhenItDoesNotFit(t *testing.T) {
+	t.Parallel()
+
+	d := goldenDriver(t)
+	d.send(kernel.SizeMsg{Width: 80, Height: 20})
+	d.credentials()
+	d.press("enter")
+	d.typeIn("PROJ")
+	d.press("enter")
+	d.atStep(stepReview)
+
+	if strings.Contains(d.frame(), "Images") {
+		t.Fatalf("the summary already fits, so this test proves nothing:\n%s", d.frame())
+	}
+	d.press("down", "down", "down")
+	if !strings.Contains(d.frame(), "Images") {
+		t.Errorf("scrolling did not reach the end of the summary:\n%s", d.frame())
+	}
+
+	d.send(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if !strings.Contains(d.frame(), "Site           "+testSite) {
+		t.Errorf("the wheel did not scroll the summary back to the top:\n%s", d.frame())
+	}
+}
+
+func TestView_DrawsNothingBeforeItHasBeenGivenASize(t *testing.T) {
+	t.Parallel()
+
+	if got := NewWith(testDeps(), nil).View(); got != "" {
+		t.Errorf("an unsized view drew %q", got)
+	}
+}
+
+func TestView_TheTokenFieldIsMasked(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.typeIn(testSite)
+	d.press("enter")
+	d.typeIn(testEmail)
+	d.press("enter")
+	d.typeIn(testToken)
+
+	frame := d.frame()
+	if strings.Contains(frame, testToken) {
+		t.Fatalf("the token is on the screen:\n%s", frame)
+	}
+	if !strings.Contains(frame, strings.Repeat("*", len(testToken))) {
+		t.Errorf("the token field is not masked:\n%s", frame)
+	}
+}

--- a/internal/ui/onboarding/steps.go
+++ b/internal/ui/onboarding/steps.go
@@ -1,0 +1,231 @@
+package onboarding
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/varijkapil13/saral/internal/config"
+)
+
+type step int
+
+const (
+	stepSite step = iota
+	stepEmail
+	stepToken
+	stepStorage
+	stepProject
+	stepReview
+	stepDone
+	stepCount
+)
+
+// steps is the number the header counts against; the summary is where the flow
+// ends rather than a step the user works through.
+const steps = int(stepCount) - 1
+
+func (s step) String() string {
+	switch s {
+	case stepSite:
+		return "site"
+	case stepEmail:
+		return "email"
+	case stepToken:
+		return "token"
+	case stepStorage:
+		return "store"
+	case stepProject:
+		return "project"
+	case stepReview:
+		return "review"
+	default:
+		return "done"
+	}
+}
+
+// title is the label on the rail down the left.
+func (s step) title() string {
+	switch s {
+	case stepSite:
+		return "Jira site"
+	case stepEmail:
+		return "Account email"
+	case stepToken:
+		return "API token"
+	case stepStorage:
+		return "Token store"
+	case stepProject:
+		return "Project"
+	case stepReview:
+		return "Review"
+	default:
+		return "Done"
+	}
+}
+
+func (s step) prompt() string {
+	switch s {
+	case stepSite:
+		return "Which Jira Cloud site?"
+	case stepEmail:
+		return "Which account is the API token for?"
+	case stepToken:
+		return "Paste the API token"
+	case stepStorage:
+		return "Where should the token live?"
+	case stepProject:
+		return "Which project should Saral open in?"
+	case stepReview:
+		return "This is what will be written."
+	default:
+		return "The profile is written."
+	}
+}
+
+func (s step) field() field {
+	switch s {
+	case stepSite:
+		return fieldSite
+	case stepEmail:
+		return fieldEmail
+	case stepToken:
+		return fieldToken
+	case stepStorage:
+		return fieldSecret
+	case stepProject:
+		return fieldProject
+	default:
+		return fieldNone
+	}
+}
+
+type field int
+
+const (
+	fieldSite field = iota
+	fieldEmail
+	fieldToken
+	fieldSecret
+	fieldProject
+	fieldCount
+	fieldNone field = -1
+)
+
+func (f field) placeholder() string {
+	switch f {
+	case fieldSite:
+		return "example.atlassian.net"
+	case fieldEmail:
+		return "you@example.com"
+	case fieldProject:
+		return "PROJ"
+	case fieldToken, fieldSecret, fieldCount, fieldNone:
+	}
+	return ""
+}
+
+type storeKind int
+
+const (
+	storeKeychain storeKind = iota
+	storeEnv
+	storeCommand
+	storeCount
+)
+
+func (k storeKind) String() string {
+	switch k {
+	case storeKeychain:
+		return "keychain"
+	case storeEnv:
+		return "environment"
+	default:
+		return "command"
+	}
+}
+
+func (k storeKind) title() string {
+	switch k {
+	case storeKeychain:
+		return "OS keychain"
+	case storeEnv:
+		return "Environment variable"
+	default:
+		return "Command"
+	}
+}
+
+// explain says what choosing this store actually does, because it is the only
+// moment anyone thinks about where a secret lives.
+func (k storeKind) explain() string {
+	switch k {
+	case storeKeychain:
+		return "Saral writes the token into the keychain now and the config file only names the entry. " +
+			"This is the one place Saral can write a secret to."
+	case storeEnv:
+		return "Saral writes nothing. Each start it reads the variable, so it has to be exported " +
+			"where Saral runs — a shell profile, a systemd unit, a container environment."
+	default:
+		return "Saral writes nothing. Each start it runs the command and reads the first line of its " +
+			"output. The command is never handed to a shell, so it is an argument list and not a pipeline."
+	}
+}
+
+func (k storeKind) label() string {
+	switch k {
+	case storeKeychain:
+		return "Keychain entry"
+	case storeEnv:
+		return "Variable name"
+	default:
+		return "Command"
+	}
+}
+
+// shellMeta is refused in a token command for the same reason internal/config
+// refuses it: the argv is never handed to a shell, so a pipeline typed here
+// would silently become literal arguments.
+const shellMeta = "|&;<>()$`\\\"'*?[]{}~!#\n\r"
+
+func (m Model) tokenSource() (config.TokenSource, error) {
+	value := strings.TrimSpace(m.input[fieldSecret].Value())
+	switch m.store {
+	case storeKeychain:
+		if value == "" {
+			return config.TokenSource{}, errors.New(`name the keychain entry, as service:account — for example saral:` + m.profileName())
+		}
+		return config.TokenSource{Keychain: value}, nil
+	case storeEnv:
+		if value == "" || strings.ContainsAny(value, " =") {
+			return config.TokenSource{}, errors.New("name the environment variable, for example JIRA_TOKEN")
+		}
+		return config.TokenSource{Env: value}, nil
+	default:
+		if i := strings.IndexAny(value, shellMeta); i >= 0 {
+			return config.TokenSource{}, fmt.Errorf("%q cannot be in the command: it is never run through a shell, so write the program and its arguments — for example: sh -lc \"pass jira | head -1\"", value[i:i+1])
+		}
+		argv := strings.Fields(value)
+		if len(argv) == 0 {
+			return config.TokenSource{}, errors.New("name the command that prints the token, for example: pass show jira")
+		}
+		return config.TokenSource{Command: argv}, nil
+	}
+}
+
+// profile is what will be written: everything collected so far, validated by
+// internal/config rather than by a second copy of its rules here.
+func (m Model) profile() (config.Profile, error) {
+	source, err := m.tokenSource()
+	if err != nil {
+		return config.Profile{}, err
+	}
+	p := config.Profile{
+		Name:    m.profileName(),
+		Site:    m.value(fieldSite),
+		Email:   m.value(fieldEmail),
+		Project: m.value(fieldProject),
+		Token:   source,
+	}
+	return p, p.Validate()
+}

--- a/internal/ui/onboarding/testdata/done_120x40.golden
+++ b/internal/ui/onboarding/testdata/done_120x40.golden
@@ -1,0 +1,38 @@
+Saral is set up
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  +  API token       verified as Sam Tester
+  +  Token store     OS keychain
+  +  Project         PROJ
+  +  Review
+
+    The profile is written.
+
+    Profile        example
+    Written to     /home/you/.config/saral/config.toml
+    Token          keychain entry saral:example
+
+    Press enter to leave, then run saral again to open example.atlassian.net.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/onboarding/testdata/done_80x20.golden
+++ b/internal/ui/onboarding/testdata/done_80x20.golden
@@ -1,0 +1,18 @@
+Saral is set up
+
+    The profile is written.
+
+    Profile        example
+    Written to     /home/you/.config/saral/config.toml
+    Token          keychain entry saral:example
+
+    Press enter to leave, then run saral again to open example.atlassian.net.
+
+
+
+
+
+
+
+
+

--- a/internal/ui/onboarding/testdata/email_120x40.golden
+++ b/internal/ui/onboarding/testdata/email_120x40.golden
@@ -1,0 +1,16 @@
+Set up Saral                                                                                                 step 2 of 6
+
+  +  Jira site       example.atlassian.net
+  -> Account email
+     API token
+     Token store
+     Project
+     Review
+
+    Which account is the API token for?
+
+    -> you@example.com                                                                                  
+
+
+    Jira Cloud sends the email and the API token together as basic auth, so a token paired with the wrong address is
+    refused exactly the way a wrong token is.

--- a/internal/ui/onboarding/testdata/email_80x20.golden
+++ b/internal/ui/onboarding/testdata/email_80x20.golden
@@ -1,0 +1,10 @@
+Set up Saral                                                         step 2 of 6
+
+    Which account is the API token for?
+
+    -> you@example.com                                          
+
+
+    Jira Cloud sends the email and the API token together as basic auth, so
+    a token paired with the wrong address is refused exactly the way a wrong
+    token is.

--- a/internal/ui/onboarding/testdata/project_120x40.golden
+++ b/internal/ui/onboarding/testdata/project_120x40.golden
@@ -1,0 +1,20 @@
+Set up Saral                                                                                                 step 5 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  +  API token       verified as Sam Tester
+  +  Token store     OS keychain
+  -> Project
+     Review
+
+    Which project should Saral open in?
+
+    Project key    -> PROJ                                                                                             
+
+    Recently worked in
+       PROJ
+
+
+    Jira grants Move, Create and Delete per project, and a board belongs to one, so the same token answers
+    differently in two projects on one site. Saral remembers the one you pick, and naming a project on the command
+    line overrides it for that run.

--- a/internal/ui/onboarding/testdata/project_80x20.golden
+++ b/internal/ui/onboarding/testdata/project_80x20.golden
@@ -1,0 +1,14 @@
+Set up Saral                                                         step 5 of 6
+
+    Which project should Saral open in?
+
+    Project key    -> PROJ                                                     
+
+    Recently worked in
+       PROJ
+
+
+    Jira grants Move, Create and Delete per project, and a board belongs to
+    one, so the same token answers differently in two projects on one site.
+    Saral remembers the one you pick, and naming a project on the command
+    line overrides it for that run.

--- a/internal/ui/onboarding/testdata/rejected_120x40.golden
+++ b/internal/ui/onboarding/testdata/rejected_120x40.golden
@@ -1,0 +1,16 @@
+Set up Saral                                                                                                 step 3 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  -> API token
+     Token store
+     Project
+     Review
+
+    Paste the API token
+
+    -> ******************** 
+    x authentication failed: the token has been revoked
+
+    Create one at id.atlassian.com/manage-profile/security/api-tokens. It is checked against the site before
+    anything at all is written, and it never goes into the config file.

--- a/internal/ui/onboarding/testdata/rejected_80x20.golden
+++ b/internal/ui/onboarding/testdata/rejected_80x20.golden
@@ -1,0 +1,10 @@
+Set up Saral                                                         step 3 of 6
+
+    Paste the API token
+
+    -> ******************** 
+    x authentication failed: the token has been revoked
+
+    Create one at id.atlassian.com/manage-profile/security/api-tokens. It is
+    checked against the site before anything at all is written, and it never
+    goes into the config file.

--- a/internal/ui/onboarding/testdata/review_120x40.golden
+++ b/internal/ui/onboarding/testdata/review_120x40.golden
@@ -1,0 +1,38 @@
+Set up Saral                                                                                                 step 6 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  +  API token       verified as Sam Tester
+  +  Token store     OS keychain
+  +  Project         PROJ
+  -> Review
+
+    This is what will be written.
+
+    Site           example.atlassian.net
+    Account        Sam Tester · you@example.com
+    Profile        example in /home/you/.config/saral/config.toml
+    Token          keychain entry saral:example
+    Project        PROJ
+
+    What this token can do in PROJ
+    + Boards
+    x Move between projects  needs Bulk Change permission
+    + Delete issues
+    + Attachments
+    x Plans                  the Plans API needs Administer Jira
+
+    Dates in       UTC
+    Images         halfblocks
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/onboarding/testdata/review_80x20.golden
+++ b/internal/ui/onboarding/testdata/review_80x20.golden
@@ -1,0 +1,18 @@
+Set up Saral                                                         step 6 of 6
+
+    This is what will be written.
+
+    Site           example.atlassian.net
+    Account        Sam Tester · you@example.com
+    Profile        example in /home/you/.config/saral/config.toml
+    Token          keychain entry saral:example
+    Project        PROJ
+
+    What this token can do in PROJ
+    + Boards
+    x Move between projects  needs Bulk Change permission
+    + Delete issues
+    + Attachments
+    x Plans                  the Plans API needs Administer Jira
+
+    Dates in       UTC

--- a/internal/ui/onboarding/testdata/site_120x40.golden
+++ b/internal/ui/onboarding/testdata/site_120x40.golden
@@ -1,0 +1,16 @@
+Set up Saral                                                                                                 step 1 of 6
+
+  -> Jira site
+     Account email
+     API token
+     Token store
+     Project
+     Review
+
+    Which Jira Cloud site?
+
+    -> example.atlassian.net                                                                            
+
+
+    The host you open in a browser, with or without the https:// in front. Saral talks to it over https and nothing
+    else.

--- a/internal/ui/onboarding/testdata/site_80x20.golden
+++ b/internal/ui/onboarding/testdata/site_80x20.golden
@@ -1,0 +1,9 @@
+Set up Saral                                                         step 1 of 6
+
+    Which Jira Cloud site?
+
+    -> example.atlassian.net                                    
+
+
+    The host you open in a browser, with or without the https:// in front.
+    Saral talks to it over https and nothing else.

--- a/internal/ui/onboarding/testdata/store-command_120x40.golden
+++ b/internal/ui/onboarding/testdata/store-command_120x40.golden
@@ -1,0 +1,21 @@
+Set up Saral                                                                                                 step 4 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  +  API token       verified as Sam Tester
+  -> Token store
+     Project
+     Review
+
+    Where should the token live?
+
+       OS keychain
+       Environment variable
+    <> Command
+
+    Command        -> pass show jira 
+
+
+    Saral writes nothing. Each start it runs the command and reads the first line of its output. The command is
+    never handed to a shell, so it is an argument list and not a pipeline. The config file only ever names the
+    source, so it stays safe to read, copy between machines and keep in a dotfiles repository.

--- a/internal/ui/onboarding/testdata/store-command_80x20.golden
+++ b/internal/ui/onboarding/testdata/store-command_80x20.golden
@@ -1,0 +1,16 @@
+Set up Saral                                                         step 4 of 6
+
+    Where should the token live?
+
+       OS keychain
+       Environment variable
+    <> Command
+
+    Command        -> pass show jira 
+
+
+    Saral writes nothing. Each start it runs the command and reads the first
+    line of its output. The command is never handed to a shell, so it is an
+    argument list and not a pipeline. The config file only ever names the
+    source, so it stays safe to read, copy between machines and keep in a
+    dotfiles repository.

--- a/internal/ui/onboarding/testdata/store_120x40.golden
+++ b/internal/ui/onboarding/testdata/store_120x40.golden
@@ -1,0 +1,21 @@
+Set up Saral                                                                                                 step 4 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  +  API token       verified as Sam Tester
+  -> Token store
+     Project
+     Review
+
+    Where should the token live?
+
+    <> OS keychain
+       Environment variable
+       Command
+
+    Keychain entry -> saral:example 
+
+
+    Saral writes the token into the keychain now and the config file only names the entry. This is the one place
+    Saral can write a secret to. The config file only ever names the source, so it stays safe to read, copy between
+    machines and keep in a dotfiles repository.

--- a/internal/ui/onboarding/testdata/store_80x20.golden
+++ b/internal/ui/onboarding/testdata/store_80x20.golden
@@ -1,0 +1,15 @@
+Set up Saral                                                         step 4 of 6
+
+    Where should the token live?
+
+    <> OS keychain
+       Environment variable
+       Command
+
+    Keychain entry -> saral:example 
+
+
+    Saral writes the token into the keychain now and the config file only
+    names the entry. This is the one place Saral can write a secret to. The
+    config file only ever names the source, so it stays safe to read, copy
+    between machines and keep in a dotfiles repository.

--- a/internal/ui/onboarding/testdata/token_120x40.golden
+++ b/internal/ui/onboarding/testdata/token_120x40.golden
@@ -1,0 +1,16 @@
+Set up Saral                                                                                                 step 3 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  -> API token
+     Token store
+     Project
+     Review
+
+    Paste the API token
+
+    -> ******************** 
+
+
+    Create one at id.atlassian.com/manage-profile/security/api-tokens. It is checked against the site before
+    anything at all is written, and it never goes into the config file.

--- a/internal/ui/onboarding/testdata/token_80x20.golden
+++ b/internal/ui/onboarding/testdata/token_80x20.golden
@@ -1,0 +1,10 @@
+Set up Saral                                                         step 3 of 6
+
+    Paste the API token
+
+    -> ******************** 
+
+
+    Create one at id.atlassian.com/manage-profile/security/api-tokens. It is
+    checked against the site before anything at all is written, and it never
+    goes into the config file.

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -9,4 +9,5 @@ package ui
 import (
 	_ "github.com/varijkapil13/saral/internal/ui/issue"
 	_ "github.com/varijkapil13/saral/internal/ui/list"
+	_ "github.com/varijkapil13/saral/internal/ui/onboarding"
 )


### PR DESCRIPTION
Closes #7

## What this is

The first run: site, email, token, project, then the probe result explained in its own words. Nothing
is written until the credentials have actually been used against the site, because there is no worse
first run than one that says "saved" and then fails on every screen.

The token never goes in the config file. `Profile.StoreToken` puts it in the OS keychain and the
alternatives are explained at the moment the user is actually thinking about it.

## What a review changed

**The form never claimed the keyboard, so a credential could not be typed.** Every Atlassian API
token contains digits and the kernel binds digits as view slots, so `ATATT3xFfGF0Rq9Quick27` reached
the connector as `ATATTxFfGF0Quick`, an email lost every `r`, and a site beginning with `q` quit the
program on the first keystroke — before the form was dirty enough to block it.

The failure was invisible from inside: the mangled credential comes back 401, the flow parks the user
on the token field, and they re-paste a token that was right the first time while the real fault sits
two steps back.

`kernel.KeyCapturer` landed on `main` for this and the rebase brought it in without this view
adopting it. The packet's own test recorded the corruption with a note saying *delete this when the
kernel grows a way for a view to claim text input* — it had, in the commit that is this branch's
direct parent. That test is replaced by one that types a credential containing a digit, an `r` and a
`?` and asserts all three fields arrive intact; it fails without the fix, with every field empty. The
project is typed now rather than clicked out of the suggestion list, since `PROJ` contains an `R`.

## Also on `main`, because of this packet

A first run never actually reached onboarding: the kernel opens whichever view claimed the first
footer slot, P1.5's list claims slot 1, and `cmd/saral` treated a missing config as an empty one. The
composition root is the only place that knows nothing is configured, so it now decides — `saral
<view>` still wins, and a build without an onboarding view falls back to the registered default.

## Gaps

The picked project is written to the profile and nothing reads it back yet; `Capabilities` is
project-scoped, so whoever consumes it next should wire that. `jira.Capabilities` still has no slot
for a failed timezone probe (#46), so a `/myself` that fails leaves dates silently rendering in UTC.

https://claude.ai/code/session_01HBdKes6chEidvtGJnqFAMm