### PR TITLE
docs: schedule Batch 1.5 so corrections land before Batch 2 writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,25 @@ You are one of several agents working on this repository at the same time. Read 
 - **Never hardcode anything instance-specific.** No `customfield_10016`, no `"In Progress"`, no
   project keys, no assumed permissions. Resolve at runtime and cache. This is the most common way a
   PR gets rejected here.
+- **Reach for the library before writing the mechanism.** If a well-maintained package solves the
+  problem — `x/sync/singleflight` for request coalescing, `x/time/rate` for limiting, `testify` or
+  `go-cmp` for comparison — use it rather than hand-rolling one. Custom code is a maintenance
+  liability that has to earn its place. **The library does not supply the domain judgement, though:**
+  swapping in `singleflight` deleted a pile of bookkeeping here and fixed none of the actual bug,
+  which was about whose context cancellation counts. Use the library for the mechanism; still think
+  about the behaviour.
+- **Never commit anything from a real instance.** Captures land in `testdata/live/`, which is
+  gitignored and stays that way. `pkg/jira/jiratest/fixtures/**` is synthetic: a capture is used to
+  correct the *shape* of a fixture — keys, nesting, types, date formats, paging envelopes — and the
+  words are invented. The scrubber is best-effort and cannot remove prose: ticket summaries, release
+  names, board names and custom field names are all somebody's private information. Run
+  `scripts/checkleak.py` before you commit, read the diff, and never `git add -A` when a capture has
+  been run in this tree.
 - **Never expose a raw destructive API shape.** The canonical example: `PUT` on a sprint nulls every
   omitted field, so the port exposes `StartSprint`/`CompleteSprint`/`UpdateSprint` instead.
 - **Tests must not touch the network.** Use `pkg/jira/jiratest`. CI fails on a non-loopback
-  connection from a test.
+  connection from a test — mechanically, once PC.4 ([#33](https://github.com/varijkapil13/saral/issues/33))
+  lands; by convention until then.
 - **No comments that restate the code.** One line only where the code cannot express a non-obvious
   constraint. No ticket or PR numbers in comments, no notes aimed at a reviewer — that belongs in the
   PR description.
@@ -46,8 +61,15 @@ Rebase on `origin/main` before every push. PRs are squash-merged, so keep the br
 
 The checklist in `docs/PARALLEL.md` is the gate. In short: works against the fake, failure paths
 tested (403 / 429 / transport), golden files for rendering, keybindings and mouse zones registered,
-benchmarks if you touched a render path, `make check` green, and the roadmap checkbox ticked in the
-same PR.
+benchmarks if you touched a render path, no instance data in the diff, `make check` green, and the
+roadmap checkbox ticked in the same PR.
+
+**If your packet changes something other packets consume, changing it is half the job.** Naming the
+consumers and checking each one actually adopted it is the other half. Batch 1 landed a kernel
+interface that let a view claim raw keypresses, rebased both waiting branches onto it, and neither
+view implemented it — so an API token typed into the connector arrived with its digits eaten, and the
+view reported success. Grep for the new symbol and expect a hit per consumer, not just at the
+definition and its own test.
 
 ## Performance is a requirement, not a follow-up
 

--- a/docs/PARALLEL.md
+++ b/docs/PARALLEL.md
@@ -38,6 +38,7 @@ The only genuinely shared files are `go.mod`, `go.sum` and the port interface.
 | `go.mod` / `go.sum` | Add dependencies in their own tiny PR, merged first. Never bundle a dep bump with feature work — it is the one guaranteed conflict. |
 | `internal/ui/kernel/**` | Owned by the kernel packet. Other packets consume it. Changes need the `kernel` label. |
 | `docs/ROADMAP.md` | Append-only status ticks. Do not restructure while others are mid-flight. |
+| `pkg/jira/jiratest/fixtures/**` | Synthetic, and shared by every packet. One manifest test lists every file, so two packets adding a fixture conflict. Needing one that is not there is an issue, not a drive-by. |
 
 If two packets both need the same new helper, the *second* one to need it consumes what the first
 landed. Duplicating a helper is better than editing across ownership lines; consolidate later in a
@@ -55,6 +56,9 @@ A packet is done when all of these hold. A PR missing any of them is not ready f
 - [ ] Public API in `pkg/**` has doc comments; `internal/**` does not need them
 - [ ] Keybindings registered, not hardcoded; mouse zones added for anything clickable
 - [ ] Benchmarks added if the packet touches a render path or a list
+- [ ] Nothing from a real instance in the diff — `scripts/checkleak.py` clean, and the fixtures you
+      touched still describe the invented site
+- [ ] Every consumer of anything shared you changed has actually adopted it, by name
 - [ ] `docs/ROADMAP.md` checkbox ticked in the same PR
 
 ## Branch and commit conventions
@@ -97,7 +101,9 @@ Reviews look for exactly four things, in order:
 
 1. Does it stay inside its ownership boundary?
 2. Does it work with the fake, and are the failure paths tested?
-3. Does it assume anything about a Jira instance? (field IDs, statuses, permissions — all forbidden)
+3. Does it assume anything about a Jira instance? (field IDs, statuses, permissions, English field
+   names — all forbidden)
 4. Does it hold the performance budget on the path it touches?
+5. If it changed something shared, did every consumer adopt the change, or only compile against it?
 
 Style is the linter's job, not a reviewer's.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,15 +1,19 @@
 # Roadmap
 
-> **Where the work lives.** This file is the plan; the trackable units are **GitHub issues
-> [#1–#31](https://github.com/varijkapil13/saral/issues)**, one per packet, grouped into
+> **Where the work lives.** This file is the plan; the trackable units are **GitHub
+> [issues](https://github.com/varijkapil13/saral/issues)**, grouped into
 > [milestones](https://github.com/varijkapil13/saral/milestones) by batch. Each packet below links to
-> its issue. Tick the checkbox here in the same PR that closes the issue.
+> its issue — usually one apiece, occasionally two where a shared file forces them into one PR. Tick
+> the checkbox here in the same PR that closes the issue.
 >
 > **Picking this up cold:** start with [`docs/BOOTSTRAP.md`](BOOTSTRAP.md) — it takes a fresh clone to
-> the first line of code. Then open the lowest-numbered open
-> milestone and take any unassigned packet with no unchecked dependency —
-> `gh issue list --milestone "Batch 0 — Foundations"`. Claim it by commenting on the issue.
+> the first line of code. Then open the **lowest-numbered open milestone** and take any unassigned
+> packet with no unchecked dependency — today that is
+> `gh issue list --milestone "Batch 1.5 — Corrections"`. Claim it by commenting on the issue.
 > `AGENTS.md` is the working agreement; `docs/PARALLEL.md` is the definition of done.
+>
+> **A batch does not open until the one before it closes**, and Batch 1.5 exists precisely so that
+> nobody starts Batch 2 on top of a claim that is not true. Lowest-numbered means 1.5 before 2.
 
 Work is organised into **batches** (waves) containing **packets** (single-PR units of work). Batches
 are ordered by *when the value arrives*, not by architectural tidiness: the aim is that Saral is
@@ -18,7 +22,9 @@ worth opening every day as early as possible, and that everything after that is 
 Within a batch, packets are independent and can run in parallel. A batch closes when all its packets
 merge; the next batch opens then. Batch 0 is the exception — it is strictly serial.
 
-Legend: `[ ]` open · `[~]` in progress · `[x]` merged · **owns** = the only paths that packet may touch.
+Legend: `[ ]` open · `[~]` in progress · `[x]` merged · **owns** = the only paths that packet may
+touch. `P<batch>.<n>` is a feature packet; `PC.<n>` is a correction packet, which pays off something
+the project already claims to be true (see Batch 1.5).
 
 ---
 
@@ -61,14 +67,62 @@ instance from day one.
 - [x] **P1.6 — First-run onboarding** · [#7](https://github.com/varijkapil13/saral/issues/7) · **owns** `internal/ui/onboarding/**`
   Site, email, token, project picker; writes the profile; explains what the probe found.
 
+## Batch 1.5 — Corrections · **PC.1 serial, then parallel ×4** · blocks Batch 2
+
+Batch 1 shipped and left the project asserting several things that are not true. None of them is a
+feature and none was worth stopping Batch 1 for; all of them are load-bearing for **Batch 2, which is
+where Saral starts writing to Jira**. A tool that reads can be wrong and merely unhelpful. A tool that
+writes and is wrong about which project it is in, or about which fields it actually fetched, damages
+someone's ticket.
+
+The claims being made good on: that CI keeps tests off the network; that the layer diagram is
+enforced; that `Capabilities` gives a reason for every negative; that an `Issue` means what its zero
+values say; that the session knows its project; that the fixture server replays the right shape; and
+that the number keys have exactly one owner.
+
+**PC.1 lands first and alone** — it amends the port, which `docs/PARALLEL.md` makes a serial change
+because it unblocks or blocks everyone. The other four run in parallel behind it.
+
+- [ ] **PC.1 — Port amendments** · [#46](https://github.com/varijkapil13/saral/issues/46), [#37](https://github.com/varijkapil13/saral/issues/37) · **owns** `pkg/jira/{port,types}.go`, `pkg/jira/cloud/{caps,search}.go`, `pkg/jira/jiratest/jiratest.go`
+  Two additive amendments, one PR, because two agents editing the frozen port is the one guaranteed
+  conflict. `Capabilities` gains a way to say the timezone probe failed, instead of leaving
+  `TimeZone` nil and rendering every date in UTC with nothing on screen to explain it. `Issue` gains
+  a way to distinguish *not requested* from *empty*, so that P2.3's fetch-edit-PUT cycle cannot blank
+  a field nobody touched.
+- [ ] **PC.2 — One owner for the number keys** · [#49](https://github.com/varijkapil13/saral/issues/49) · **owns** `internal/ui/kernel/{view,keys}.go`, `internal/ui/list/register.go`, `internal/app/search.go`, `docs/UX.md`
+  Three claimants on `1`–`9`: kernel view slots, the six root views `docs/UX.md` promises, and
+  `SavedQuery.Slot`, which P1.2 built and tested and nothing calls. Pick one, give the others a
+  prefix, and write down the slot allocation so six later packets do not each guess.
+  **A product decision, not a defect — it wants a human answer.**
+- [ ] **PC.3 — Session project scope** · [#50](https://github.com/varijkapil13/saral/issues/50) · **owns** `cmd/saral/main.go`, `internal/ui/kernel/kernel.go`, `internal/ui/list/list.go`
+  Onboarding asks which project you work in, validates it, writes it to the profile, and nothing ever
+  reads it back: `deps.Project` comes only from `--project`. So the capability probe resolves
+  per-project permissions against an empty key and the list opens unscoped over the whole site.
+  Includes deciding what no-project-at-all means and how a project is changed mid-session.
+- [ ] **PC.4 — Make the test rules enforceable** · [#33](https://github.com/varijkapil13/saral/issues/33), [#35](https://github.com/varijkapil13/saral/issues/35) · **owns** `.github/workflows/ci.yml`, `internal/arch/**`
+  `AGENTS.md` and `docs/TESTING.md` both say CI fails a test that opens a non-loopback connection. It
+  does not. `internal/arch` enforces four of the six rules the layer diagram implies. Both are rules
+  the project relies on being mechanical and are currently honour-system.
+- [ ] **PC.5 — Fixture gaps** · [#34](https://github.com/varijkapil13/saral/issues/34) · **owns** `pkg/jira/jiratest/{fixtures/**,server.go}`
+  `GET /task/{id}` replays the bulk-move body, which is the wrong shape and would let an adapter
+  decode it wrongly and still pass; the `createmeta` issue-type list page is missing entirely. Landed
+  here rather than in P2.2 and P7.1 because the fixture tree is shared and both would edit the same
+  hardcoded manifest, two batches apart.
+
 ## Batch 2 — Change your work · parallel ×4
+
+**Gated on Batch 1.5.** Do not open a Batch 2 packet while the corrections milestone has an open
+issue. This is the first batch that mutates a real instance, and every one of PC.1, PC.3 and PC.5 is
+a thing Batch 2 would otherwise get quietly wrong.
 
 - [ ] **P2.1 — Markdown to ADF** · [#8](https://github.com/varijkapil13/saral/issues/8) · **owns** `pkg/adf/parse*.go`
   The inverse of P1.4, with round-trip property tests asserting byte-stability on untouched docs.
 - [ ] **P2.2 — Schema-driven forms** · [#9](https://github.com/varijkapil13/saral/issues/9) · **owns** `internal/ui/form/**`, `pkg/jira/cloud/meta.go`
   `createmeta` → widgets, required-field validation, `ValidationError` mapped to fields.
+  Needs PC.3 (`createmeta` is keyed by project and issue type) and PC.5 (the issue-type list page).
 - [ ] **P2.3 — Create, edit, transition** · [#10](https://github.com/varijkapil13/saral/issues/10) · **owns** `internal/ui/issue/edit*.go`, `pkg/jira/cloud/issue.go`
   `$EDITOR` handoff for long text, transition picker with per-issue transitions.
+  Needs PC.1: an edit must send only fields it actually fetched, or it blanks the rest.
 - [ ] **P2.4 — Comments CRUD** · [#11](https://github.com/varijkapil13/saral/issues/11) · **owns** `internal/ui/comment/**`, `pkg/jira/cloud/comment.go`
 
 ## Batch 3 — Make it a daily driver · parallel ×5
@@ -77,9 +131,13 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
 
 - [ ] **P3.1 — Command palette** · [#12](https://github.com/varijkapil13/saral/issues/12) · **owns** `internal/ui/palette/**`
   `ctrl+k`, fuzzy over the command registry, frecency ranking, shows the keybinding for what you ran.
+  Wires up `app.SavedQuery`, whose number-key binding PC.2 settles.
 - [ ] **P3.2 — Cache and offline** · [#13](https://github.com/varijkapil13/saral/issues/13) · **owns** `internal/store/**`, `go.mod`
   Adds the bbolt dependency, in its own commit ahead of the code that needs it. bbolt buckets, TTLs,
-  stale-while-revalidate, cursor-preserving row patching, stale badge.
+  stale-while-revalidate, cursor-preserving row patching, stale badge. Row patching is the other
+  consumer of PC.1's field-presence answer. **Adds the `internal/store` must-not-import-`internal/ui`
+  rule to `internal/arch` in the same PR** — PC.4 adds its sibling and cannot add this one, because
+  the package does not exist yet.
 - [ ] **P3.3 — Mouse** · [#14](https://github.com/varijkapil13/saral/issues/14) · **owns** `internal/ui/widget/zone*.go` + zone wiring in own files
   Click, double-click, wheel-under-pointer, drag-to-resize, clickable chips and footer.
 - [ ] **P3.4 — Local fuzzy index** · [#15](https://github.com/varijkapil13/saral/issues/15) · **owns** `internal/app/index.go`
@@ -110,23 +168,33 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
 
 - [ ] **P6.1 — Board configuration** · [#22](https://github.com/varijkapil13/saral/issues/22) · **owns** `pkg/jira/cloud/board.go`
   Columns by `statusCategory`, estimation field and rank field read from board config — never guessed.
+  **Every part of a board config is optional and the absences are not exotic.** A Kanban board sends
+  no estimation object at all, which is why `BoardConfig.Estimation` is a pointer; a board may expose
+  no rank field, so drag-to-reorder has to be a capability and not an assumption; and a board may be
+  ordered by priority rather than by rank. Match everything by id or `untranslatedName`, never by
+  display name — on a German instance the field, status and priority names all arrive translated, and
+  `clauseNames` follows the translation too.
 - [ ] **P6.2 — Sprint lifecycle** · [#23](https://github.com/varijkapil13/saral/issues/23) · **owns** `pkg/jira/cloud/sprint.go`
   `UpdateSprint` over the partial-update `POST`; `StartSprint`/`CompleteSprint` validate state
   locally first. **The raw `PUT` must never be reachable from the port** — it nulls omitted fields.
 - [ ] **P6.3 — Board and backlog views** · [#24](https://github.com/varijkapil13/saral/issues/24) · **owns** `internal/ui/board/**`, `internal/ui/backlog/**`
   Column view, drag or key to move between sprint and backlog (50-issue cap per call), rank-aware
-  reorder when the board exposes a rank field.
+  reorder when the board exposes a rank field. Takes the footer slot PC.2 assigns it; the kernel
+  rejects a duplicate at startup, so this cannot be settled by guessing.
 
 ## Batch 7 — Cross-project move · parallel ×1
 
 - [ ] **P7.1 — Move wizard** · [#25](https://github.com/varijkapil13/saral/issues/25) · **owns** `pkg/jira/cloud/bulkmove.go`, `internal/ui/move/**`
   Target project and issue type, status remap, mandatory-field resolution, a confirm screen showing
   the full mapping, submit, then poll the task. Hidden with a reason when `BULK_CHANGE` is absent.
+  Polls `/bulk/queue/{taskId}`, not `/task/{taskId}` — different shapes, both fixtured by PC.5.
 
 ## Batch 8 — Timeline and plans · parallel ×3
 
 - [ ] **P8.1 — Date resolution** · [#26](https://github.com/varijkapil13/saral/issues/26) · **owns** `internal/app/dates.go`
   The cascade that gives every issue a start and an end (see below). Reports provenance per bar.
+  Rule 4 needs [#38](https://github.com/varijkapil13/saral/issues/38) first: an issue's sprint value
+  carries `{id, name}` and no dates, and the timeline has no board id to look them up with.
 - [ ] **P8.2 — Timeline view** · [#27](https://github.com/varijkapil13/saral/issues/27) · **owns** `internal/ui/timeline/**`
   Horizontal bars, zoom by day/week/month/quarter, today marker, version and sprint markers,
   milestone diamonds where only one date resolves. Virtualized like every other list.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -84,8 +84,9 @@ Bubble Tea's `teatest` drives full programs where an interaction sequence matter
 - `t.Parallel()` wherever there is no shared state — which should be everywhere.
 - No `time.Sleep` in tests. Inject a clock; `jiratest.Delay` plus `teatest`'s wait helpers cover the
   async cases.
-- No network in any test. There is a CI check that fails the build if a test opens a non-loopback
-  connection.
+- No network in any test. A CI check fails the build if a test opens a non-loopback connection —
+  once PC.4 ([#33](https://github.com/varijkapil13/saral/issues/33)) lands. Until then the rule is
+  enforced by review, and it is exactly as load-bearing either way.
 - Test names describe behaviour: `TestReleaseVersion_RefusesWhenUnresolvedIssuesExist`.
 
 ## Import boundaries

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -43,7 +43,7 @@ telemetry leaves the machine, ever.
 A stack, not a graph — so "back" always means something.
 
 ```
-views (footer 1–6)     board · backlog · sprints · releases · timeline · plans
+views (footer 1–6)     board · backlog · sprints · releases · timeline · plans   ← contested, see #49
 push                   enter          open the thing under the cursor
 pop                    esc            back, never quits from a pushed view
 quit                   q / ctrl+c     only from a root view, and only when no draft is open
@@ -55,6 +55,11 @@ refresh                r / R          current view / purge and refetch
 ```
 
 Vim keys and arrows are both always bound. `j/k` and `↑/↓` are not a preference to configure.
+
+The footer row above is **not yet true and not yet decided**: the issue list holds slot 1, `board`
+does not exist until P6.3, and `app.SavedQuery` claims the same nine digits from the other direction.
+PC.2 ([#49](https://github.com/varijkapil13/saral/issues/49)) settles who owns them and rewrites this
+line. Do not register a slot against it until then.
 
 ## Mouse
 


### PR DESCRIPTION
Six follow-ups from Batches 0 and 1 had no milestone and no place in the plan. An agent reading
`docs/ROADMAP.md` cold would have opened Batch 2 and started writing to Jira on top of all of them —
and Batch 2 is the first batch that mutates a real instance, which is what turns each of these from
tidy-up into a prerequisite.

## Batch 1.5 — Corrections

A new milestone between 1 and 2, five packets. `PC.<n>` distinguishes a correction packet from a
feature packet at a glance. PC.1 is serial because it amends the frozen port; the other four run in
parallel behind it.

| Packet | Issues | What it makes true |
|---|---|---|
| PC.1 — Port amendments | #46, #37 | `Capabilities` can report a failed timezone probe instead of silently rendering UTC; `Issue` can distinguish *not requested* from *empty* |
| PC.2 — One owner for the number keys | #49 (new) | Kernel view slots, `docs/UX.md`'s six root views and `app.SavedQuery.Slot` all claim `1`–`9` |
| PC.3 — Session project scope | #50 (new) | Onboarding writes the project to the profile and nothing reads it back |
| PC.4 — Make the test rules enforceable | #33, #35 | CI actually fails a non-loopback connection; `internal/arch` covers `internal/app` |
| PC.5 — Fixture gaps | #34 | `/task/{id}` stops replaying the bulk-move shape; the `createmeta` list page exists |

#46+#37 and #33+#35 are paired into one packet each because they touch the same shared file —
`pkg/jira/port.go` in the first case — and `docs/PARALLEL.md` already makes that a serial change.

#38 moves to **Batch 8**, where its only consumer lives. Adding `Sprint(ctx, id)` to the port now
would mean a port method with no caller to prove it right.

## The two new issues

**#49 — three claimants on the number keys.** `kernel/keys.go:45` binds `1`–`9` to view switching and
the issue list holds slot 1. `docs/UX.md:46` promises `board · backlog · sprints · releases ·
timeline · plans` at 1–6, and `board` arrives in P6.3. P1.2 shipped `app.SavedQuery.Slot` with
`MaxSavedSlot = 9` and `BySlot`, documented as "the number key that runs this query" — and nothing in
the UI calls it. Nothing is broken today only because two of the three have no code yet. This is a
product decision rather than a defect, so it wants a human answer.

**#50 — the session never learns its project.** `cmd/saral/main.go:123` is the whole story:

```go
deps.Project = opt.project     // the --project flag, and only the flag
```

`profile.Project` is parsed, validated and serialised, and never read into `Deps`. So the second
launch probes `Capabilities(ctx, "")` — every per-project permission resolved against nothing — and
`list.go:118` builds its default query from an empty key, opening unscoped over the whole site.

## Dependencies, written down where they will be read

Every dependent packet now names what it is waiting on, on its own roadmap line: P2.2 (PC.3, PC.5),
P2.3 (PC.1), P3.1 (PC.2), P3.2 (PC.1, plus the `internal/store` arch rule PC.4 cannot add because the
package does not exist yet), P6.3 (PC.2), P7.1 (PC.5), P8.1 (#38). The header's cold-start command
points at Batch 1.5, and Batch 2 carries an explicit gate.

## Feedback from Batch 1 the working agreement did not carry

- **Reach for the library before writing the mechanism** — with the caveat that it does not supply
  the domain judgement. Swapping in `x/sync/singleflight` deleted a pile of bookkeeping here and
  fixed none of the actual bug, which was about whose context cancellation counts.
- **Never commit anything from a real instance.** The scrubber cannot remove prose: ticket summaries,
  release names and custom field names are all somebody's private information.
- **A change to something shared is unfinished until its consumers adopt it.** Batch 1 landed a kernel
  interface letting a view claim raw keypresses, rebased both waiting branches onto it, and neither
  view implemented it — so an API token arrived at the connector with its digits eaten and the view
  reported success.

## Corrections to claims already in the tree

`AGENTS.md` and `docs/TESTING.md` both stated that CI fails a test opening a non-loopback connection.
It does not, until PC.4. Both now say so. `docs/UX.md`'s footer row is marked contested so nobody
registers a slot against it before #49 is settled.

Docs only — no code changes. `make check` green.

https://claude.ai/code/session_01HBdKes6chEidvtGJnqFAMm