### PR TITLE
PC.4 — make the test rules mechanical instead of stated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,26 @@ jobs:
         run: go mod tidy && git diff --exit-code
       - name: vet
         run: go vet ./...
-      - name: test with race detector
-        run: go test -race -count=1 ./...
+      - name: warm the caches while the network is still there
+        run: go test -race -count=1 -run '^$' ./...
+      - name: test with race detector, on a loopback-only network
+        run: |
+          sudo env "PATH=$PATH" "HOME=$HOME" \
+            "GOCACHE=$(go env GOCACHE)" "GOMODCACHE=$(go env GOMODCACHE)" \
+            GOPROXY=off GOTOOLCHAIN=local \
+            unshare -n -- sh -euc '
+              ip link set lo up
+              ip -o link show lo | grep -qw UP || { echo "::error::loopback is down inside the namespace"; exit 1; }
+              command -v curl >/dev/null || { echo "::error::no curl to prove the namespace isolates"; exit 1; }
+              if curl -sS --max-time 5 -o /dev/null https://proxy.golang.org; then
+                echo "::error::a request left the namespace, so this check proves nothing"
+                exit 1
+              fi
+              go test -race -count=1 ./...
+            '
+      - name: give the caches back to the runner
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" "$(go env GOCACHE)" "$(go env GOMODCACHE)"
       - name: build
         run: go build -trimpath -ldflags "-s -w" -o saral ./cmd/saral
       - name: binary size budget

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,10 @@ You are one of several agents working on this repository at the same time. Read 
   been run in this tree.
 - **Never expose a raw destructive API shape.** The canonical example: `PUT` on a sprint nulls every
   omitted field, so the port exposes `StartSprint`/`CompleteSprint`/`UpdateSprint` instead.
-- **Tests must not touch the network.** Use `pkg/jira/jiratest`. CI fails on a non-loopback
-  connection from a test — mechanically, once PC.4 ([#33](https://github.com/varijkapil13/saral/issues/33))
-  lands; by convention until then.
+- **Tests must not touch the network.** Use `pkg/jira/jiratest`. CI runs the race suite inside a
+  network namespace with only loopback up, and the step proves the namespace isolates before it
+  trusts it, so a test that reaches a real host fails the build rather than passing for you and
+  failing for everyone else. A test that needs a server starts one on loopback with `httptest`.
 - **No comments that restate the code.** One line only where the code cannot express a non-obvious
   constraint. No ticket or PR numbers in comments, no notes aimed at a reviewer — that belongs in the
   PR description.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,8 +35,16 @@ Three constraints drive every decision below:
 ```
 
 Dependencies point **downward only**. `pkg/*` must never import `internal/*`; `internal/ui` must
-never import `pkg/jira/cloud` directly — it takes the port interface. This is enforced in CI by an
-import-boundary test (see `docs/TESTING.md`).
+never import `pkg/jira/cloud` directly — it takes the port interface; only `cmd/*` and
+`internal/config` construct a concrete adapter; `internal/app` must never import `internal/ui`,
+because a use case is driven by a view and never reaches back up into one; and `pkg/adf` must never
+import `pkg/jira`, because the document library does not know about issues. All five are enforced in
+CI by an import-boundary test (see `docs/TESTING.md`). The sixth the diagram implies —
+`internal/store` must not import `internal/ui` — lands with the package, in P3.2.
+
+The "no IO libs" on `internal/app` is the one line above that no test can hold you to: the
+import-boundary test only sees imports within this module, so a `net/http` in a use case is invisible
+to it. Treat it as a rule a reviewer enforces.
 
 ## Ports and adapters
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,10 +99,14 @@ because it unblocks or blocks everyone. The other four run in parallel behind it
   reads it back: `deps.Project` comes only from `--project`. So the capability probe resolves
   per-project permissions against an empty key and the list opens unscoped over the whole site.
   Includes deciding what no-project-at-all means and how a project is changed mid-session.
-- [ ] **PC.4 — Make the test rules enforceable** · [#33](https://github.com/varijkapil13/saral/issues/33), [#35](https://github.com/varijkapil13/saral/issues/35) · **owns** `.github/workflows/ci.yml`, `internal/arch/**`
-  `AGENTS.md` and `docs/TESTING.md` both say CI fails a test that opens a non-loopback connection. It
-  does not. `internal/arch` enforces four of the six rules the layer diagram implies. Both are rules
-  the project relies on being mechanical and are currently honour-system.
+- [x] **PC.4 — Make the test rules enforceable** · [#33](https://github.com/varijkapil13/saral/issues/33), [#35](https://github.com/varijkapil13/saral/issues/35) · **owns** `.github/workflows/ci.yml`, `internal/arch/**`
+  `AGENTS.md` and `docs/TESTING.md` both said CI fails a test that opens a non-loopback connection,
+  and it did not. Now it does: the race suite runs inside a network namespace with only loopback up,
+  behind a warm-up that compiles the test binaries while the network is still there, and the step
+  proves the namespace isolates before it trusts it. `internal/arch` already enforced five of the six
+  rules the layer diagram implies — P1.2 landed the `internal/app` one — so what was left there was
+  three documents miscounting them and a rule table that could hold a rule unable to fire. Both docs
+  now describe the mechanism instead of the honour system.
 - [ ] **PC.5 — Fixture gaps** · [#34](https://github.com/varijkapil13/saral/issues/34) · **owns** `pkg/jira/jiratest/{fixtures/**,server.go}`
   `GET /task/{id}` replays the bulk-move body, which is the wrong shape and would let an adapter
   decode it wrongly and still pass; the `createmeta` issue-type list page is missing entirely. Landed

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -84,17 +84,36 @@ Bubble Tea's `teatest` drives full programs where an interaction sequence matter
 - `t.Parallel()` wherever there is no shared state — which should be everywhere.
 - No `time.Sleep` in tests. Inject a clock; `jiratest.Delay` plus `teatest`'s wait helpers cover the
   async cases.
-- No network in any test. A CI check fails the build if a test opens a non-loopback connection —
-  once PC.4 ([#33](https://github.com/varijkapil13/saral/issues/33)) lands. Until then the rule is
-  enforced by review, and it is exactly as load-bearing either way.
+- No network in any test, and CI is what makes that true. The race suite runs inside a network
+  namespace with only loopback up, so a test that reaches for a real host fails the build instead of
+  passing for whoever wrote it. A step before it compiles every test binary while the network is
+  still reachable, because the namespace has no route to the module proxy; `GOPROXY=off` inside turns
+  a cache miss into a legible error rather than a timeout. The jailed step first proves it isolates —
+  it attempts a request to the module proxy and fails the build if that request gets out — because an
+  `unshare` that quietly stopped working reads as a hermetic suite. A test that needs a server starts
+  one on loopback with `httptest`, which is what `jiratest.Server` does; `internal/arch` asserts that
+  the workflow still runs the suite that way.
 - Test names describe behaviour: `TestReleaseVersion_RefusesWhenUnresolvedIssuesExist`.
 
 ## Import boundaries
 
-A test in `internal/arch` asserts the layering from `docs/ARCHITECTURE.md`:
+A test in `internal/arch` asserts the layering from `docs/ARCHITECTURE.md`. Five rules, one table
+entry each:
 
 - `pkg/**` must not import `internal/**`
 - `internal/ui/**` must not import `pkg/jira/cloud`
 - only `cmd/**` and `internal/config` may construct a concrete adapter
+- `internal/app` must not import `internal/ui`
+- `pkg/adf` must not import `pkg/jira`
+
+The sixth rule the layer diagram implies — `internal/store` must not import `internal/ui` — waits for
+P3.2 to create the package; its case is already in the table, expecting nothing.
+
+A second test reads the table itself, because a rule can be wrong in a way that only ever shows up as
+green: a duplicated name, a missing `why`, an exemption that no package the rule covers could match,
+or one broad enough to swallow the rule's whole scope.
+
+The rules only see imports within this module. "No IO libs in `internal/app`" is a convention nobody
+can check this way — a `net/http` import there is invisible to the walk.
 
 This catches the most common way a modular design quietly stops being modular.

--- a/internal/arch/arch.go
+++ b/internal/arch/arch.go
@@ -1,3 +1,4 @@
-// Package arch holds the import-boundary test that enforces the layering
-// described in docs/ARCHITECTURE.md. There is no runtime code here.
+// Package arch holds the tests that keep docs/ARCHITECTURE.md and
+// docs/TESTING.md honest: the import boundaries between the layers, and the CI
+// workflow's network namespace. There is no runtime code here.
 package arch

--- a/internal/arch/ci_test.go
+++ b/internal/arch/ci_test.go
@@ -1,0 +1,172 @@
+package arch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const workflowPath = ".github/workflows/ci.yml"
+
+const theRule = "docs/TESTING.md says no test opens a non-loopback connection, and CI is what makes that true " +
+	"rather than a convention: the suite runs under `unshare -n` with only loopback up"
+
+type looseGoTest struct {
+	line int
+	text string
+}
+
+type workflowScan struct {
+	jail    []string
+	warmUps []string
+	loose   []looseGoTest
+}
+
+// scanWorkflow sorts every `go test` by where it runs. The namespace block runs
+// from the `unshare -n` line to the next list item indented outside it, which in
+// a workflow is the next step.
+func scanWorkflow(content string) workflowScan {
+	var scan workflowScan
+	jailIndent := -1
+
+	for i, line := range strings.Split(content, "\n") {
+		body := strings.TrimLeft(line, " ")
+		indent := len(line) - len(body)
+		if jailIndent >= 0 && indent < jailIndent && strings.HasPrefix(body, "- ") {
+			jailIndent = -1
+		}
+		if strings.Contains(line, "unshare -n") {
+			jailIndent = indent
+		}
+		if jailIndent >= 0 {
+			scan.jail = append(scan.jail, line)
+		}
+		if !strings.Contains(line, "go test") {
+			continue
+		}
+		switch {
+		case jailIndent >= 0:
+		case strings.Contains(line, "-run") && strings.Contains(line, "^$"):
+			scan.warmUps = append(scan.warmUps, strings.TrimSpace(line))
+		default:
+			scan.loose = append(scan.loose, looseGoTest{line: i + 1, text: strings.TrimSpace(line)})
+		}
+	}
+	return scan
+}
+
+func TestCIWorkflow_RunsTheSuiteWithOnlyLoopbackReachable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(moduleRoot(t), filepath.FromSlash(workflowPath))
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", workflowPath, err)
+	}
+
+	scan := scanWorkflow(string(content))
+	if len(scan.jail) == 0 {
+		t.Fatalf("%s no longer runs anything under a network namespace.\n%s", workflowPath, theRule)
+	}
+
+	jail := strings.Join(scan.jail, "\n")
+	if !strings.Contains(jail, "go test") {
+		t.Errorf("%s builds a network namespace and does not run the suite inside it.\n%s", workflowPath, theRule)
+	}
+	if !strings.Contains(jail, "curl") || !strings.Contains(jail, "exit 1") {
+		t.Errorf("the namespace block in %s no longer proves that it isolates.\n"+
+			"A request has to be attempted and has to fail, or an `unshare` that stopped working "+
+			"reads as a hermetic suite and the green tick means nothing.", workflowPath)
+	}
+	for _, loose := range scan.loose {
+		t.Errorf("%s:%d runs the suite with the network reachable: %s\n%s",
+			workflowPath, loose.line, loose.text, theRule)
+	}
+}
+
+func TestScanWorkflow_SortsEveryGoTestByWhereItRuns(t *testing.T) {
+	t.Parallel()
+
+	const jailed = `
+      - name: warm the caches
+        run: go test -race -count=1 -run '^$' ./...
+      - name: test on a loopback-only network
+        run: |
+          sudo env "PATH=$PATH" \
+            unshare -n -- sh -euc '
+              ip link set lo up
+              if curl -sS --max-time 5 -o /dev/null https://proxy.golang.org; then
+                exit 1
+              fi
+              go test -race -count=1 ./...
+            '
+      - name: build
+        run: go build ./...
+`
+
+	tests := []struct {
+		name    string
+		content string
+		jail    bool
+		warmUps int
+		loose   []string
+	}{
+		{
+			name:    "the workflow as this packet leaves it",
+			content: jailed,
+			jail:    true,
+			warmUps: 1,
+		},
+		{
+			name:    "the suite run straight, the way it was before",
+			content: "      - name: test\n        run: go test -race -count=1 ./...\n",
+			loose:   []string{"run: go test -race -count=1 ./..."},
+		},
+		{
+			name:    "a second, unjailed run smuggled in after the jail",
+			content: jailed + "      - name: also test\n        run: go test ./...\n",
+			jail:    true,
+			warmUps: 1,
+			loose:   []string{"run: go test ./..."},
+		},
+		{
+			name:    "a step with no name straight after the jail",
+			content: jailed + "      - run: go test ./...\n",
+			jail:    true,
+			warmUps: 1,
+			loose:   []string{"- run: go test ./..."},
+		},
+		{
+			name:    "the whole jail written on one line",
+			content: "      - run: sudo unshare -n -- sh -c 'ip link set lo up && curl -f https://x || exit 1; go test ./...'\n",
+			jail:    true,
+		},
+		{
+			name:    "a warm-up that quietly stopped being one",
+			content: "      - name: warm\n        run: go test -race -count=1 ./...\n",
+			loose:   []string{"run: go test -race -count=1 ./..."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scan := scanWorkflow(tt.content)
+			if got := len(scan.jail) > 0; got != tt.jail {
+				t.Errorf("found a namespace block = %t, want %t", got, tt.jail)
+			}
+			if got := len(scan.warmUps); got != tt.warmUps {
+				t.Errorf("found %d warm-ups %v, want %d", got, scan.warmUps, tt.warmUps)
+			}
+			got := make([]string, 0, len(scan.loose))
+			for _, loose := range scan.loose {
+				got = append(got, loose.text)
+			}
+			if strings.Join(got, "\n") != strings.Join(tt.loose, "\n") {
+				t.Errorf("runs outside the namespace = %q, want %q", got, tt.loose)
+			}
+		})
+	}
+}

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -86,6 +86,50 @@ func brokenRules(pkgDir, importPath string) []importRule {
 	return out
 }
 
+func TestImportRules_AreWellFormed(t *testing.T) {
+	t.Parallel()
+
+	if len(importRules) == 0 {
+		t.Fatal("the rule table is empty, so the layering test proves nothing")
+	}
+
+	root := moduleRoot(t)
+	at := make(map[string]int, len(importRules))
+	for i, rule := range importRules {
+		switch {
+		case rule.name == "":
+			t.Errorf("rule %d has no name, which is what its failure message and the table below key on", i)
+		case at[rule.name] > 0:
+			t.Errorf("rules %d and %d are both named %q", at[rule.name]-1, i, rule.name)
+		}
+		at[rule.name] = i + 1
+
+		if rule.forbid == "" {
+			t.Errorf("rule %q forbids nothing, so it breaks on every module-local import", rule.name)
+		}
+		if rule.why == "" {
+			t.Errorf("rule %q does not say why, and the why is the half of the failure a reader acts on", rule.name)
+		}
+
+		for _, exempt := range rule.except {
+			if !underPath(exempt, rule.from) {
+				t.Errorf("rule %q exempts %q, which is not under %q: no package the rule covers can match it",
+					rule.name, exempt, rule.from)
+			}
+			if underPath(rule.from, exempt) {
+				t.Errorf("rule %q exempts %q, which covers the whole of %q: the rule can never fire",
+					rule.name, exempt, rule.from)
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(exempt))); err != nil {
+				t.Errorf("rule %q exempts %q, which is not a directory here: %v\n"+
+					"an exemption naming nothing is misspelt or left behind, and either way nobody finds out "+
+					"until the package it meant to name imports %q",
+					rule.name, exempt, err, rule.forbid)
+			}
+		}
+	}
+}
+
 func TestImports_ObeyTheLayeringInTheArchitectureDoc(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #33. Closes #35.

Two rules the project relies on being mechanical were being enforced by asking nicely, and three
documents said otherwise. This makes the first one real, verifies that the second already is, and
corrects the documents that were counting wrong.

## Part 1 — CI now fails a test that leaves loopback (#33)

`.github/workflows/ci.yml` had no such step. The race run in the existing `test` job is now three
steps in the same position, between `vet` and `build`:

1. `go test -race -count=1 -run '^$' ./...` — compiles and links every test binary, runs zero tests.
   `go mod tidy` above it already populated GOMODCACHE, but not race-instrumented build objects, so
   without this the jailed run would try to compile with no route to anywhere.
2. the race suite under `sudo env … unshare -n`, which brings `lo` up, **proves the namespace
   isolates**, and only then runs the tests.
3. `chown -R` of GOCACHE and GOMODCACHE back to the runner, `if: always()`.

**It wraps the existing step rather than adding a job.** A second job pays for another checkout,
another setup-go and another full `-race` compile to run the identical suite twice, and it leaves a
lenient twin of the jailed run to hide behind. This way the jailed run is the only race run, so CI is
honest by construction.

Details that are load-bearing and should not be tidied away:

- **`sudo env "PATH=$PATH" "HOME=$HOME" …`, not `sudo -E`.** `unshare` execs with the inherited
  environ and strips nothing; `sudo` is the trap. Ubuntu's `env_reset` + `secure_path` replaces PATH
  either way, which drops setup-go's `/opt/hostedtoolcache/go/…/bin` and yields
  `go: command not found`. Losing HOME makes `go` read `/root/.config/go/env`, derive
  `GOPATH=/root/go`, find an empty module cache and reach for the proxy from inside a namespace with
  no route. Neither failure looks anything like the rule firing.
- **`GOPROXY=off`** turns a residual cache miss into an immediate legible error instead of a network
  timeout. **`GOTOOLCHAIN=local`** stops a future `go` directive bump from trying to download a
  toolchain in the jail.
- **The curl probe.** Without it a broken `unshare` degrades silently back to the honour system, and
  the green tick would mean less than nothing. It is the same instinct as the `scanned == 0` guard at
  `internal/arch/imports_test.go:190-193`. The `command -v curl` guard matters because under `sh -e`
  a missing curl exits 127 inside an `if`, which reads as "isolated".
- **The chown.** Root-owned cache entries otherwise break the `build` step and setup-go's post
  cache-save.
- **The jail stays on one step.** `lint` is its own job and `go install …golangci-lint` needs the
  proxy.

No fallback if the jail cannot be built on `ubuntu-latest` — that would be a CI defect, and a green
tick would be a lie. Deliberately not using unprivileged `unshare -rn`: Ubuntu 24.04+ ships
`kernel.apparmor_restrict_unprivileged_userns=1`, so it is runner-image-dependent in exactly the way
this packet exists to remove.

### Why the suite is expected to be green in the jail

Grepped rather than assumed:

- the only server anywhere is `httptest.NewServer` at `pkg/jira/jiratest/server.go:127`, which binds
  127.0.0.1;
- `pkg/jira/cloud/client.go:168-179` builds a real `*http.Client`, but every test that reaches `do`
  either injects a fake `Doer` or points at `s.URL()`. `TestDo_TreatsADialFailureAsATransportFailure`
  (`pkg/jira/cloud/client_test.go:459-466`) dials a *closed* loopback port on purpose;
- every `*.atlassian.net` string in a test is data or a hardcoded expected error message —
  `internal/ui/kernel/kernel_test.go:653` and `pkg/jira/cloud/caps_test.go:656` are the two that look
  most like a dial and are neither;
- the onboarding connector is injected (`internal/ui/onboarding/harness_test.go:71-83`), so nothing
  there verifies a site over the wire;
- keyring tests use `keyring.MockInit()`.

Also checked what changes when the suite runs **as root**, since `sudo` is in the picture: no test
calls `os.Chmod` or asserts a permission-denied error, so nothing depends on not being root, and the
tests that care about HOME set it themselves (`internal/config/config_test.go:374`).

### The workflow guard

`internal/arch/ci_test.go` is a plain-string assertion over `../../.github/workflows/ci.yml`: the
suite must run under `unshare -n`, the namespace block must still contain the request that proves it
isolates, and no other step may run `go test` unless it is the `-run '^$'` warm-up. Plain scanning, no
YAML dependency — a `go.mod` change needs its own PR. Verified it goes red on the pre-packet workflow
(`.github/workflows/ci.yml no longer runs anything under a network namespace`) and that the classifier
handles a run smuggled in after the jail, a `- run:` step with no name, the whole jail written on one
line, and a warm-up that quietly stopped being one.

## Part 2 — #35 was already done, so this counts the rules instead

**Verified, not added.** The rule #35 asks for already exists: `app-must-not-import-the-ui` at
`internal/arch/imports_test.go:46-51`, landed by P1.2 (ff7f4f4, #44), under a slightly different name
from the one the issue suggested. Its cases are at 268-291, including one at 286-291 confirming a view
*may* drive a use case. `internal/app` imports only `pkg/jira` and `pkg/jira/jiratest`, so nothing was
red. The rule is **not** renamed — the table keys on the current name at line 272 and a rename buys
nothing.

So the table holds five of the six rules the layer diagram implies, not four. The sixth
(`internal/store` must not import `internal/ui`) is P3.2's per `docs/ROADMAP.md:141-143`, and its
`want: nil` placeholder at 292-297 is left alone.

What was actually missing: `TestImportRules_AreWellFormed`. A rule table entry can be wrong in a way
that only ever shows up as green, and there are three such ways, all now caught — verified by
injecting a malformed rule and watching each one fire:

- an `except` entry not under the rule's own `from` — it can never match a package the rule covers;
- an `except` entry broad enough to cover the whole `from` — the rule can never fire at all;
- an `except` entry naming a directory that is not in the tree — misspelt or left behind, and nobody
  finds out until the package it meant to name imports the forbidden path. This is the one that bites
  in practice: nothing under `cmd/` imports `pkg/jira/cloud` yet, so a typo in that exemption would
  sit green until the packet that wires the adapter hit a confusing arch failure.

Plus a missing name, a duplicate name, a missing `forbid` and a missing `why`.

One correction to what I wrote on #35 while claiming it: a misspelt exemption does not turn its rule
into a no-op, it turns the *exemption* into one, which usually surfaces as a red test. The class that
is genuinely silent is the over-broad exemption that swallows the rule's scope. Both are covered above;
the framing in the claim comment was the wrong way round.

`underPath(except, from)` alone does not make a typo impossible — the one rule with exemptions has
`from: ""`, and `underPath(anything, "")` is true. That is why the existence check is there as well. It
is a deliberate strengthening beyond what the packet spec describes.

## Documents corrected

- `AGENTS.md:40-43` — "mechanically, once PC.4 lands; by convention until then" now states the
  mechanism, and says where a test that needs a server puts it.
- `docs/TESTING.md:87-95` — same, at length: the namespace, why the warm-up has to come first, the
  isolation proof, `httptest` on loopback.
- `docs/TESTING.md:98-119` — the rule list was three of five; it is now five, names the sixth as
  P3.2's, and describes the table check.
- `docs/ARCHITECTURE.md:37-43` — named two of five; now names all five and the sixth.
- `docs/ROADMAP.md:102-109` — ticked, and the row's prose rewritten: it described the defect and said
  `internal/arch` "enforces four of the six rules", which was already wrong before this branch.

## The one line the arch test structurally cannot enforce

`docs/ARCHITECTURE.md:25` says `internal/app — use cases, orchestration, no IO libs`. The walk at
`internal/arch/imports_test.go:175-178` does `strings.CutPrefix(imported, modPath+"/")` and
`continue`s on a non-match, so stdlib and third-party imports are invisible to the rule engine —
`internal/app` could import `net/http` tomorrow and the suite would stay green.

**I softened the doc rather than filing a follow-up.** Once the doc stops claiming it is enforced there
is no untrue claim left, and widening the engine to non-module imports needs an answer to "which
stdlib packages count as IO libs" that no packet needs yet. `docs/ARCHITECTURE.md:45-47` and
`docs/TESTING.md:116-117` now both mark it as a rule a reviewer holds you to. Say so on the review if
you would rather have the issue.

## Consumers of shared changes

Nothing exported or importable changed — the diff is one workflow, two `_test.go` files in
`internal/arch`, that package's doc comment, and four documents. Nothing outside `internal/arch` can
reference any of it: `grep -rn "scanWorkflow\|workflowScan\|looseGoTest\|TestImportRules"` hits only
`internal/arch/`. The consumers of the CI change are the two documents that describe it, both updated
here (`AGENTS.md:40-43`, `docs/TESTING.md:87-95`), and the arch test that asserts it stays.

## Failure paths tested, golden files, benchmarks

No golden file changed — this packet renders nothing and touches no render path, so no benchmark
either. The failure paths exercised are the guards' own: the workflow guard verified red against the
pre-packet workflow and against four ways of getting `go test` out of the jail, and the rule-table
guard verified red against a rule with a duplicate name, no `forbid`, no `why`, a dead exemption, a
scope-swallowing exemption and a misspelt one.

Local: `go mod tidy` clean, `go vet`, `golangci-lint run` (0 issues), `go test -race -count=1 ./...`
green across all 12 packages, release build ok, `scripts/checkleak.py` clean.

## Ownership widening

The packet owns `.github/workflows/ci.yml` and `internal/arch/**`. It also touches the named sentences
in `AGENTS.md`, `docs/TESTING.md`, `docs/ARCHITECTURE.md` and `docs/ROADMAP.md` listed above, and
nothing else in those files. That widening was approved with the packet and is stated on #33: three of
the four sentences this packet exists to make true live in docs, and merging the code while the docs
still described the honour system would re-create the defect. `Makefile`, `scripts/` and every `.go`
file outside `internal/arch` are untouched.

## Follow-up filed

#53 — `scripts/checkleak.py` is wired into nothing. `AGENTS.md:36` and `docs/PARALLEL.md:59` both
require it; there is no CI step and no git hook. Third rule of the same shape as this packet's two,
and the issue notes that a naive CI step over the current script would prove nothing, because with no
capture present it exits successfully.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
