### PR TITLE
wip: PC.6 — the Cloud adapter is not a jira.Client, so nothing can wire it

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,7 +67,7 @@ instance from day one.
 - [x] **P1.6 — First-run onboarding** · [#7](https://github.com/varijkapil13/saral/issues/7) · **owns** `internal/ui/onboarding/**`
   Site, email, token, project picker; writes the profile; explains what the probe found.
 
-## Batch 1.5 — Corrections · **PC.1 serial, then parallel ×4** · blocks Batch 2
+## Batch 1.5 — Corrections · **PC.1 serial, then parallel ×4; PC.6 blocked** · blocks Batch 2
 
 Batch 1 shipped and left the project asserting several things that are not true. None of them is a
 feature and none was worth stopping Batch 1 for; all of them are load-bearing for **Batch 2, which is
@@ -80,9 +80,27 @@ enforced; that `Capabilities` gives a reason for every negative; that an `Issue`
 values say; that the session knows its project; that the fixture server replays the right shape; and
 that the number keys have exactly one owner.
 
-**PC.1 lands first and alone** — it amends the port, which `docs/PARALLEL.md` makes a serial change
-because it unblocks or blocks everyone. The other four run in parallel behind it.
+PC.6 adds the largest of them: that a build of Saral can reach a Jira site at all. Recon proved that
+one cannot be paid off in this batch, and its row says why — it changes what Batch 1.5 can close on.
 
+**PC.1 lands first and alone** — it amends the port, which `docs/PARALLEL.md` makes a serial change
+because it unblocks or blocks everyone. The other four run in parallel behind it. PC.6 is listed
+first because everything else here is only observable once it lands, and blocked for the reason its
+row gives.
+
+- [ ] **PC.6 — Wire the Jira adapter into the composition root** · [#52](https://github.com/varijkapil13/saral/issues/52) · **owns** `cmd/saral/main.go`, `cmd/saral/main_test.go`, `docs/ROADMAP.md`
+  Nothing in the shipped binary constructs the Cloud adapter, so it cannot talk to Jira at all — and
+  it says something else instead: onboarding answers three typed-in credentials with "nothing wired an
+  adapter", every capability-gated view is hidden by a probe that never ran, and the list has nothing
+  to read from. `build()` sets `Site`, `Project` and `Theme` and never `deps.Jira`.
+  **Blocked, and not by anything in its own paths:** `pkg/jira/cloud` implements 2 of the port's 34
+  methods — `Capabilities` and `Search` — so `*cloud.Client` is not a `jira.Client`, and neither
+  `onboarding.SetConnector` nor `kernel.Deps.Jira` will take it. The only type in the tree that
+  implements the port is `jiratest.Fake`. Unblocking it is a `contract` decision with a human's name
+  on it — grow the adapter (Batch 2 work, which this batch gates) or narrow the port to what each
+  caller needs: [#55](https://github.com/varijkapil13/saral/issues/55).
+  Goes before **PC.3**, which edits the same `build()`, and PC.3's probe scope fix is unobservable
+  until it lands.
 - [ ] **PC.1 — Port amendments** · [#46](https://github.com/varijkapil13/saral/issues/46), [#37](https://github.com/varijkapil13/saral/issues/37) · **owns** `pkg/jira/{port,types}.go`, `pkg/jira/cloud/{caps,search}.go`, `pkg/jira/jiratest/jiratest.go`
   Two additive amendments, one PR, because two agents editing the frozen port is the one guaranteed
   conflict. `Capabilities` gains a way to say the timezone probe failed, instead of leaving


### PR DESCRIPTION
**DO NOT MERGE as a packet completion.** PC.6 ([#52](https://github.com/varijkapil13/saral/issues/52))
is blocked, by something outside its owned paths. What is in this PR is the correction to
`docs/ROADMAP.md`, which is mergeable on its own and is the part worth having on `main` today. The
wiring the packet exists for is not here, because it does not compile.

## The blocker

`pkg/jira/cloud` implements **2 of the port's 34 methods** — `Capabilities` and `Search`. So
`*cloud.Client` is not a `jira.Client`, and there is no way to construct one at the composition root:

```
$ go vet ./cmd/...
vet: cmd/saral/main.go:187:9: cannot use client (variable of type *cloud.Client) as jira.Client
value in return statement: *cloud.Client does not implement jira.Client (missing method AddComment)
```

Missing, in port order: `Issue, CreateIssue, UpdateIssue, Transitions, Transition, Comments,
AddComment, EditComment, DeleteComment, Attachments, Upload, Download, DeleteAttachment, Versions,
SaveVersion, UnresolvedCount, ReleaseVersion, Boards, BoardConfig, Sprints, CreateSprint,
UpdateSprint, StartSprint, CompleteSprint, MoveToSprint, MoveToBacklog, Fields, CreateMeta, BulkMove,
Task, Plans, Me`.

Every seam that would take a client wants the whole port, so none of them can be fed:

- `kernel.Deps.Jira` is a `jira.Client` — `internal/ui/kernel/view.go:62`
- `onboarding.Connector` returns a `jira.Client` — `internal/ui/onboarding/onboarding.go:43` — and
  the first thing the flow does with one is `client.Me(ctx)`, `internal/ui/onboarding/commands.go:155`
- `app.NewSearch` takes a `jira.Client` — `internal/app/search.go:137`

**The only type in the tree that implements `jira.Client` is `jiratest.Fake`.** Everything Batch 1
shipped works — against the fake. That is why nothing imports `pkg/jira/cloud`: not an oversight in
the composition root, an adapter that cannot be assigned to the interface it is the adapter for.

Filed as [#55](https://github.com/varijkapil13/saral/issues/55) with the two candidate resolutions
(grow the adapter, or narrow the port into the role interfaces each caller actually needs — the
precedent for which is `internal/app.Counter` and its doc comment at `internal/app/search.go:20-29`).
It is a `contract` decision and wants a human answer, so it is an issue, not a drive-by. The
scheduling knot worth naming: Batch 1.5 gates Batch 2, and the missing 32 methods *are* Batch 2 and
later `pkg/jira/cloud/*.go` work, so PC.6 currently needs the batch its own batch blocks.

## What is in the diff

`docs/ROADMAP.md` only:

- The **PC.6 row**, in Batch 1.5, listed first because everything else in the batch is only observable
  once it lands — **unticked**, with the blocker named and linked, and with the note that it precedes
  PC.3 ([#50](https://github.com/varijkapil13/saral/issues/50)), which edits the same `build()` and
  whose probe-scope fix is unobservable until this does land.
- The batch heading now says `PC.6 blocked` rather than implying five packets are in flight, and the
  batch's list of claims-being-made-good gains the one this packet found: that a build of Saral can
  reach a Jira site at all.

## What was written and then reverted

The wiring itself, complete apart from being unassignable, is preserved verbatim in
[#55](https://github.com/varijkapil13/saral/issues/55) for whoever unblocks it:
`onboarding.SetConnector` over `cloud.New` registered unconditionally (a first run is exactly the path
with no token yet, and the error path returns a nil interface rather than a `*cloud.Client` in a
non-nil `jira.Client`); `config.Profile.ResolveToken` under a 20-second bound, chosen to sit above
`internal/config`'s own 15-second command timeout plus its 2-second wait delay so the resolver's
wording reaches the user; a resolution failure carried to the status line as a warning instead of
stopping the program; `deps.Caps` left zero because no first frame waits on a request (`docs/UX.md:9`).
Its tests drove the real onboarding view over the registered connector as far as the connection
attempt without running it, and resolved tokens from `TokenSource.Env`, so nothing left the machine.

I am not landing a partial version of that. There is no honest half: a connector that always fails, or
a `jira.Client` in `cmd` that embeds the adapter and errors for the other 32 methods, would both put a
new wrong sentence in front of the user, which is the class of thing Batch 1.5 exists to delete.

## Checklist

- **Consumers of a shared change:** none — nothing shared changed. `cmd/saral/main.go`,
  `cmd/saral/main_test.go` and every package are byte-identical to `origin/main`.
- **Ownership:** the spec for this packet widened its owned paths to include `docs/ROADMAP.md`, which
  is approved and stated on the issue; nothing else was touched. No widening of my own.
- **Golden files:** none changed. No render path touched.
- **Failure paths:** none reachable to test, because no code landed. The ones the reverted wiring
  covered are listed on #55: an unresolvable token source, a profile `cloud.New` refuses (no email),
  no config file at all, and the typed-nil return.
- **Probe:** deliberately not made synchronous. Probing on `Init` rather than only on `R` is
  `internal/ui/kernel/kernel.go`, which belongs to PC.3. **Until PC.3 lands, a real session shows no
  capabilities even with a client**: `available()` hides every gated view and `open()` says
  "is not available on this site" for a probe that never ran.
- `go mod tidy` clean · `go vet ./...` · `golangci-lint run` (0 issues) · `go test -race -count=1 ./...`
  (all packages ok, `internal/arch` included and run again on its own) · `go build -trimpath` ok ·
  `scripts/checkleak.py` clean.
- The roadmap checkbox is **not** ticked, because the packet is not done. That is the one deviation
  from the packet spec, and it is deliberate.
