### PR TITLE
PC.2 — one owner for the number keys: saved queries on 1-9, views behind g

### DIFF
--- a/cmd/saral/main.go
+++ b/cmd/saral/main.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/config"
 	_ "github.com/varijkapil13/saral/internal/ui"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
@@ -122,6 +123,13 @@ func build(opt options) (kernel.Deps, []kernel.Option, error) {
 	deps.Site = profile.Site
 	deps.Project = opt.project
 
+	saved, err := app.NewSavedQueries(profile.Queries...)
+	if err != nil {
+		return deps, nil, err
+	}
+	deps.Saved = saved
+	deps.SaveQueries = queryWriter(profile.Name)
+
 	// Nothing configured means the first thing to show is the thing that
 	// configures it. Without this the kernel opens whichever view claimed the
 	// first footer slot, and setup is reachable only by someone who already
@@ -147,6 +155,31 @@ func build(opt options) (kernel.Deps, []kernel.Option, error) {
 		kopts = append(kopts, kernel.WithInitialView(kernel.SetupViewID))
 	}
 	return deps, kopts, nil
+}
+
+// queryWriter persists a changed set of saved queries back into the profile
+// they came from. It re-reads the file rather than writing back the copy this
+// session started with, because onboarding may have written one since; an empty
+// name is the first run, where the profile to write into is whichever one is
+// active by the time a key is bound.
+func queryWriter(name string) func(app.SavedQueries) error {
+	return func(saved app.SavedQueries) error {
+		path, err := config.Path()
+		if err != nil {
+			return err
+		}
+		cfg, err := config.LoadFile(path)
+		if err != nil {
+			return err
+		}
+		profile, err := profileFor(cfg, name)
+		if err != nil {
+			return err
+		}
+		profile.Queries = saved.All()
+		cfg.Profiles[profile.Name] = profile
+		return cfg.Save(path)
+	}
 }
 
 func profileFor(cfg config.Config, name string) (config.Profile, error) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ func init() {
 	kernel.RegisterView(kernel.ViewSpec{
 		ID:       "board",
 		Title:    "Board",
-		Slot:     1,                       // footer position
+		Slot:     2,                       // footer position, reached with g2
 		Requires: kernel.CapBoards,        // hidden when absent
 		New:      func(d kernel.Deps) kernel.View { return New(d) },
 	})
@@ -189,6 +189,11 @@ Three registries, all with the same conflict-free property:
 | `RegisterView` | each view package's `register.go` | footer, view stack, `saral <view>` |
 | `RegisterCommand` | any package | command palette (`ctrl+k`) |
 | `RegisterKeys` | each view, scoped to itself | help overlay, footer hints |
+
+Slots are allocated, not picked: the table in `docs/UX.md` says which view holds which digit, and
+`RegisterView` refuses a second claim on one at startup. A bare digit runs a saved query in a root
+view, so a slot is reached with `g` and its digit; the kernel buffers that `g` rather than forwarding
+it, because two views already spend `g` on gestures of their own.
 
 A view that is taking typing — a filter, a form field, the command palette — implements
 `kernel.KeyCapturer` and answers `WantsRawKeys() true` while it is. The kernel then hands it every
@@ -319,7 +324,16 @@ token = { keychain = "saral:work" }   # or { env = "JIRA_TOKEN" } / { command = 
 [profiles.work.timeline]
 start = ["Target start", "Start date"]   # resolved by name to field IDs at runtime
 end   = ["Target end", "Due date"]
+
+[[profiles.work.queries]]
+name = "Blockers"
+jql  = "priority = Highest AND resolution = EMPTY ORDER BY updated DESC"
+key  = 2                                 # the number key that runs it; omit for none
 ```
+
+The queries are held by `app.SavedQueries` and validated by its rules rather than a second copy of
+them, so a file and a keypress cannot disagree about what a saved query is. The file refuses the two
+things a keyboard cannot express: two queries under one name, and two on one key.
 
 ## Decisions recorded separately
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,11 +93,19 @@ because it unblocks or blocks everyone. The other four run in parallel behind it
   cannot blank a field nobody touched. The owned paths grew by the fake's field masking and the one
   line in onboarding that names a timezone, which are the only consumers either amendment has:
   without them the packet adds two things nobody uses.
-- [ ] **PC.2 — One owner for the number keys** · [#49](https://github.com/varijkapil13/saral/issues/49) · **owns** `internal/ui/kernel/{view,keys}.go`, `internal/ui/list/register.go`, `internal/app/search.go`, `docs/UX.md`
-  Three claimants on `1`–`9`: kernel view slots, the six root views `docs/UX.md` promises, and
-  `SavedQuery.Slot`, which P1.2 built and tested and nothing calls. Pick one, give the others a
-  prefix, and write down the slot allocation so six later packets do not each guess.
-  **A product decision, not a defect — it wants a human answer.**
+- [x] **PC.2 — One owner for the number keys** · [#49](https://github.com/varijkapil13/saral/issues/49) · **owns** `internal/ui/kernel/**`, `internal/ui/list/**`, `internal/app/search.go`, `internal/config/**`, `cmd/saral/main.go`, `docs/{UX,ARCHITECTURE,ROADMAP}.md`
+  Three claimants on `1`–`9`, settled by the owner on the issue: **the digits are contextual.** A
+  bare `1`–`9` in a root view runs the saved query bound to it; a view is reached with `g` and its
+  digit from anywhere. The kernel *buffers* that `g` rather than forwarding it, so the `gg` and `ge`
+  that two views already hardcode keep working and no view is left holding half a gesture the kernel
+  finished. The slot allocation is written down in `docs/UX.md` and the registry rejects a second
+  claim on one, so six later packets no longer each guess.
+  Saved queries were built, tested and unreachable, so making the digits alive on day one was the
+  other half: a `[[profiles.x.queries]]` schema held to `app.SavedQueries`' own rules rather than a
+  second copy of them, `s` in the issue list — and a palette command — to bind the query on screen to
+  a key with a confirmation when it is taking one, and the injection through `kernel.Deps` and
+  `cmd/saral/main.go`. The owned paths grew to match: the digit dispatch, the footer and the memo key
+  are all in `kernel.go`, and saved-query persistence was owned by nobody at all.
 - [ ] **PC.3 — Session project scope** · [#50](https://github.com/varijkapil13/saral/issues/50) · **owns** `cmd/saral/main.go`, `internal/ui/kernel/kernel.go`, `internal/ui/list/list.go`
   Onboarding asks which project you work in, validates it, writes it to the profile, and nothing ever
   reads it back: `deps.Project` comes only from `--project`. So the capability probe resolves

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -30,7 +30,7 @@ The mechanisms that make familiarity pay off, in the order a user meets them:
 | First hour | The footer teaches the six keys that matter here. Mouse works, so nothing is blocked on learning. |
 | First week | Frecency: projects, assignees, versions and labels reorder so your usual choices are first. |
 | | Hints: after you reach an action through the palette three times, the status line notes its key. |
-| Ongoing | JQL history with fuzzy recall; saved queries bound to `1`–`9`. |
+| Ongoing | JQL history with fuzzy recall; saved queries bound to `1`–`9` and kept in the profile. |
 | | Local fuzzy index — typing a key or a few words of a summary finds it with no round trip. |
 | | Session resume: reopening lands exactly where you left, including scroll and filter. |
 | Fluent | `saral PROJ-142`, `saral board PROJ`, piping a JQL query in, scriptable subcommands for the rest. |
@@ -43,23 +43,55 @@ telemetry leaves the machine, ever.
 A stack, not a graph — so "back" always means something.
 
 ```
-views (footer 1–6)     board · backlog · sprints · releases · timeline · plans   ← contested, see #49
+run a saved query      1 – 9          in a root view; the profile's own searches
+switch view            g then 1–9     from anywhere, including a pushed view
 push                   enter          open the thing under the cursor
 pop                    esc            back, never quits from a pushed view
 quit                   q / ctrl+c     only from a root view, and only when no draft is open
-switch pane            tab            focus moves, selection does not
 palette                ctrl+k         everything, fuzzy
 search in view         /              filter rows live
-jump to key            g then key     or paste a Jira URL anywhere
+save this search       s              bind the query on screen to a number key
 refresh                r / R          current view / purge and refetch
 ```
 
 Vim keys and arrows are both always bound. `j/k` and `↑/↓` are not a preference to configure.
 
-The footer row above is **not yet true and not yet decided**: the issue list holds slot 1, `board`
-does not exist until P6.3, and `app.SavedQuery` claims the same nine digits from the other direction.
-PC.2 ([#49](https://github.com/varijkapil13/saral/issues/49)) settles who owns them and rewrites this
-line. Do not register a slot against it until then.
+### Who owns the number keys
+
+Settled in PC.2 ([#49](https://github.com/varijkapil13/saral/issues/49)): **the digits are
+contextual.** In a root view a bare digit runs the saved query bound to it — the searches the profile
+keeps, which is what makes the keys worth having on the first day rather than the first month. A view
+is reached with `g` and its digit, from anywhere. `ctrl+k` still reaches everything.
+
+`g` is a prefix the kernel **buffers**: it forwards nothing when you press it, and on the next key
+either takes a digit for itself or hands the view both keys in the order they were typed. That is why
+`gg` and `ge` inside a list still go to the first and last row. `esc` throws a half-typed gesture
+away, and a view that is taking typing gets the keys before any of this happens.
+
+The footer advertises only what works: the digits that actually have a query bound, named after the
+query, and the view slots as `g1`–`g9`.
+
+| Slot | View | Arrives with |
+|---|---|---|
+| 1 | issues | P1.5 — shipped |
+| 2 | board | P6.3 ([#24](https://github.com/varijkapil13/saral/issues/24)) |
+| 3 | backlog | P6.3 |
+| 4 | sprints | P6.3 |
+| 5 | releases | P5.1 ([#20](https://github.com/varijkapil13/saral/issues/20)) |
+| 6 | timeline | P8.2 ([#27](https://github.com/varijkapil13/saral/issues/27)) |
+| 7 | plans | P8.3 ([#28](https://github.com/varijkapil13/saral/issues/28)) |
+| 8, 9 | free | — |
+
+Everything else registers `Slot: 0` and is reached by being pushed, by name or from the palette:
+issue detail, onboarding, the palette itself, forms, comments, attachment preview and the move
+wizard. `kernel.RegisterView` refuses a second claim on a slot at startup, so the table above is
+enforced rather than merely written down — but it is written down so that six later packets do not
+each pick a number.
+
+Two things this table does not promise. There is no `tab`: no view has two panes yet, and the gesture
+that moves focus between them belongs to the first one that grows a second pane. And jumping to an
+issue by key — typing `PROJ-142`, or pasting a Jira URL — is not built; it is
+[#62](https://github.com/varijkapil13/saral/issues/62).
 
 ## Mouse
 

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -471,6 +471,19 @@ func (q SavedQueries) ByName(name string) (SavedQuery, bool) {
 	return SavedQuery{}, false
 }
 
+// Slots lists the number keys that have a query bound, in ascending order. It
+// is what a footer showing only the keys that work right now is built from.
+func (q SavedQueries) Slots() []int {
+	out := make([]int, 0, len(q.items))
+	for _, item := range q.items {
+		if item.Slot > 0 {
+			out = append(out, item.Slot)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
 // BySlot finds the query bound to a number key.
 func (q SavedQueries) BySlot(slot int) (SavedQuery, bool) {
 	if slot <= 0 {

--- a/internal/app/search_test.go
+++ b/internal/app/search_test.go
@@ -503,6 +503,25 @@ func TestSavedQueries_KeepsTheOrderAddedAndFindsAQueryByNameOrKey(t *testing.T) 
 	}
 }
 
+func TestSavedQueries_ListsTheKeysThatActuallyRunSomething(t *testing.T) {
+	t.Parallel()
+
+	saved, err := NewSavedQueries(
+		SavedQuery{Name: "Third", JQL: testJQL, Slot: 3},
+		SavedQuery{Name: "Unbound", JQL: testJQL},
+		SavedQuery{Name: "First", JQL: testJQL, Slot: 1},
+	)
+	if err != nil {
+		t.Fatalf("saving: %v", err)
+	}
+	if got := saved.Slots(); !slices.Equal(got, []int{1, 3}) {
+		t.Errorf("the bound keys are %v, want [1 3] in that order", got)
+	}
+	if got := (SavedQueries{}).Slots(); len(got) != 0 {
+		t.Errorf("an empty set reports keys %v", got)
+	}
+}
+
 func TestSavedQueries_RebindingAKeyTakesItFromWhicheverQueryHadIt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/varijkapil13/saral/internal/app"
 )
 
 const (
@@ -54,6 +57,11 @@ type Profile struct {
 	Timeline Timeline
 	Theme    string
 	Glyphs   string
+	// Queries are the searches this profile keeps, each optionally bound to a
+	// number key. They are app's own type, validated by app's own rules, so that
+	// a file and a keypress cannot disagree about what a saved query is; the
+	// projection is not written, because a saved query opens into the issue list.
+	Queries []app.SavedQuery
 }
 
 // TokenSource names where the API token comes from. Exactly one field is set.
@@ -153,6 +161,13 @@ type fileProfile struct {
 	Timeline Timeline       `toml:"timeline"`
 	Theme    string         `toml:"theme"`
 	Glyphs   string         `toml:"glyphs"`
+	Queries  []fileQuery    `toml:"queries"`
+}
+
+type fileQuery struct {
+	Name string `toml:"name"`
+	JQL  string `toml:"jql"`
+	Key  int    `toml:"key"`
 }
 
 type fileToken struct {
@@ -233,11 +248,27 @@ func decodeProfile(md *toml.MetaData, name string, fp fileProfile) (Profile, err
 		Timeline: fp.Timeline,
 		Theme:    strings.TrimSpace(fp.Theme),
 		Glyphs:   strings.TrimSpace(fp.Glyphs),
+		Queries:  decodeQueries(fp.Queries),
 	}
 	if err := p.Validate(); err != nil {
 		return Profile{}, err
 	}
 	return p, nil
+}
+
+func decodeQueries(in []fileQuery) []app.SavedQuery {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]app.SavedQuery, 0, len(in))
+	for _, q := range in {
+		out = append(out, app.SavedQuery{
+			Name: strings.TrimSpace(q.Name),
+			JQL:  strings.TrimSpace(q.JQL),
+			Slot: q.Key,
+		})
+	}
+	return out
 }
 
 func decodeToken(md *toml.MetaData, name string, prim toml.Primitive) (TokenSource, error) {
@@ -386,6 +417,34 @@ func (p Profile) Validate() error {
 	if !slices.Contains(glyphSets, p.Glyphs) {
 		return fmt.Errorf("profile %q: glyphs %q is not one of %s", p.Name, p.Glyphs, strings.Join(glyphSets[1:], ", "))
 	}
+	return validateQueries(p.Name, p.Queries)
+}
+
+// validateQueries holds a query in the file to the rules app applies to one
+// bound at the keyboard, and refuses the two things a file can say that a
+// keypress cannot: two queries under one name, or two on one key. Add resolves
+// both by taking the newer, which here would drop a line somebody wrote.
+func validateQueries(profile string, queries []app.SavedQuery) error {
+	names := make(map[string]struct{}, len(queries))
+	keys := make(map[int]string, len(queries))
+	for _, q := range queries {
+		name := strings.TrimSpace(q.Name)
+		lowered := strings.ToLower(name)
+		if _, dup := names[lowered]; dup {
+			return fmt.Errorf("profile %q: two saved queries are called %q", profile, name)
+		}
+		names[lowered] = struct{}{}
+		if q.Slot <= 0 {
+			continue
+		}
+		if other, dup := keys[q.Slot]; dup {
+			return fmt.Errorf("profile %q: %q and %q both ask for key %d", profile, other, name, q.Slot)
+		}
+		keys[q.Slot] = name
+	}
+	if _, err := app.NewSavedQueries(queries...); err != nil {
+		return fmt.Errorf("profile %q: %w", profile, err)
+	}
 	return nil
 }
 
@@ -526,26 +585,37 @@ func (c Config) encode() ([]byte, error) {
 			pairs = append(pairs, [2]string{"glyphs", quote(p.Glyphs)})
 		}
 		pairs = append(pairs, [2]string{"token", inlineToken(p.Token)})
-		width := 0
-		for _, kv := range pairs {
-			width = max(width, len(kv[0]))
-		}
-		for _, kv := range pairs {
-			fmt.Fprintf(&b, "%-*s = %s\n", width, kv[0], kv[1])
-		}
+		writePairs(&b, pairs)
 
-		if len(p.Timeline.Start) == 0 && len(p.Timeline.End) == 0 {
-			continue
+		if len(p.Timeline.Start) > 0 || len(p.Timeline.End) > 0 {
+			fmt.Fprintf(&b, "\n[profiles.%s.timeline]\n", tomlKey(name))
+			if len(p.Timeline.Start) > 0 {
+				fmt.Fprintf(&b, "start = %s\n", tomlArray(p.Timeline.Start))
+			}
+			if len(p.Timeline.End) > 0 {
+				fmt.Fprintf(&b, "end   = %s\n", tomlArray(p.Timeline.End))
+			}
 		}
-		fmt.Fprintf(&b, "\n[profiles.%s.timeline]\n", tomlKey(name))
-		if len(p.Timeline.Start) > 0 {
-			fmt.Fprintf(&b, "start = %s\n", tomlArray(p.Timeline.Start))
-		}
-		if len(p.Timeline.End) > 0 {
-			fmt.Fprintf(&b, "end   = %s\n", tomlArray(p.Timeline.End))
+		for _, q := range p.Queries {
+			fmt.Fprintf(&b, "\n[[profiles.%s.queries]]\n", tomlKey(name))
+			query := [][2]string{{"name", quote(q.Name)}, {"jql", quote(q.JQL)}}
+			if q.Slot > 0 {
+				query = append(query, [2]string{"key", strconv.Itoa(q.Slot)})
+			}
+			writePairs(&b, query)
 		}
 	}
 	return []byte(b.String()), nil
+}
+
+func writePairs(b *strings.Builder, pairs [][2]string) {
+	width := 0
+	for _, kv := range pairs {
+		width = max(width, len(kv[0]))
+	}
+	for _, kv := range pairs {
+		fmt.Fprintf(b, "%-*s = %s\n", width, kv[0], kv[1])
+	}
 }
 
 func inlineToken(t TokenSource) string {

--- a/internal/config/queries_test.go
+++ b/internal/config/queries_test.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/app"
+)
+
+func profileWith(queries ...app.SavedQuery) Config {
+	return Config{
+		Active: "work",
+		Mouse:  true,
+		Profiles: map[string]Profile{"work": {
+			Name:    "work",
+			Site:    "example.atlassian.net",
+			Email:   "you@example.com",
+			Token:   TokenSource{Keychain: "saral:work"},
+			Queries: queries,
+		}},
+	}
+}
+
+func saveAndLoad(t *testing.T, cfg Config) (string, Config) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	got, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v\n%s", err, written)
+	}
+	return string(written), got
+}
+
+func TestSavedQueries_RoundTripThroughTheFile(t *testing.T) {
+	t.Parallel()
+
+	queries := []app.SavedQuery{
+		{Name: "Blockers", JQL: "priority = Highest AND resolution = EMPTY ORDER BY updated DESC", Slot: 2},
+		{Name: "Anything I reported", JQL: "reporter = currentUser() ORDER BY created DESC"},
+	}
+	written, got := saveAndLoad(t, profileWith(queries...))
+
+	if !strings.Contains(written, "[[profiles.work.queries]]") || !strings.Contains(written, "key  = 2") {
+		t.Errorf("the file does not read as a list of queries:\n%s", written)
+	}
+	back := got.Profiles["work"].Queries
+	if len(back) != len(queries) {
+		t.Fatalf("read back %d queries, want %d:\n%s", len(back), len(queries), written)
+	}
+	for i, want := range queries {
+		if got := back[i]; got.Name != want.Name || got.JQL != want.JQL || got.Slot != want.Slot {
+			t.Errorf("query %d round-tripped as %+v, want %+v", i, got, want)
+		}
+	}
+	if strings.Contains(written, "key  = 0") {
+		t.Errorf("a query bound to no key wrote one anyway:\n%s", written)
+	}
+}
+
+func TestSavedQueries_AProfileWithNoneWritesNoSection(t *testing.T) {
+	t.Parallel()
+
+	written, got := saveAndLoad(t, profileWith())
+	if strings.Contains(written, "queries") {
+		t.Errorf("a profile with no saved queries wrote a section for them:\n%s", written)
+	}
+	if len(got.Profiles["work"].Queries) != 0 {
+		t.Errorf("read back %+v, want nothing", got.Profiles["work"].Queries)
+	}
+}
+
+func TestSavedQueries_TheFileIsHeldToTheSameRulesAsTheKeyboard(t *testing.T) {
+	t.Parallel()
+
+	const header = "active = \"work\"\n\n[profiles.work]\nsite  = \"example.atlassian.net\"\n" +
+		"email = \"you@example.com\"\ntoken = { keychain = \"saral:work\" }\n"
+
+	tests := map[string]struct {
+		queries string
+		want    string
+	}{
+		"a key that is not on the keyboard row": {
+			queries: "\n[[profiles.work.queries]]\nname = \"Blockers\"\njql = \"priority = Highest\"\nkey = 12\n",
+			want:    "the keys are 1 to 9",
+		},
+		"a query with nothing to run": {
+			queries: "\n[[profiles.work.queries]]\nname = \"Blockers\"\njql = \"\"\nkey = 2\n",
+			want:    "has no JQL to run",
+		},
+		"a query with no name to reach it by": {
+			queries: "\n[[profiles.work.queries]]\njql = \"priority = Highest\"\nkey = 2\n",
+			want:    "needs a name",
+		},
+		"two queries on one key": {
+			queries: "\n[[profiles.work.queries]]\nname = \"Blockers\"\njql = \"priority = Highest\"\nkey = 2\n" +
+				"\n[[profiles.work.queries]]\nname = \"Mine\"\njql = \"assignee = currentUser()\"\nkey = 2\n",
+			want: "both ask for key 2",
+		},
+		"two queries under one name": {
+			queries: "\n[[profiles.work.queries]]\nname = \"Blockers\"\njql = \"priority = Highest\"\n" +
+				"\n[[profiles.work.queries]]\nname = \"blockers\"\njql = \"assignee = currentUser()\"\n",
+			want: "two saved queries are called",
+		},
+		"a key nobody meant to write": {
+			queries: "\n[[profiles.work.queries]]\nname = \"Blockers\"\njql = \"priority = Highest\"\nslot = 2\n",
+			want:    "unknown key",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(header+tc.queries), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadFile(path)
+			if err == nil {
+				t.Fatalf("the file was accepted:\n%s", header+tc.queries)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not say %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSavedQueries_ARefusedSetIsNeverWritten(t *testing.T) {
+	t.Parallel()
+
+	cfg := profileWith(app.SavedQuery{Name: "Blockers", JQL: "priority = Highest", Slot: app.MaxSavedSlot + 1})
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := cfg.Save(path); err == nil {
+		t.Fatal("a query on a key that does not exist was written to the file")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("the file was replaced although the config was refused")
+	}
+}

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	zone "github.com/lrstanley/bubblezone/v2"
 
+	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -62,6 +63,7 @@ type chromeKey struct {
 	width     int
 	themeGen  int
 	capsGen   int
+	savedGen  int
 	rootID    string
 	topID     string
 	title     string
@@ -70,6 +72,7 @@ type chromeKey struct {
 	depth     int
 	palette   bool
 	capturing bool
+	prefixed  bool
 }
 
 type chromeCache struct {
@@ -102,8 +105,16 @@ type Model struct {
 	// every frame and would put a few hundred allocations under every scroll.
 	chrome *chromeCache
 
+	// prefix holds the go-to key while it waits for the one that completes it.
+	// It is buffered rather than forwarded, because a view that spends g on its
+	// own gestures must not be left half way through one when the kernel takes
+	// the digit that follows.
+	prefix    tea.KeyPressMsg
+	prefixSet bool
+
 	width, height int
 	capsGen       int
+	savedGen      int
 	status        string
 	statusLevel   StatusLevel
 	showHelp      bool
@@ -272,6 +283,9 @@ func (m Model) route(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.status, m.statusLevel = msg.Text, msg.Level
 		return m, nil
 
+	case BindQueryMsg:
+		return m.bindQuery(msg)
+
 	case CapabilitiesMsg:
 		m.deps.Caps = msg.Caps
 		m.roots = Views()
@@ -303,6 +317,13 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	if m.prefixSet {
+		return m.resolvePrefix(msg)
+	}
+	if Matches(msg, m.keys.Go) {
+		m.prefix, m.prefixSet = msg, true
+		return m, nil
+	}
 
 	switch {
 	case Matches(msg, m.keys.Help):
@@ -312,12 +333,17 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case Matches(msg, m.keys.Palette):
 		return m.open(PaletteViewID)
 
-	case Matches(msg, m.keys.Slot):
+	case Matches(msg, m.keys.Saved):
+		// A pushed view keeps its own digits: a saved query belongs to the root,
+		// and a view switch is g and the digit from anywhere.
+		if len(m.stack) != 1 {
+			break
+		}
 		slot, err := strconv.Atoi(msg.String())
 		if err != nil {
 			break
 		}
-		return m.openSlot(slot)
+		return m.runSaved(slot)
 
 	case Matches(msg, m.keys.Quit):
 		if len(m.stack) > 1 {
@@ -394,6 +420,106 @@ func (m Model) openSlot(slot int) (tea.Model, tea.Cmd) {
 	}
 	m.status, m.statusLevel = fmt.Sprintf("nothing is bound to %d yet", slot), LevelInfo
 	return m, nil
+}
+
+// resolvePrefix spends the buffered go-to key on whatever followed it. A digit
+// is the kernel's; esc throws the gesture away; anything else was meant for the
+// view, which then sees both keys in the order they were typed.
+func (m Model) resolvePrefix(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	buffered := m.prefix
+	m.prefix, m.prefixSet = tea.KeyPressMsg{}, false
+	switch {
+	case Matches(msg, m.keys.Back):
+		return m, nil
+	case Matches(msg, m.keys.Slot):
+		if slot, err := strconv.Atoi(msg.String()); err == nil {
+			return m.openSlot(slot)
+		}
+	}
+	first, cmd := m.forwardTop(buffered)
+	model, ok := first.(Model)
+	if !ok {
+		return first, cmd
+	}
+	next, follow := model.forwardTop(msg)
+	return next, tea.Batch(cmd, follow)
+}
+
+// runSaved opens the view that runs searches and hands it the query bound to a
+// number key.
+func (m Model) runSaved(slot int) (tea.Model, tea.Cmd) {
+	query, bound := m.deps.Saved.BySlot(slot)
+	if !bound {
+		m.status, m.statusLevel = fmt.Sprintf("no saved query is bound to %d yet", slot), LevelInfo
+		return m, nil
+	}
+	spec, ok := m.queryView()
+	if !ok {
+		m.status, m.statusLevel = "nothing in this build can run a saved query", LevelWarn
+		return m, nil
+	}
+	opened, cmd := m.open(spec.ID)
+	model, ok := opened.(Model)
+	if !ok || len(model.stack) == 0 || model.top().spec.ID != spec.ID {
+		return opened, cmd
+	}
+	next, follow := model.forwardTop(RunQueryMsg{JQL: query.JQL, Title: query.Name})
+	return next, tea.Batch(cmd, follow)
+}
+
+func (m Model) queryView() (ViewSpec, bool) {
+	for _, spec := range m.roots {
+		if spec.RunsQueries && m.available(spec) {
+			return spec, true
+		}
+	}
+	return ViewSpec{}, false
+}
+
+// bindQuery puts a query on a number key and writes it back to the profile. The
+// set is the kernel's because the keypress is: a view holding a copy of its own
+// would dispatch a key the kernel no longer agrees about.
+func (m Model) bindQuery(msg BindQueryMsg) (tea.Model, tea.Cmd) {
+	replaced, taken := m.deps.Saved.BySlot(msg.Slot)
+	saved, err := m.deps.Saved.Add(app.SavedQuery{Name: msg.Name, JQL: msg.JQL, Slot: msg.Slot})
+	if err != nil {
+		m.status, m.statusLevel = err.Error(), LevelWarn
+		return m, nil
+	}
+	m.deps.Saved = saved
+	m.savedGen++
+	told, cmd := m.forwardAll(SavedQueriesMsg{Queries: saved})
+	model, ok := told.(Model)
+	if !ok {
+		return told, cmd
+	}
+	note := fmt.Sprintf("%d runs %q", msg.Slot, msg.Name)
+	switch {
+	case msg.Slot == 0:
+		note = fmt.Sprintf("%q is saved, on no key", msg.Name)
+	case taken && !strings.EqualFold(replaced.Name, msg.Name):
+		note = fmt.Sprintf("%d runs %q instead of %q", msg.Slot, msg.Name, replaced.Name)
+	}
+	if model.deps.SaveQueries == nil {
+		note += ", for this session; there is no profile to save it to"
+	}
+	model.status, model.statusLevel = note, LevelInfo
+	return model, tea.Batch(cmd, model.persistQueries(saved))
+}
+
+// persistQueries writes the set back where it came from. The key already works
+// when this runs, so a failure is reported without taking the binding away.
+func (m Model) persistQueries(saved app.SavedQueries) tea.Cmd {
+	save := m.deps.SaveQueries
+	if save == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		if err := save(saved); err != nil {
+			return StatusMsg{Text: "the key works for this session, but saving it failed: " + err.Error(), Level: LevelError}
+		}
+		return nil
+	}
 }
 
 func (m Model) open(id string) (tea.Model, tea.Cmd) {
@@ -629,8 +755,9 @@ func (m Model) chromeFor() (header, footer string) {
 	_, palette := LookupView(PaletteViewID)
 	key := chromeKey{
 		width: m.width, themeGen: m.deps.Theme.Gen, capsGen: m.capsGen,
-		status: m.status, help: m.showHelp, depth: len(m.stack), palette: palette,
-		capturing: m.capturing(),
+		savedGen: m.savedGen, status: m.status, help: m.showHelp,
+		depth: len(m.stack), palette: palette,
+		capturing: m.capturing(), prefixed: m.prefixSet,
 	}
 	if len(m.stack) > 0 {
 		key.rootID = m.stack[0].spec.ID
@@ -745,7 +872,7 @@ func (m Model) footer() string {
 		if len(m.stack) > 0 && m.stack[0].spec.ID == spec.ID {
 			style = t.SlotOn
 		}
-		label := strconv.Itoa(spec.Slot) + " " + spec.Title
+		label := m.keys.Go.Keys()[0] + strconv.Itoa(spec.Slot) + " " + spec.Title
 		slots = append(slots, m.deps.Zones.Mark(m.zonePrefix+"slot:"+spec.ID, style.Render(label)))
 	}
 	left := strings.Join(slots, "")
@@ -772,6 +899,14 @@ func (m Model) hintLine(width int) string {
 	if m.showHelp {
 		return h.View(keyMap{short: []Binding{Bind([]string{"?", "esc", "q"}, "?", "close help")}})
 	}
+	if m.prefixSet {
+		// The globals are unreachable until the gesture finishes, so the line
+		// shows what can finish it rather than what it has taken away.
+		return h.View(keyMap{short: []Binding{
+			Bind(m.keys.Slot.Keys(), "1-9", "switch view"),
+			Bind(m.keys.Back.Keys(), "esc", "cancel"),
+		}})
+	}
 	set := KeySet{}
 	if len(m.stack) > 0 {
 		set = KeysFor(m.top().spec.ID)
@@ -789,7 +924,11 @@ func (m Model) hintLine(width int) string {
 // the only way that stays true is to derive it rather than write it down.
 func (m Model) liveGlobals() KeySet {
 	g := m.keys
-	set := KeySet{Short: make([]Binding, 0, 3)}
+	set := KeySet{Short: make([]Binding, 0, 4)}
+	bound := m.boundQueries()
+	if len(bound) > 0 {
+		set.Short = append(set.Short, savedHint(bound))
+	}
 	set.Short = append(set.Short, g.Help)
 	if _, ok := LookupView(PaletteViewID); ok {
 		set.Short = append(set.Short, g.Palette)
@@ -799,6 +938,39 @@ func (m Model) liveGlobals() KeySet {
 	} else {
 		set.Short = append(set.Short, g.Quit)
 	}
-	set.Full = [][]Binding{{g.Slot, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}}
+	set.Full = [][]Binding{{g.Saved, g.Slot, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}}
+	if len(bound) > 0 {
+		set.Full = append([][]Binding{bound}, set.Full...)
+	}
 	return set
+}
+
+// boundQueries is one binding per saved query that has a number key, named
+// after the query. It is empty in a pushed view, where the digits are the
+// view's own.
+func (m Model) boundQueries() []Binding {
+	if len(m.stack) != 1 {
+		return nil
+	}
+	slots := m.deps.Saved.Slots()
+	out := make([]Binding, 0, len(slots))
+	for _, slot := range slots {
+		query, ok := m.deps.Saved.BySlot(slot)
+		if !ok {
+			continue
+		}
+		digit := strconv.Itoa(slot)
+		out = append(out, Bind([]string{digit}, digit, query.Name))
+	}
+	return out
+}
+
+// savedHint collapses the bound digits into the one entry the footer has room
+// for; the help overlay is where they are listed by name.
+func savedHint(bound []Binding) Binding {
+	keys := make([]string, 0, len(bound))
+	for _, b := range bound {
+		keys = append(keys, b.Keys()...)
+	}
+	return Bind(keys, strings.Join(keys, "/"), "saved query")
 }

--- a/internal/ui/kernel/kernel_test.go
+++ b/internal/ui/kernel/kernel_test.go
@@ -43,9 +43,15 @@ func newAt(t *testing.T, d Deps, w, h int, opts ...Option) Model {
 	return next.(Model)
 }
 
-func press(m Model, keys string) (Model, tea.Cmd) {
-	next, cmd := m.Update(keyPress(keys))
-	return next.(Model), cmd
+// press sends one key, or a gesture spelt out one key at a time.
+func press(m Model, keys ...string) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	for _, k := range keys {
+		var next tea.Model
+		next, cmd = m.Update(keyPress(k))
+		m = next.(Model)
+	}
+	return m, cmd
 }
 
 func keyPress(s string) tea.KeyPressMsg {
@@ -98,13 +104,13 @@ func TestFooter_HidesAViewWhoseCapabilityIsAbsentAndExplainsItOnItsKey(t *testin
 	if strings.Contains(frame, "Plans") {
 		t.Errorf("an unavailable view is in the footer:\n%s", frame)
 	}
-	m, _ = press(m, "2")
+	m, _ = press(m, "g", "2")
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "Administer Jira") {
 		t.Errorf("pressing an unavailable view's key did not show the reason:\n%s", got)
 	}
 }
 
-func TestKeys_SlotSwitchesRootView(t *testing.T) {
+func TestKeys_GoThenADigitSwitchesRootView(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)
 	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
@@ -114,9 +120,9 @@ func TestKeys_SlotSwitchesRootView(t *testing.T) {
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "board body") {
 		t.Fatalf("did not start on the first slot:\n%s", got)
 	}
-	m, _ = press(m, "2")
+	m, _ = press(m, "g", "2")
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "backlog body") {
-		t.Errorf("slot 2 did not switch view:\n%s", got)
+		t.Errorf("g 2 did not switch view:\n%s", got)
 	}
 }
 
@@ -126,7 +132,7 @@ func TestKeys_UnboundSlotSaysSoRatherThanDoingNothing(t *testing.T) {
 	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
 
 	m := newAt(t, testDeps(), 120, 30)
-	m, _ = press(m, "7")
+	m, _ = press(m, "g", "7")
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "nothing is bound to 7") {
 		t.Errorf("silent no-op on an unbound slot:\n%s", got)
 	}
@@ -231,7 +237,7 @@ func TestFooter_ShowsOnlyTheFocusedViewsHints(t *testing.T) {
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "move issue") || strings.Contains(got, "sprint") {
 		t.Errorf("footer shows the wrong view's keys:\n%s", got)
 	}
-	m, _ = press(m, "2")
+	m, _ = press(m, "g", "2")
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "sprint") || strings.Contains(got, "move issue") {
 		t.Errorf("footer did not follow the focus:\n%s", got)
 	}
@@ -515,8 +521,8 @@ func TestSwitchingRootViewsAndBackKeepsTheUsersPlace(t *testing.T) {
 
 	m := newAt(t, testDeps(), 120, 30)
 	board.content = "cursor is on row 42"
-	m, _ = press(m, "2")
-	m, _ = press(m, "1")
+	m, _ = press(m, "g", "2")
+	m, _ = press(m, "g", "1")
 
 	if built != 1 {
 		t.Errorf("the board was rebuilt %d times; switching away should not throw it away", built)
@@ -540,7 +546,7 @@ func TestOpen_WorksWhenNothingWasAvailableAtStartup(t *testing.T) {
 
 	next, _ := m.Update(CapabilitiesMsg{Caps: fullCaps()})
 	m = next.(Model)
-	m, _ = press(m, "1")
+	m, _ = press(m, "g", "1")
 
 	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "plans body") {
 		t.Errorf("opening a view that only just became available did not work:\n%s", got)
@@ -580,7 +586,7 @@ func TestThemeChange_ReachesARootViewTheUserSwitchedAwayFrom(t *testing.T) {
 	d := testDeps()
 	d.Theme = NewTheme(ThemeAuto, false, UnicodeGlyphs())
 	m := newAt(t, d, 120, 30)
-	m, _ = press(m, "2")
+	m, _ = press(m, "g", "2")
 	board.seen = nil
 
 	next, _ := m.Update(tea.BackgroundColorMsg{Color: black()})
@@ -676,8 +682,11 @@ func TestBlocker_IsAskedBeforeAnythingThatWouldDiscardTheView(t *testing.T) {
 
 	draft := &stubView{id: "editor", blocks: "the comment you are writing is unsaved"}
 	for name, act := range map[string]func(Model) (tea.Model, tea.Cmd){
-		"going back with esc":      func(m Model) (tea.Model, tea.Cmd) { return m.Update(keyPress("esc")) },
-		"switching view by key":    func(m Model) (tea.Model, tea.Cmd) { return m.Update(keyPress("2")) },
+		"going back with esc": func(m Model) (tea.Model, tea.Cmd) { return m.Update(keyPress("esc")) },
+		"switching view by key": func(m Model) (tea.Model, tea.Cmd) {
+			next, _ := m.Update(keyPress("g"))
+			return next.(Model).Update(keyPress("2"))
+		},
 		"switching view by name":   func(m Model) (tea.Model, tea.Cmd) { return m.Update(OpenMsg{ID: "backlog"}) },
 		"popping programmatically": func(m Model) (tea.Model, tea.Cmd) { return m.Update(PopMsg{}) },
 	} {

--- a/internal/ui/kernel/keys.go
+++ b/internal/ui/kernel/keys.go
@@ -29,7 +29,15 @@ type GlobalKeys struct {
 	Palette Binding
 	Refresh Binding
 	Purge   Binding
-	Slot    Binding
+	// Go is the prefix the view slots sit behind. The kernel buffers it rather
+	// than forwarding it, because two views already spend g on gg and ge.
+	Go Binding
+	// Slot switches to a footer slot. Its keys are the bare digits because that
+	// is what arrives after the prefix; its help text is the whole gesture.
+	Slot Binding
+	// Saved runs the query bound to a number key. Same nine digits, pressed
+	// alone, and only in a root view.
+	Saved Binding
 }
 
 // DefaultGlobalKeys is the keymap from docs/UX.md. Vim keys and arrows are both
@@ -42,15 +50,19 @@ func DefaultGlobalKeys() GlobalKeys {
 		Palette: Bind([]string{"ctrl+k"}, "ctrl+k", "commands"),
 		Refresh: Bind([]string{"r"}, "r", "refresh"),
 		Purge:   Bind([]string{"R"}, "R", "refetch everything"),
-		Slot:    Bind([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}, "1-9", "switch view"),
+		Go:      Bind([]string{"g"}, "g", "go to"),
+		Slot:    Bind(digits, "g 1-9", "switch view"),
+		Saved:   Bind(digits, "1-9", "saved query"),
 	}
 }
+
+var digits = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}
 
 // KeySet renders the global keys for the footer and the help overlay.
 func (g GlobalKeys) KeySet() KeySet {
 	return KeySet{
 		Short: []Binding{g.Help, g.Palette, g.Quit},
-		Full:  [][]Binding{{g.Slot, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}},
+		Full:  [][]Binding{{g.Saved, g.Slot, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}},
 	}
 }
 

--- a/internal/ui/kernel/msg.go
+++ b/internal/ui/kernel/msg.go
@@ -3,6 +3,7 @@ package kernel
 import (
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -23,6 +24,27 @@ type OpenMsg struct{ ID string }
 // BroadcastMsg carries a message to every view on the stack, which is how one
 // view tells another that something changed without holding a pointer to it.
 type BroadcastMsg struct{ Msg tea.Msg }
+
+// RunQueryMsg carries a search to the view that registered RunsQueries. The
+// kernel sends it when a number key runs a saved query; the view turns it into
+// whatever retargeting means for it.
+type RunQueryMsg struct {
+	JQL   string
+	Title string
+}
+
+// BindQueryMsg asks for a query to be bound to a number key and kept. A view
+// sends it for the search it is showing, because the kernel does not know what
+// is on screen; the kernel owns the set, because it is what dispatches the key.
+type BindQueryMsg struct {
+	Name string
+	JQL  string
+	Slot int
+}
+
+// SavedQueriesMsg carries the saved queries after one changed, so that a view
+// offering to bind another can say what a key already runs.
+type SavedQueriesMsg struct{ Queries app.SavedQueries }
 
 // SizeMsg tells a view the box it has been given. It is not the terminal size:
 // the kernel has already taken the header, status line and footer out of it.
@@ -78,6 +100,12 @@ func Broadcast(msg tea.Msg) tea.Cmd {
 // Refresh returns a command that asks the focused view to refetch.
 func Refresh(purge bool) tea.Cmd {
 	return func() tea.Msg { return RefreshMsg{Purge: purge} }
+}
+
+// BindQuery returns a command that binds a query to a number key and persists
+// it.
+func BindQuery(name, jql string, slot int) tea.Cmd {
+	return func() tea.Msg { return BindQueryMsg{Name: name, JQL: jql, Slot: slot} }
 }
 
 // Status returns a command that shows a plain status message.

--- a/internal/ui/kernel/query_test.go
+++ b/internal/ui/kernel/query_test.go
@@ -1,0 +1,478 @@
+package kernel
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/app"
+)
+
+func querySpec(id string, slot int, v *stubView) ViewSpec {
+	s := spec(id, slot, "", v)
+	s.RunsQueries = true
+	return s
+}
+
+func savedQueries(t *testing.T, in ...app.SavedQuery) app.SavedQueries {
+	t.Helper()
+	q, err := app.NewSavedQueries(in...)
+	if err != nil {
+		t.Fatalf("NewSavedQueries: %v", err)
+	}
+	return q
+}
+
+func twoQueries(t *testing.T) app.SavedQueries {
+	t.Helper()
+	return savedQueries(t,
+		app.SavedQuery{Name: "Blockers", JQL: "priority = Highest ORDER BY updated DESC", Slot: 1},
+		app.SavedQuery{Name: "Mine", JQL: "assignee = currentUser() ORDER BY updated DESC", Slot: 3},
+	)
+}
+
+// run executes a command and returns the messages it produced, flattening the
+// batches the kernel builds out of several of them.
+func run(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	switch msg := msg.(type) {
+	case nil:
+		return nil
+	case tea.BatchMsg:
+		var out []tea.Msg
+		for _, c := range msg {
+			out = append(out, run(c)...)
+		}
+		return out
+	default:
+		return []tea.Msg{msg}
+	}
+}
+
+func TestDigits_RunTheQueryBoundToThemInARootView(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	issues := &stubView{id: "issues"}
+	RegisterView(querySpec("issues", 1, issues))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 120, 30)
+	issues.seen = nil
+
+	if _, _ = press(m, "3"); !saw(issues, "query:assignee = currentUser() ORDER BY updated DESC") {
+		t.Errorf("3 did not run the query bound to it: %v", issues.seen)
+	}
+}
+
+func TestDigits_RunAQueryInTheViewThatRunsThemWhateverIsOnScreen(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	issues := &stubView{id: "issues"}
+	RegisterView(spec("board", 1, "", board))
+	RegisterView(querySpec("issues", 2, issues))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 120, 30)
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "board body") {
+		t.Fatalf("did not start on the board:\n%s", got)
+	}
+
+	m, _ = press(m, "1")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "issues body") {
+		t.Errorf("a saved query did not switch to the view that runs one:\n%s", got)
+	}
+	if !saw(issues, "query:priority = Highest ORDER BY updated DESC") {
+		t.Errorf("the query never reached the view: %v", issues.seen)
+	}
+}
+
+func TestDigits_SayNothingIsBoundRatherThanRunningSomethingElse(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	issues := &stubView{id: "issues"}
+	RegisterView(querySpec("issues", 1, issues))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 120, 30)
+	issues.seen = nil
+
+	m, _ = press(m, "5")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "no saved query is bound to 5") {
+		t.Errorf("an unbound digit was silent:\n%s", got)
+	}
+	for _, s := range issues.seen {
+		if strings.HasPrefix(s, "query:") {
+			t.Errorf("an unbound digit ran a query anyway: %v", issues.seen)
+		}
+	}
+}
+
+func TestDigits_InAPushedViewReachTheViewRatherThanASavedQuery(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	issues := &stubView{id: "issues"}
+	RegisterView(querySpec("issues", 1, issues))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 120, 30)
+	detail := &stubView{id: "detail"}
+	next, _ := m.Update(PushMsg{View: detail, ID: "issue", Title: "PROJ-1"})
+	m = next.(Model)
+	issues.seen, detail.seen = nil, nil
+
+	m, _ = press(m, "3")
+	if saw(issues, "query:assignee = currentUser() ORDER BY updated DESC") {
+		t.Error("a digit under a pushed view ran a saved query")
+	}
+	if !saw(detail, "key:3") {
+		t.Errorf("the digit never reached the pushed view: %v", detail.seen)
+	}
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "detail body") {
+		t.Errorf("a digit under a pushed view changed the screen:\n%s", got)
+	}
+}
+
+func TestRunSaved_SaysSoWhenNothingInTheBuildRunsQueries(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 120, 30)
+
+	m, _ = press(m, "1")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "nothing in this build can run a saved query") {
+		t.Errorf("a bound digit with nowhere to run was silent:\n%s", got)
+	}
+}
+
+func TestGoPrefix_SwitchesViewFromAnywhereAndIsBufferedUntilItIsSpent(t *testing.T) {
+	tests := map[string]struct {
+		keys     []string
+		wantBody string
+		wantSeen []string
+		wantGone []string
+	}{
+		"a digit switches to that slot": {
+			keys:     []string{"g", "2"},
+			wantBody: "backlog body",
+			wantGone: []string{"key:g", "key:2"},
+		},
+		"a second g reaches the view as both keys, in order": {
+			keys:     []string{"g", "g"},
+			wantBody: "board body",
+			wantSeen: []string{"key:g", "key:g"},
+		},
+		"a letter reaches the view behind the buffered prefix": {
+			keys:     []string{"g", "e"},
+			wantBody: "board body",
+			wantSeen: []string{"key:g", "key:e"},
+		},
+		"esc throws the gesture away and forwards nothing": {
+			keys:     []string{"g", "esc"},
+			wantBody: "board body",
+			wantGone: []string{"key:g", "key:esc"},
+		},
+		"a global key is the view's while the prefix is buffered": {
+			keys:     []string{"g", "r"},
+			wantBody: "board body",
+			wantSeen: []string{"key:g", "key:r"},
+			wantGone: []string{"refresh"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			board := &stubView{id: "board"}
+			RegisterView(spec("board", 1, "", board))
+			RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+			m := newAt(t, testDeps(), 120, 30)
+			board.seen = nil
+			m, _ = press(m, tc.keys...)
+
+			if got := ansi.Strip(m.Frame()); !strings.Contains(got, tc.wantBody) {
+				t.Errorf("frame does not show %q:\n%s", tc.wantBody, got)
+			}
+			for _, want := range tc.wantSeen {
+				if !saw(board, want) {
+					t.Errorf("the view was not handed %q: %v", want, board.seen)
+				}
+			}
+			for _, gone := range tc.wantGone {
+				if saw(board, gone) {
+					t.Errorf("the view was handed %q, which the kernel had taken: %v", gone, board.seen)
+				}
+			}
+			if len(tc.wantSeen) > 1 && !equalOrder(board.seen, tc.wantSeen) {
+				t.Errorf("the keys arrived as %v, want %v in that order", board.seen, tc.wantSeen)
+			}
+		})
+	}
+}
+
+func TestGoPrefix_OpensASlotFromAPushedView(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	next, _ := m.Update(PushMsg{View: &stubView{id: "detail"}, ID: "issue"})
+	m = next.(Model)
+
+	m, _ = press(m, "g", "2")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "backlog body") {
+		t.Errorf("g 2 did not switch view from a pushed one:\n%s", got)
+	}
+}
+
+func TestGoPrefix_DoesNotLatchWhileAViewIsTakingTyping(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	form := &stubView{id: "form", capturing: true}
+	RegisterView(spec("form", 1, "", form))
+	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 120, 30)
+	form.seen = nil
+
+	m, _ = press(m, "g", "2", "1")
+	for _, want := range []string{"key:g", "key:2", "key:1"} {
+		if !saw(form, want) {
+			t.Errorf("a view taking typing did not get %q: %v", want, form.seen)
+		}
+	}
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "form body") {
+		t.Errorf("a gesture latched under a view that was taking typing:\n%s", got)
+	}
+}
+
+func TestFooter_FollowsTheLatchedPrefixAndTheBoundDigits(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(querySpec("issues", 1, &stubView{id: "issues"}))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 140, 30)
+
+	footer := lastLine(ansi.Strip(m.Frame()))
+	if !strings.Contains(footer, "1/3") || !strings.Contains(footer, "saved query") {
+		t.Errorf("the footer does not offer the bound digits:\n%s", footer)
+	}
+
+	m, _ = press(m, "g")
+	latched := lastLine(ansi.Strip(m.Frame()))
+	if !strings.Contains(latched, "switch view") || !strings.Contains(latched, "cancel") {
+		t.Errorf("the footer did not repaint for the latched prefix:\n%s", latched)
+	}
+	if strings.Contains(latched, "saved query") {
+		t.Errorf("the footer still offers keys the prefix has taken:\n%s", latched)
+	}
+}
+
+func TestHelp_NamesEveryQueryTheDigitsRun(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(querySpec("issues", 1, &stubView{id: "issues"}))
+
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	m := newAt(t, d, 140, 30)
+	m, _ = press(m, "?")
+
+	overlay := ansi.Strip(m.Frame())
+	for _, want := range []string{"Blockers", "Mine", "switch view", "saved query"} {
+		if !strings.Contains(overlay, want) {
+			t.Errorf("the help overlay does not mention %q:\n%s", want, overlay)
+		}
+	}
+}
+
+func TestFooter_OffersNoDigitsWhenNothingIsBound(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(querySpec("issues", 1, &stubView{id: "issues"}))
+
+	m := newAt(t, testDeps(), 140, 30)
+	if footer := lastLine(ansi.Strip(m.Frame())); strings.Contains(footer, "saved query") {
+		t.Errorf("the footer offers a saved query on a profile that has none:\n%s", footer)
+	}
+}
+
+func TestFooter_RepaintsWhenAQueryTakesAKey(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(querySpec("issues", 1, &stubView{id: "issues"}))
+
+	m := newAt(t, testDeps(), 140, 30)
+	_ = m.Frame()
+
+	next, _ := m.Update(BindQueryMsg{Name: "Blockers", JQL: "priority = Highest", Slot: 2})
+	m = next.(Model)
+	if footer := lastLine(ansi.Strip(m.Frame())); !strings.Contains(footer, "saved query") {
+		t.Errorf("the footer did not repaint after a key was bound:\n%s", footer)
+	}
+	if !strings.Contains(ansi.Strip(m.Frame()), `2 runs "Blockers"`) {
+		t.Errorf("binding a key said nothing:\n%s", ansi.Strip(m.Frame()))
+	}
+}
+
+func TestBindQuery_TakesTheKeyFromWhateverHeldItAndSaysSo(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	issues := &stubView{id: "issues"}
+	RegisterView(querySpec("issues", 1, issues))
+
+	var written []app.SavedQuery
+	d := testDeps()
+	d.Saved = twoQueries(t)
+	d.SaveQueries = func(q app.SavedQueries) error {
+		written = q.All()
+		return nil
+	}
+	m := newAt(t, d, 140, 30)
+
+	next, cmd := m.Update(BindQueryMsg{Name: "Shipped", JQL: `status = "Shipped"`, Slot: 3})
+	m = next.(Model)
+	for _, msg := range run(cmd) {
+		if status, ok := msg.(StatusMsg); ok && status.Level == LevelError {
+			t.Errorf("saving reported %q", status.Text)
+		}
+	}
+
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, `3 runs "Shipped" instead of "Mine"`) {
+		t.Errorf("the user was not told what the key stopped doing:\n%s", got)
+	}
+	if len(written) != 3 {
+		t.Fatalf("the profile was written with %d queries, want 3", len(written))
+	}
+	if q, ok := m.deps.Saved.BySlot(3); !ok || q.Name != "Shipped" {
+		t.Errorf("3 runs %+v, want the query just bound", q)
+	}
+	for _, q := range written {
+		if q.Name == "Mine" && q.Slot != 0 {
+			t.Errorf("the query that lost the key kept it: %+v", q)
+		}
+	}
+
+	issues.seen = nil
+	m, _ = press(m, "3")
+	if !saw(issues, `query:status = "Shipped"`) {
+		t.Errorf("the key does not run what was just bound to it: %v", issues.seen)
+	}
+}
+
+func TestBindQuery_ReportsWhatWentWrongWithoutTakingTheKeyAway(t *testing.T) {
+	tests := map[string]struct {
+		save    func(app.SavedQueries) error
+		bind    BindQueryMsg
+		want    string
+		bound   bool
+		isError bool
+	}{
+		"a session with no profile keeps the key for itself": {
+			bind:  BindQueryMsg{Name: "Shipped", JQL: `status = "Shipped"`, Slot: 2},
+			want:  "there is no profile to save it to",
+			bound: true,
+		},
+		"a failed write is reported, not swallowed": {
+			save:    func(app.SavedQueries) error { return errors.New("the config file is read-only") },
+			bind:    BindQueryMsg{Name: "Shipped", JQL: `status = "Shipped"`, Slot: 2},
+			want:    "the config file is read-only",
+			bound:   true,
+			isError: true,
+		},
+		"a key outside the range is refused in app's own words": {
+			bind: BindQueryMsg{Name: "Shipped", JQL: `status = "Shipped"`, Slot: 12},
+			want: "the keys are 1 to 9",
+		},
+		"a query saved on no key at all says so": {
+			bind: BindQueryMsg{Name: "Shipped", JQL: `status = "Shipped"`},
+			want: `"Shipped" is saved, on no key`,
+		},
+		"a query with no JQL is refused": {
+			bind: BindQueryMsg{Name: "Shipped", Slot: 2},
+			want: "has no JQL to run",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			RegisterView(querySpec("issues", 1, &stubView{id: "issues"}))
+
+			d := testDeps()
+			d.SaveQueries = tc.save
+			m := newAt(t, d, 140, 30)
+
+			next, cmd := m.Update(tc.bind)
+			m = next.(Model)
+			text := ansi.Strip(m.Frame())
+			for _, msg := range run(cmd) {
+				if status, ok := msg.(StatusMsg); ok {
+					text += "\n" + status.Text
+					if tc.isError && status.Level != LevelError {
+						t.Errorf("a failed write was reported at level %v", status.Level)
+					}
+				}
+			}
+			if !strings.Contains(text, tc.want) {
+				t.Errorf("nothing said %q:\n%s", tc.want, text)
+			}
+			if _, bound := m.deps.Saved.BySlot(tc.bind.Slot); bound != tc.bound {
+				t.Errorf("the key is bound=%v, want %v", bound, tc.bound)
+			}
+		})
+	}
+}
+
+func TestBindQuery_TellsEveryViewTheSetChanged(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	issues := &stubView{id: "issues"}
+	board := &stubView{id: "board"}
+	RegisterView(querySpec("issues", 1, issues))
+	RegisterView(spec("board", 2, "", board))
+
+	m := newAt(t, testDeps(), 140, 30)
+	m, _ = press(m, "g", "2")
+	m, _ = press(m, "g", "1")
+	issues.seen, board.seen = nil, nil
+
+	_, _ = m.Update(BindQueryMsg{Name: "Shipped", JQL: `status = "Shipped"`, Slot: 2})
+	if !saw(issues, "saved:1") {
+		t.Errorf("the focused view was not told: %v", issues.seen)
+	}
+	if !saw(board, "saved:1") {
+		t.Errorf("a parked root view was not told: %v", board.seen)
+	}
+}
+
+func equalOrder(seen, want []string) bool {
+	at := 0
+	for _, s := range seen {
+		if at < len(want) && s == want[at] {
+			at++
+		}
+	}
+	return at == len(want)
+}

--- a/internal/ui/kernel/registry_test.go
+++ b/internal/ui/kernel/registry_test.go
@@ -1,6 +1,7 @@
 package kernel
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -63,6 +64,10 @@ func msgName(msg tea.Msg) string {
 			return "focus"
 		}
 		return "blur"
+	case RunQueryMsg:
+		return "query:" + m.JQL
+	case SavedQueriesMsg:
+		return "saved:" + strconv.Itoa(m.Queries.Len())
 	case tea.KeyPressMsg:
 		return "key:" + m.String()
 	default:

--- a/internal/ui/kernel/testdata/frame_120x40.golden
+++ b/internal/ui/kernel/testdata/frame_120x40.golden
@@ -37,4 +37,4 @@ PROJ-2  Fix the other thing
                                                                                                                         
                                                                                                                         
                                                                                                                         
- 1 Board  2 Backlog                                                              enter open | / filter | ? help | q quit
+ g1 Board  g2 Backlog                                                            enter open | / filter | ? help | q quit

--- a/internal/ui/kernel/testdata/frame_80x20.golden
+++ b/internal/ui/kernel/testdata/frame_80x20.golden
@@ -17,4 +17,4 @@ PROJ-2  Fix the other thing
                                                                                 
                                                                                 
                                                                                 
- 1 Board  2 Backlog                      enter open | / filter | ? help | q quit
+ g1 Board  g2 Backlog                    enter open | / filter | ? help | q quit

--- a/internal/ui/kernel/view.go
+++ b/internal/ui/kernel/view.go
@@ -6,6 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	zone "github.com/lrstanley/bubblezone/v2"
 
+	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -29,9 +30,14 @@ type ViewSpec struct {
 	ID string
 	// Title is the footer label.
 	Title string
-	// Slot is the footer position, 1-9. Zero means the view is reachable only
-	// by being pushed or opened by name.
+	// Slot is the footer position, 1-9, reached with g and the digit. Zero means
+	// the view is reachable only by being pushed or opened by name. The
+	// allocation is written down in docs/UX.md; the registry rejects a duplicate.
 	Slot int
+	// RunsQueries marks the view a saved query opens into. The kernel switches
+	// to it and hands it a RunQueryMsg, which is as much as the kernel knows
+	// about what a search is.
+	RunsQueries bool
 	// Requires names the capability this view needs. An empty key means the
 	// view is always available; an absent capability hides it and its reason is
 	// what the user sees instead.
@@ -73,6 +79,12 @@ type Deps struct {
 	Site string
 	// Now is the clock. Tests inject a fixed one.
 	Now func() time.Time
+	// Saved are the queries the number keys run, as the profile last had them.
+	Saved app.SavedQueries
+	// SaveQueries persists a changed set. A session with nowhere to write them —
+	// no profile yet — leaves it nil, and the kernel says so rather than
+	// pretending the binding survived.
+	SaveQueries func(app.SavedQueries) error
 }
 
 // KeySet is a view's keys, scoped to itself. Short is the footer hint line, in

--- a/internal/ui/list/keys.go
+++ b/internal/ui/list/keys.go
@@ -14,6 +14,7 @@ type keyMap struct {
 	Bottom   kernel.Binding
 	Open     kernel.Binding
 	Filter   kernel.Binding
+	Save     kernel.Binding
 	Accept   kernel.Binding
 	Clear    kernel.Binding
 }
@@ -31,6 +32,7 @@ func defaultKeys() keyMap {
 		Bottom:   kernel.Bind([]string{"G", "end"}, "G", "last row"),
 		Open:     kernel.Bind([]string{"enter"}, "enter", "open"),
 		Filter:   kernel.Bind([]string{"/"}, "/", "filter"),
+		Save:     kernel.Bind([]string{"s"}, "s", "save this query to a key"),
 		Accept:   kernel.Bind([]string{"enter"}, "enter", "keep filter"),
 		Clear:    kernel.Bind([]string{"esc", "ctrl+g"}, "esc", "clear filter"),
 	}
@@ -45,7 +47,7 @@ func (k keyMap) keySet() kernel.KeySet {
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
-			{k.Open, k.Filter, k.Accept, k.Clear},
+			{k.Open, k.Filter, k.Save, k.Accept, k.Clear},
 		},
 	}
 }
@@ -65,6 +67,7 @@ const (
 	actBottom
 	actOpen
 	actFilter
+	actSave
 	actAccept
 	actClear
 )
@@ -80,6 +83,7 @@ func (k keyMap) tables() (normal, filtering map[string]action) {
 		binding{k.HalfDown, actHalfDown}, binding{k.HalfUp, actHalfUp},
 		binding{k.Go, actGo}, binding{k.Top, actTop}, binding{k.Bottom, actBottom},
 		binding{k.Open, actOpen}, binding{k.Filter, actFilter},
+		binding{k.Save, actSave},
 	)
 	filtering = table(binding{k.Accept, actAccept}, binding{k.Clear, actClear})
 	return normal, filtering

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -79,6 +79,13 @@ type Model struct {
 	filter    textinput.Model
 	query     string
 
+	// saved is the kernel's set of saved queries, as this view was built and as
+	// the kernel last changed it, kept so that binding a key can name what that
+	// key already runs.
+	saved    app.SavedQueries
+	bind     bindStep
+	bindSlot int
+
 	pendingGo bool
 
 	loading bool
@@ -89,10 +96,22 @@ type Model struct {
 	zonePrefix string
 }
 
-// WantsRawKeys is true while the filter is open. Without it the kernel matches
-// its own bindings first, so a query loses every digit, r triggers a refetch,
-// esc cannot cancel, and q quits the program out from under the typing.
-func (m *Model) WantsRawKeys() bool { return m.filtering }
+// bindStep is how far the gesture that binds this query to a number key has
+// got.
+type bindStep uint8
+
+const (
+	bindNone bindStep = iota
+	bindPick
+	bindConfirm
+)
+
+// WantsRawKeys is true while the filter is open, and while a number key is
+// being picked. Without it the kernel matches its own bindings first, so a
+// query loses every digit, r triggers a refetch, esc cannot cancel, and q quits
+// the program out from under the typing — and the digit that was meant to bind
+// a key would run whatever is already on it instead.
+func (m *Model) WantsRawKeys() bool { return m.filtering || m.bind != bindNone }
 
 // New builds the issue list. The query it opens on is the user's own work,
 // narrowed to the session's project when there is one; both halves are resolved
@@ -103,6 +122,7 @@ func New(d kernel.Deps) kernel.View {
 		styles: newStyles(d.Theme),
 		rows:   newRowCache(rowCacheLimit),
 		filter: newFilterInput(),
+		saved:  d.Saved,
 	}
 	if m.deps.Theme == nil {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
@@ -147,6 +167,11 @@ type QueryMsg struct {
 	Title string
 }
 
+// SaveQueryMsg starts the gesture that binds the query on screen to a number
+// key. It is exported so that the palette reaches the same gesture the key
+// does, rather than a second implementation of it.
+type SaveQueryMsg struct{}
+
 // Init runs the opening search.
 func (m *Model) Init() tea.Cmd { return m.load() }
 
@@ -175,6 +200,15 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 
 	case QueryMsg:
 		cmd = m.retarget(msg)
+
+	case kernel.RunQueryMsg:
+		cmd = m.retarget(QueryMsg{JQL: msg.JQL, Title: msg.Title})
+
+	case kernel.SavedQueriesMsg:
+		m.saved = msg.Queries
+
+	case SaveQueryMsg:
+		m.startBind()
 
 	case loadedMsg:
 		cmd = m.loadedPage(msg)
@@ -250,7 +284,7 @@ func (m *Model) widestKey() int {
 // column captions and the filter prompt when one is open.
 func (m *Model) rowsHeight() int {
 	h := m.height - 2
-	if m.filtering {
+	if m.filtering || m.bind != bindNone {
 		h--
 	}
 	return max(h, 1)
@@ -509,6 +543,9 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 	if m.filtering {
 		return m.filterKey(msg, stroke)
 	}
+	if m.bind != bindNone {
+		return m.bindKey(stroke)
+	}
 	if m.pendingGo {
 		m.pendingGo = false
 		switch stroke {
@@ -541,6 +578,8 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 		return m.open()
 	case actFilter:
 		return m.startFilter()
+	case actSave:
+		m.startBind()
 	case actNone, actAccept, actClear:
 	}
 	return nil
@@ -582,6 +621,65 @@ func (m *Model) startFilter() tea.Cmd {
 	_ = m.filter.Focus()
 	m.clampScroll()
 	return nil
+}
+
+func (m *Model) startBind() {
+	m.bind, m.bindSlot = bindPick, 0
+	m.clampScroll()
+}
+
+// bindKey takes the digit the gesture is waiting for. Anything else ends it,
+// so there is no mode to guess a way out of, and a key another query holds is
+// named in a confirmation before it changes hands.
+func (m *Model) bindKey(stroke string) tea.Cmd {
+	step := m.bind
+	m.bind = bindNone
+	switch step {
+	case bindPick:
+		slot, err := strconv.Atoi(stroke)
+		if err != nil || slot < 1 || slot > app.MaxSavedSlot {
+			m.clampScroll()
+			return nil
+		}
+		held, taken := m.saved.BySlot(slot)
+		if taken && !strings.EqualFold(held.Name, m.title) {
+			m.bind, m.bindSlot = bindConfirm, slot
+			return nil
+		}
+		return m.commitBind(slot)
+	case bindConfirm:
+		slot := m.bindSlot
+		m.bindSlot = 0
+		if stroke != "y" {
+			m.clampScroll()
+			return nil
+		}
+		return m.commitBind(slot)
+	case bindNone:
+	}
+	return nil
+}
+
+func (m *Model) commitBind(slot int) tea.Cmd {
+	m.bind, m.bindSlot = bindNone, 0
+	m.clampScroll()
+	return kernel.BindQuery(m.title, m.jql, slot)
+}
+
+// bindPrompt is the line the gesture puts under the rows: what is being bound,
+// and what will be lost if it goes ahead. The name is what gives way on a
+// narrow terminal, never the keys that answer.
+func (m *Model) bindPrompt() string {
+	label := "bind " + strconv.Quote(m.title) + " to a key"
+	hint := "  1-" + strconv.Itoa(app.MaxSavedSlot) + ", any other key cancels"
+	if m.bind == bindConfirm {
+		held, _ := m.saved.BySlot(m.bindSlot)
+		label = strconv.Itoa(m.bindSlot) + " runs " + strconv.Quote(held.Name)
+		hint = "  y replaces it, any other key cancels"
+	}
+	room := max(m.width-ansi.StringWidth(hint), 8)
+	return m.styles.prompt.Render(ansi.Truncate(label, room, m.deps.Theme.Glyphs.Ellipsis)) +
+		m.styles.muted.Render(hint)
 }
 
 func (m *Model) open() tea.Cmd {
@@ -654,6 +752,9 @@ func (m *Model) View() string {
 	}
 	if m.filtering {
 		lines = append(lines, m.filter.View())
+	}
+	if m.bind != bindNone {
+		lines = append(lines, m.bindPrompt())
 	}
 	m.lines = lines
 	return strings.Join(lines, "\n")

--- a/internal/ui/list/query_test.go
+++ b/internal/ui/list/query_test.go
@@ -1,0 +1,208 @@
+package list
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const shippedJQL = `project = "PROJ" AND status = "Shipped" ORDER BY key`
+
+// keys drives the whole program rather than the view, because what these tests
+// are about is which of the two got the keystroke.
+func keys(t *testing.T, m kernel.Model, strokes ...string) kernel.Model {
+	t.Helper()
+	for _, stroke := range strokes {
+		m = send(t, m, keyPress(stroke))
+	}
+	return m
+}
+
+// selectedKey reads the issue under the cursor out of the drawn frame, which is
+// the only place a test above the view can see it.
+func selectedKey(frame string) string {
+	for _, line := range strings.Split(frame, "\n") {
+		if !strings.HasPrefix(line, "> ") {
+			continue
+		}
+		if fields := strings.Fields(line); len(fields) > 1 {
+			return fields[1]
+		}
+	}
+	return ""
+}
+
+func savedDeps(t *testing.T, client jira.Client, queries ...app.SavedQuery) (kernel.Deps, *[]app.SavedQuery) {
+	t.Helper()
+	saved, err := app.NewSavedQueries(queries...)
+	if err != nil {
+		t.Fatalf("NewSavedQueries: %v", err)
+	}
+	d := testDeps(client)
+	d.Saved = saved
+	written := new([]app.SavedQuery)
+	d.SaveQueries = func(q app.SavedQueries) error {
+		*written = q.All()
+		return nil
+	}
+	return d, written
+}
+
+func TestList_KeepsItsOwnGGesturesUnderTheKernelsPrefix(t *testing.T) {
+	t.Parallel()
+
+	m := startAll(t, testDeps(newFake(40)), 120, 30)
+	if got := selectedKey(frame(m)); got != "PROJ-1" {
+		t.Fatalf("the list opened on %q, want PROJ-1", got)
+	}
+
+	m = keys(t, m, "g", "5")
+	if got := frame(m); !strings.Contains(got, "nothing is bound to 5") {
+		t.Fatalf("g 5 was not the kernel's:\n%s", got)
+	}
+
+	m = keys(t, m, "g", "e")
+	last := selectedKey(frame(m))
+	if last == "PROJ-1" || last == "" {
+		t.Errorf("g e left the cursor on %q; the view saw half a gesture the kernel had eaten", last)
+	}
+
+	m = keys(t, m, "g", "g")
+	if got := selectedKey(frame(m)); got != "PROJ-1" {
+		t.Errorf("g g left the cursor on %q, want PROJ-1", got)
+	}
+}
+
+func TestList_RunsTheQueryTheKernelDispatchesFromANumberKey(t *testing.T) {
+	t.Parallel()
+
+	d, _ := savedDeps(t, newFake(20), app.SavedQuery{Name: "Shipped work", JQL: shippedJQL, Slot: 2})
+	m := start(t, d, 120, 30)
+
+	m = keys(t, m, "2")
+	got := frame(m)
+	mustContain(t, got, "Shipped work")
+	if selectedKey(got) == "" {
+		t.Errorf("the saved query brought no rows:\n%s", got)
+	}
+}
+
+func TestList_BindsTheQueryOnScreenToANumberKeyAndKeepsIt(t *testing.T) {
+	t.Parallel()
+
+	d, written := savedDeps(t, newFake(20))
+	m := startAll(t, d, 120, 30)
+
+	m = keys(t, m, "s")
+	mustContain(t, frame(m), `bind "All issues" to a key`, "any other key cancels")
+
+	m = keys(t, m, "4")
+	mustContain(t, frame(m), `4 runs "All issues"`)
+	if len(*written) != 1 {
+		t.Fatalf("the profile was written with %d queries, want 1", len(*written))
+	}
+	if q := (*written)[0]; q.Slot != 4 || q.JQL != allJQL || q.Name != "All issues" {
+		t.Errorf("wrote %+v, want the query on screen bound to 4", q)
+	}
+
+	if footer := frame(m); !strings.Contains(footer, "saved query") {
+		t.Errorf("the footer does not offer the key that was just bound:\n%s", footer)
+	}
+}
+
+func TestList_ConfirmsBeforeTakingAKeyAnotherQueryHolds(t *testing.T) {
+	t.Parallel()
+
+	d, written := savedDeps(t, newFake(20), app.SavedQuery{Name: "Shipped work", JQL: shippedJQL, Slot: 2})
+	m := startAll(t, d, 120, 30)
+
+	m = keys(t, m, "s", "2")
+	got := frame(m)
+	mustContain(t, got, `2 runs "Shipped work"`, "y replaces it", "All issues")
+	if len(*written) != 0 {
+		t.Fatalf("the key changed hands before the confirmation: %+v", *written)
+	}
+
+	m = keys(t, m, "n")
+	if len(*written) != 0 {
+		t.Errorf("refusing the confirmation still rebound the key: %+v", *written)
+	}
+
+	m = keys(t, m, "s", "2", "y")
+	if len(*written) != 2 {
+		t.Fatalf("the profile was written with %d queries, want 2", len(*written))
+	}
+	mustContain(t, frame(m), `2 runs "All issues" instead of "Shipped work"`)
+	for _, q := range *written {
+		if q.Name == "Shipped work" && q.Slot != 0 {
+			t.Errorf("the query that lost the key kept it: %+v", q)
+		}
+	}
+}
+
+func TestList_TakesTheDigitItselfWhileItIsPickingAKey(t *testing.T) {
+	t.Parallel()
+
+	d, _ := savedDeps(t, newFake(20), app.SavedQuery{Name: "Shipped work", JQL: shippedJQL, Slot: 2})
+	m := startAll(t, d, 120, 30)
+
+	m = keys(t, m, "s", "2")
+	if got := frame(m); !strings.Contains(got, "All issues") {
+		t.Errorf("the digit that was picking a key ran the query bound to it instead:\n%s", got)
+	}
+}
+
+func TestList_TheSaveGestureIsReachableFromThePaletteAsWell(t *testing.T) {
+	t.Parallel()
+
+	d, written := savedDeps(t, newFake(20))
+	m := startAll(t, d, 120, 30)
+
+	m = send(t, m, kernel.BroadcastMsg{Msg: SaveQueryMsg{}})
+	mustContain(t, frame(m), `bind "All issues" to a key`)
+
+	keys(t, m, "6")
+	if len(*written) != 1 || (*written)[0].Slot != 6 {
+		t.Errorf("the command did not reach the same gesture the key does: %+v", *written)
+	}
+}
+
+func TestList_ARejectedKeyEndsTheGestureRatherThanTrappingTheUser(t *testing.T) {
+	t.Parallel()
+
+	d, written := savedDeps(t, newFake(20))
+	m := startAll(t, d, 120, 30)
+
+	m = keys(t, m, "s", "x")
+	if got := frame(m); strings.Contains(got, "to a key") {
+		t.Errorf("a key that binds nothing left the gesture open:\n%s", got)
+	}
+	m = keys(t, m, "j")
+	if got := selectedKey(frame(m)); got != "PROJ-2" {
+		t.Errorf("the cursor is on %q, want PROJ-2: j was swallowed by a gesture nobody could see", got)
+	}
+	if len(*written) != 0 {
+		t.Errorf("a cancelled gesture wrote something: %+v", *written)
+	}
+}
+
+func TestList_BindPrompt_Golden(t *testing.T) {
+	t.Parallel()
+
+	for name, strokes := range map[string][]string{
+		"pick":    {"s"},
+		"confirm": {"s", "2"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d, _ := savedDeps(t, newFake(12), app.SavedQuery{Name: "Shipped work", JQL: shippedJQL, Slot: 2})
+			dr := openAll(t, d, 120, 20)
+			dr.key(strokes...)
+			golden(t, "list_bind_"+name+"_120x20.golden", dr.view())
+		})
+	}
+}

--- a/internal/ui/list/register.go
+++ b/internal/ui/list/register.go
@@ -10,10 +10,11 @@ import (
 
 func init() {
 	kernel.RegisterView(kernel.ViewSpec{
-		ID:    ViewID,
-		Title: "Issues",
-		Slot:  1,
-		New:   New,
+		ID:          ViewID,
+		Title:       "Issues",
+		Slot:        1,
+		RunsQueries: true,
+		New:         New,
 	})
 	kernel.RegisterKeys(ViewID, defaultKeys().keySet())
 	kernel.RegisterCommand(kernel.Command{
@@ -21,6 +22,14 @@ func init() {
 		Title: "Issues",
 		Group: "Go to",
 		Run:   func(kernel.Deps) tea.Cmd { return kernel.Open(ViewID) },
+	})
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "issues.save-query",
+		Title: "Save this query to a number key",
+		Group: "Search",
+		Run: func(kernel.Deps) tea.Cmd {
+			return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(SaveQueryMsg{}))
+		},
 	})
 	for _, q := range []struct{ id, title, jql string }{
 		{"issues.mine", "My issues", "assignee = currentUser() ORDER BY updated DESC"},

--- a/internal/ui/list/testdata/list_100x30.golden
+++ b/internal/ui/list/testdata/list_100x30.golden
@@ -27,4 +27,4 @@ All issues                                                                      
                                                                                                     
                                                                                                     
                                                                                                     
- 1 Issues                                ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ g1 Issues                               ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_120x40.golden
+++ b/internal/ui/list/testdata/list_120x40.golden
@@ -37,4 +37,4 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
                                                                                                                         
- 1 Issues                                                    ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_80x20.golden
+++ b/internal/ui/list/testdata/list_80x20.golden
@@ -17,4 +17,4 @@ All issues                                                             12 issues
                                                                                 
                                                                                 
                                                                                 
- 1 Issues            ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_bind_confirm_120x20.golden
+++ b/internal/ui/list/testdata/list_bind_confirm_120x20.golden
@@ -1,0 +1,20 @@
+All issues                                                                                                     12 issues
+  KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
+  PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
+  PROJ-3   Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
+  PROJ-4   Document CSV import                                   Defect     Building      unassigned        02 Mar 18:00
+  PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00
+  PROJ-6   Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
+  PROJ-7   Fix the search index                                  Defect     Building      Grace Hopper      03 Mar 00:00
+  PROJ-8   Add invoice rounding                                  Chore      Shipped       unassigned        03 Mar 02:00
+  PROJ-9   Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
+  PROJ-10  Investigate the release checklist                     Defect     Building      Grace Hopper      03 Mar 06:00
+  PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
+  PROJ-12  Retire the nightly export                             Story      Triage        unassigned        03 Mar 10:00
+
+
+
+
+
+2 runs "Shipped work"  y replaces it, any other key cancels

--- a/internal/ui/list/testdata/list_bind_pick_120x20.golden
+++ b/internal/ui/list/testdata/list_bind_pick_120x20.golden
@@ -1,0 +1,20 @@
+All issues                                                                                                     12 issues
+  KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
+  PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
+  PROJ-3   Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
+  PROJ-4   Document CSV import                                   Defect     Building      unassigned        02 Mar 18:00
+  PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00
+  PROJ-6   Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
+  PROJ-7   Fix the search index                                  Defect     Building      Grace Hopper      03 Mar 00:00
+  PROJ-8   Add invoice rounding                                  Chore      Shipped       unassigned        03 Mar 02:00
+  PROJ-9   Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
+  PROJ-10  Investigate the release checklist                     Defect     Building      Grace Hopper      03 Mar 06:00
+  PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
+  PROJ-12  Retire the nightly export                             Story      Triage        unassigned        03 Mar 10:00
+
+
+
+
+
+bind "All issues" to a key  1-9, any other key cancels

--- a/internal/ui/list/testdata/list_no_caps_120x30.golden
+++ b/internal/ui/list/testdata/list_no_caps_120x30.golden
@@ -27,4 +27,4 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
                                                                                                                         
- 1 Issues                                                    ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit


### PR DESCRIPTION
Closes #49.

Implements the decision recorded on the issue — **the digits are contextual** — and the owner's
follow-up decision that PC.2 also lands persistence, because saved queries were built, tested and
unreachable and the digits would otherwise be dead on every fresh install.

## What the keys do now

| Gesture | Result |
|---|---|
| `1`–`9` in a root view | run the saved query bound to that key; says `no saved query is bound to 5 yet` when there is none |
| `1`–`9` in a pushed view | the view's own key; the kernel takes nothing |
| `g` then `1`–`9` | switch to that footer slot, from anywhere |
| `g` then anything else | the view gets `g` and then that key, in the order they were typed |
| `g` then `esc` | the gesture is thrown away and nothing is forwarded |
| `s` in the issue list | bind the query on screen to a number key |
| `ctrl+k` | unchanged — still reports that the palette is not in this build |

## The `g` collision, and why the kernel buffers

`g` was already a hardcoded, unregistered prefix in **two** views — `internal/ui/list` (`gg`, `ge`)
and `internal/ui/issue` (the same) — and `list/keys.go` binds `Top` to `home` while its help text
says `g g`. A global `g` that forwarded the keypress and then ate the digit would leave `pendingGo`
set in the view, and the *next* keystroke there would misfire.

So the kernel latches `g` and forwards nothing. On the next key it either takes a digit for itself,
drops the gesture on `esc`, or forwards the buffered `g` followed by the key that came after it.
**`internal/ui/issue` therefore needed no change at all**, which was the point of the design: I read
`issue.go:185-193` to confirm its `pendingGo` still receives both keys, and the equivalent path is
covered end-to-end for the list in `TestList_KeepsItsOwnGGesturesUnderTheKernelsPrefix`, which drives
the whole program rather than the view. That test fails if the kernel forwards `g` at latch time — I
checked by making the change and watching it go red.

Ordering inside `handleKey` is load-bearing and matches what the issue asked for: `ctrl+c`, then
`m.capturing()`, then the help swallow, then the prefix, then the flat switch. A prefix cannot latch
under a view that is taking typing (`TestGoPrefix_DoesNotLatchWhileAViewIsTakingTyping`, which also
goes red if the branch is moved one step earlier).

## Slot allocation, written down

`docs/UX.md` now carries the table from the issue: 1 issues, 2 board, 3 backlog, 4 sprints,
5 releases, 6 timeline, 7 plans, 8-9 free, everything else `Slot: 0`. The list keeps slot 1.
`docs/ARCHITECTURE.md:160` showed `board` at `Slot: 1`, contradicting the table — fixed to `Slot: 2`,
with a paragraph saying slots are allocated rather than picked and that the registry rejects a second
claim at startup.

## Persistence, and the gesture that creates a query

- **Schema.** `[[profiles.x.queries]]` with `name`, `jql` and `key`, following the existing
  `Profile`/`fileProfile`/`decodeProfile`/`Validate`/`encode` shape. It holds `[]app.SavedQuery` and
  validates through `app.NewSavedQueries`, so there is one set of rules rather than two; the file
  additionally refuses the two things a keypress cannot say — two queries under one name, and two on
  one key — because `Add` resolves both by taking the newer, which in a file silently drops a line
  somebody wrote. A typo in a key is an error through the existing `unknownKeys` handling.
- **The gesture.** `s` in the issue list opens a prompt naming the query; a digit binds it; a digit
  another query holds is confirmed by name first (`2 runs "Shipped work"  y replaces it, any other
  key cancels`), per UX principle 4. Any key that is not `1`-`9` ends the gesture, so there is no mode
  to guess a way out of. The list answers `WantsRawKeys()` while it is picking, which is what stops
  the kernel running the query already on that digit.
- **Reachable three ways-ish.** The key and a registered `Command` (`issues.save-query`) drive the
  same message, so P3.1's palette picks it up for free. Mouse is P3.3's packet.
- **Injection.** `kernel.Deps` gains `Saved` and `SaveQueries`; `cmd/saral/main.go` reads the queries
  out of the profile and hands the kernel a writer that re-reads the file before saving, so a profile
  onboarding wrote mid-session is not overwritten with a stale copy. A session with nowhere to write
  says so instead of pretending: `2 runs "Blockers", for this session; there is no profile to save it
  to`, and a failed write is reported without taking the binding away.

## Consumers of everything shared this PR changed

| Symbol | Consumer that adopted it |
|---|---|
| `ViewSpec.RunsQueries` | `internal/ui/list/register.go:16`, read at `kernel.go:472` |
| `kernel.RunQueryMsg` | sent `kernel.go:466`, handled `list/list.go:204` → its existing `QueryMsg` → `retarget` |
| `kernel.SavedQueriesMsg` | broadcast `kernel.go:491`, handled `list/list.go:207` |
| `kernel.BindQueryMsg` / `BindQuery` | sent `list/list.go:666`, handled `kernel.go:286` |
| `list.SaveQueryMsg` | sent by the palette command `register.go:31`, handled `list.go:210` |
| `Deps.Saved` / `Deps.SaveQueries` | set `cmd/saral/main.go:130-131`; read `kernel.go:451,500,510`; seeded into the list at `list.go:125` |
| `config.Profile.Queries` | `cmd/saral/main.go:126,179`, `config.go:251,420,599` |
| `app.SavedQueries.Slots` | `kernel.go:952` (the footer hints) |
| `app.SavedQueries.BySlot` | `kernel.go:451,955`, `list.go` — the dead code the issue was about |

## Golden files — three UI changes

1. **Every footer slot label gained a `g`.** `1 Issues` → `g1 Issues`, in
   `kernel/testdata/frame_*.golden` and `list/testdata/list_*.golden`. That is the whole diff in
   those five files: bare digits no longer switch views, so advertising them as if they did would be
   a lie.
2. **The footer gains a saved-query entry when one is bound**, built from the digits that actually
   have a query (`1/3  saved query`), and the help overlay lists each by name. Nothing appears on a
   profile with no queries, per UX principle 2.
3. **Two new goldens** for the bind prompt, `list_bind_pick_120x20.golden` and
   `list_bind_confirm_120x20.golden` — one line under the rows, taking a row from the list the way
   the filter does.

While a prefix is latched the footer switches to `1-9 switch view | esc cancel`. `chromeKey` gained
`prefixed` and `savedGen`; without `prefixed` the footer does not repaint when `g` latches, and the
test for it goes red if the field is removed.

## Owned paths — widened, and declared

Raised on #49 before starting. The roadmap gave PC.2 `kernel/{view,keys}.go`, which the packet cannot
land inside: the digit dispatch is `kernel.go:315`, the footer that draws the slots is
`kernel.go:737-760` and the memo key is at `kernel.go:61`. `docs/PARALLEL.md` asks for the `kernel`
label on changes there and #49 carries it. The widened set — `internal/ui/kernel/**`,
`internal/ui/list/**`, `internal/app/search.go`, `internal/config/**`, `cmd/saral/main.go` and the
three docs — is corrected in the packet's own roadmap row in this PR. Nobody owned saved-query
persistence; that was a hole, not a scope question.

`internal/ui/issue/**` and `pkg/**` are untouched.

**PC.3 (#50) also edits `kernel.go` and `main.go`.** This PR touches key dispatch, the footer, `Deps`
and the config schema; PC.3 touches the capability probe around `:578` and `deps.Project`. Rebasing
PC.3 onto this should be mechanical, but it is the one thing worth merging in order.

## Docs

- `docs/UX.md`: the navigation block rewritten to the decided model; "Who owns the number keys" with
  the allocation table; `tab` removed — nothing binds it and no view has two panes yet, so the line
  was false; the `g` then key promise amended, because **no part of it exists** — no key parser, no
  prompt, no URL handling, no positional routing in `main.go`. Filed as #62 rather than left standing.
- `docs/ARCHITECTURE.md`: the `Slot: 1` example corrected, the config sample gained a `queries`
  table, and the registry section says how slots are allocated.
- `docs/ROADMAP.md`: PC.2 ticked, `owns` corrected, description rewritten to what landed.

## Also found, filed not fixed

**#63 — re-running onboarding over an existing profile drops everything it does not ask about.**
`onboarding/steps.go` builds a fresh `config.Profile` from the four fields on screen and `save()`
overwrites the existing entry with it, so `Theme`, `Glyphs`, `Timeline` and now `Queries` are lost.
That is pre-existing (it already loses a theme today) and `internal/ui/onboarding/**` is not this
packet's, so it is an issue with the fix described rather than a widened diff.

## Verification

`go mod tidy` clean · `go vet` · `golangci-lint run` (0 issues) · `go test -race -count=1 ./...` all
green · `go build -trimpath -ldflags "-s -w"` 5.2M · `scripts/checkleak.py` clean (no capture in this
tree; nothing from a real instance in the diff — every JQL, name and key in the tests is invented).
No `go.mod` change. `BenchmarkFrame` holds at 297 allocs/op, unchanged from `origin/main`, because the
footer stays memoized.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
