### PR TITLE
PC.1 — port amendments: why the dates are in UTC, and which fields an issue holds

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -10,6 +10,7 @@ here cost time to find out; read this before writing an adapter method.
 | `/rest/api/3/search` returns **410 Gone** | Use `POST /rest/api/3/search/jql`. Not optional. |
 | `/search/jql` pages by opaque `nextPageToken` and returns **no `total`** | The UI must work without a count. Use `POST /rest/api/3/search/approximate-count` — no `/jql` segment — where a number is genuinely needed. Guard against a token that repeats. |
 | `/search/jql` returns almost nothing without `fields` | Always send an explicit, narrow field list. |
+| The response carries only the field keys it **actually returned** — nothing anywhere says what the endpoint did with the list you sent | The field list cannot be recovered from the answer, so the `jira.FieldMask` on `Issue.Requested` records what was *asked for*, never what the site had. "Requested and absent" means the site sent nothing for that field, and a field ID the site does not have looks exactly the same. Every consumer of the mask has to know that. |
 | The Agile API still uses `startAt`/`maxResults`/`total` | Two pagination models in one client, unified behind `Page[T]`. It also silently truncates against an unreadable instance limit. |
 | There is a **third** paging style: `/rest/api/3/plans/plan` uses `cursor`/`nextPageCursor` and *does* report a `total` and an `isLast` | It is neither of the other two. `Plans` returns a plain slice for that reason. A fourth shape — no paging at all — covers `/field`, `/project/{key}/versions` and attachment upload. |
 | The Plans API lives at `/rest/api/3/plans/plan` — the doubled segment is correct | `GET /rest/api/3/plans` does not exist. |
@@ -40,6 +41,7 @@ here cost time to find out; read this before writing an adapter method.
 | `timetracking` is `{}` — an empty object, not `null` — on an issue with no estimates | Decoding into a struct gives zeroes, which is right; decoding into a pointer never gives nil. |
 | `statusCategory.id` is a **number** while `status.id` is a **string** | The four categories are fixed on every site: 1 `undefined`, 2 `new`, 3 `done`, 4 `indeterminate`. Branch on `key`; `name` is localised. |
 | `GET /rest/api/3/issue/createmeta?expand=…` is deprecated | Use the paginated pair, `GET /issue/createmeta/{projectIdOrKey}/issuetypes` then `…/issuetypes/{issueTypeId}`. |
+| A `timeZone` on `/rest/api/3/myself` is not a promise this machine can load it | The name comes out of the site's own zone database and is resolved locally against Go's zoneinfo, which a slim container image may not carry at all. That failure is **local**: report it as this machine having no entry for the zone the account is set to, never as Jira failing to answer, and fall back to UTC. |
 
 ## Things that vary per instance — never hardcode
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,6 +95,9 @@ Rules for the port:
   underlying `PUT /rest/agile/1.0/sprint/{id}` nulls every omitted field. The port hides that.
 - **No `map[string]any` in signatures.** Custom fields are carried in `Issue.Fields` as a typed
   `FieldSet` keyed by resolved field ID, with accessors that take a `FieldRef`.
+- **An issue knows which fields it was read with**, in `Issue.Requested`. A narrow read is otherwise
+  indistinguishable from an empty one — a nil `Assignee` means both unassigned and never asked for —
+  and anything that merges, caches or writes an issue back has to tell those apart.
 - **Every method takes `context.Context`** and must honour cancellation — views cancel in-flight
   work when they close.
 
@@ -124,13 +127,14 @@ read it; nobody re-probes ad hoc.
 
 ```go
 type Capabilities struct {
-	Plans        Capability // Administer Jira required
-	BulkMove     Capability // BULK_CHANGE + MOVE_ISSUES + CREATE_ISSUES
-	Boards       Capability // project has at least one board
-	Attachments  Capability // instance-wide setting
-	DeleteIssues Capability
-	Graphics     GraphicsMode // kitty | iterm2 | halfblocks | none
-	TimeZone     *time.Location
+	Plans          Capability // Administer Jira required
+	BulkMove       Capability // BULK_CHANGE + MOVE_ISSUES + CREATE_ISSUES
+	Boards         Capability // project has at least one board
+	Attachments    Capability // instance-wide setting
+	DeleteIssues   Capability
+	Graphics       GraphicsMode // kitty | iterm2 | halfblocks | none
+	TimeZone       *time.Location
+	TimeZoneReason string // why the zone is not the account's own; empty when it is
 }
 
 type Capability struct {
@@ -141,6 +145,12 @@ type Capability struct {
 
 A view whose capability is absent is never registered into the footer, and any keybinding that would
 reach it renders `Reason` in the status line. **A 403 is a capability answer, not an error.**
+
+A timezone the probe could not establish is reported the same way. `TimeZone` stays nil,
+`TimeZoneReason` carries the sentence — a refusal in Jira's own words, a zone name this machine has
+no zoneinfo entry for, or an account that named none — and `Zone()` hands a view both at once. Dates
+render in UTC whichever it was, so that sentence is the only thing on screen that can say why they
+may be an hour out.
 
 The probe is scoped to a project, because three of these are: boards belong to a project, and Jira
 scopes Move, Delete and Create as project permissions, so one token answers differently in two

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,12 +83,16 @@ that the number keys have exactly one owner.
 **PC.1 lands first and alone** — it amends the port, which `docs/PARALLEL.md` makes a serial change
 because it unblocks or blocks everyone. The other four run in parallel behind it.
 
-- [ ] **PC.1 — Port amendments** · [#46](https://github.com/varijkapil13/saral/issues/46), [#37](https://github.com/varijkapil13/saral/issues/37) · **owns** `pkg/jira/{port,types}.go`, `pkg/jira/cloud/{caps,search}.go`, `pkg/jira/jiratest/jiratest.go`
+- [x] **PC.1 — Port amendments** · [#46](https://github.com/varijkapil13/saral/issues/46), [#37](https://github.com/varijkapil13/saral/issues/37) · **owns** `pkg/jira/{port,types}.go`, `pkg/jira/cloud/{caps,search}.go`, `pkg/jira/jiratest/{jiratest,fake}.go`, `internal/ui/onboarding/render.go`, `docs/{ARCHITECTURE,API-NOTES}.md`
   Two additive amendments, one PR, because two agents editing the frozen port is the one guaranteed
-  conflict. `Capabilities` gains a way to say the timezone probe failed, instead of leaving
-  `TimeZone` nil and rendering every date in UTC with nothing on screen to explain it. `Issue` gains
-  a way to distinguish *not requested* from *empty*, so that P2.3's fetch-edit-PUT cycle cannot blank
-  a field nobody touched.
+  conflict. Both landed in `types.go`: `port.go` needed no edit at all, since neither amendment
+  touches a method signature. `Capabilities` gained `TimeZoneReason` and `Zone()`, so a probe that
+  could not establish the account's zone says which of its three ways it failed instead of leaving
+  `TimeZone` nil and rendering every date in UTC with nothing on screen to explain it. `Issue` gained
+  `Requested`, a `FieldMask` naming the fields it was read with, so that P2.3's fetch-edit-PUT cycle
+  cannot blank a field nobody touched. The owned paths grew by the fake's field masking and the one
+  line in onboarding that names a timezone, which are the only consumers either amendment has:
+  without them the packet adds two things nobody uses.
 - [ ] **PC.2 — One owner for the number keys** · [#49](https://github.com/varijkapil13/saral/issues/49) · **owns** `internal/ui/kernel/{view,keys}.go`, `internal/ui/list/register.go`, `internal/app/search.go`, `docs/UX.md`
   Three claimants on `1`–`9`: kernel view slots, the six root views `docs/UX.md` promises, and
   `SavedQuery.Slot`, which P1.2 built and tested and nothing calls. Pick one, give the others a

--- a/internal/ui/onboarding/render.go
+++ b/internal/ui/onboarding/render.go
@@ -362,8 +362,17 @@ func (m Model) summary() []string {
 		rows = append(rows, m.capabilityRow(c.key, c.label))
 	}
 	return append(rows, "",
-		m.pair("Dates in", m.caps.Location().String()),
+		m.pair("Dates in", m.datesLine()),
 		m.pair("Images", m.caps.Graphics.String()))
+}
+
+func (m Model) datesLine() string {
+	loc, why := m.caps.Zone()
+	dates := loc.String()
+	if why != "" {
+		dates += m.styles.muted.Render(" · " + why)
+	}
+	return dates
 }
 
 func (m Model) capsHeading() string {

--- a/internal/ui/onboarding/render_test.go
+++ b/internal/ui/onboarding/render_test.go
@@ -18,7 +18,12 @@ const goldenPath = "/home/you/.config/saral/config.toml"
 
 func goldenDriver(t *testing.T) *driver {
 	t.Helper()
-	d := newDriver(t, testFake(jiratest.WithCapabilities(jiratest.NoBulkMove, jiratest.NoPlans)))
+	return goldenDriverWith(t, jiratest.NoBulkMove, jiratest.NoPlans)
+}
+
+func goldenDriverWith(t *testing.T, mods ...jiratest.CapMod) *driver {
+	t.Helper()
+	d := newDriver(t, testFake(jiratest.WithCapabilities(mods...)))
 	d.send(configLoadedMsg{path: goldenPath})
 	return d
 }
@@ -136,6 +141,40 @@ func TestView_TheSummaryScrollsWhenItDoesNotFit(t *testing.T) {
 	if !strings.Contains(d.frame(), "Site           "+testSite) {
 		t.Errorf("the wheel did not scroll the summary back to the top:\n%s", d.frame())
 	}
+}
+
+// TestView_SaysWhyTheDatesAreNotInTheAccountsZone covers the one line in the
+// program that names a timezone. Every date renders in UTC when the probe could
+// not establish the account's zone, and this row is the only place that can say
+// so — without it a user in Berlin reads timestamps an hour out and nothing on
+// screen accounts for it.
+func TestView_SaysWhyTheDatesAreNotInTheAccountsZone(t *testing.T) {
+	t.Parallel()
+
+	const why = "Jira did not answer what timezone this account is in"
+
+	unknown := goldenDriverWith(t, jiratest.NoBulkMove, jiratest.NoPlans, jiratest.NoTimeZone)
+	unknown.send(kernel.SizeMsg{Width: 120, Height: 40})
+	unknown.credentials()
+	unknown.press("enter")
+	unknown.typeIn("PROJ")
+	unknown.press("enter")
+	unknown.atStep(stepReview)
+	unknown.mustContain("Dates in       UTC · " + why)
+	golden(t, "review-unknown-zone_120x40.golden", unknown.frame())
+
+	// The zone the account is really in explains nothing, so it says nothing.
+	known := goldenDriver(t)
+	known.send(kernel.SizeMsg{Width: 120, Height: 40})
+	known.credentials()
+	known.press("enter")
+	known.typeIn("PROJ")
+	known.press("enter")
+	known.atStep(stepReview)
+	if strings.Contains(known.frame(), why) {
+		t.Errorf("the summary explains a timezone that needs no explaining:\n%s", known.frame())
+	}
+	known.mustContain("Dates in       UTC\n")
 }
 
 func TestView_DrawsNothingBeforeItHasBeenGivenASize(t *testing.T) {

--- a/internal/ui/onboarding/testdata/review-unknown-zone_120x40.golden
+++ b/internal/ui/onboarding/testdata/review-unknown-zone_120x40.golden
@@ -1,0 +1,38 @@
+Set up Saral                                                                                                 step 6 of 6
+
+  +  Jira site       example.atlassian.net
+  +  Account email   you@example.com
+  +  API token       verified as Sam Tester
+  +  Token store     OS keychain
+  +  Project         PROJ
+  -> Review
+
+    This is what will be written.
+
+    Site           example.atlassian.net
+    Account        Sam Tester · you@example.com
+    Profile        example in /home/you/.config/saral/config.toml
+    Token          keychain entry saral:example
+    Project        PROJ
+
+    What this token can do in PROJ
+    + Boards
+    x Move between projects  needs Bulk Change permission
+    + Delete issues
+    + Attachments
+    x Plans                  the Plans API needs Administer Jira
+
+    Dates in       UTC · Jira did not answer what timezone this account is in
+    Images         halfblocks
+
+
+
+
+
+
+
+
+
+
+
+

--- a/pkg/jira/cloud/caps.go
+++ b/pkg/jira/cloud/caps.go
@@ -196,15 +196,25 @@ func (c *Client) capsTimeZone(ctx context.Context) (capsApply, error) {
 	}, &body)
 
 	var zone *time.Location
-	if err == nil && body.TimeZone != "" {
-		// A machine carrying no zoneinfo database, or a zone name Go does not
-		// know, is not a Jira failure and must not read as one: dates then
-		// render in UTC, which is what Capabilities.Location falls back to.
-		if loaded, loadErr := time.LoadLocation(body.TimeZone); loadErr == nil {
-			zone = loaded
+	var reason string
+	switch {
+	case err != nil:
+		reason = capsFailed("what timezone this account is in", err)
+	case body.TimeZone == "":
+		reason = "Jira did not say what timezone this account is in"
+	default:
+		loaded, loadErr := time.LoadLocation(body.TimeZone)
+		if loadErr != nil {
+			// A zone Jira knows and this machine does not is a local failure, not Jira's.
+			reason = "This machine has no zoneinfo entry for " + body.TimeZone +
+				", the timezone this account is set to"
+			break
 		}
+		zone = loaded
 	}
-	return func(caps *jira.Capabilities) { caps.TimeZone = zone }, err
+	return func(caps *jira.Capabilities) {
+		caps.TimeZone, caps.TimeZoneReason = zone, reason
+	}, err
 }
 
 // capsPlans asks whether the Plans API answers this token at all. A 403 is the

--- a/pkg/jira/cloud/caps_test.go
+++ b/pkg/jira/cloud/caps_test.go
@@ -289,6 +289,9 @@ func TestCapabilities_KeepsTheOtherAnswersWhenOneProbeFails(t *testing.T) {
 	if got.TimeZone == nil {
 		t.Error("the timezone probe was lost with the configuration one")
 	}
+	if got.TimeZoneReason != "" {
+		t.Errorf("TimeZoneReason = %q while the zone came back; the two are never both set", got.TimeZoneReason)
+	}
 }
 
 func TestCapabilities_SaysWhichAnswersNeedAProjectWhenThereIsNone(t *testing.T) {
@@ -343,26 +346,97 @@ func TestCapabilities_ReadsTheAccountTimezoneRatherThanTheMachines(t *testing.T)
 	if got.Location() != got.TimeZone {
 		t.Error("Location did not return the probed zone")
 	}
+	zone, why := got.Zone()
+	if zone != got.TimeZone || why != "" {
+		t.Errorf("Zone() = %s with reason %q, want the account's zone and nothing to explain", zone, why)
+	}
 }
 
-func TestCapabilities_FallsBackToUTCWhenTheZoneNameIsUnknownHere(t *testing.T) {
+// TestCapabilities_SaysWhyTheTimezoneIsNotTheAccountsOwn covers the three ways
+// the zone can be missing, which are three different sentences: a zone renders
+// as UTC whichever it was, and this reason is the only thing on screen that can
+// tell someone in Berlin why their timestamps are an hour out.
+func TestCapabilities_SaysWhyTheTimezoneIsNotTheAccountsOwn(t *testing.T) {
 	t.Parallel()
 
-	s := jiratest.NewServer(capsJSON(http.MethodGet, capsMyselfPath, http.StatusOK,
-		`{"accountId":"5b10a2844c20165700ede21g","timeZone":"Mars/Olympus"}`))
+	tests := []struct {
+		name   string
+		serve  jiratest.ServerOption
+		reason string
+	}{
+		{
+			name: "this machine has no entry for the zone Jira named",
+			serve: capsJSON(http.MethodGet, capsMyselfPath, http.StatusOK,
+				`{"accountId":"5b10a2844c20165700ede21g","timeZone":"Mars/Olympus"}`),
+			reason: "This machine has no zoneinfo entry for Mars/Olympus, the timezone this account is set to",
+		},
+		{
+			name: "the account answered without a zone at all",
+			serve: capsJSON(http.MethodGet, capsMyselfPath, http.StatusOK,
+				`{"accountId":"5b10a2844c20165700ede21g"}`),
+			reason: "Jira did not say what timezone this account is in",
+		},
+		{
+			// The site knows which permission scheme refused and this client does
+			// not, so the sentence a user reads has to be Jira's own.
+			name: "the site refused to say who this token is",
+			serve: capsJSON(http.MethodGet, capsMyselfPath, http.StatusForbidden,
+				`{"errorMessages":["You do not have permission to view this user profile."],"errors":{}}`),
+			reason: "You do not have permission to view this user profile.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(tt.serve)
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL())
+			got, err := c.Capabilities(t.Context(), capsProject)
+			if err != nil {
+				t.Fatalf("an unusable timezone sank the whole probe: %v", err)
+			}
+			if got.TimeZone != nil {
+				t.Errorf("timezone = %v, want none", got.TimeZone)
+			}
+			if got.TimeZoneReason != tt.reason {
+				t.Errorf("TimeZoneReason = %q, want %q", got.TimeZoneReason, tt.reason)
+			}
+			zone, why := got.Zone()
+			if zone != time.UTC || why != tt.reason {
+				t.Errorf("Zone() = %s with reason %q, want UTC with %q", zone, why, tt.reason)
+			}
+			capsAssert(t, "Boards", got.Boards, true, "")
+			capsAssert(t, "Attachments", got.Attachments, true, "")
+		})
+	}
+}
+
+func TestCapabilities_KeepsTheOtherAnswersWhenTheTimezoneProbeFails(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, capsMyselfPath, http.StatusInternalServerError, ""))
 	defer s.Close()
 
-	c, _ := testClient(t, s.URL())
+	c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
 	got, err := c.Capabilities(t.Context(), capsProject)
 	if err != nil {
-		t.Fatalf("a zone this machine cannot load sank the probe: %v", err)
+		t.Fatalf("the failed timezone probe sank the whole capability probe: %v", err)
 	}
-	if got.TimeZone != nil {
-		t.Errorf("timezone = %v, want none for a zone no zoneinfo database has", got.TimeZone)
+
+	const reason = "Jira did not answer what timezone this account is in: " +
+		"GET /rest/api/3/myself failed with HTTP 500: Internal Server Error"
+	if got.TimeZoneReason != reason {
+		t.Errorf("TimeZoneReason = %q, want %q", got.TimeZoneReason, reason)
 	}
 	if got.Location() != time.UTC {
 		t.Errorf("Location = %v, want UTC", got.Location())
 	}
+	capsAssert(t, "Boards", got.Boards, true, "")
+	capsAssert(t, "BulkMove", got.BulkMove, true, "")
+	capsAssert(t, "Attachments", got.Attachments, true, "")
 }
 
 func TestCapabilities_ReturnsTheRejectedCredentialRatherThanAbsentCapabilities(t *testing.T) {

--- a/pkg/jira/cloud/search.go
+++ b/pkg/jira/cloud/search.go
@@ -80,7 +80,9 @@ func (s apiFieldSchema) domain() jira.FieldSchema {
 //
 // Query.Fields must name the fields the caller wants. An empty list is refused
 // rather than sent: the endpoint answers such a request with an id and a key
-// per issue, which looks like a result set and is not one.
+// per issue, which looks like a result set and is not one. Every issue comes
+// back carrying that list as its jira.FieldMask, so a later merge or write can
+// tell a field nobody asked for from one the site had nothing to send for.
 //
 // Pages are walked by jira.Cursor, whose repeated-token guard is what makes the
 // walk terminate. The token is reachable only from inside the returned Page, on
@@ -92,6 +94,7 @@ func (c *Client) Search(ctx context.Context, q jira.Query) (jira.Page[jira.Issue
 	if len(fields) == 0 {
 		return jira.Page[jira.Issue]{}, errSearchNeedsFields()
 	}
+	mask := jira.NewFieldMask(fields)
 	body := apiSearchBody{
 		JQL:        strings.TrimSpace(q.JQL),
 		Fields:     fields,
@@ -114,7 +117,7 @@ func (c *Client) Search(ctx context.Context, q jira.Query) (jira.Page[jira.Issue
 	}
 	op := http.MethodPost + " " + searchJQLPath
 	return cursorPages(ctx, c, build, func(resp *response) ([]jira.Issue, string, error) {
-		return decodeSearchPage(resp, op)
+		return decodeSearchPage(resp, op, mask)
 	})
 }
 
@@ -149,7 +152,7 @@ func errSearchNeedsFields() error {
 	}}}
 }
 
-func decodeSearchPage(resp *response, op string) ([]jira.Issue, string, error) {
+func decodeSearchPage(resp *response, op string, mask jira.FieldMask) ([]jira.Issue, string, error) {
 	var page apiSearchPage
 	if err := resp.decode(op, &page); err != nil {
 		return nil, "", err
@@ -157,7 +160,7 @@ func decodeSearchPage(resp *response, op string) ([]jira.Issue, string, error) {
 	raw := page.items()
 	issues := make([]jira.Issue, 0, len(raw))
 	for i := range raw {
-		issues = append(issues, decodeIssue(raw[i], page.Schema))
+		issues = append(issues, decodeIssue(raw[i], page.Schema, mask))
 	}
 	return issues, page.next(), nil
 }
@@ -205,9 +208,10 @@ func uniqueStrings(in []string) []string {
 // the JSON it arrived as: a dropped field is one a user cannot tell is missing,
 // and one odd custom field must not blank an issue. Unset fields arrive as an
 // explicit null and are skipped, so a narrow field list really does produce an
-// issue with everything else absent.
-func decodeIssue(in apiIssue, schema map[string]apiFieldSchema) jira.Issue {
-	iss := jira.Issue{ID: in.ID, Key: in.Key}
+// issue with everything else absent — and the mask is what says which list that
+// was, since the issue itself can no longer tell.
+func decodeIssue(in apiIssue, schema map[string]apiFieldSchema, mask jira.FieldMask) jira.Issue {
+	iss := jira.Issue{ID: in.ID, Key: in.Key, Requested: mask}
 	values := make(map[string]jira.FieldValue, len(in.Fields))
 	for id, raw := range in.Fields {
 		if isJSONNull(raw) {

--- a/pkg/jira/cloud/search_test.go
+++ b/pkg/jira/cloud/search_test.go
@@ -94,9 +94,67 @@ func TestSearch_RefusesAQueryThatNamesNoFieldsWithoutAskingTheSite(t *testing.T)
 
 	// The fake refuses the same query, and the two adapters have to agree about
 	// why, or a view written against one reads differently against the other.
-	_, fakeErr := jiratest.New().Search(t.Context(), jira.Query{JQL: "project = EX"})
-	if fakeErr == nil || fakeErr.Error() != err.Error() {
-		t.Errorf("the fake refuses it as %v; the cloud adapter as %v", fakeErr, err)
+	// The whitespace matters: a field list that trims away to nothing is a list
+	// that names no fields, and both adapters have to see that the same way.
+	for _, fields := range [][]string{nil, {"  "}, {"", " \t "}} {
+		_, fakeErr := jiratest.New().Search(t.Context(), jira.Query{JQL: "project = EX", Fields: fields})
+		if fakeErr == nil || fakeErr.Error() != err.Error() {
+			t.Errorf("with Fields %q the fake refuses it as %v; the cloud adapter as %v", fields, fakeErr, err)
+		}
+	}
+}
+
+// TestSearch_TellsEveryIssueWhichFieldsWereAskedFor is the half of a narrow read
+// that the issue itself cannot express: a nil assignee on an issue read without
+// the assignee is not an unassigned issue, and only the mask says which it is.
+func TestSearch_TellsEveryIssueWhichFieldsWereAskedFor(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	want := slices.Sorted(slices.Values(listFields))
+	first := searchOnce(t, s, listQuery())
+	all, err := jira.Collect(t.Context(), first, 0)
+	if err != nil {
+		t.Fatalf("walking the pages: %v", err)
+	}
+	if len(all) < 3 {
+		t.Fatalf("the fixture pages carried %d issues, want the walk to reach page two", len(all))
+	}
+
+	for _, issue := range all {
+		if issue.Requested.Wide() {
+			t.Errorf("%s claims every field was asked for", issue.Key)
+		}
+		if got := issue.Requested.IDs(); !slices.Equal(got, want) {
+			t.Errorf("%s was read with %q, want exactly %q", issue.Key, got, want)
+		}
+		if !issue.Requested.Has("assignee") {
+			t.Errorf("%s does not know the assignee was asked for, so an unassigned issue reads as unfetched", issue.Key)
+		}
+		if issue.Requested.Has("labels") {
+			t.Errorf("%s claims labels were asked for; they were not, so its empty labels mean nothing", issue.Key)
+		}
+	}
+}
+
+// TestSearch_MarksAFieldTheSiteDoesNotHaveAsRequestedAnyway pins the caveat the
+// mask cannot avoid: a response carries only the fields it returned, so a field
+// ID this site does not have is in the mask and never in the values.
+func TestSearch_MarksAFieldTheSiteDoesNotHaveAsRequestedAnyway(t *testing.T) {
+	t.Parallel()
+
+	s := searchServing(onePage(`{"id":"1","key":"EX-1","fields":{"summary":"A row"}}`))
+	defer s.Close()
+
+	const absent = "customfield_99999"
+	got := firstIssue(t, searchOnce(t, s, jira.Query{JQL: "project = EX", Fields: []string{"summary", absent}}))
+	if !got.Requested.Has(absent) {
+		t.Errorf("the mask dropped %s; it records what was asked for, not what the site had", absent)
+	}
+	if _, ok := got.Fields.ByID(absent); ok {
+		t.Errorf("the site sent a value for %s, which it never echoed", absent)
 	}
 }
 
@@ -434,7 +492,7 @@ func TestSearch_ReadsAnIssueShapedLikeARealOne(t *testing.T) {
 		t.Fatalf("parsing the fixture: %v", err)
 	}
 
-	got := decodeIssue(wire, nil)
+	got := decodeIssue(wire, nil, jira.AllFields())
 
 	if got.Key != "EX-1" || got.ID != "10001" {
 		t.Errorf("the issue is %s/%s, want EX-1/10001", got.Key, got.ID)
@@ -811,10 +869,11 @@ func BenchmarkDecodeSearchPage(b *testing.B) {
 		b.Fatalf("reading the fixture: %v", err)
 	}
 	resp := &response{status: http.StatusOK, body: raw}
+	mask := jira.NewFieldMask(listFields)
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, _, err := decodeSearchPage(resp, "POST "+searchJQLPath); err != nil {
+		if _, _, err := decodeSearchPage(resp, "POST "+searchJQLPath, mask); err != nil {
 			b.Fatalf("decoding: %v", err)
 		}
 	}
@@ -835,7 +894,7 @@ func TestDecodeIssue_WithoutASchemaKeepsAnUnlabelledArrayAsItsBytes(t *testing.T
 	if err := json.Unmarshal([]byte(wire), &in); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	got := decodeIssue(in, nil)
+	got := decodeIssue(in, nil, jira.AllFields())
 
 	ref := jira.FieldRef{ID: "attachment"}
 	if opts, ok := got.Fields.Options(ref); ok {

--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -76,6 +76,7 @@ func (f *Fake) Fields(ctx context.Context) ([]jira.Field, error) {
 // jql, so a query the fake cannot honour never passes as a query that matched
 // everything.
 func (f *Fake) Search(ctx context.Context, q jira.Query) (jira.Page[jira.Issue], error) {
+	mask := jira.NewFieldMask(q.Fields)
 	return jira.Cursor(ctx, func(ctx context.Context, token string) ([]jira.Issue, string, error) {
 		if err := f.fakeBegin(ctx, "Search"); err != nil {
 			return nil, "", err
@@ -83,7 +84,7 @@ func (f *Fake) Search(ctx context.Context, q jira.Query) (jira.Page[jira.Issue],
 		f.mu.Lock()
 		defer f.mu.Unlock()
 
-		if len(q.Fields) == 0 {
+		if mask.Len() == 0 && !mask.Wide() {
 			return nil, "", fakeInvalid("fields", "a search must name the fields it wants; /search/jql returns almost nothing without them")
 		}
 		plan, err := fakeParseJQL(q.JQL)
@@ -108,7 +109,7 @@ func (f *Fake) Search(ctx context.Context, q jira.Query) (jira.Page[jira.Issue],
 		items := make([]jira.Issue, 0, end-offset)
 		for _, iss := range matched[offset:end] {
 			clone := fakeCloneIssue(iss)
-			fakeApplyFieldMask(&clone, q.Fields)
+			fakeApplyFieldMask(&clone, mask)
 			items = append(items, clone)
 		}
 		next := ""
@@ -1397,72 +1398,72 @@ func fakeAttachmentBytes(att *jira.Attachment) []byte {
 // the custom-field set and the struct fields. A fake that hands back a whole
 // issue whatever was asked for lets a list view be written against data the
 // real endpoint will not send.
-func fakeApplyFieldMask(iss *jira.Issue, fields []string) {
-	keep := make(map[string]bool, len(fields))
-	for _, name := range fields {
-		if name == "*all" || name == "*navigable" {
-			return
-		}
-		keep[name] = true
+//
+// The mask both blanks the fields and records itself on the issue, so the fake
+// cannot mask one set and claim another.
+func fakeApplyFieldMask(iss *jira.Issue, mask jira.FieldMask) {
+	iss.Requested = mask
+	if mask.Wide() {
+		return
 	}
 	// Identity is not a field and always comes back.
-	if !keep["summary"] {
+	if !mask.Has("summary") {
 		iss.Summary = ""
 	}
-	if !keep["description"] {
+	if !mask.Has("description") {
 		iss.Description = adf.Doc{}
 	}
-	if !keep["status"] {
+	if !mask.Has("status") {
 		iss.Status = jira.Status{}
 	}
-	if !keep["issuetype"] {
+	if !mask.Has("issuetype") {
 		iss.Type = jira.IssueType{}
 	}
-	if !keep["priority"] {
+	if !mask.Has("priority") {
 		iss.Priority = nil
 	}
-	if !keep["resolution"] {
+	if !mask.Has("resolution") {
 		iss.Resolution, iss.Resolved = nil, nil
 	}
-	if !keep["assignee"] {
+	if !mask.Has("assignee") {
 		iss.Assignee = nil
 	}
-	if !keep["reporter"] {
+	if !mask.Has("reporter") {
 		iss.Reporter = nil
 	}
-	if !keep["labels"] {
+	if !mask.Has("labels") {
 		iss.Labels = nil
 	}
-	if !keep["components"] {
+	if !mask.Has("components") {
 		iss.Components = nil
 	}
-	if !keep["fixVersions"] {
+	if !mask.Has("fixVersions") {
 		iss.FixVersions = nil
 	}
-	if !keep["parent"] {
+	if !mask.Has("parent") {
 		iss.Parent = nil
 	}
-	if !keep["subtasks"] {
+	if !mask.Has("subtasks") {
 		iss.Subtasks = nil
 	}
-	if !keep["issuelinks"] {
+	if !mask.Has("issuelinks") {
 		iss.Links = nil
 	}
-	if !keep["duedate"] {
+	if !mask.Has("duedate") {
 		iss.Due = jira.Date{}
 	}
-	if !keep["created"] {
+	if !mask.Has("created") {
 		iss.Created = time.Time{}
 	}
-	if !keep["updated"] {
+	if !mask.Has("updated") {
 		iss.Updated = time.Time{}
 	}
-	if !keep["timetracking"] {
+	if !mask.Has("timetracking") {
 		iss.TimeTracking = nil
 	}
 	drop := make(map[string]bool)
 	for _, id := range iss.Fields.IDs() {
-		if !keep[id] {
+		if !mask.Has(id) {
 			drop[id] = true
 		}
 	}

--- a/pkg/jira/jiratest/fake_test.go
+++ b/pkg/jira/jiratest/fake_test.go
@@ -360,12 +360,143 @@ func TestSearch_NarrowsTheFieldSetToTheFieldsAsked(t *testing.T) {
 	if _, present := narrow.Items[0].Fields.Get(rank.Ref()); present {
 		t.Error("a field the query did not ask for must not come back")
 	}
-	wide, err := c.Search(ctx, jira.Query{JQL: `key = PROJ-1`, Fields: []string{"*all"}})
+	wide, err := c.Search(ctx, jira.Query{JQL: `key = PROJ-1`, Fields: []string{jira.FieldsAll}})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
 	if _, present := wide.Items[0].Fields.Get(rank.Ref()); !present {
 		t.Error("*all must return the whole field set")
+	}
+}
+
+// TestSearch_ReportsTheSameFieldsItMasked is the anti-lying test: the fake
+// blanks the fields the query did not name and reports what it blanked from the
+// same value, so it cannot mask one set and claim another. A fake that could
+// would be worse than no fake, since every consumer of the mask is written
+// against it.
+func TestSearch_ReportsTheSameFieldsItMasked(t *testing.T) {
+	t.Parallel()
+	c := fakeNewWithIssues(t, 6, jiratest.WithPageSize(100))
+
+	page, err := c.Search(t.Context(), jira.Query{JQL: `project = PROJ ORDER BY key`, Fields: fakeNarrow})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(page.Items) == 0 {
+		t.Fatal("the search matched nothing")
+	}
+
+	want := slices.Sorted(slices.Values(fakeNarrow))
+	for _, iss := range page.Items {
+		if iss.Requested.Wide() {
+			t.Errorf("%s claims every field was asked for", iss.Key)
+		}
+		if got := iss.Requested.IDs(); !slices.Equal(got, want) {
+			t.Errorf("%s reports %q as requested, want %q", iss.Key, got, want)
+		}
+		for _, id := range iss.Fields.IDs() {
+			if !iss.Requested.Has(id) {
+				t.Errorf("%s carries the field %s, which it says was never asked for", iss.Key, id)
+			}
+		}
+		carried := map[string]bool{
+			"summary":      iss.Summary != "",
+			"status":       iss.Status.Name != "",
+			"description":  !iss.Description.IsZero(),
+			"issuetype":    iss.Type.ID != "",
+			"priority":     iss.Priority != nil,
+			"reporter":     iss.Reporter != nil,
+			"components":   iss.Components != nil,
+			"fixVersions":  iss.FixVersions != nil,
+			"duedate":      !iss.Due.IsZero(),
+			"created":      !iss.Created.IsZero(),
+			"updated":      !iss.Updated.IsZero(),
+			"timetracking": iss.TimeTracking != nil,
+		}
+		for id, present := range carried {
+			if present && !iss.Requested.Has(id) {
+				t.Errorf("%s carries %s while reporting it was not asked for", iss.Key, id)
+			}
+		}
+		if !carried["summary"] || !carried["status"] {
+			t.Errorf("%s is missing a field the query did ask for: %+v", iss.Key, iss)
+		}
+	}
+}
+
+func TestSearch_ReportsAWideMaskForAWildcard(t *testing.T) {
+	t.Parallel()
+	c := fakeNewWithIssues(t, 2, jiratest.WithPageSize(100))
+
+	for _, wildcard := range []string{jira.FieldsAll, jira.FieldsNavigable} {
+		page, err := c.Search(t.Context(), jira.Query{JQL: `project = PROJ`, Fields: []string{wildcard}})
+		if err != nil {
+			t.Fatalf("Search with %s: %v", wildcard, err)
+		}
+		iss := page.Items[0]
+		if !iss.Requested.Wide() {
+			t.Errorf("%s asked for with %s does not report a wide read", iss.Key, wildcard)
+		}
+		if !iss.Requested.Has("assignee") || !iss.Requested.Has("a-field-nothing-has-enumerated") {
+			t.Errorf("a wide read must answer for every field, including ones nothing enumerated")
+		}
+	}
+}
+
+// TestIssue_AndCreateIssue_ComeBackWide covers the two calls that return a bare
+// issue with no field list anywhere: both read everything, so an edit built off
+// one may write any field back.
+func TestIssue_AndCreateIssue_ComeBackWide(t *testing.T) {
+	t.Parallel()
+	c := fakeNewWithIssues(t, 3)
+	ctx := t.Context()
+
+	fetched, err := c.Issue(ctx, "PROJ-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if !fetched.Requested.Wide() {
+		t.Error("a fetched issue does not report a wide read, so an edit off it would refuse every field")
+	}
+
+	created, err := c.CreateIssue(ctx, jira.IssueInput{
+		ProjectKey:  "PROJ",
+		IssueTypeID: fetched.Type.ID,
+		Summary:     "A new row",
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if !created.Requested.Wide() {
+		t.Error("a created issue does not report a wide read")
+	}
+	again, err := c.Issue(ctx, created.Key)
+	if err != nil {
+		t.Fatalf("Issue after CreateIssue: %v", err)
+	}
+	if !again.Requested.Wide() {
+		t.Error("an issue read back after creation does not report a wide read")
+	}
+}
+
+// TestSearch_RefusesAFieldListThatOnlyLooksLikeOne pins the fake to the cloud
+// adapter, which drops blanks before it counts what it was given: a list of
+// spaces names no fields, and an adapter that accepts it teaches a view that a
+// search with no fields works.
+func TestSearch_RefusesAFieldListThatOnlyLooksLikeOne(t *testing.T) {
+	t.Parallel()
+	c := fakeNewWithIssues(t, 2)
+
+	for _, fields := range [][]string{nil, {}, {"  "}, {"", "\t"}} {
+		_, err := c.Search(t.Context(), jira.Query{JQL: `project = PROJ`, Fields: fields})
+
+		var invalid *jira.ValidationError
+		if !errors.As(err, &invalid) {
+			t.Fatalf("Fields %q was answered with %v, want a *jira.ValidationError", fields, err)
+		}
+		if _, ok := invalid.For("fields"); !ok {
+			t.Errorf("the refusal of %q does not name the fields list: %v", fields, invalid)
+		}
 	}
 }
 
@@ -1578,7 +1709,7 @@ func fakeHasVersion(versions []jira.Version, id string) bool {
 
 func fakeIssuesOnVersion(t *testing.T, c *jiratest.Fake, versionID string) []jira.Issue {
 	t.Helper()
-	page, err := c.Search(t.Context(), jira.Query{JQL: "project = PROJ ORDER BY key", Fields: []string{"*all"}})
+	page, err := c.Search(t.Context(), jira.Query{JQL: "project = PROJ ORDER BY key", Fields: []string{jira.FieldsAll}})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}

--- a/pkg/jira/jiratest/jiratest.go
+++ b/pkg/jira/jiratest/jiratest.go
@@ -67,12 +67,26 @@ var (
 	NoAttachments = CapReason(jira.CapAttachments, "attachments are disabled on this site")
 	// NoDeleteIssues turns off the delete-issues capability.
 	NoDeleteIssues = CapReason(jira.CapDeleteIssues, "needs Delete Issues permission")
+	// NoTimeZone leaves the account timezone unknown, which makes every date
+	// render in UTC with the reason beside it.
+	NoTimeZone = CapZone(nil, "Jira did not answer what timezone this account is in")
 )
 
 // CapReason turns a capability off with wording of the caller's own.
 func CapReason(k jira.CapabilityKey, reason string) CapMod {
 	return func(c *jira.Capabilities) {
 		fakeSetCap(c, k, jira.Capability{Reason: reason})
+	}
+}
+
+// CapZone sets the account timezone and, when there is none, why there is none.
+// A location clears the reason: a probe never has both.
+func CapZone(loc *time.Location, reason string) CapMod {
+	return func(c *jira.Capabilities) {
+		if loc != nil {
+			reason = ""
+		}
+		c.TimeZone, c.TimeZoneReason = loc, reason
 	}
 }
 
@@ -402,6 +416,8 @@ func (f *Fake) fakePutIssue(in *jira.Issue) {
 		f.fakeAddProject(in.Project.Key, NoBoard)
 	}
 	stored := fakeCloneIssue(in)
+	// The one funnel into the store, so a seeded issue is as honest as a fetched one.
+	stored.Requested = jira.AllFields()
 	if _, ok := f.issues[stored.Key]; !ok {
 		f.issueKeys = append(f.issueKeys, stored.Key)
 	}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -475,6 +475,10 @@ type Issue struct {
 	Resolved     *time.Time
 	TimeTracking *TimeTracking
 	Fields       FieldSet
+	// Requested is the set of fields this issue was read with. A field outside
+	// it is absent because nothing asked for it, which is a different answer
+	// from Jira having nothing to send.
+	Requested FieldMask
 }
 
 // IssueInput is a new issue. Anything beyond the fields named here goes in
@@ -895,6 +899,75 @@ type Query struct {
 	MaxResults int
 }
 
+// The two wildcards Query.Fields understands. Either asks for every field the
+// site has, on every issue in the result set, which is the expensive mistake
+// Query.Fields exists to avoid.
+const (
+	FieldsAll       = "*all"
+	FieldsNavigable = "*navigable"
+)
+
+// FieldMask is the set of field IDs an issue was read with.
+//
+// A narrow read is otherwise indistinguishable from an empty one: Assignee is
+// nil both for an unassigned issue and for a search whose Query.Fields never
+// named the assignee. Anything that merges, caches or writes an issue back has
+// to know which of those two it is holding, or a refresh that never asked about
+// the assignee unassigns the issue.
+//
+// The zero mask asked for nothing, which is the honest answer for an issue that
+// did not come from a read, and the answer that refuses a write rather than
+// permitting one.
+//
+// It is immutable for the reason FieldSet is: a mask travels by value into an
+// Issue, into the cache and back out, and a collection that could be written
+// through would mean seeding an edit form from a cached issue rewrites the
+// cached issue.
+type FieldMask struct {
+	ids []string
+	all bool
+}
+
+// NewFieldMask builds a mask from the field IDs a read asked for, dropping
+// blanks and repeats and sorting what is left. Either wildcard makes the whole
+// mask wide, because that is what the endpoint does with it.
+func NewFieldMask(ids []string) FieldMask {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		trimmed := strings.TrimSpace(id)
+		switch {
+		case trimmed == "":
+		case trimmed == FieldsAll || trimmed == FieldsNavigable:
+			return FieldMask{all: true}
+		case !slices.Contains(out, trimmed):
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return FieldMask{}
+	}
+	slices.Sort(out)
+	return FieldMask{ids: out}
+}
+
+// AllFields is the mask of a read that asked for everything the site holds.
+func AllFields() FieldMask { return FieldMask{all: true} }
+
+// Has reports whether the read asked for a field. When it did, that field being
+// absent from the issue means the site had nothing to send for it.
+func (m FieldMask) Has(id string) bool { return m.all || slices.Contains(m.ids, id) }
+
+// Wide reports whether the read asked for every field the site has.
+func (m FieldMask) Wide() bool { return m.all }
+
+// IDs returns the field IDs the read named, sorted. A wide mask names none:
+// what it asked for is the site's list, which no client can enumerate.
+func (m FieldMask) IDs() []string { return slices.Clone(m.ids) }
+
+// Len reports how many field IDs the mask names. That is zero for a wide mask
+// as well as for the zero one, so Wide is what tells those two apart.
+func (m FieldMask) Len() int { return len(m.ids) }
+
 // GraphicsMode is how, if at all, this terminal can show an image.
 type GraphicsMode int
 
@@ -949,6 +1022,11 @@ type Capabilities struct {
 	DeleteIssues Capability
 	Graphics     GraphicsMode
 	TimeZone     *time.Location
+	// TimeZoneReason is why TimeZone is not the account's own, worded the way a
+	// Capability.Reason is and empty exactly when TimeZone is set. Dates render
+	// in UTC either way, so this sentence is the only thing that can tell a user
+	// their timestamps are an hour out.
+	TimeZoneReason string
 }
 
 // Capability returns the probe result for a key. An unknown key comes back as
@@ -989,4 +1067,14 @@ func (c Capabilities) Location() *time.Location {
 		return time.UTC
 	}
 	return c.TimeZone
+}
+
+// Zone returns the timezone to render dates in and, when that is not the
+// account's own, the reason it is not. The reason is empty exactly when the
+// zone is the account's.
+func (c Capabilities) Zone() (zone *time.Location, reason string) {
+	if c.TimeZone == nil {
+		return time.UTC, c.TimeZoneReason
+	}
+	return c.TimeZone, ""
 }

--- a/pkg/jira/types_test.go
+++ b/pkg/jira/types_test.go
@@ -649,6 +649,174 @@ func TestCapabilities_LocationFallsBackToUTC(t *testing.T) {
 	}
 }
 
+func TestCapabilities_ZoneCarriesTheReasonItIsNotTheAccounts(t *testing.T) {
+	t.Parallel()
+
+	berlin := location(t, "Europe/Berlin")
+
+	tests := []struct {
+		name       string
+		caps       jira.Capabilities
+		wantZone   *time.Location
+		wantReason string
+	}{
+		{
+			name:     "the account's own zone comes back with nothing to explain",
+			caps:     jira.Capabilities{TimeZone: berlin, TimeZoneReason: "ignored while there is a zone"},
+			wantZone: berlin,
+		},
+		{
+			name:       "a probe that failed says so beside UTC",
+			caps:       jira.Capabilities{TimeZoneReason: "Jira did not answer what timezone this account is in"},
+			wantZone:   time.UTC,
+			wantReason: "Jira did not answer what timezone this account is in",
+		},
+		{
+			name:     "an unprobed value is UTC with nothing claimed about it",
+			caps:     jira.Capabilities{},
+			wantZone: time.UTC,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotZone, gotReason := tt.caps.Zone()
+			if gotZone != tt.wantZone {
+				t.Errorf("Zone() = %s, want %s", gotZone, tt.wantZone)
+			}
+			if gotReason != tt.wantReason {
+				t.Errorf("Zone() reason = %q, want %q", gotReason, tt.wantReason)
+			}
+			if gotZone != tt.caps.Location() {
+				t.Errorf("Zone() and Location() disagree: %s and %s", gotZone, tt.caps.Location())
+			}
+		})
+	}
+}
+
+// TestCapabilities_StaysComparable pins what keeps the whole value object usable
+// as a probe result: the adapter compares it against the zero value to say that
+// a rejected credential produced no answer at all.
+func TestCapabilities_StaysComparable(t *testing.T) {
+	t.Parallel()
+
+	var unprobed, alsoUnprobed jira.Capabilities
+	if unprobed != alsoUnprobed {
+		t.Fatal("two unprobed values compare unequal")
+	}
+	withReason := jira.Capabilities{TimeZoneReason: "Jira did not say what timezone this account is in"}
+	if withReason == unprobed {
+		t.Error("a value carrying a timezone reason compares equal to an unprobed one")
+	}
+}
+
+func TestNewFieldMask_DropsBlanksAndRepeatsAndSorts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       []string
+		want     []string
+		wantWide bool
+	}{
+		{name: "nothing asked for", in: nil, want: []string{}},
+		{name: "blanks are not fields", in: []string{"", "   ", "\t"}, want: []string{}},
+		{name: "sorted so two equal reads compare equal", in: []string{"status", "assignee", "summary"}, want: []string{"assignee", "status", "summary"}},
+		{name: "a repeat was still asked for once", in: []string{"summary", "summary"}, want: []string{"summary"}},
+		{name: "surrounding space is not part of an ID", in: []string{" summary ", "customfield_11101"}, want: []string{"customfield_11101", "summary"}},
+		{name: "*all is every field there is", in: []string{"summary", jira.FieldsAll}, want: []string{}, wantWide: true},
+		{name: "*navigable is wide too", in: []string{jira.FieldsNavigable}, want: []string{}, wantWide: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := jira.NewFieldMask(tt.in)
+			if !slices.Equal(got.IDs(), tt.want) {
+				t.Errorf("IDs() = %q, want %q", got.IDs(), tt.want)
+			}
+			if got.Wide() != tt.wantWide {
+				t.Errorf("Wide() = %v, want %v", got.Wide(), tt.wantWide)
+			}
+			if got.Len() != len(tt.want) {
+				t.Errorf("Len() = %d, want %d", got.Len(), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestFieldMask_HasAnswersForWhatWasAskedFor(t *testing.T) {
+	t.Parallel()
+
+	narrow := jira.NewFieldMask([]string{"summary", "status"})
+	if !narrow.Has("summary") || !narrow.Has("status") {
+		t.Error("a field the read named is not in the mask")
+	}
+	if narrow.Has("assignee") {
+		t.Error("a field the read never named is in the mask, so a nil assignee reads as unassigned")
+	}
+
+	wide := jira.AllFields()
+	if !wide.Has("assignee") || !wide.Has("a-field-nothing-has-enumerated") {
+		t.Error("a wide mask must answer for every field, including ones no client can enumerate")
+	}
+	if wide.Len() != 0 || len(wide.IDs()) != 0 {
+		t.Errorf("a wide mask names %d fields; the list is the site's, not the caller's", wide.Len())
+	}
+
+	var unread jira.FieldMask
+	if unread.Has("summary") || unread.Wide() {
+		t.Error("the zero mask asked for something; an issue that came from no read must refuse a write")
+	}
+}
+
+func TestFieldMask_IsImmutableSoAReaderCannotWidenIt(t *testing.T) {
+	t.Parallel()
+
+	mask := jira.NewFieldMask([]string{"summary", "assignee"})
+	ids := mask.IDs()
+	ids[0] = "labels"
+
+	if mask.Has("labels") {
+		t.Error("writing into the slice IDs() handed back changed the mask, so a cached issue can be told it read a field it did not")
+	}
+	if !slices.Equal(mask.IDs(), []string{"assignee", "summary"}) {
+		t.Errorf("IDs() = %q after a caller wrote into an earlier copy", mask.IDs())
+	}
+}
+
+// TestFieldMask_CostsNothingToCarryOnAnIssue is why the mask is a sorted slice
+// behind a value type rather than a map or a per-issue copy: an adapter builds
+// one per read and hands the same one to every issue on the page, so a page of
+// ten thousand rows pays for it once.
+func TestFieldMask_CostsNothingToCarryOnAnIssue(t *testing.T) {
+	mask := jira.NewFieldMask([]string{"summary", "status", "assignee", "priority", "updated", "issuetype"})
+	issues := make([]jira.Issue, 512)
+
+	carry := testing.AllocsPerRun(50, func() {
+		for i := range issues {
+			issues[i].Requested = mask
+		}
+	})
+	if carry != 0 {
+		t.Errorf("carrying the mask onto %d issues cost %.0f allocations, want none", len(issues), carry)
+	}
+
+	read := testing.AllocsPerRun(50, func() {
+		for i := range issues {
+			if !issues[i].Requested.Has("assignee") || issues[i].Requested.Has("labels") {
+				t.Fatal("the mask lost what it was asked for")
+			}
+		}
+	})
+	if read != 0 {
+		t.Errorf("reading the mask %d times cost %.0f allocations, want none", len(issues), read)
+	}
+}
+
 func TestIssuePatch_IsEmptyOnlyWhenItWouldChangeNothing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
PC.1, both halves in one PR because two agents editing the frozen port is the one guaranteed conflict. Closes #46 and #37.

Both amendments are additive and land in `pkg/jira/types.go`. **`port.go` needed no edit at all** — neither amendment touches a method signature — so the roadmap row has been corrected to say so.

## A (#46) — the timezone probe can say why it failed

`Capabilities` gains `TimeZoneReason string` as its last field, plus `Zone() (*time.Location, string)` beside `Location()`.

`capsTimeZone` already worked out three distinguishable outcomes and threw away which one happened, leaving `TimeZone` nil. Dates then render in UTC with nothing on screen to account for it, which is the worst shape a wrong answer can take — it looks like an answer. The three now read:

- the site would not answer → `capsFailed("what timezone this account is in", err)`, so a 403 on `/myself` reads in **Jira's own localised words** through `*jira.CapabilityError`, exactly as the other four probes do, and anything else reads "Jira did not answer …";
- the account named no zone → "Jira did not say what timezone this account is in";
- Jira named a zone this machine cannot load → "This machine has no zoneinfo entry for X, the timezone this account is set to". That failure is **local** and must not read as Jira's.

The probe still returns `err` unchanged, so `capsVoid` behaves as before: one failing probe does not void the others.

**Why a string and not the alternatives in the issue.** A `CapTimeZone` key has no slot for a `*time.Location`, so it would need two fields for one thing, and `internal/ui/onboarding/render.go` draws `capabilityList` as check/cross rows — a sixth key would put a red cross next to "Timezone" as though the token lacked a permission, and a zone is not a permission. Changing `TimeZone`'s type is not additive. And a string keeps `Capabilities` **comparable**, which `pkg/jira/cloud/caps_test.go:456,477,496` rely on (`got != (jira.Capabilities{})`); a slice or a map would have broken all three.

## B (#37) — an issue knows which fields were asked for

A new immutable value type `jira.FieldMask` in a new `Issue.Requested`. A narrow read was otherwise indistinguishable from an empty one: `Assignee` is nil both for an unassigned issue and for a search that never named the assignee, so P2.3's fetch-edit-PUT can blank a field nobody touched and P3.2's background refresh can unassign a cached row. The zero mask asked for nothing, which is the honest answer for an issue that did not come from a read and the answer that refuses a write rather than permitting one.

**Why on `Issue` and not on `Page[Issue]`.** `Client.Issue(ctx, key)` returns a bare `jira.Issue` with no page at all, and that is the call an edit starts from — the case where the damage is somebody's ticket rather than a stale cache row. `Page[T]` also lives in `pkg/jira/page.go`, which this packet does not own, is generic (a `Fields` there is meaningless for `Page[Sprint]`), and would have to be threaded through `cursorPage`'s recursive successor closure or page 2 of a walk loses it. Documentation-only fails on a fact in the tree: `internal/app/search.go` throws `resolved.IDs` away and belongs to PC.2 this batch.

Modelled on the `FieldSet` precedent and its stated reason — an immutable value over a never-mutated collection, so seeding an edit form from a cached issue cannot rewrite the cached issue. A sorted slice with a linear `Has` beats a map for the 6–20 IDs a projection names, and it is built **once per read** and copied by value into each issue: `TestFieldMask_CostsNothingToCarryOnAnIssue` pins that carrying and reading it allocate nothing, and `BenchmarkDecodeSearchPage` is flat at **74 allocs/op / 12.3 kB per page before and after**, identical for a wide mask, a 6-field mask and a 60-field mask.

Deliberately **not** here: `Issue.Merge(newer Issue)`. P2.3 does not need it (it builds a sparse `IssuePatch`, so `iss.Requested.Has(id)` is the whole answer) and P3.2 does, where it owns `internal/store` and can put one there. `docs/PARALLEL.md:43-45` sanctions exactly that.

## A real divergence closed while here

`fake.Search` guarded on `len(q.Fields) == 0` while `cloud.Search` guards on `len(uniqueStrings(q.Fields)) == 0`, so `Query{Fields: []string{"  "}}` was refused by the cloud adapter and accepted by the fake — a search naming no fields passed in tests and failed against a site. The fake's guard now sits on the mask (`pkg/jira/jiratest/fake.go:87`), and two tests pin the adapters agreeing.

## Every consumer that adopted a shared change, by name

| Shared thing | Consumer | Where |
|---|---|---|
| `Capabilities.TimeZoneReason` | the cloud probe writes it | `pkg/jira/cloud/caps.go:216` |
| `Capabilities.TimeZoneReason` | the fake sets it | `pkg/jira/jiratest/jiratest.go:89` (`CapZone`, `:84`), standard negative `NoTimeZone` `:72` |
| `Capabilities.Zone()` | the only place in the program that names a timezone on screen | `internal/ui/onboarding/render.go:370` (`datesLine`, `:369`) |
| `jiratest.NoTimeZone` | the golden test for that screen | `internal/ui/onboarding/render_test.go:156` |
| `Issue.Requested` | the cloud decoder | `pkg/jira/cloud/search.go:214`, mask built once at `:97`, threaded through `decodeSearchPage` `:155` |
| `Issue.Requested` | the fake's masking, which now blanks and reports from one value | `pkg/jira/jiratest/fake.go:1405` (`fakeApplyFieldMask`, `:1404`), applied at `:112` |
| `Issue.Requested` | every issue entering the fake's store, one funnel for `WithIssues(Gen(n))` and `CreateIssue` alike | `pkg/jira/jiratest/jiratest.go:420` |
| `jira.FieldsAll` / `FieldsNavigable` | replaced the duplicated `"*all"`/`"*navigable"` literals the fake carried | `pkg/jira/types.go:940`, and `pkg/jira/jiratest/fake_test.go:363,431,1712` |

**Checked and correctly needing no change:** `internal/ui/list/list.go:679`, `internal/ui/issue/issue.go:182` and `pkg/adf/render_inline.go:138-142` keep using `Location()` — a table row and an inline date have no room for a sentence, and the reason belongs where a user is being told what the setup found. `internal/app/search.go` needs none either: the mask now travels on the issues themselves, so the field list it discards no longer has to be re-threaded (and that file is PC.2's this batch). `pkg/jira/jiratest/gen.go` is untouched, so `reflect.DeepEqual(Gen(120), Gen(120))` is unaffected — the store, not the generator, is what marks a seeded issue as read wide.

## Ownership widening — approved by the packet spec, declared on both issues

Beyond the `docs/ROADMAP.md` row: **`pkg/jira/jiratest/fake.go`** and **`internal/ui/onboarding/{render.go,render_test.go,testdata/**}`**, plus `docs/{ARCHITECTURE,API-NOTES}.md`. Both code widenings are required by the "every consumer adopted it" gate — the fake's masking lives in `fake.go`, and `render.go` is the only on-screen consumer of the zone. Without them the packet adds two things nobody uses. Nothing else in Batch 1.5 owns either file. `pkg/jira/page.go`, `internal/app/search.go`, `pkg/jira/jiratest/gen.go` and `pkg/jira/jiratest/{server.go,fixtures/**}` are untouched — the last is PC.5's this wave. Said so on #46 and #37 before starting.

## Golden files

No existing golden changed. One new file, `internal/ui/onboarding/testdata/review-unknown-zone_120x40.golden`, for a screen state that could not be drawn before: the review summary now reads

```
    Dates in       UTC · Jira did not answer what timezone this account is in
```

where it previously read `Dates in       UTC` with no way to say why. The default case is unchanged, and the test asserts the reason is absent when the zone is the account's own.

## Failure paths tested

- **403** on `/myself` → the reason is Jira's own sentence, not ours (`caps_test.go`, `TestCapabilities_SaysWhyTheTimezoneIsNotTheAccountsOwn`).
- **500** on `/myself` with retries off → "Jira did not answer …", and Boards, BulkMove and Attachments all still answer (`TestCapabilities_KeepsTheOtherAnswersWhenTheTimezoneProbeFails`). The mirror case, a failing `/configuration` leaving the zone intact, now also asserts the reason stays empty.
- **429** and a **rejected credential** still void the whole probe and return `(jira.Capabilities{}, err)` — unchanged, and the comparability assertions those tests rest on are pinned by `TestCapabilities_StaysComparable`.
- A zone name with no zoneinfo entry, and an account that names no zone.
- A field list of nothing but whitespace, refused identically by both adapters (`search_test.go` and `fake_test.go`).
- The mask surviving a cursor walk to page 2, and a field ID the site does not have staying in the mask while never appearing in the values — the caveat now written into `docs/API-NOTES.md`.

`make check` green; `go build -trimpath` green.

## Follow-up, not caused here

`internal/app` `TestRun_CollapsesIdenticalSearchesThatAreInFlightAtOnce` failed twice under a cold-cache full-suite run and passes 260 times in a row on its own, on `origin/main` as well as on this branch. It is a race in the test between "every caller entered `Run`" and "every caller joined the singleflight". That file is PC.2's owned path this batch, so it is not fixed here — worth an issue.
