### PR TITLE
P2.1 — markdown back into a document, keeping the parts nobody edited

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -80,6 +80,10 @@ here cost time to find out; read this before writing an adapter method.
 | The validator *repairs* rather than rejects: unknown `attrs` keys are deleted and an `unsupportedNodeAttribute` mark is appended | Sending a document you rebuilt from a partial model is lossy even when it validates. Send back what you were given wherever you did not edit. |
 | `text` on a text node has `minLength: 1` | An empty text node is invalid. Drop it; never emit `"text": ""`. |
 | A node's permitted marks depend on where it sits — the schema encodes this with `_with_no_marks` / `_with_alignment` / `_root_only` variants | A paragraph at the root may carry `alignment`; the same paragraph inside a list item may carry none. |
+| `mention` carries an account id, `status` carries a colour, `date` carries epoch millis, `media` carries a collection, and a `taskItem` carries a `localId` the editor generated | None of them has a markdown spelling, so ADF → markdown → ADF cannot rebuild any of them: a mention comes back as its display text and a lozenge as bracketed text. Editing a document means reconciling against the one you were given — `adf.ParseMarkdownInto` reuses the original node for every block the author did not touch, which is the only way the ids survive. Never invent a `localId`: a made-up one is a *new* item, not the one that was there. |
+| `orderedList` numbers from **one** — `order` is a positive integer | A list stored with `order: 0` is displayed from 1, so reading a "0." back as a list starting at zero invents a document Jira does not have. |
+| ADF has **no nested tables**, and no `table`, `heading` or `rule` inside a `blockquote` or a `listItem` | Markdown can ask for every one of those. Refuse with a typed error rather than sending something the validator will silently repair into a shape nobody wrote. |
+| ADF's content model for a task or decision list is `(item | list)+` | Indenting an action item in the editor stores a sibling `taskList` *inside* the parent list, not inside the item above it. Treating that child as an item loses every checkbox under it. |
 
 ## Localisation, which breaks resolution by name
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,8 +123,12 @@ because it unblocks or blocks everyone. The other four run in parallel behind it
 issue. This is the first batch that mutates a real instance, and every one of PC.1, PC.3 and PC.5 is
 a thing Batch 2 would otherwise get quietly wrong.
 
-- [ ] **P2.1 — Markdown to ADF** · [#8](https://github.com/varijkapil13/saral/issues/8) · **owns** `pkg/adf/parse*.go`
-  The inverse of P1.4, with round-trip property tests asserting byte-stability on untouched docs.
+- [x] **P2.1 — Markdown to ADF** · [#8](https://github.com/varijkapil13/saral/issues/8) · **owns** `pkg/adf/parse*.go` and their tests, `pkg/adf/testdata/**` (new files only), `docs/API-NOTES.md`
+  The inverse of P1.4. `ParseMarkdownInto` reconciles edited markdown against the document it was
+  rendered from and reuses the original node for every block nobody touched, which is what makes an
+  untouched document come back byte-identical — markdown alone carries no account id, no lozenge
+  colour and none of an unknown node's attributes. Landed ahead of the Batch 1.5 gate on purpose:
+  PC.1, PC.3 and PC.5 are all outside `pkg/adf`.
 - [ ] **P2.2 — Schema-driven forms** · [#9](https://github.com/varijkapil13/saral/issues/9) · **owns** `internal/ui/form/**`, `pkg/jira/cloud/meta.go`
   `createmeta` → widgets, required-field validation, `ValidationError` mapped to fields.
   Needs PC.3 (`createmeta` is keyed by project and issue type) and PC.5 (the issue-type list page).

--- a/pkg/adf/parse.go
+++ b/pkg/adf/parse.go
@@ -1,0 +1,739 @@
+package adf
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ParseMarkdown turns markdown back into an ADF document.
+//
+// Its input language is exactly what [Markdown] emits, which is markdown by
+// shape rather than by standard, so this is the inverse of that function and
+// not a general CommonMark implementation. Anything it cannot map to a node it
+// keeps as prose, so text is never silently dropped.
+//
+// The conversion ADF → markdown → ADF is not lossless on its own: markdown has
+// no spelling for an account id, a lozenge colour or the attributes of a node
+// type nobody has published yet. Use [ParseMarkdownInto] whenever the document
+// the markdown was rendered from is still to hand — it restores every block the
+// author did not touch from the original bytes, which is the only way an
+// untouched document survives byte for byte. [ParseMarkdownDropsOnly] lists
+// what a parse without the original loses.
+func ParseMarkdown(md string) (Doc, error) { return ParseMarkdownWith(md, Options{}) }
+
+// ParseMarkdownWith parses markdown with explicit options.
+//
+// Only [Options.ASCII] changes how the markdown is read: it selects the marker
+// set a panel, a decision item and an expand are recognised by, and it has to
+// match the option the markdown was rendered with. TableWidth and Location are
+// carried for [ParseMarkdownInto], which re-renders the original document to
+// find out which blocks are untouched.
+func ParseMarkdownWith(md string, opt Options) (Doc, error) {
+	p := newParser(opt)
+	nodes, err := p.blocks(splitLines(md), "doc")
+	if err != nil {
+		return Doc{}, err
+	}
+	return NewDoc(nodes...), nil
+}
+
+// ParseMarkdownInto parses markdown that was rendered from d, and reuses d's
+// own nodes for every top-level block the author left alone.
+//
+// This is what makes an edit safe. A reused node keeps the bytes it was parsed
+// from, so it re-encodes exactly as it arrived — attributes this package does
+// not model, node types it has never heard of, the account id behind a mention,
+// the colour of a lozenge and the key order Jira happened to use. Markdown
+// carries none of those; the original document does.
+//
+//	md := adf.Markdown(d)          // hand to $EDITOR
+//	out, err := adf.ParseMarkdownInto(d, edited, adf.Options{})
+//
+// When edited is byte-identical to md, adf.Marshal(out) is byte-identical to
+// adf.Marshal(d). Blocks the author did change are parsed from the markdown and
+// lose whatever markdown could not carry.
+//
+// opt must be the options d was rendered with, or nothing will match. Leave
+// TableWidth at zero for markdown somebody is going to edit: a bounded render
+// truncates a table's cells with an ellipsis, and an edit anywhere in that
+// table writes the truncation back.
+func ParseMarkdownInto(d Doc, md string, opt Options) (Doc, error) {
+	nodes, err := newParser(opt).reconcile(splitLines(md), d.Content)
+	if err != nil {
+		return Doc{}, err
+	}
+	// A field Jira holds as null arrives as the zero document and has to go back
+	// as null, not as an empty one.
+	if len(nodes) == 0 && d.IsZero() {
+		return d, nil
+	}
+	out := d
+	out.Version, out.Type = max(d.Version, 1), cmp.Or(d.Type, "doc")
+	out.Content = nodes
+	out.extra = maps.Clone(d.extra)
+	return out, nil
+}
+
+// ParseMarkdownDropsOnly names, in document order, every construct that ADF →
+// markdown → ADF cannot reproduce without the original document. It is here so
+// that a caller can tell a user what an edit will cost rather than finding out
+// afterwards, and so that the list is maintained beside the code that causes
+// it.
+//
+// [ParseMarkdownInto] restores all of these for a block the author did not
+// touch. Nothing in this list is dropped as text: a mention still reads
+// "@Someone" and a lozenge still reads "[Done]", they are simply prose again.
+func ParseMarkdownDropsOnly() []string {
+	return []string{
+		"mention: the account id, which markdown has no room for, so a mention becomes its own display text",
+		"status: the lozenge colour, so a lozenge becomes bracketed text",
+		"date: the instant, which renders as a day in one timezone and cannot be read back as an epoch",
+		"emoji: the shortName and id behind the character",
+		"media: the collection, dimensions and layout of an attachment",
+		"table: colspan, rowspan, cell background, layout and the number column; a cell's blocks are folded to one line",
+		"table: every cell of a table rendered with a TableWidth, which is truncated to fit the width",
+		"panel: the case of a panelType this package does not know, which renders uppercased",
+		"heading: a heading with no content, which renders as nothing at all",
+		"hardBreak: one that opens a block, or sits in a heading, or is followed by a line that reads as a marker",
+		"text: prose that begins a line with a marker, because the renderer does not escape what an author typed",
+		"text: trailing whitespace on a line, and the control characters the renderer strips",
+		"marks: the order marks arrived in, which is meaningless but byte-significant",
+		"marks: neighbouring runs whose marks overlap, which spell the same characters as one run inside another",
+		"any node type ADF gained after this package was written, which renders as an [unsupported: …] marker",
+	}
+}
+
+// ParseError reports markdown this package will not turn into ADF, and where.
+type ParseError struct {
+	// Line is 1-based, and counts the lines of the markdown as it was given.
+	Line int
+	// Text is the line the parser stopped on.
+	Text string
+	Err  error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("adf: line %d: %v: %q", e.Line, e.Err, e.Text)
+}
+
+func (e *ParseError) Unwrap() error { return e.Err }
+
+var (
+	// ErrUnsupportedMarker reports an "[unsupported: …]" marker that could not
+	// be matched to a node in the document the markdown came from. The marker
+	// stands for a node whose attributes markdown never carried, so rebuilding
+	// it would either invent a node Jira rejects or quietly delete one.
+	ErrUnsupportedMarker = errors.New("this stands for a node markdown cannot rebuild, and no original was given to restore it from")
+
+	// ErrNesting reports a nesting ADF has no shape for, such as a table inside
+	// a quote or a heading inside a list item.
+	ErrNesting = errors.New("ADF cannot nest these")
+)
+
+// line is one line of the input with the number it had before any prefix was
+// stripped from it, so that an error points at the line the author sees.
+type line struct {
+	text string
+	no   int
+}
+
+func (l line) blank() bool { return strings.TrimRight(l.text, " \t") == "" }
+
+func (l line) indent() int {
+	for i := range len(l.text) {
+		if l.text[i] != ' ' {
+			return i
+		}
+	}
+	return len(l.text)
+}
+
+// undent removes up to n leading spaces, which is how a continuation line is
+// taken out of the block that indented it.
+func (l line) undent(n int) line {
+	i := 0
+	for i < n && i < len(l.text) && l.text[i] == ' ' {
+		i++
+	}
+	l.text = l.text[i:]
+	return l
+}
+
+func splitLines(md string) []line {
+	md = strings.TrimPrefix(md, "\ufeff")
+	if strings.ContainsRune(md, '\r') {
+		md = strings.ReplaceAll(md, "\r\n", "\n")
+		md = strings.ReplaceAll(md, "\r", "\n")
+	}
+	parts := strings.Split(md, "\n")
+	out := make([]line, len(parts))
+	for i := range parts {
+		out[i] = line{text: parts[i], no: i + 1}
+	}
+	return out
+}
+
+type parser struct {
+	opt Options
+	gl  glyphs
+	// scratch is reused by every render the parser does of its own work, which
+	// is one per line that holds a marker.
+	scratch []byte
+}
+
+func newParser(opt Options) *parser { return &parser{opt: opt, gl: glyphsFor(opt.ASCII)} }
+
+func (p *parser) fail(l line, err error) error {
+	return &ParseError{Line: l.no, Text: l.text, Err: err}
+}
+
+// forbidden is the part of ADF's content model that markdown can ask this
+// parser to break. It is deliberately short: only nestings ADF has no shape at
+// all for are refused, because guessing wider rejects documents Jira itself
+// stores.
+var forbidden = map[string]map[string]bool{
+	"blockquote": {"table": true, "heading": true, "rule": true},
+	"listItem":   {"table": true, "heading": true, "rule": true},
+	"panel":      {"table": true, "panel": true},
+}
+
+func (p *parser) blocks(ls []line, parent string) ([]Node, error) {
+	var out []Node
+	for i := 0; i < len(ls); {
+		if ls[i].blank() {
+			i++
+			continue
+		}
+		n, next, err := p.block(ls, i, parent)
+		if err != nil {
+			return nil, err
+		}
+		if forbidden[parent][n.Type] {
+			return nil, p.fail(ls[i], fmt.Errorf("%w: a %s inside a %s", ErrNesting, n.Type, parent))
+		}
+		out = append(out, n)
+		i = next
+	}
+	return out, nil
+}
+
+// block reads one block starting at a non-blank line. The index it returns is
+// where the next block starts and is valid even when the error is not nil, so
+// that a caller reconciling against an original document can still measure the
+// block it could not build.
+func (p *parser) block(ls []line, i int, parent string) (Node, int, error) {
+	l := ls[i]
+	switch {
+	case isFence(l.text):
+		return p.codeBlock(ls, i)
+	case strings.HasPrefix(l.text, ">"):
+		return p.quoted(ls, i)
+	case strings.HasPrefix(l.text, "|"):
+		return p.table(ls, i)
+	case isRule(l.text):
+		return NewNode("rule"), i + 1, nil
+	case headingLevel(l.text) > 0:
+		return p.heading(ls, i)
+	case p.expandTitle(l.text) != nil:
+		return p.expand(ls, i, parent)
+	case isMarker(l.text, p.gl):
+		return p.list(ls, i)
+	case isImageLine(l.text):
+		return p.media(ls, i)
+	}
+	return p.paragraph(ls, i)
+}
+
+// startsBlock reports whether a line would begin a new block, which is what
+// ends the paragraph above it. Prose is never wrapped by the renderer, so the
+// only reason a paragraph runs to a second line is a hard break.
+func (p *parser) startsBlock(l line) bool {
+	return isFence(l.text) || strings.HasPrefix(l.text, ">") || strings.HasPrefix(l.text, "|") ||
+		isRule(l.text) || headingLevel(l.text) > 0 || p.expandTitle(l.text) != nil ||
+		isMarker(l.text, p.gl) || isImageLine(l.text)
+}
+
+func (p *parser) paragraph(ls []line, i int) (Node, int, error) {
+	end := i + 1
+	for end < len(ls) && !ls[end].blank() && !p.startsBlock(ls[end]) {
+		end++
+	}
+	content, err := p.inline(ls[i:end])
+	if err != nil {
+		return Node{}, end, err
+	}
+	return NewNode("paragraph").WithContent(content...), end, nil
+}
+
+// headingLevel reports the level of an ATX heading, and zero for a line that is
+// not one. A row of hashes with nothing after it is prose: the renderer writes
+// nothing at all for a heading with no content, so a line that says only "#"
+// was typed rather than rendered, and reading it as a heading would delete it.
+func headingLevel(text string) int {
+	n := 0
+	for n < len(text) && text[n] == '#' {
+		n++
+	}
+	if n == 0 || n > 6 || n == len(text) || text[n] != ' ' {
+		return 0
+	}
+	if strings.TrimSpace(text[n:]) == "" {
+		return 0
+	}
+	return n
+}
+
+func (p *parser) heading(ls []line, i int) (Node, int, error) {
+	level := headingLevel(ls[i].text)
+	rest := line{text: strings.TrimSpace(ls[i].text[level:]), no: ls[i].no}
+	content, err := p.inline([]line{rest})
+	if err != nil {
+		return Node{}, i + 1, err
+	}
+	n := NewNode("heading").WithAttrs(Attrs{"level": level}).WithContent(content...)
+	return n, i + 1, nil
+}
+
+// isRule matches a thematic break. The renderer only ever writes "---", but a
+// document that has been through an editor can carry any of the three spellings.
+func isRule(text string) bool {
+	t := strings.TrimRight(text, " \t")
+	if len(t) < 3 {
+		return false
+	}
+	c := t[0]
+	if c != '-' && c != '*' && c != '_' {
+		return false
+	}
+	n := 0
+	for i := range len(t) {
+		switch t[i] {
+		case c:
+			n++
+		case ' ', '\t':
+		default:
+			return false
+		}
+	}
+	return n >= 3
+}
+
+func isFence(text string) bool { _, _, ok := fenceAt(text); return ok }
+
+// fenceAt reads a code fence, returning the character it is drawn with and how
+// long it is. A fence closes on a run of the same character at least as long.
+func fenceAt(text string) (c byte, n int, ok bool) {
+	if text == "" || (text[0] != '`' && text[0] != '~') {
+		return 0, 0, false
+	}
+	c = text[0]
+	for n < len(text) && text[n] == c {
+		n++
+	}
+	if n < 3 {
+		return 0, 0, false
+	}
+	if c == '`' && strings.ContainsRune(text[n:], '`') {
+		return 0, 0, false
+	}
+	return c, n, true
+}
+
+func (p *parser) codeBlock(ls []line, i int) (Node, int, error) {
+	c, n, _ := fenceAt(ls[i].text)
+	language := strings.TrimSpace(ls[i].text[n:])
+	end := i + 1
+	for end < len(ls) {
+		if cc, nn, ok := fenceAt(strings.TrimRight(ls[end].text, " \t")); ok && cc == c && nn >= n &&
+			strings.TrimRight(ls[end].text, " \t") == strings.Repeat(string(c), nn) {
+			break
+		}
+		end++
+	}
+	code := make([]string, 0, end-i-1)
+	for _, l := range ls[i+1 : end] {
+		code = append(code, l.text)
+	}
+	if end < len(ls) {
+		end++
+	}
+
+	node := NewNode("codeBlock")
+	if language != "" {
+		node = node.WithAttrs(Attrs{"language": language})
+	}
+	if text := sanitize(strings.Join(code, "\n")); text != "" {
+		node = node.WithContent(NewText(text))
+	}
+	return node, end, nil
+}
+
+// quoted reads the block a run of "> " lines carries. Three different nodes
+// come out of that prefix — a quote, a panel, and the marker the renderer
+// leaves where a node type it does not know used to be — so the prefix is
+// stripped first and the block identified from what is under it.
+func (p *parser) quoted(ls []line, i int) (Node, int, error) {
+	end := i
+	inner := make([]line, 0, 4)
+	for end < len(ls) && strings.HasPrefix(ls[end].text, ">") {
+		l := ls[end]
+		l.text = strings.TrimPrefix(l.text[1:], " ")
+		inner = append(inner, l)
+		end++
+	}
+
+	if typ, ok := unsupportedMarker(inner[0].text); ok {
+		return Node{}, end, p.fail(inner[0], fmt.Errorf("%w: %s", ErrUnsupportedMarker, typ))
+	}
+	if attrs, ok := p.panelAttrs(inner[0].text); ok {
+		content, err := p.blocks(inner[1:], "panel")
+		if err != nil {
+			return Node{}, end, err
+		}
+		return NewNode("panel").WithAttrs(attrs).WithContent(filled(content)...), end, nil
+	}
+	content, err := p.blocks(inner, "blockquote")
+	if err != nil {
+		return Node{}, end, err
+	}
+	return NewNode("blockquote").WithContent(filled(content)...), end, nil
+}
+
+// panelAttrs inverts the marker and label the renderer puts on a panel's first
+// line. An unknown panelType is rendered uppercased and comes back lowercased,
+// because ADF's own types are lower case and the original spelling is gone.
+func (p *parser) panelAttrs(text string) (Attrs, bool) {
+	marker, label, ok := strings.Cut(text, " ")
+	if !ok || !isLabel(label) {
+		return nil, false
+	}
+	switch {
+	case marker == p.gl.info && label == "INFO":
+		return Attrs{"panelType": "info"}, true
+	case marker == p.gl.note && label == "NOTE":
+		return Attrs{"panelType": "note"}, true
+	case marker == p.gl.success && (label == "SUCCESS" || label == "TIP"):
+		return Attrs{"panelType": strings.ToLower(label)}, true
+	case marker == p.gl.warning && label == "WARNING":
+		return Attrs{"panelType": "warning"}, true
+	case marker == p.gl.failure && label == "ERROR":
+		return Attrs{"panelType": "error"}, true
+	case marker == p.gl.custom && label == "PANEL":
+		return Attrs{"panelType": "custom"}, true
+	case marker == p.gl.custom:
+		return Attrs{"panelType": strings.ToLower(label)}, true
+	case label == "PANEL":
+		return Attrs{"panelType": "custom", "panelIconText": marker}, true
+	}
+	return nil, false
+}
+
+// isLabel reports whether a word is the shouted label the renderer writes
+// beside a panel marker, which is what tells a panel from a quote whose first
+// line happens to start with a glyph.
+func isLabel(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == ' ', r == '-', r == '_', r == '/':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// unsupportedMarker reads the marker the renderer leaves in place of a node
+// type it does not know, and reports the type it stood for.
+func unsupportedMarker(text string) (string, bool) {
+	const open = "[unsupported: "
+	if !strings.HasPrefix(text, open) || !strings.HasSuffix(text, "]") {
+		return "", false
+	}
+	body := text[len(open) : len(text)-1]
+	typ, _, _ := strings.Cut(body, ":")
+	if typ == "" {
+		return "", false
+	}
+	for i, r := range typ {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return "", false
+		}
+	}
+	return typ, true
+}
+
+func (p *parser) expandTitle(text string) *string {
+	if text != p.gl.expand && !strings.HasPrefix(text, p.gl.expand+" ") {
+		return nil
+	}
+	title := strings.TrimSpace(text[len(p.gl.expand):])
+	return &title
+}
+
+func (p *parser) expand(ls []line, i int, parent string) (Node, int, error) {
+	title := *p.expandTitle(ls[i].text)
+	end, inner := gather(ls, i+1, 2)
+
+	typ := "expand"
+	if parent == "expand" || parent == "nestedExpand" {
+		typ = "nestedExpand"
+	}
+	content, err := p.blocks(inner, typ)
+	if err != nil {
+		return Node{}, end, err
+	}
+	n := NewNode(typ).WithContent(filled(content)...)
+	if title != "" {
+		n = n.WithAttrs(Attrs{"title": title})
+	}
+	return n, end, nil
+}
+
+// gather collects the lines indented under a block that opened at i-1, undented
+// by width, and returns where the block ends. A blank line only continues the
+// block when something indented follows it.
+func gather(ls []line, i, width int) (end int, inner []line) {
+	for i < len(ls) {
+		if !ls[i].blank() {
+			if ls[i].indent() < width {
+				break
+			}
+			inner = append(inner, ls[i].undent(width))
+			i++
+			continue
+		}
+		next := i
+		for next < len(ls) && ls[next].blank() {
+			next++
+		}
+		if next == len(ls) || ls[next].indent() < width {
+			break
+		}
+		for ; i < next; i++ {
+			inner = append(inner, line{no: ls[i].no})
+		}
+	}
+	return i, inner
+}
+
+// marker is one list item's bullet, number or checkbox, and the width its
+// continuation lines are indented by.
+type marker struct {
+	list  string // bulletList, orderedList, taskList or decisionList
+	item  string // listItem, taskItem or decisionItem
+	width int
+	rest  string
+	attrs Attrs
+}
+
+func isMarker(text string, gl glyphs) bool { _, ok := markerAt(text, gl); return ok }
+
+func markerAt(text string, gl glyphs) (marker, bool) {
+	bullet, rest, ok := cutMarker(text)
+	if !ok {
+		return marker{}, false
+	}
+	if isDigit(bullet[0]) {
+		number, err := strconv.Atoi(bullet[:len(bullet)-2])
+		if err != nil {
+			return marker{}, false
+		}
+		return marker{
+			list: "orderedList", item: "listItem", rest: rest,
+			// ADF numbers a list from one. A list written to start at zero is
+			// rendered from one, so it is read back from one too.
+			width: ansi.StringWidth(bullet), attrs: Attrs{"order": max(number, 1)},
+		}, true
+	}
+	if box, tail, ok := cutInner(rest, "[ ]", "[x]", "[X]"); ok {
+		state := "TODO"
+		if box != "[ ]" {
+			state = "DONE"
+		}
+		return marker{
+			list: "taskList", item: "taskItem", rest: tail,
+			width: ansi.StringWidth(bullet) + len(box) + 1, attrs: Attrs{"state": state},
+		}, true
+	}
+	if _, tail, ok := cutInner(rest, gl.decision); ok {
+		return marker{
+			list: "decisionList", item: "decisionItem", rest: tail,
+			width: ansi.StringWidth(bullet+gl.decision) + 1, attrs: Attrs{"state": "DECIDED"},
+		}, true
+	}
+	return marker{list: "bulletList", item: "listItem", rest: rest, width: ansi.StringWidth(bullet)}, true
+}
+
+// cutInner takes the checkbox or the lozenge that follows a bullet off the rest
+// of the line. An item with nothing in it has the marker and no space after it,
+// because the renderer trims the trailing space off every line it writes.
+func cutInner(rest string, want ...string) (mark, tail string, ok bool) {
+	for _, w := range want {
+		switch {
+		case rest == w:
+			return w, "", true
+		case strings.HasPrefix(rest, w+" "):
+			return w, rest[len(w)+1:], true
+		}
+	}
+	return "", "", false
+}
+
+// cutMarker takes the marker off the front of a line: a bullet, an ordered
+// number, or the checkbox or lozenge that follows one. The marker keeps the
+// single space after it, because that space is part of the width the
+// continuation lines are indented by.
+func cutMarker(text string) (mark, rest string, ok bool) {
+	end := 0
+	switch {
+	case text == "":
+		return "", "", false
+	case text[0] == '-' || text[0] == '*' || text[0] == '+':
+		end = 1
+	default:
+		for end < len(text) && end < 9 && isDigit(text[end]) {
+			end++
+		}
+		if end == 0 || end == len(text) || (text[end] != '.' && text[end] != ')') {
+			return "", "", false
+		}
+		end++
+	}
+	switch {
+	case end == len(text):
+		// A line that is only a marker is an item with nothing in it, and the
+		// renderer writes those with a hyphen or a number. A lone star is the
+		// character an author typed.
+		if text[0] == '*' || text[0] == '+' {
+			return "", "", false
+		}
+		return text + " ", "", true
+	case text[end] == ' ':
+		return text[:end+1], text[end+1:], true
+	}
+	return "", "", false
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+// list reads one list. A blank line ends it: the renderer never puts one
+// between the items of a single list, so a blank line means the author started
+// a second one.
+func (p *parser) list(ls []line, i int) (Node, int, error) {
+	first, _ := markerAt(ls[i].text, p.gl)
+	node := NewNode(first.list)
+	if first.list == "orderedList" {
+		if order, _ := attrInt(first.attrs, "order"); order != 1 {
+			node = node.WithAttrs(Attrs{"order": order})
+		}
+	}
+
+	// A list runs to the end of its items even when one of them will not parse,
+	// so that a caller reconciling against an original document is told how far
+	// the list reached and can reuse the node it already had.
+	var failed error
+	for i < len(ls) {
+		// ADF's content model for a task or decision list is (item | list)+:
+		// indenting an action item in the editor stores a sibling list inside
+		// its parent rather than inside the item above it, and the renderer
+		// indents that sibling by two rather than by a marker's width.
+		if checklist(first.list) && !ls[i].blank() && ls[i].indent() > 0 {
+			end, inner := gather(ls, i, 2)
+			if end == i {
+				break
+			}
+			nested, err := p.blocks(inner, first.list)
+			failed = cmp.Or(failed, err)
+			node.Content = append(node.Content, nested...)
+			i = end
+			continue
+		}
+
+		m, ok := markerAt(ls[i].text, p.gl)
+		if !ok || m.list != first.list {
+			break
+		}
+		end, inner := gather(ls, i+1, m.width)
+		inner = append([]line{{text: m.rest, no: ls[i].no}}, inner...)
+
+		content, err := p.blocks(inner, m.item)
+		failed = cmp.Or(failed, err)
+		item := NewNode(m.item).WithContent(content...)
+		if m.item == "listItem" {
+			item = item.WithContent(filled(content)...)
+		} else {
+			item = item.WithAttrs(m.attrs)
+			// A task or decision item holds inline content where a list item
+			// holds blocks, so the paragraph the line parsed into is unwrapped.
+			if len(content) == 1 && content[0].Type == "paragraph" {
+				item = item.WithContent(content[0].Content...)
+			}
+		}
+		node.Content = append(node.Content, item)
+		i = end
+	}
+	return node, i, failed
+}
+
+func checklist(list string) bool { return list == "taskList" || list == "decisionList" }
+
+// filled gives a container that must hold at least one block an empty
+// paragraph to hold. An empty list item, quote or cell is something an author
+// can write, and ADF has no shape for a container with nothing in it.
+func filled(content []Node) []Node {
+	if len(content) > 0 {
+		return content
+	}
+	return []Node{NewNode("paragraph")}
+}
+
+// media reads a run of image lines, and the caption line the renderer puts
+// under a single one. Several images with no blank line between them are one
+// group, which is how ADF stores an editor's row of attachments.
+func (p *parser) media(ls []line, i int) (Node, int, error) {
+	end := i
+	var images []Node
+	for end < len(ls) && isImageLine(ls[end].text) {
+		n, _, ok := imageNode(ls[end].text, "media")
+		if !ok {
+			break
+		}
+		images = append(images, n)
+		end++
+	}
+	switch {
+	case len(images) == 0:
+		return p.paragraph(ls, i)
+	case len(images) > 1:
+		return NewNode("mediaGroup").WithContent(images...), end, nil
+	}
+
+	single := NewNode("mediaSingle").WithContent(images...)
+	if end < len(ls) && !ls[end].blank() && !p.startsBlock(ls[end]) {
+		caption, err := p.inline(ls[end : end+1])
+		if err != nil {
+			return Node{}, end + 1, err
+		}
+		single = single.WithContent(images[0],
+			NewNode("caption").WithContent(NewNode("paragraph").WithContent(caption...)))
+		end++
+	}
+	return single, end, nil
+}
+
+func isImageLine(text string) bool {
+	_, n, ok := imageNode(text, "media")
+	return ok && n == len(text)
+}

--- a/pkg/adf/parse_bench_test.go
+++ b/pkg/adf/parse_bench_test.go
@@ -1,0 +1,120 @@
+package adf_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// The parse path runs once per save, not once per frame, so what is guarded
+// here is the shape of the cost rather than a frame budget: parsing has to stay
+// linear in the text, and reconciling an untouched document has to cost about
+// what one render costs rather than a re-encode of the whole tree.
+
+var docSink adf.Doc
+
+// known drops the node the fixture carries to prove an unknown type survives.
+// A parse with no original to restore it from refuses that marker on purpose,
+// which is a case for a test rather than for a benchmark.
+func known(d adf.Doc) adf.Doc {
+	content := make([]adf.Node, 0, len(d.Content))
+	for i := range d.Content {
+		if n := d.Content[i]; !strings.HasPrefix(n.Type, "future") {
+			content = append(content, n)
+		}
+	}
+	return adf.NewDoc(content...)
+}
+
+func BenchmarkParseMarkdown_RichFixture(b *testing.B) {
+	md := adf.Markdown(known(fixtureDescription(b)))
+	b.SetBytes(int64(len(md)))
+	b.ReportAllocs()
+	for b.Loop() {
+		d, err := adf.ParseMarkdown(md)
+		if err != nil {
+			b.Fatal(err)
+		}
+		docSink = d
+	}
+}
+
+func BenchmarkParseMarkdown_LargeDocument(b *testing.B) {
+	md := adf.Markdown(known(largeDoc(b, 200)))
+	b.SetBytes(int64(len(md)))
+	b.ReportAllocs()
+	for b.Loop() {
+		d, err := adf.ParseMarkdown(md)
+		if err != nil {
+			b.Fatal(err)
+		}
+		docSink = d
+	}
+}
+
+// BenchmarkParseMarkdown_Prose is the common case: a comment body, all text and
+// no markup, which must not pay for the reading-check the ambiguous lines do.
+func BenchmarkParseMarkdown_Prose(b *testing.B) {
+	md := strings.TrimSpace(strings.Repeat("The basket total is recalculated before the line items are read.\n\n", 200))
+	b.SetBytes(int64(len(md)))
+	b.ReportAllocs()
+	for b.Loop() {
+		d, err := adf.ParseMarkdown(md)
+		if err != nil {
+			b.Fatal(err)
+		}
+		docSink = d
+	}
+}
+
+func BenchmarkParseMarkdownInto_Unchanged(b *testing.B) {
+	d := largeDoc(b, 200)
+	md := adf.Markdown(d)
+	b.SetBytes(int64(len(md)))
+	b.ReportAllocs()
+	for b.Loop() {
+		out, err := adf.ParseMarkdownInto(d, md, adf.Options{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		docSink = out
+	}
+}
+
+func BenchmarkParseMarkdownInto_OneBlockEdited(b *testing.B) {
+	d := largeDoc(b, 200)
+	md := strings.Replace(adf.Markdown(d), "The basket total is", "The basket sum is", 1)
+	b.SetBytes(int64(len(md)))
+	b.ReportAllocs()
+	for b.Loop() {
+		out, err := adf.ParseMarkdownInto(d, md, adf.Options{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		docSink = out
+	}
+}
+
+// BenchmarkParseMarkdown_ScalesWithTheText is the assertion the numbers above
+// cannot make on their own: ten times the text costs about ten times as much,
+// not a hundred. A parser that rescans a line per delimiter passes every other
+// test in this file and then falls over on a description somebody pasted a log
+// into.
+func BenchmarkParseMarkdown_ScalesWithTheText(b *testing.B) {
+	for _, size := range []int{1, 10, 100} {
+		md := strings.TrimSpace(strings.Repeat(
+			"A **bold** claim about `basketTotal()` and [the runbook](https://example.com/x).\n\n", size*20))
+		b.Run(itoa(size), func(b *testing.B) {
+			b.SetBytes(int64(len(md)))
+			b.ReportAllocs()
+			for b.Loop() {
+				d, err := adf.ParseMarkdown(md)
+				if err != nil {
+					b.Fatal(err)
+				}
+				docSink = d
+			}
+		})
+	}
+}

--- a/pkg/adf/parse_fuzz_test.go
+++ b/pkg/adf/parse_fuzz_test.go
@@ -1,0 +1,312 @@
+package adf_test
+
+import (
+	"errors"
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// FuzzParseMarkdown asserts the two things that must hold for any input at all,
+// including input no renderer produced: the parser answers a document Jira
+// would accept, and rendering and re-parsing it settles.
+//
+// Settling is what stops a save from eating text. The first render is allowed
+// to change the markdown, because the renderer does not escape prose — a
+// paragraph that reads "0)" is spelled exactly like an ordered list, and one
+// pass through markdown makes it one. What must not happen is drift: a document
+// that grows a marker, or loses a character, every time it is opened and saved.
+// TestParseMarkdown_HoldsBothPropertiesOverGeneratedDocuments asserts the
+// stronger one-pass version over documents that started life as ADF.
+func FuzzParseMarkdown(f *testing.F) {
+	for _, seed := range []string{
+		"", "\n", "   ", "\r\n", "a", "# a", "###### a", "####### a",
+		"- a\n- b", "1. a\n2. b", "9. a", "- [ ] a\n- [x] b", "- ◇ a",
+		"- a\n  - b\n    - c", "- a\n\n  b", "-", "- ",
+		"> a", ">", "> a\n>\n> b", "> ℹ INFO\n> a", "> ◆ PANEL\n> a", "> 🛠 PANEL\n> a",
+		"> [unsupported: futureBlock]\n> a", "[unsupported: futureInline]",
+		"```", "```go\na\n```", "````\n```\n````", "```\n\n```", "~~~\na\n~~~",
+		"---", "***", "___", "- - -",
+		"| a | b |", "| a | b |\n| - | - |\n| 1 | 2 |", `| a \| b |`, "|  |  |", "|",
+		"**a**", "*a*", "~~a~~", "_a_", "`a`", "``a ` b``", "`` ` ``",
+		"***a***", "**a *b* c**", "*a **b** c*", "a_b_c", "__a__",
+		"[a](b)", "[a [b] c](d)", "[a](<b c>)", "[a](<b%3Cc%3E d>)", "<https://x/y>", "<a>",
+		"![a](media:1)", "![a](media:1)\n![b](media:2)", "![a](media:1)\ncaption", "![](x)",
+		"▾ a\n  b", "▾", "v a\n  b",
+		"a\nb", "a\n- b", "- a\n# b", "a | b", "a  ",
+		"a\n\n\n\nb", "\ufeffa", "# \n\n#",
+		"> | a |", "> # a", "- | a |",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, md string) {
+		for _, opt := range []adf.Options{{}, {ASCII: true}} {
+			at := md
+			for range 4 {
+				d, err := adf.ParseMarkdownWith(at, opt)
+				if err != nil {
+					var perr *adf.ParseError
+					if !errors.As(err, &perr) {
+						t.Fatalf("%q: an error that is not a *adf.ParseError: %v", at, err)
+					}
+					break
+				}
+				mustBeValid(t, d, at)
+				next := adf.MarkdownWith(d, opt)
+				if next == at {
+					break
+				}
+				if at = next; at == "" {
+					break
+				}
+			}
+			settled, err := adf.ParseMarkdownWith(at, opt)
+			if err != nil {
+				continue
+			}
+			if got := adf.MarkdownWith(settled, opt); got != at {
+				t.Fatalf("%q does not settle\n--- at ---\n%q\n--- then ---\n%q", md, at, got)
+			}
+		}
+	})
+}
+
+// mustBeValid checks the rules a document has to obey before Jira will look at
+// what is in it.
+func mustBeValid(tb testing.TB, d adf.Doc, from string) {
+	tb.Helper()
+	if d.Version != 1 || d.Type != "doc" {
+		tb.Fatalf("%q answered version %d type %q", from, d.Version, d.Type)
+	}
+	d.Walk(func(n adf.Node) bool {
+		switch {
+		case n.Type == "":
+			tb.Fatalf("%q answered a node with no type", from)
+		case n.Type == "text" && n.Text == "":
+			tb.Fatalf("%q answered an empty text node", from)
+		case n.Type != "text" && n.Text != "":
+			tb.Fatalf("%q answered a %s carrying text", from, n.Type)
+		}
+		return true
+	})
+	if _, err := adf.Marshal(d); err != nil {
+		tb.Fatalf("%q answered a document that will not encode: %v", from, err)
+	}
+}
+
+// TestParseMarkdown_HoldsBothPropertiesOverGeneratedDocuments walks a few
+// thousand documents nobody would write by hand. The seeded generator makes the
+// failures reproducible, and the seed is printed with any of them.
+//
+// Byte-stability is asserted for every option set. The fixed point is asserted
+// only where the markdown is what a caller would hand to an editor: bounding a
+// table's width truncates its cells, and truncation is not a round trip.
+func TestParseMarkdown_HoldsBothPropertiesOverGeneratedDocuments(t *testing.T) {
+	t.Parallel()
+	for seed := range seeds() {
+		rng := rand.New(rand.NewPCG(seed, 0x5a4a1))
+		in := generated(rng)
+		d := parse(t, in)
+
+		for _, opt := range renderOptions() {
+			md := adf.MarkdownWith(d, opt)
+
+			into, err := adf.ParseMarkdownInto(d, md, opt)
+			if err != nil {
+				t.Fatalf("seed %d %+v: %v\n%s", seed, opt, err, in)
+			}
+			if got, want := encoded(t, into), encoded(t, d); got != want {
+				t.Fatalf("seed %d %+v: an untouched document did not come back\n--- want ---\n%s\n--- got ---\n%s\n--- markdown ---\n%s",
+					seed, opt, want, got, md)
+			}
+
+			if opt.TableWidth != 0 {
+				continue
+			}
+			fresh, err := adf.ParseMarkdownWith(md, opt)
+			if errors.Is(err, adf.ErrUnsupportedMarker) {
+				continue
+			}
+			if err != nil {
+				t.Fatalf("seed %d %+v: %v\n%s", seed, opt, err, md)
+			}
+			mustBeValid(t, fresh, md)
+			if twice := adf.MarkdownWith(fresh, opt); twice != md {
+				t.Fatalf("seed %d %+v: the render does not settle\n--- once ---\n%q\n--- twice ---\n%q",
+					seed, opt, md, twice)
+			}
+		}
+	}
+}
+
+// seeds is how many documents to walk. The number is a trade against the race
+// suite's wall clock, which pays about ten times per document; raising it
+// locally and running without -race is how to go looking for more.
+func seeds() uint64 {
+	if testing.Short() {
+		return 200
+	}
+	return 1500
+}
+
+// generated builds one ADF document as JSON. It writes JSON rather than nodes
+// so that the failing case can be pasted straight into a test.
+func generated(rng *rand.Rand) string {
+	blocks := make([]string, 0, 8)
+	for range rng.IntN(7) + 1 {
+		blocks = append(blocks, genBlock(rng, 0))
+	}
+	return wrap(strings.Join(blocks, ","))
+}
+
+func genBlock(rng *rand.Rand, depth int) string {
+	kinds := []string{"paragraph", "heading", "bulletList", "orderedList", "codeBlock", "rule",
+		"panel", "table", "taskList", "decisionList", "blockquote", "expand", "mediaSingle", "unknown"}
+	if depth > 0 {
+		// ADF has no shape for a heading, a rule or a table below the root, and
+		// the parser refuses to invent one, so the generator does not either.
+		kinds = []string{"paragraph", "bulletList", "orderedList", "codeBlock", "taskList", "mediaSingle"}
+	}
+	switch kinds[rng.IntN(len(kinds))] {
+	case "heading":
+		// No hard break: a heading is one line in markdown and cannot hold one.
+		return node("heading", `"attrs":{"level":`+itoa(rng.IntN(6)+1)+`},"content":[`+text(genWords(rng))+`]`)
+	case "bulletList":
+		return node("bulletList", `"content":[`+genItems(rng, depth, "listItem")+`]`)
+	case "orderedList":
+		return node("orderedList", `"attrs":{"order":`+itoa(rng.IntN(20)+1)+`},"content":[`+genItems(rng, depth, "listItem")+`]`)
+	case "codeBlock":
+		return node("codeBlock", `"attrs":{"language":"`+pick(rng, "go", "sh", "")+`"},"content":[`+
+			text(pick(rng, `x := 1`, `a\nb`, `if x {\n\tdo()\n}`, "`"+"`"+"`"))+`]`)
+	case "rule":
+		return node("rule", "")
+	case "panel":
+		return node("panel", `"attrs":{"panelType":"`+pick(rng, "info", "note", "warning", "error", "success", "custom", "surprise")+
+			`"},"content":[`+node("paragraph", `"content":[`+genInline(rng)+`]`)+`]`)
+	case "table":
+		return genTable(rng)
+	case "taskList":
+		return node("taskList", `"content":[`+genItems(rng, depth, "taskItem")+`]`)
+	case "decisionList":
+		return node("decisionList", `"content":[`+genItems(rng, depth, "decisionItem")+`]`)
+	case "blockquote":
+		return node("blockquote", `"content":[`+node("paragraph", `"content":[`+genInline(rng)+`]`)+`]`)
+	case "expand":
+		return node("expand", `"attrs":{"title":"`+pick(rng, "The long version", "")+`"},"content":[`+
+			node("paragraph", `"content":[`+genInline(rng)+`]`)+`]`)
+	case "mediaSingle":
+		return node("mediaSingle", `"content":[{"type":"media","attrs":{"id":"`+
+			pick(rng, "3f6b", "a1", "c9d2")+`","type":"file","collection":"jira-issue-1"}}]`)
+	case "unknown":
+		return node("futureBlock", `"attrs":{"variant":"callout"},"content":[`+
+			node("paragraph", `"content":[`+genInline(rng)+`]`)+`]`)
+	}
+	return node("paragraph", `"content":[`+genInline(rng)+`]`)
+}
+
+func genItems(rng *rand.Rand, depth int, item string) string {
+	items := make([]string, 0, 3)
+	for range rng.IntN(3) + 1 {
+		switch item {
+		case "taskItem":
+			items = append(items, node("taskItem", `"attrs":{"state":"`+pick(rng, "TODO", "DONE")+`"},"content":[`+genInline(rng)+`]`))
+		case "decisionItem":
+			items = append(items, node("decisionItem", `"attrs":{"state":"DECIDED"},"content":[`+genInline(rng)+`]`))
+		default:
+			body := node("paragraph", `"content":[`+genInline(rng)+`]`)
+			if depth < 2 && rng.IntN(3) == 0 {
+				body += "," + genBlock(rng, depth+1)
+			}
+			items = append(items, node("listItem", `"content":[`+body+`]`))
+		}
+	}
+	return strings.Join(items, ",")
+}
+
+func genTable(rng *rand.Rand) string {
+	columns, header := rng.IntN(3)+1, rng.IntN(2) == 0
+	rows := make([]string, 0, 3)
+	for r := range rng.IntN(3) + 1 {
+		cells := make([]string, 0, columns)
+		for range columns {
+			typ := "tableCell"
+			if header && r == 0 {
+				typ = "tableHeader"
+			}
+			cells = append(cells, node(typ, `"content":[`+node("paragraph", `"content":[`+genInline(rng)+`]`)+`]`))
+		}
+		rows = append(rows, node("tableRow", `"content":[`+strings.Join(cells, ",")+`]`))
+	}
+	return node("table", `"attrs":{"layout":"default"},"content":[`+strings.Join(rows, ",")+`]`)
+}
+
+// genInline builds a run of inline nodes. Its words start with a letter on
+// purpose: the renderer does not escape prose, so text that begins a line with
+// a bullet or a hash reads back as the block it looks like, which is the one
+// ambiguity this dialect cannot resolve and which has its own test.
+func genInline(rng *rand.Rand) string {
+	out := make([]string, 0, 4)
+	for range rng.IntN(4) + 1 {
+		switch rng.IntN(10) {
+		case 0:
+			out = append(out, `{"type":"mention","attrs":{"id":"5b10ac8d","text":"@Someone"}}`)
+		case 1:
+			out = append(out, `{"type":"status","attrs":{"text":"Blocked","color":"red"}}`)
+		case 2:
+			out = append(out, `{"type":"emoji","attrs":{"shortName":":smile:","id":"1f604","text":"😄"}}`)
+		case 3:
+			out = append(out, `{"type":"inlineCard","attrs":{"url":"https://example.com/p"}}`)
+		case 4:
+			out = append(out, `{"type":"text","text":"`+genWords(rng)+`","marks":[`+genMarks(rng)+`]}`)
+		case 5:
+			// Never first: a hard break with nothing before it on its line is
+			// a blank line in markdown, and markdown drops those between
+			// blocks. TestParseMarkdown_CannotUndoTheseRenderings covers it.
+			if len(out) == 0 {
+				out = append(out, text(genWords(rng)))
+				continue
+			}
+			out = append(out, `{"type":"hardBreak"}`, text(genWords(rng)))
+		case 6:
+			out = append(out, `{"type":"futureInline","attrs":{"x":1}}`)
+		default:
+			out = append(out, text(genWords(rng)))
+		}
+	}
+	return strings.Join(out, ",")
+}
+
+func genWords(rng *rand.Rand) string {
+	words := make([]string, 0, 4)
+	words = append(words, pick(rng, "basket", "checkout", "order", "retry", "staging"))
+	for range rng.IntN(4) {
+		words = append(words, pick(rng,
+			"total", "empty", "日本語", "e\\u0301cole", "snake_case", "a|b", "x(y)",
+			"two  spaces", "trailing", "0", "-", "*", "#", "|", "[x]", "@you"))
+	}
+	return strings.Join(words, " ")
+}
+
+func genMarks(rng *rand.Rand) string {
+	all := []string{`{"type":"strong"}`, `{"type":"em"}`, `{"type":"strike"}`,
+		`{"type":"underline"}`, `{"type":"code"}`, `{"type":"link","attrs":{"href":"https://example.com/x"}}`}
+	rng.Shuffle(len(all), func(i, j int) { all[i], all[j] = all[j], all[i] })
+	return strings.Join(all[:rng.IntN(3)+1], ",")
+}
+
+func pick(rng *rand.Rand, from ...string) string { return from[rng.IntN(len(from))] }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/pkg/adf/parse_inline.go
+++ b/pkg/adf/parse_inline.go
@@ -1,0 +1,492 @@
+package adf
+
+import (
+	"fmt"
+	"strings"
+)
+
+// markSet is the emphasis in force at a point in the scan. The renderer wraps
+// text in a fixed order — link outermost, then strong, em, strike, underline,
+// and code innermost — so reading that order back is a matter of recursing
+// once per delimiter rather than of pairing delimiters after the fact.
+type markSet struct {
+	strong, em, strike, underline, code bool
+	linked                              bool
+	plain                               bool // emphasis markers are characters, not markers
+	href                                string
+}
+
+// marks builds the mark list in ProseMirror rank order, which is the order the
+// Jira editor writes and therefore the order a document that has been opened in
+// a browser comes back in.
+func (m markSet) marks() []Mark {
+	var out []Mark
+	if m.linked {
+		out = append(out, NewMark("link", Attrs{"href": m.href}))
+	}
+	if m.em {
+		out = append(out, NewMark("em", nil))
+	}
+	if m.strong {
+		out = append(out, NewMark("strong", nil))
+	}
+	if m.strike {
+		out = append(out, NewMark("strike", nil))
+	}
+	if m.underline {
+		out = append(out, NewMark("underline", nil))
+	}
+	if m.code {
+		out = append(out, NewMark("code", nil))
+	}
+	return out
+}
+
+// inline turns the lines of one paragraph into inline nodes. A paragraph only
+// runs to a second line because the author put a hard break there: the renderer
+// never wraps prose, so that a viewport can reflow it.
+//
+// What it reads is checked against what it would render, and a reading that
+// does not reproduce the line it came from is thrown away for one that treats
+// the markers as the characters they are. Star soup — adjacent runs of emphasis
+// whose marks overlap — has no single reading, and picking one anyway is how a
+// paragraph grows a marker every time somebody saves it. The last reading is
+// the line itself as prose, which always renders back to what it was, so this
+// never answers something that would come out different next time.
+func (p *parser) inline(ls []line) ([]Node, error) {
+	out, err := p.inlineWith(ls, markSet{})
+	if err != nil {
+		return nil, err
+	}
+	if !ambiguous(ls) || p.rendersBack(out, ls) {
+		return out, nil
+	}
+	if plain, err := p.inlineWith(ls, markSet{plain: true}); err == nil && p.rendersBack(plain, ls) {
+		return plain, nil
+	}
+	return p.prose(ls), nil
+}
+
+// prose is the reading of last resort: every line as the characters it holds.
+func (p *parser) prose(ls []line) []Node {
+	var out []Node
+	for i := range ls {
+		if i > 0 {
+			out = append(out, NewNode("hardBreak"))
+		}
+		if text := sanitize(strings.TrimRight(ls[i].text, " \t")); text != "" {
+			out = append(out, NewText(text))
+		}
+	}
+	return out
+}
+
+func (p *parser) inlineWith(ls []line, ms markSet) ([]Node, error) {
+	var out []Node
+	for i := range ls {
+		if i > 0 {
+			out = append(out, NewNode("hardBreak"))
+		}
+		nodes, err := p.scan(sanitize(strings.TrimRight(ls[i].text, " \t")), ls[i], ms)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, nodes...)
+	}
+	return merge(out), nil
+}
+
+// ambiguous reports whether a paragraph is worth checking, which is only when
+// it holds a character a marker can start with. Prose that holds none of them
+// is its own rendering.
+func ambiguous(ls []line) bool {
+	for i := range ls {
+		if strings.ContainsAny(ls[i].text, "*_~`[<!") {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) rendersBack(nodes []Node, ls []line) bool {
+	p.scratch = AppendMarkdown(p.scratch[:0], NewDoc(NewNode("paragraph").WithContent(nodes...)), p.opt)
+	at := 0
+	for i := range ls {
+		want := sanitize(strings.TrimRight(ls[i].text, " \t"))
+		if i > 0 {
+			if at >= len(p.scratch) || p.scratch[at] != '\n' {
+				return false
+			}
+			at++
+		}
+		if len(p.scratch)-at < len(want) || string(p.scratch[at:at+len(want)]) != want {
+			return false
+		}
+		at += len(want)
+	}
+	return at == len(p.scratch)
+}
+
+func (p *parser) scan(s string, ln line, ms markSet) ([]Node, error) {
+	var out []Node
+	start := 0
+	flush := func(end int) {
+		if end > start {
+			out = append(out, NewText(s[start:end], ms.marks()...))
+		}
+	}
+	// emphasis reads a delimited run. A marker with a space inside it is not
+	// emphasis — the renderer keeps the spaces outside the markers precisely so
+	// that "*a* b" cannot be read as one run — and an underscore that continues
+	// a word is a name.
+	emphasis := func(i int, delim string, inner markSet) (int, error) {
+		body := i + len(delim)
+		if body >= len(s) || spaceByte(s[body]) {
+			return 0, nil
+		}
+		// Strong wraps em, so "***both***" opens with two stars and one, and the
+		// closing run has to give its last two back to the strong. A plain
+		// "**a****b**" is two runs of two and closes at the front of each.
+		tail := delim == "**" && runLen(s, i, '*') > 2
+
+		for at := findClose(s, delim, body); at >= body; at = findClose(s, delim, at+1) {
+			end := at
+			if tail {
+				end = at + runLen(s, at, '*') - 2
+			}
+			switch {
+			case end <= body || spaceByte(s[end-1]):
+			case delim == "_" && end+1 < len(s) && wordByte(s[end+1]):
+			default:
+				flush(i)
+				nodes, err := p.scan(s[body:end], ln, inner)
+				if err != nil {
+					return 0, err
+				}
+				out = append(out, nodes...)
+				return end + len(delim), nil
+			}
+		}
+		return 0, nil
+	}
+
+	for i := 0; i < len(s); {
+		var next int
+		var err error
+		switch {
+		case s[i] == '`' && !ms.code:
+			if content, n, ok := codeSpanAt(s[i:]); ok {
+				flush(i)
+				coded := ms
+				coded.code = true
+				if content != "" {
+					out = append(out, NewText(content, coded.marks()...))
+				}
+				next = i + n
+			}
+		case strings.HasPrefix(s[i:], "!["):
+			if node, n, ok := imageNode(s[i:], "mediaInline"); ok {
+				flush(i)
+				out = append(out, node)
+				next = i + n
+			}
+		case s[i] == '[':
+			if typ, ok := unsupportedMarker(markerSpan(s[i:])); ok {
+				return nil, p.fail(ln, fmt.Errorf("%w: %s", ErrUnsupportedMarker, typ))
+			}
+			if !ms.linked {
+				if text, dest, n, ok := linkAt(s[i:]); ok {
+					linked := ms
+					linked.linked, linked.href = true, dest
+					flush(i)
+					nodes, scanErr := p.scan(text, ln, linked)
+					if scanErr != nil {
+						return nil, scanErr
+					}
+					out = append(out, nodes...)
+					next = i + n
+				}
+			}
+		case s[i] == '<' && !ms.linked:
+			if url, n, ok := autolinkAt(s[i:]); ok {
+				flush(i)
+				linked := ms
+				linked.linked, linked.href = true, url
+				out = append(out, NewText(url, linked.marks()...))
+				next = i + n
+			}
+		case strings.HasPrefix(s[i:], "**") && !ms.strong && !ms.plain:
+			strong := ms
+			strong.strong = true
+			next, err = emphasis(i, "**", strong)
+		case strings.HasPrefix(s[i:], "~~") && !ms.strike && !ms.plain:
+			strike := ms
+			strike.strike = true
+			next, err = emphasis(i, "~~", strike)
+		case s[i] == '*' && !ms.em && !ms.plain:
+			em := ms
+			em.em = true
+			next, err = emphasis(i, "*", em)
+		case s[i] == '_' && !ms.underline && !ms.plain && (i == 0 || !wordByte(s[i-1])):
+			underline := ms
+			underline.underline = true
+			next, err = emphasis(i, "_", underline)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if next > i {
+			i, start = next, next
+			continue
+		}
+		i++
+	}
+	flush(len(s))
+	return out, nil
+}
+
+// merge joins neighbouring runs of unmarked text, so that a paragraph does not
+// come out of the parser split at every delimiter that turned out not to be
+// one. Marked runs are left alone: two links in a row are two links, and
+// joining them turns a pair of bare addresses into one link with both of them
+// as its text.
+func merge(in []Node) []Node {
+	out := make([]Node, 0, len(in))
+	for i := range in {
+		last := len(out) - 1
+		if last >= 0 && plainText(in[i]) && plainText(out[last]) {
+			out[last].Text += in[i].Text
+			continue
+		}
+		out = append(out, in[i])
+	}
+	return out
+}
+
+func plainText(n Node) bool { return n.Type == "text" && len(n.Marks) == 0 }
+
+// codeSpanAt reads a backtick span, undoing the padding the renderer adds when
+// the code itself starts or ends with a backtick.
+func codeSpanAt(s string) (content string, n int, ok bool) {
+	fence := 0
+	for fence < len(s) && s[fence] == '`' {
+		fence++
+	}
+	rest := s[fence:]
+	for i := 0; i < len(rest); {
+		if rest[i] != '`' {
+			i++
+			continue
+		}
+		run := i
+		for run < len(rest) && rest[run] == '`' {
+			run++
+		}
+		if run-i == fence {
+			return unpad(rest[:i]), fence + run, true
+		}
+		i = run
+	}
+	return "", 0, false
+}
+
+func unpad(s string) string {
+	if len(s) >= 2 && s[0] == ' ' && s[len(s)-1] == ' ' && strings.Trim(s, " ") != "" {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// linkAt reads "[text](dest)". The renderer does not escape the text, so a
+// bracket inside it is matched by depth rather than by the first "]".
+func linkAt(s string) (text, dest string, n int, ok bool) {
+	if s == "" || s[0] != '[' {
+		return "", "", 0, false
+	}
+	shut := closeBracket(s)
+	if shut < 0 || shut+1 >= len(s) || s[shut+1] != '(' {
+		return "", "", 0, false
+	}
+	text, i := s[1:shut], shut+2
+
+	if i < len(s) && s[i] == '<' {
+		end := strings.IndexByte(s[i:], '>')
+		if end < 0 || i+end+1 >= len(s) || s[i+end+1] != ')' {
+			return "", "", 0, false
+		}
+		return text, unangle(s[i+1 : i+end]), i + end + 2, true
+	}
+	depth := 1
+	for j := i; j < len(s); j++ {
+		switch s[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return text, s[i:j], j + 1, true
+			}
+		}
+	}
+	return "", "", 0, false
+}
+
+func closeBracket(s string) int {
+	depth := 0
+	for i := 0; i < len(s); {
+		if s[i] == '`' {
+			if _, n, ok := codeSpanAt(s[i:]); ok {
+				i += n
+				continue
+			}
+		}
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+// markerSpan returns the bracketed run starting at s, which is what an
+// "[unsupported: …]" marker is tested against.
+func markerSpan(s string) string {
+	if shut := closeBracket(s); shut > 0 {
+		return s[:shut+1]
+	}
+	return ""
+}
+
+// angles undoes what the renderer had to do to put an address inside angle
+// brackets. It only ever runs on a destination that arrived in that form, which
+// is one the renderer only writes for an address holding a space, a bracket or
+// a parenthesis.
+var unangles = strings.NewReplacer("%3C", "<", "%3E", ">")
+
+func unangle(s string) string { return unangles.Replace(s) }
+
+func autolinkAt(s string) (url string, n int, ok bool) {
+	if s == "" || s[0] != '<' {
+		return "", 0, false
+	}
+	end := strings.IndexByte(s, '>')
+	if end < 2 {
+		return "", 0, false
+	}
+	url = s[1:end]
+	if strings.ContainsAny(url, " \t<") || !hasScheme(url) {
+		return "", 0, false
+	}
+	return url, end + 1, true
+}
+
+func hasScheme(s string) bool {
+	if s == "" || !letterByte(s[0]) {
+		return false
+	}
+	for i := range len(s) {
+		switch c := s[i]; {
+		case letterByte(c) || isDigit(c) || c == '+' || c == '-' || c == '.':
+		case c == ':':
+			return i+1 < len(s)
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// findClose finds the delimiter that closes an emphasis run, stepping over the
+// spans that are not prose: a closing marker inside a code span or inside a
+// link's address is not a closing marker.
+//
+// A doubled star met while looking for the end of an em run is the ambiguity of
+// this dialect. "*a**b*" is two italic runs the renderer wrote side by side
+// because their other marks differ, and "*a **b** c*" is one italic sentence
+// with a bold word in it. What tells them apart is where the spaces are: a run
+// with a space in front of it cannot end anything, so it opens a strong that a
+// later run has to close, and that later run is spoken for.
+func findClose(s, delim string, from int) int {
+	strong := 0
+	for i := from; i < len(s); {
+		if s[i] == '`' {
+			if _, n, ok := codeSpanAt(s[i:]); ok {
+				i += n
+				continue
+			}
+		}
+		if s[i] == '[' || strings.HasPrefix(s[i:], "![") {
+			at := i
+			if s[i] == '!' {
+				at++
+			}
+			if _, _, n, ok := linkAt(s[at:]); ok {
+				i = at + n
+				continue
+			}
+		}
+		if delim == "*" && strings.HasPrefix(s[i:], "**") {
+			n := runLen(s, i, '*')
+			opens := i+n < len(s) && !spaceByte(s[i+n])
+			switch closes := i > from && !spaceByte(s[i-1]); {
+			case closes && strong == 0:
+				return i
+			case closes && strong > 0:
+				strong--
+			case opens:
+				strong++
+			}
+			i += n
+			continue
+		}
+		if strings.HasPrefix(s[i:], delim) {
+			return i
+		}
+		i++
+	}
+	return -1
+}
+
+func runLen(s string, at int, c byte) int {
+	n := 0
+	for at+n < len(s) && s[at+n] == c {
+		n++
+	}
+	return n
+}
+
+// imageNode reads "![alt](dest)" into a media node of the given type.
+func imageNode(s, typ string) (Node, int, bool) {
+	if !strings.HasPrefix(s, "![") {
+		return Node{}, 0, false
+	}
+	alt, dest, n, ok := linkAt(s[1:])
+	if !ok || dest == "" {
+		return Node{}, 0, false
+	}
+	attrs := Attrs{}
+	if id, found := strings.CutPrefix(dest, "media:"); found && id != "" {
+		attrs["id"], attrs["type"] = id, "file"
+	} else {
+		attrs["url"], attrs["type"] = dest, "external"
+	}
+	// The renderer spells a missing alt "media", so that is what it means here.
+	if alt != "" && alt != "media" {
+		attrs["alt"] = alt
+	}
+	return NewNode(typ).WithAttrs(attrs), n + 1, true
+}
+
+func letterByte(c byte) bool { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
+
+func spaceByte(c byte) bool { return c == ' ' || c == '\t' }
+
+// wordByte reports whether a byte continues a word, which is what stops
+// snake_case from reading as underlined text.
+func wordByte(c byte) bool { return letterByte(c) || isDigit(c) || c >= 0x80 }

--- a/pkg/adf/parse_oneway_test.go
+++ b/pkg/adf/parse_oneway_test.go
@@ -1,0 +1,142 @@
+package adf_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// TestParseMarkdown_CannotUndoTheseRenderings pins the cases where ADF →
+// markdown is not invertible, with the answer the parser actually gives. Every
+// one of them is a place the renderer had to choose between showing a reader
+// what the author typed and keeping enough to rebuild the node, and chose the
+// reader — which is the right call for a viewer and the reason
+// [adf.ParseMarkdownInto] exists.
+//
+// A case moving out of this table is a fix. A case appearing in it that nobody
+// wrote down is a bug. The width case is next door, because it needs a table
+// wide enough to be truncated.
+func TestParseMarkdown_CannotUndoTheseRenderings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		in    string // ADF
+		once  string // what the renderer writes
+		twice string // what rendering the parse of that writes
+	}{
+		{
+			name:  "prose that begins a line with a marker, because the renderer does not escape",
+			in:    wrap(para(text("- not a list"))),
+			once:  "- not a list",
+			twice: "- not a list",
+		},
+		{
+			name:  "a hard break followed by a line that reads as a block",
+			in:    wrap(para(text("above") + `,{"type":"hardBreak"},` + text("- below"))),
+			once:  "above\n- below",
+			twice: "above\n\n- below",
+		},
+		{
+			name:  "a hard break with nothing before it, which markdown spells as a blank line",
+			in:    wrap(para(`{"type":"hardBreak"},` + text("after"))),
+			once:  "\nafter",
+			twice: "after",
+		},
+		{
+			name:  "a hard break inside a heading, which markdown ends at the newline",
+			in:    wrap(node("heading", `"attrs":{"level":2},"content":[`+text("one")+`,{"type":"hardBreak"},`+text("two")+`]`)),
+			once:  "## one\ntwo",
+			twice: "## one\n\ntwo",
+		},
+		{
+			name:  "a heading with nothing in it, which the renderer erases",
+			in:    wrap(node("heading", `"attrs":{"level":2}`) + "," + para(text("after"))),
+			once:  "after",
+			twice: "after",
+		},
+		{
+			name: "adjacent emphasis whose marks overlap, which has no single reading",
+			in: wrap(para(marked("one", "em") + "," +
+				`{"type":"text","text":"two","marks":[{"type":"em"},{"type":"code"}]}`)),
+			once:  "*one**" + bt + "two" + bt + "*",
+			twice: "*one**" + bt + "two" + bt + "*",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := parse(t, tc.in)
+			if got := adf.Markdown(d); got != tc.once {
+				t.Fatalf("the renderer changed\n got %q\nwant %q", got, tc.once)
+			}
+			out, err := adf.ParseMarkdown(tc.once)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := adf.Markdown(out); got != tc.twice {
+				t.Errorf("\n got %q\nwant %q", got, tc.twice)
+			}
+		})
+	}
+}
+
+// TestParseMarkdown_CannotWidenATableThatWasNarrowedToFit is the width case:
+// a bounded render truncates a cell with an ellipsis, and the ellipsis is what
+// comes back. Markdown handed to an editor is rendered with no TableWidth for
+// exactly this reason.
+func TestParseMarkdown_CannotWidenATableThatWasNarrowedToFit(t *testing.T) {
+	t.Parallel()
+	d := parse(t, wrap(headedTable))
+	narrow := adf.MarkdownWith(d, adf.Options{TableWidth: 20})
+	if !strings.Contains(narrow, "…") {
+		t.Fatalf("the table was not truncated at all, so this proves nothing:\n%s", narrow)
+	}
+
+	out, err := adf.ParseMarkdownWith(narrow, adf.Options{TableWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kept := ""
+	out.Walk(func(n adf.Node) bool {
+		kept += n.Text
+		return true
+	})
+	if !strings.Contains(kept, "…") {
+		t.Error("the ellipsis did not survive, so the truncation was silently repaired")
+	}
+	if strings.Contains(kept, "Environment") {
+		t.Error("a truncated cell came back whole, which markdown cannot know")
+	}
+}
+
+// TestParseMarkdownInto_RestoresEveryOneWayCase is the other half: none of the
+// cases above cost anything when the document they came from is still to hand.
+func TestParseMarkdownInto_RestoresEveryOneWayCase(t *testing.T) {
+	t.Parallel()
+	for name, in := range map[string]string{
+		"prose that reads as a marker": wrap(para(text("- not a list"))),
+		"a hard break before a marker": wrap(para(text("above") + `,{"type":"hardBreak"},` + text("- below"))),
+		"a leading hard break":         wrap(para(`{"type":"hardBreak"},` + text("after"))),
+		"a hard break in a heading":    wrap(node("heading", `"attrs":{"level":2},"content":[`+text("one")+`,{"type":"hardBreak"},`+text("two")+`]`)),
+		"an empty heading":             wrap(node("heading", `"attrs":{"level":2}`) + "," + para(text("after"))),
+		"overlapping emphasis": wrap(para(marked("one", "em") + "," +
+			`{"type":"text","text":"two","marks":[{"type":"em"},{"type":"code"}]}`)),
+		"a narrowed table": wrap(headedTable),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			d := parse(t, in)
+			for _, opt := range renderOptions() {
+				out, err := adf.ParseMarkdownInto(d, adf.MarkdownWith(d, opt), opt)
+				if err != nil {
+					t.Fatalf("%+v: %v", opt, err)
+				}
+				if got, want := encoded(t, out), encoded(t, d); got != want {
+					t.Errorf("%+v\n got %s\nwant %s", opt, got, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/adf/parse_reconcile.go
+++ b/pkg/adf/parse_reconcile.go
@@ -1,0 +1,88 @@
+package adf
+
+import "strings"
+
+// reconcile matches the edited markdown against the document it was rendered
+// from, so that a block the author left alone comes back as the node it already
+// was rather than as whatever markdown could say about it.
+//
+// The match is on the rendered lines, not on the parsed shape: a node is reused
+// only when the markdown at that point is byte-for-byte what that node renders
+// to. Matching the rendering rather than re-parsing and comparing is what makes
+// this independent of how the parser would have divided those lines up — a
+// heading holding a hard break is two blocks to markdown and one node to ADF,
+// and it still comes back as the node.
+func (p *parser) reconcile(ls []line, original []Node) ([]Node, error) {
+	pieces := make([][]string, len(original))
+	first := make(map[string][]int, len(original))
+	for i := range original {
+		p.scratch = AppendMarkdown(p.scratch[:0], NewDoc(original[i]), p.opt)
+		if len(p.scratch) == 0 {
+			continue
+		}
+		pieces[i] = strings.Split(string(p.scratch), "\n")
+		first[pieces[i][0]] = append(first[pieces[i][0]], i)
+	}
+
+	var out []Node
+	taken := 0
+	// A match is tried before a blank line is skipped: a paragraph that opens
+	// with a hard break renders with a blank first line, and skipping it would
+	// look for that block one line too late.
+	for i := 0; i < len(ls); {
+		if at, lines, ok := match(ls, i, pieces, first[ls[i].text], taken); ok {
+			out = append(out, unseen(original, pieces, taken, at)...)
+			out = append(out, original[at].Clone())
+			taken, i = at+1, i+lines
+			continue
+		}
+		if ls[i].blank() {
+			i++
+			continue
+		}
+		node, next, err := p.block(ls, i, "doc")
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, node)
+		i = next
+	}
+	return append(out, unseen(original, pieces, taken, len(original))...), nil
+}
+
+// match reports which original node renders to exactly the lines starting at i,
+// and how many lines that took. Reuse stays in document order — an edited block
+// that happens to render like a block further down does not steal its node.
+func match(ls []line, i int, pieces [][]string, candidates []int, taken int) (at, lines int, ok bool) {
+	for _, c := range candidates {
+		if c < taken || i+len(pieces[c]) > len(ls) {
+			continue
+		}
+		if end := i + len(pieces[c]); end < len(ls) && !ls[end].blank() {
+			continue
+		}
+		same := true
+		for n, text := range pieces[c] {
+			same = same && ls[i+n].text == text
+		}
+		if same {
+			return c, len(pieces[c]), true
+		}
+	}
+	return 0, 0, false
+}
+
+// unseen carries forward the nodes between two matches that render to nothing
+// at all — an empty heading is the one the renderer really does erase. The
+// author never saw them, so they cannot have deleted them; but if anything
+// visible was deleted in the same span, the intent is gone and so are they.
+func unseen(original []Node, pieces [][]string, from, to int) []Node {
+	var out []Node
+	for i := from; i < to; i++ {
+		if len(pieces[i]) > 0 {
+			return nil
+		}
+		out = append(out, original[i].Clone())
+	}
+	return out
+}

--- a/pkg/adf/parse_roundtrip_test.go
+++ b/pkg/adf/parse_roundtrip_test.go
@@ -1,0 +1,276 @@
+package adf_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// encoded is the JSON a document or a node writes, which is what "byte-stable"
+// is measured against.
+func encoded(tb testing.TB, d adf.Doc) string {
+	tb.Helper()
+	b, err := adf.Marshal(d)
+	if err != nil {
+		tb.Fatalf("encoding: %v", err)
+	}
+	return string(b)
+}
+
+func encodedNode(tb testing.TB, n adf.Node) string {
+	tb.Helper()
+	b, err := n.MarshalJSON()
+	if err != nil {
+		tb.Fatalf("encoding: %v", err)
+	}
+	return string(b)
+}
+
+// corpus is the set of documents both round-trip properties are asserted over.
+// It is the renderer's own test data plus the fixture, so that a change to
+// either shows up here rather than in a golden file nobody re-reads.
+func corpus(tb testing.TB) map[string]adf.Doc {
+	tb.Helper()
+	out := map[string]adf.Doc{"the rich fixture description": fixtureDescription(tb)}
+	for name, in := range map[string]string{
+		"nested lists and quotes": nestedLists,
+		"a table with a header":   wrap(headedTable),
+		"a table with no header":  wrap(headlessTable),
+		"a ragged table":          wrap(raggedTable),
+		"a table of wide runes":   wrap(wideTable),
+		"an empty document":       `{"version":1,"type":"doc","content":[]}`,
+		"a document that is null": `null`,
+		"a paragraph":             wrap(para(text("The basket is empty."))),
+		"every heading level":     wrap(node("heading", `"attrs":{"level":1},"content":[`+text("one")+`]`) + "," + node("heading", `"attrs":{"level":6},"content":[`+text("six")+`]`)),
+		"every mark":              wrap(para(marked("bold", "strong") + "," + marked("italic", "em") + "," + marked("gone", "strike") + "," + marked("under", "underline") + "," + marked("code()", "code"))),
+		"a link":                  wrap(para(`{"type":"text","text":"the runbook","marks":[{"type":"link","attrs":{"href":"https://example.com/x"}}]}`)),
+		"a link whose text is its address": wrap(para(
+			`{"type":"text","text":"https://example.com/x","marks":[{"type":"link","attrs":{"href":"https://example.com/x"}}]}`)),
+		"a link to an address holding a bracket": wrap(para(
+			`{"type":"text","text":"wiki","marks":[{"type":"link","attrs":{"href":"https://example.com/a(b)"}}]}`)),
+		"a link whose text holds a bracket": wrap(para(
+			`{"type":"text","text":"a [b] c","marks":[{"type":"link","attrs":{"href":"https://example.com/x"}}]}`)),
+		"inline code holding a backtick": wrap(para(marked("a "+bt+" b", "code"))),
+		"a hard break":                   wrap(para(text("first") + `,{"type":"hardBreak"},` + text("second"))),
+		"a mention":                      wrap(para(text("Ask ") + `,{"type":"mention","attrs":{"id":"5b10ac8d","text":"@Someone"}},` + text(" about it"))),
+		"a status lozenge":               wrap(para(`{"type":"status","attrs":{"text":"Wartet auf Freigabe","color":"yellow"}}`)),
+		"an emoji":                       wrap(para(`{"type":"emoji","attrs":{"shortName":":smile:","id":"1f604","text":"😄"}}`)),
+		"a date":                         wrap(para(`{"type":"date","attrs":{"timestamp":"1772409600000"}}`)),
+		"an inline card":                 wrap(para(`{"type":"inlineCard","attrs":{"url":"https://example.atlassian.net/browse/EX-2"}}`)),
+		"an image with a caption": wrap(node("mediaSingle", `"content":[{"type":"media","attrs":{"id":"3f","type":"file"}},`+
+			node("caption", `"content":[`+text("Figure 1")+`]`)+`]`)),
+		"a group of images": wrap(node("mediaGroup", `"content":[`+
+			`{"type":"media","attrs":{"id":"a","type":"file"}},{"type":"media","attrs":{"id":"b","type":"file"}}]`)),
+		"a rule between paragraphs":    wrap(para(text("above")) + "," + node("rule", "") + "," + para(text("below"))),
+		"a code block":                 wrap(node("codeBlock", `"attrs":{"language":"go"},"content":[`+text("x := 1\\ny := 2")+`]`)),
+		"a code block holding a fence": wrap(node("codeBlock", `"content":[`+text("a\\n"+bt+bt+bt+"\\nb")+`]`)),
+		"every panel type": wrap(node("panel", `"attrs":{"panelType":"info"},"content":[`+para(text("i"))+`]`) + "," +
+			node("panel", `"attrs":{"panelType":"note"},"content":[`+para(text("n"))+`]`) + "," +
+			node("panel", `"attrs":{"panelType":"success"},"content":[`+para(text("s"))+`]`) + "," +
+			node("panel", `"attrs":{"panelType":"warning"},"content":[`+para(text("w"))+`]`) + "," +
+			node("panel", `"attrs":{"panelType":"error"},"content":[`+para(text("e"))+`]`)),
+		"a custom panel with its own icon": wrap(node("panel", `"attrs":{"panelType":"custom","panelIconText":"🛠"},"content":[`+para(text("c"))+`]`)),
+		"a task list": wrap(node("taskList", `"content":[`+
+			node("taskItem", `"attrs":{"state":"DONE"},"content":[`+text("done")+`]`)+`,`+
+			node("taskItem", `"attrs":{"state":"TODO"},"content":[`+text("todo")+`]`)+`]`)),
+		"a nested task list": wrap(node("taskList", `"content":[`+
+			node("taskItem", `"attrs":{"state":"TODO"},"content":[`+text("ship")+`]`)+`,`+
+			node("taskList", `"content":[`+node("taskItem", `"attrs":{"state":"DONE"},"content":[`+text("test")+`]`)+`]`)+`,`+
+			node("taskItem", `"attrs":{"state":"TODO"},"content":[`+text("tell")+`]`)+`]`)),
+		"a decision list": wrap(node("decisionList", `"content":[`+node("decisionItem", `"content":[`+text("ship it")+`]`)+`]`)),
+		"an ordered list that does not start at one": wrap(node("orderedList", `"attrs":{"order":9},"content":[`+
+			item("nine")+`,`+item("ten")+`,`+item("eleven")+`]`)),
+		"a list item with nothing in it": wrap(node("bulletList", `"content":[`+node("listItem", "")+`,`+item("second")+`]`)),
+		"an expand":                      wrap(node("expand", `"attrs":{"title":"The long version"},"content":[`+para(text("detail"))+`]`)),
+		"an unknown block":               wrap(node("futureBlock", `"attrs":{"variant":"callout"},"content":[`+para(text("kept"))+`]`)),
+		"an unknown inline":              wrap(para(text("before ") + `,{"type":"futureInline","attrs":{"x":1}},` + text(" after"))),
+		"the node Jira stores for something it could not parse": wrap(
+			node("unsupportedBlock", `"attrs":{"originalValue":{"type":"someMacro","attrs":{"k":1}}}`)),
+	} {
+		out[name] = parse(tb, in)
+	}
+	return out
+}
+
+// TestParseMarkdownInto_LeavesAnUntouchedDocumentByteIdentical is the property
+// the packet exists for. Rendering a document and parsing it straight back must
+// return the bytes that came in — not an equivalent document, the same one —
+// including the node types, attributes and key order this package does not
+// model.
+func TestParseMarkdownInto_LeavesAnUntouchedDocumentByteIdentical(t *testing.T) {
+	t.Parallel()
+	for name, d := range corpus(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, opt := range renderOptions() {
+				md := adf.MarkdownWith(d, opt)
+				got, err := adf.ParseMarkdownInto(d, md, opt)
+				if err != nil {
+					t.Fatalf("%+v: %v", opt, err)
+				}
+				if back, want := encoded(t, got), encoded(t, d); back != want {
+					t.Errorf("%+v\n--- want ---\n%s\n--- got ---\n%s\n--- markdown ---\n%s", opt, want, back, md)
+				}
+			}
+		})
+	}
+}
+
+// TestParseMarkdown_ReachesAFixedPointAfterOneRender is the property a parse
+// without the original document can hold: what the author saw is what comes
+// back. The first render can lose what markdown cannot say; rendering the parse
+// of it must not lose anything more.
+func TestParseMarkdown_ReachesAFixedPointAfterOneRender(t *testing.T) {
+	t.Parallel()
+	for name, d := range corpus(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, opt := range editOptions() {
+				once := adf.MarkdownWith(d, opt)
+				out, err := adf.ParseMarkdownWith(once, opt)
+				if errors.Is(err, adf.ErrUnsupportedMarker) {
+					// The only refusal this corpus is allowed to provoke, and
+					// the reason ParseMarkdownInto exists.
+					continue
+				}
+				if err != nil {
+					t.Fatalf("%+v: %v\n%s", opt, err, once)
+				}
+				if twice := adf.MarkdownWith(out, opt); twice != once {
+					t.Errorf("%+v\n--- rendered ---\n%q\n--- re-rendered ---\n%q", opt, once, twice)
+				}
+			}
+		})
+	}
+}
+
+func renderOptions() []adf.Options {
+	return []adf.Options{{}, {ASCII: true}, {TableWidth: 20}, {ASCII: true, TableWidth: 30}}
+}
+
+// editOptions are the options markdown meant to be edited is rendered with. A
+// TableWidth is missing on purpose: bounding a table truncates its cells with
+// an ellipsis and repads the columns, so what comes back is a table of
+// truncated text. TestParseMarkdown_CannotUndoTheseRenderings has the case.
+func editOptions() []adf.Options { return []adf.Options{{}, {ASCII: true}} }
+
+// TestParseMarkdownInto_KeepsTheBytesJiraSent is what "byte-stable" has to mean
+// to be worth anything: not that two documents re-encode to the same canonical
+// form, but that the indentation and key order the wire happened to carry come
+// back out. A test that marshals both sides would pass on a parser that threw
+// the original away.
+func TestParseMarkdownInto_KeepsTheBytesJiraSent(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile(richFixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Fields struct {
+			Description json.RawMessage `json:"description"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	sent := string(envelope.Fields.Description)
+	if !strings.Contains(sent, "\n      ") {
+		t.Fatal("the fixture is no longer indented, so this test proves nothing")
+	}
+
+	d, err := adf.Unmarshal([]byte(sent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := adf.ParseMarkdownInto(d, adf.Markdown(d), adf.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back := encoded(t, out); back != sent {
+		t.Errorf("the document came back re-encoded\n--- sent ---\n%s\n--- back ---\n%s", sent, back)
+	}
+}
+
+// TestParseMarkdownInto_ReparsesOnlyTheBlockThatChanged proves the half of the
+// promise that is not about doing nothing: an edit to one paragraph must not
+// re-encode the blocks around it, or an unknown node three blocks away is lost
+// to a typo.
+func TestParseMarkdownInto_ReparsesOnlyTheBlockThatChanged(t *testing.T) {
+	t.Parallel()
+	d := fixtureDescription(t)
+	md := adf.Markdown(d)
+	edited := strings.Replace(md, "The basket total is", "The basket sum is", 1)
+	if edited == md {
+		t.Fatal("the fixture no longer holds the sentence this test edits")
+	}
+
+	out, err := adf.ParseMarkdownInto(d, edited, adf.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Content) != len(d.Content) {
+		t.Fatalf("the document went from %d blocks to %d", len(d.Content), len(out.Content))
+	}
+	for i := range out.Content {
+		got, want := encodedNode(t, out.Content[i]), encodedNode(t, d.Content[i])
+		switch {
+		case i == 0 && got == want:
+			t.Error("the edited paragraph came back unchanged")
+		case i > 0 && got != want:
+			t.Errorf("block %d was re-encoded although it was not edited\n got %s\nwant %s", i, got, want)
+		}
+	}
+}
+
+// TestParseMarkdownInto_KeepsAnUnknownNodeAcrossAnEditBesideIt is the case the
+// issue names: the marker the renderer leaves for a node type it has never
+// heard of carries the type and nothing else, so the only way that node comes
+// back is out of the document it came from.
+func TestParseMarkdownInto_KeepsAnUnknownNodeAcrossAnEditBesideIt(t *testing.T) {
+	t.Parallel()
+	d := fixtureDescription(t)
+	edited := adf.Markdown(d) + "\n\nOne more note."
+
+	out, err := adf.ParseMarkdownInto(d, edited, adf.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := out.NodeTypes()["futureBlock"]; got != 1 {
+		t.Fatalf("the unknown node is there %d times, want once", got)
+	}
+	last := out.Content[len(out.Content)-1]
+	if last.Type != "paragraph" {
+		t.Fatalf("the appended block came back as %q", last.Type)
+	}
+	unknown := encodedNode(t, out.Content[len(out.Content)-2])
+	if want := encodedNode(t, d.Content[len(d.Content)-1]); unknown != want {
+		t.Errorf("the unknown node was rebuilt rather than restored\n got %s\nwant %s", unknown, want)
+	}
+}
+
+func TestParseMarkdown_RefusesAMarkerItCannotRebuild(t *testing.T) {
+	t.Parallel()
+	for name, in := range map[string]string{
+		"a block":   "> [unsupported: futureBlock]\n> kept",
+		"an inline": "before [unsupported: futureInline] after",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := adf.ParseMarkdown(in)
+			var perr *adf.ParseError
+			if !errors.As(err, &perr) {
+				t.Fatalf("want a *adf.ParseError, got %v", err)
+			}
+			if !errors.Is(err, adf.ErrUnsupportedMarker) {
+				t.Errorf("want ErrUnsupportedMarker, got %v", err)
+			}
+			if perr.Line != 1 {
+				t.Errorf("want line 1, got %d", perr.Line)
+			}
+		})
+	}
+}

--- a/pkg/adf/parse_table.go
+++ b/pkg/adf/parse_table.go
@@ -1,0 +1,86 @@
+package adf
+
+import "strings"
+
+// table reads a run of pipe rows back into a table.
+//
+// The grid the renderer draws is padded so that it lines up in a monospaced
+// pager, and a cell holding more than one block was folded onto one line to fit
+// in it. Neither survives: a cell comes back as one paragraph, and the widths
+// are recomputed from the text the next time it is rendered. What a merged cell
+// spanned is gone too — it was written out as one value and as many empty
+// columns as it covered, and that is what comes back.
+func (p *parser) table(ls []line, i int) (Node, int, error) {
+	end := i
+	for end < len(ls) && strings.HasPrefix(ls[end].text, "|") {
+		end++
+	}
+
+	rows := make([][]string, 0, end-i)
+	for _, l := range ls[i:end] {
+		rows = append(rows, splitRow(l.text))
+	}
+	header := len(rows) > 1 && isDelimiterRow(rows[1]) && len(rows[1]) == len(rows[0])
+	if header {
+		rows = append(rows[:1], rows[2:]...)
+	}
+
+	node := NewNode("table")
+	for r, cells := range rows {
+		typ := "tableCell"
+		if header && r == 0 {
+			typ = "tableHeader"
+		}
+		row := NewNode("tableRow")
+		for _, text := range cells {
+			content, err := p.inline([]line{{text: text, no: ls[i].no}})
+			if err != nil {
+				return Node{}, end, err
+			}
+			cell := NewNode(typ, NewNode("paragraph").WithContent(content...))
+			row.Content = append(row.Content, cell)
+		}
+		node.Content = append(node.Content, row)
+	}
+	return node, end, nil
+}
+
+// splitRow takes a pipe row apart. The renderer escapes the one character the
+// grid is drawn with, so a backslash before a pipe is the author's pipe.
+func splitRow(text string) []string {
+	text = strings.TrimSuffix(strings.TrimPrefix(strings.TrimRight(text, " \t"), "|"), "|")
+	var (
+		cells []string
+		cell  strings.Builder
+	)
+	for i := 0; i < len(text); i++ {
+		switch {
+		case text[i] == '\\' && i+1 < len(text) && text[i+1] == '|':
+			cell.WriteByte('|')
+			i++
+		case text[i] == '|':
+			cells = append(cells, strings.TrimSpace(cell.String()))
+			cell.Reset()
+		default:
+			cell.WriteByte(text[i])
+		}
+	}
+	return append(cells, strings.TrimSpace(cell.String()))
+}
+
+// isDelimiterRow reports the row of dashes that says the row above it is a
+// header. The renderer writes one only when every cell of the first row is a
+// header cell, which is the only case a pager can honestly show.
+func isDelimiterRow(cells []string) bool {
+	for _, cell := range cells {
+		if cell == "" {
+			return false
+		}
+		for i := range len(cell) {
+			if cell[i] != '-' {
+				return false
+			}
+		}
+	}
+	return len(cells) > 0
+}

--- a/pkg/adf/parse_test.go
+++ b/pkg/adf/parse_test.go
@@ -1,0 +1,557 @@
+package adf_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// txt spells a text node the way the canonical encoder writes one: type first,
+// then marks, then the text itself.
+func txt(s string, marks ...string) string {
+	if len(marks) == 0 {
+		return `{"type":"text","text":"` + s + `"}`
+	}
+	return `{"type":"text","marks":[` + strings.Join(marks, ",") + `],"text":"` + s + `"}`
+}
+
+func mark(typ string) string { return `{"type":"` + typ + `"}` }
+
+func linkMark(href string) string {
+	return `{"type":"link","attrs":{"href":"` + href + `"}}`
+}
+
+func paraOf(content ...string) string {
+	if len(content) == 0 {
+		return `{"type":"paragraph"}`
+	}
+	return `{"type":"paragraph","content":[` + strings.Join(content, ",") + `]}`
+}
+
+func TestParseMarkdown_ReadsEveryShapeTheRendererWrites(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a paragraph",
+			in:   "The basket is empty.",
+			want: paraOf(txt("The basket is empty.")),
+		},
+		{
+			name: "a heading",
+			in:   "## Steps",
+			want: `{"type":"heading","attrs":{"level":2},"content":[` + txt("Steps") + `]}`,
+		},
+		{
+			name: "a hash with no space after it, which is a word and not a heading",
+			in:   "#checkout is the label",
+			want: paraOf(txt("#checkout is the label")),
+		},
+		{
+			name: "seven hashes, which is deeper than markdown goes",
+			in:   "####### too deep",
+			want: paraOf(txt("####### too deep")),
+		},
+		{
+			name: "every mark",
+			in:   "**bold** *italic* ~~gone~~ _under_ `code()`",
+			want: paraOf(
+				txt("bold", mark("strong")), txt(" "), txt("italic", mark("em")), txt(" "),
+				txt("gone", mark("strike")), txt(" "), txt("under", mark("underline")), txt(" "),
+				txt("code()", mark("code"))),
+		},
+		{
+			name: "marks nested the way the renderer nests them",
+			in:   "[**the runbook**](https://example.com/x)",
+			want: paraOf(txt("the runbook", linkMark("https://example.com/x"), mark("strong"))),
+		},
+		{
+			name: "an underscore inside a word, which is a name and not emphasis",
+			in:   "snake_case_name",
+			want: paraOf(txt("snake_case_name")),
+		},
+		{
+			name: "a link whose text holds brackets, which the renderer does not escape",
+			in:   "[a [b] c](https://example.com/x)",
+			want: paraOf(txt("a [b] c", linkMark("https://example.com/x"))),
+		},
+		{
+			name: "an address in angle brackets, which is how one holding a bracket is written",
+			in:   "[wiki](<https://example.com/a(b)>)",
+			want: paraOf(txt("wiki", linkMark("https://example.com/a(b)"))),
+		},
+		{
+			name: "an address whose angle brackets the renderer had to escape",
+			in:   "[q](<https://example.com/s?a=%3Cb%3E c>)",
+			want: paraOf(txt("q", linkMark(`https://example.com/s?a=\u003cb\u003e c`))),
+		},
+		{
+			name: "an autolink",
+			in:   "<https://example.com/x>",
+			want: paraOf(txt("https://example.com/x", linkMark("https://example.com/x"))),
+		},
+		{
+			name: "angle brackets that are not an address",
+			in:   "a < b and b > a",
+			want: paraOf(txt(`a \u003c b and b \u003e a`)),
+		},
+		{
+			name: "inline code holding a backtick, which is fenced in two",
+			in:   "``a ` b``",
+			want: paraOf(txt("a ` b", mark("code"))),
+		},
+		{
+			name: "inline code that had to be padded off its own fence",
+			in:   "`` ` ``",
+			want: paraOf(txt("`", mark("code"))),
+		},
+		{
+			name: "a hard break, which is the only reason prose runs to a second line",
+			in:   "first\nsecond",
+			want: paraOf(txt("first"), `{"type":"hardBreak"}`, txt("second")),
+		},
+		{
+			name: "a bullet list",
+			in:   "- one\n- two",
+			want: `{"type":"bulletList","content":[` +
+				`{"type":"listItem","content":[` + paraOf(txt("one")) + `]},` +
+				`{"type":"listItem","content":[` + paraOf(txt("two")) + `]}]}`,
+		},
+		{
+			name: "an ordered list that does not start at one",
+			in:   "9. nine\n10. ten",
+			want: `{"type":"orderedList","attrs":{"order":9},"content":[` +
+				`{"type":"listItem","content":[` + paraOf(txt("nine")) + `]},` +
+				`{"type":"listItem","content":[` + paraOf(txt("ten")) + `]}]}`,
+		},
+		{
+			name: "an ordered list that does start at one, which needs no attribute",
+			in:   "1. one",
+			want: `{"type":"orderedList","content":[{"type":"listItem","content":[` + paraOf(txt("one")) + `]}]}`,
+		},
+		{
+			name: "a list item with nothing in it",
+			in:   "-\n- second",
+			want: `{"type":"bulletList","content":[` +
+				`{"type":"listItem","content":[` + paraOf() + `]},` +
+				`{"type":"listItem","content":[` + paraOf(txt("second")) + `]}]}`,
+		},
+		{
+			name: "a list inside a list",
+			in:   "- one\n  - nested",
+			want: `{"type":"bulletList","content":[{"type":"listItem","content":[` + paraOf(txt("one")) + `,` +
+				`{"type":"bulletList","content":[{"type":"listItem","content":[` + paraOf(txt("nested")) + `]}]}]}]}`,
+		},
+		{
+			name: "a second paragraph under a list item",
+			in:   "- two\n\n  still two",
+			want: `{"type":"bulletList","content":[{"type":"listItem","content":[` +
+				paraOf(txt("two")) + `,` + paraOf(txt("still two")) + `]}]}`,
+		},
+		{
+			name: "a task list",
+			in:   "- [ ] todo\n- [x] done",
+			want: `{"type":"taskList","content":[` +
+				`{"type":"taskItem","attrs":{"state":"TODO"},"content":[` + txt("todo") + `]},` +
+				`{"type":"taskItem","attrs":{"state":"DONE"},"content":[` + txt("done") + `]}]}`,
+		},
+		{
+			name: "a task list indented under another one, which ADF stores as a sibling",
+			in:   "- [ ] ship\n  - [x] test",
+			want: `{"type":"taskList","content":[` +
+				`{"type":"taskItem","attrs":{"state":"TODO"},"content":[` + txt("ship") + `]},` +
+				`{"type":"taskList","content":[{"type":"taskItem","attrs":{"state":"DONE"},"content":[` + txt("test") + `]}]}]}`,
+		},
+		{
+			name: "a decision list",
+			in:   "- ◇ ship it",
+			want: `{"type":"decisionList","content":[` +
+				`{"type":"decisionItem","attrs":{"state":"DECIDED"},"content":[` + txt("ship it") + `]}]}`,
+		},
+		{
+			name: "a quote",
+			in:   "> quoted\n>\n> twice",
+			want: `{"type":"blockquote","content":[` + paraOf(txt("quoted")) + `,` + paraOf(txt("twice")) + `]}`,
+		},
+		{
+			name: "a panel",
+			in:   "> ⚠ WARNING\n> Do not retry.",
+			want: `{"type":"panel","attrs":{"panelType":"warning"},"content":[` + paraOf(txt("Do not retry.")) + `]}`,
+		},
+		{
+			name: "a panel of a type nobody has published yet, which came back uppercased",
+			in:   "> ◆ SURPRISE\n> p",
+			want: `{"type":"panel","attrs":{"panelType":"surprise"},"content":[` + paraOf(txt("p")) + `]}`,
+		},
+		{
+			name: "a custom panel carrying its own icon",
+			in:   "> 🛠 PANEL\n> c",
+			want: `{"type":"panel","attrs":{"panelIconText":"🛠","panelType":"custom"},"content":[` + paraOf(txt("c")) + `]}`,
+		},
+		{
+			name: "a quote whose first line only looks like a panel",
+			in:   "> ⚠ Warning: this is prose",
+			want: `{"type":"blockquote","content":[` + paraOf(txt("⚠ Warning: this is prose")) + `]}`,
+		},
+		{
+			name: "a code block with a language",
+			in:   "```go\nx := 1\n```",
+			want: `{"type":"codeBlock","attrs":{"language":"go"},"content":[` + txt("x := 1") + `]}`,
+		},
+		{
+			name: "a code block with no language and nothing in it",
+			in:   "```\n\n```",
+			want: `{"type":"codeBlock"}`,
+		},
+		{
+			name: "a line that only looks like a list, inside a code fence",
+			in:   "```\n- not a bullet\n# not a heading\n```",
+			want: `{"type":"codeBlock","content":[` + txt(`- not a bullet\n# not a heading`) + `]}`,
+		},
+		{
+			name: "a fence longer than three, which is how code holding a fence is written",
+			in:   "````\na\n```\nb\n````",
+			want: `{"type":"codeBlock","content":[` + txt(`a\n`+"```"+`\nb`) + `]}`,
+		},
+		{
+			name: "a fence nobody closed",
+			in:   "```sh\nmake check",
+			want: `{"type":"codeBlock","attrs":{"language":"sh"},"content":[` + txt("make check") + `]}`,
+		},
+		{
+			name: "a rule",
+			in:   "---",
+			want: `{"type":"rule"}`,
+		},
+		{
+			name: "an expand",
+			in:   "▾ The long version\n  detail",
+			want: `{"type":"expand","attrs":{"title":"The long version"},"content":[` + paraOf(txt("detail")) + `]}`,
+		},
+		{
+			name: "an expand with no title",
+			in:   "▾\n  detail",
+			want: `{"type":"expand","content":[` + paraOf(txt("detail")) + `]}`,
+		},
+		{
+			name: "an expand inside an expand, which ADF spells with a different node",
+			in:   "▾ outer\n  ▾ inner\n    detail",
+			want: `{"type":"expand","attrs":{"title":"outer"},"content":[` +
+				`{"type":"nestedExpand","attrs":{"title":"inner"},"content":[` + paraOf(txt("detail")) + `]}]}`,
+		},
+		{
+			name: "an image on its own line",
+			in:   "![the trace](media:3f)",
+			want: `{"type":"mediaSingle","content":[{"type":"media","attrs":{"alt":"the trace","id":"3f","type":"file"}}]}`,
+		},
+		{
+			name: "an image with the alt the renderer writes when there was none",
+			in:   "![media](media:3f)",
+			want: `{"type":"mediaSingle","content":[{"type":"media","attrs":{"id":"3f","type":"file"}}]}`,
+		},
+		{
+			name: "an externally hosted image",
+			in:   "![a](https://example.com/a.png)",
+			want: `{"type":"mediaSingle","content":[{"type":"media","attrs":{"alt":"a","type":"external","url":"https://example.com/a.png"}}]}`,
+		},
+		{
+			name: "an image with a caption under it",
+			in:   "![media](media:3f)\nFigure 1",
+			want: `{"type":"mediaSingle","content":[{"type":"media","attrs":{"id":"3f","type":"file"}},` +
+				`{"type":"caption","content":[` + paraOf(txt("Figure 1")) + `]}]}`,
+		},
+		{
+			name: "a row of images, which is a group rather than several singles",
+			in:   "![media](media:a)\n![media](media:b)",
+			want: `{"type":"mediaGroup","content":[{"type":"media","attrs":{"id":"a","type":"file"}},` +
+				`{"type":"media","attrs":{"id":"b","type":"file"}}]}`,
+		},
+		{
+			name: "an image inside a sentence, which is inline",
+			in:   "see ![a](media:x) here",
+			want: paraOf(txt("see "), `{"type":"mediaInline","attrs":{"alt":"a","id":"x","type":"file"}}`, txt(" here")),
+		},
+		{
+			name: "a table with a header row",
+			in:   "| a | b |\n| - | - |\n| 1 | 2 |",
+			want: `{"type":"table","content":[` +
+				`{"type":"tableRow","content":[` +
+				`{"type":"tableHeader","content":[` + paraOf(txt("a")) + `]},` +
+				`{"type":"tableHeader","content":[` + paraOf(txt("b")) + `]}]},` +
+				`{"type":"tableRow","content":[` +
+				`{"type":"tableCell","content":[` + paraOf(txt("1")) + `]},` +
+				`{"type":"tableCell","content":[` + paraOf(txt("2")) + `]}]}]}`,
+		},
+		{
+			name: "a table with no header row",
+			in:   "| left | right |",
+			want: `{"type":"table","content":[{"type":"tableRow","content":[` +
+				`{"type":"tableCell","content":[` + paraOf(txt("left")) + `]},` +
+				`{"type":"tableCell","content":[` + paraOf(txt("right")) + `]}]}]}`,
+		},
+		{
+			name: "a table cell holding the character the grid is drawn with",
+			in:   `| a \| b | c |`,
+			want: `{"type":"table","content":[{"type":"tableRow","content":[` +
+				`{"type":"tableCell","content":[` + paraOf(txt(`a | b`)) + `]},` +
+				`{"type":"tableCell","content":[` + paraOf(txt("c")) + `]}]}]}`,
+		},
+		{
+			name: "a table cell with nothing in it",
+			in:   "| a |  |",
+			want: `{"type":"table","content":[{"type":"tableRow","content":[` +
+				`{"type":"tableCell","content":[` + paraOf(txt("a")) + `]},` +
+				`{"type":"tableCell","content":[` + paraOf() + `]}]}]}`,
+		},
+		{
+			name: "a pipe in prose, which is not a table",
+			in:   "a | b",
+			want: paraOf(txt("a | b")),
+		},
+		{
+			name: "trailing whitespace, which the renderer does not write and this does not keep",
+			in:   "a line   ",
+			want: paraOf(txt("a line")),
+		},
+		{
+			name: "the control characters a terminal would act on",
+			in:   "safe \u001b[31mred\u001b[0m",
+			want: paraOf(txt(`safe [31mred[0m`)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d, err := adf.ParseMarkdown(tc.in)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			got, err := adf.Marshal(d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := wrap(tc.want); string(got) != want {
+				t.Errorf("\n got %s\nwant %s", got, want)
+			}
+		})
+	}
+}
+
+func TestParseMarkdown_ReadsTheASCIIMarkerSetWhenAskedTo(t *testing.T) {
+	t.Parallel()
+	const in = "> ! WARNING\n> careful\n\n- <> ship\n\nv more\n  detail"
+	d, err := adf.ParseMarkdownWith(in, adf.Options{ASCII: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for typ, want := range map[string]int{"panel": 1, "decisionList": 1, "expand": 1} {
+		if got := d.NodeTypes()[typ]; got != want {
+			t.Errorf("%s appears %d times, want %d", typ, got, want)
+		}
+	}
+
+	// The same markdown read with the Unicode marker set is prose and a quote,
+	// which is why the option has to match the one it was rendered with.
+	unicode, err := adf.ParseMarkdown(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := unicode.NodeTypes()["panel"]; got != 0 {
+		t.Errorf("the ASCII markers were read as a panel with Unicode markers in force")
+	}
+}
+
+func TestParseMarkdown_HandlesADocumentWithNothingInIt(t *testing.T) {
+	t.Parallel()
+	for name, in := range map[string]string{
+		"empty":                 "",
+		"one newline":           "\n",
+		"only whitespace":       "   \n\t\n  ",
+		"only blank lines":      "\n\n\n\n",
+		"windows line endings":  "\r\n\r\n",
+		"a byte order mark":     "\ufeff",
+		"whitespace and a mark": "\ufeff   ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			d, err := adf.ParseMarkdown(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := adf.Marshal(d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := `{"version":1,"type":"doc","content":[]}`; string(got) != want {
+				t.Errorf("\n got %s\nwant %s", got, want)
+			}
+		})
+	}
+}
+
+func TestParseMarkdown_ReadsWindowsAndClassicMacLineEndings(t *testing.T) {
+	t.Parallel()
+	want, err := adf.ParseMarkdown("# One\n\nTwo\nthree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantJSON := encoded(t, want)
+	for name, in := range map[string]string{
+		"crlf": "# One\r\n\r\nTwo\r\nthree",
+		"cr":   "# One\r\rTwo\rthree",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := adf.ParseMarkdown(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotJSON := encoded(t, got); gotJSON != wantJSON {
+				t.Errorf("\n got %s\nwant %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestParseMarkdown_RefusesANestingADFHasNoShapeFor(t *testing.T) {
+	t.Parallel()
+	for name, in := range map[string]string{
+		"a table inside a quote":       "> | a | b |",
+		"a table inside a list item":   "- one\n  | a | b |",
+		"a heading inside a quote":     "> # shouted",
+		"a heading inside a list item": "- one\n  # shouted",
+		"a rule inside a quote":        "> above\n>\n> ---",
+		"a panel inside a panel":       "> ℹ INFO\n> > ⚠ WARNING\n> > careful",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := adf.ParseMarkdown(in)
+			if !errors.Is(err, adf.ErrNesting) {
+				t.Fatalf("want ErrNesting, got %v", err)
+			}
+			var perr *adf.ParseError
+			if !errors.As(err, &perr) {
+				t.Fatalf("want a *adf.ParseError, got %T", err)
+			}
+			if perr.Line == 0 {
+				t.Error("the error does not say which line it stopped on")
+			}
+		})
+	}
+}
+
+// TestParseMarkdown_NeverWritesAnEmptyTextNode guards the one rule in the ADF
+// schema that a text-shaped parser breaks by accident: text has minLength 1, and
+// a document carrying an empty one is rejected outright.
+func TestParseMarkdown_NeverWritesAnEmptyTextNode(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{
+		"****", "``", "~~~~", "__", "[]()", "**", "*", "_", "`", "[](x)", "![]()",
+		"a ****", "> ", ">", "- ", "|  |", "```\n```", "#", "# ",
+	} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			d, err := adf.ParseMarkdown(in)
+			if err != nil {
+				return
+			}
+			d.Walk(func(n adf.Node) bool {
+				if n.Type == "text" && n.Text == "" {
+					t.Errorf("%q parsed to a text node with no text", in)
+				}
+				return true
+			})
+			if _, err := adf.Marshal(d); err != nil {
+				t.Errorf("%q parsed to a document that will not encode: %v", in, err)
+			}
+		})
+	}
+}
+
+// TestParseMarkdown_AlwaysAnswersADocument keeps the envelope honest: whatever
+// comes in, what goes out has a version, a type and a content array, because
+// anything else is rejected before Jira looks at the content.
+func TestParseMarkdown_AlwaysAnswersADocument(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "a", "- a", "> a", "| a |", "```\na\n```", "---", "# a"} {
+		d, err := adf.ParseMarkdown(in)
+		if err != nil {
+			t.Fatalf("%q: %v", in, err)
+		}
+		if d.Version != 1 || d.Type != "doc" {
+			t.Errorf("%q answered version %d type %q", in, d.Version, d.Type)
+		}
+		got, err := adf.Marshal(d)
+		if err != nil {
+			t.Fatalf("%q: %v", in, err)
+		}
+		if !strings.HasPrefix(string(got), `{"version":1,"type":"doc","content":[`) {
+			t.Errorf("%q answered %s", in, got)
+		}
+	}
+}
+
+func TestParseMarkdownDropsOnly_NamesTheConstructsTheTestsProve(t *testing.T) {
+	t.Parallel()
+	drops := adf.ParseMarkdownDropsOnly()
+	if len(drops) == 0 {
+		t.Fatal("the list is empty, which is a claim this package cannot make")
+	}
+	for _, want := range []string{"mention", "status", "date", "table", "media", "heading", "hardBreak", "text", "marks"} {
+		found := false
+		for _, drop := range drops {
+			found = found || strings.HasPrefix(drop, want+":")
+		}
+		if !found {
+			t.Errorf("%q is lossy and is not in the list", want)
+		}
+	}
+}
+
+// TestParseMarkdown_TurnsWhatItCannotRebuildBackIntoProse is the honest half of
+// the loss: a mention, a lozenge and a date are not dropped, they stop being
+// nodes. A reader still sees every word the author wrote.
+func TestParseMarkdown_TurnsWhatItCannotRebuildBackIntoProse(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct{ in, want string }{
+		"a mention": {
+			in:   wrap(para(text("Ask ") + `,{"type":"mention","attrs":{"id":"5b10ac8d","text":"@Someone"}},` + text(" about it"))),
+			want: "Ask @Someone about it",
+		},
+		"a status lozenge": {
+			in:   wrap(para(`{"type":"status","attrs":{"text":"Wartet auf Freigabe","color":"yellow"}}`)),
+			want: "[Wartet auf Freigabe]",
+		},
+		"a date": {
+			in:   wrap(para(`{"type":"date","attrs":{"timestamp":"1772409600000"}}`)),
+			want: "2026-03-02",
+		},
+		"an emoji": {
+			in:   wrap(para(`{"type":"emoji","attrs":{"shortName":":smile:","id":"1f604","text":"😄"}}`)),
+			want: "😄",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out, err := adf.ParseMarkdown(adf.Markdown(parse(t, tc.in)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := adf.Markdown(out); got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+			for typ := range out.NodeTypes() {
+				switch typ {
+				case "mention", "status", "date", "emoji":
+					t.Errorf("a %s came back as a node, which markdown cannot carry the attributes of", typ)
+				}
+			}
+		})
+	}
+}

--- a/pkg/adf/testdata/fuzz/FuzzParseMarkdown/3c6baa4bb0762283
+++ b/pkg/adf/testdata/fuzz/FuzzParseMarkdown/3c6baa4bb0762283
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x100***0*0**")

--- a/pkg/adf/testdata/fuzz/FuzzParseMarkdown/62cbec4df631d88d
+++ b/pkg/adf/testdata/fuzz/FuzzParseMarkdown/62cbec4df631d88d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0\x00\x7f)")

--- a/pkg/adf/testdata/fuzz/FuzzParseMarkdown/89bc59571d223c99
+++ b/pkg/adf/testdata/fuzz/FuzzParseMarkdown/89bc59571d223c99
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("#\x10")

--- a/pkg/adf/testdata/fuzz/FuzzParseMarkdown/9e678cb0883474ed
+++ b/pkg/adf/testdata/fuzz/FuzzParseMarkdown/9e678cb0883474ed
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x7f>````` 000`")

--- a/pkg/adf/testdata/fuzz/FuzzParseMarkdown/acab1a26a0b9ca1c
+++ b/pkg/adf/testdata/fuzz/FuzzParseMarkdown/acab1a26a0b9ca1c
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("*0`0`0*")

--- a/pkg/adf/testdata/fuzz/FuzzParseMarkdown/c2d5aa832027bea7
+++ b/pkg/adf/testdata/fuzz/FuzzParseMarkdown/c2d5aa832027bea7
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("*\x19")


### PR DESCRIPTION
Closes #8. The inverse of P1.4: markdown back into `adf.Doc`.

## Running ahead of the Batch 1.5 gate, on purpose

The gate exists because PC.1, PC.3 and PC.5 are things Batch 2 would otherwise get quietly wrong.
None of them touches `pkg/adf`. This packet is a pure parser in files nobody else owns, so it is safe
to land now. `pkg/adf/{doc,render,render_inline,render_table}.go` and `render_test.go` are untouched —
`git diff origin/main --stat` shows only the new `parse*` files, new `testdata/fuzz` seeds, and two docs.

**Owned paths widened, as the packet spec approved:** the roadmap row said `pkg/adf/parse*.go`; it now
says `pkg/adf/parse*.go` and their tests, `pkg/adf/testdata/**` (new files only), `docs/API-NOTES.md`.
The row is corrected in this PR and the widening was stated on the issue before any code was written.

## The API

```go
func ParseMarkdown(md string) (Doc, error)
func ParseMarkdownWith(md string, opt Options) (Doc, error)
func ParseMarkdownInto(d Doc, md string, opt Options) (Doc, error)
func ParseMarkdownDropsOnly() []string
type ParseError struct{ Line int; Text string; Err error }
var ErrUnsupportedMarker, ErrNesting error
```

## The honest version of "byte-stable", and why the packet needed a third function

The issue asks for byte-stability on untouched documents. **Parsing markdown on its own cannot deliver
that, for any parser.** The renderer's output is a lossy projection by design — its own doc comment says
so: it renders a mention as `@Someone` and drops the account id, a lozenge as `[Done]` and drops the
colour, a date as a day and drops the epoch, an unknown node as `[unsupported: futureBlock]` and drops
its attributes. There is no marker or escape carrying that through; I went looking for one in
`render.go` first, and the "mechanism" is `unknownBlock`, which writes the node's *type* and its
rendered text and nothing else.

So the packet's promise is kept the only way it can be: `ParseMarkdownInto` reconciles the edited
markdown against the document it was rendered from. Each top-level node is rendered on its own; where
the markdown at that point is byte-for-byte that rendering, the **original node** is reused — still
carrying the bytes `Unmarshal` kept, so `doc.go`'s verbatim mechanism re-emits them exactly. That is
the other half of a contract `doc.go` already built.

The result:

- `Marshal(ParseMarkdownInto(d, Markdown(d), opt)) == Marshal(d)`, **byte for byte, for every document
  in the corpus and 1,500 generated ones, across four option sets.** `TestParseMarkdownInto_KeepsTheBytesJiraSent`
  proves it means what it says: it compares against the raw, pretty-printed description bytes read out
  of the fixture file, not against a canonical re-encode of both sides.
- An unknown node survives an edit three blocks away (`TestParseMarkdownInto_KeepsAnUnknownNodeAcrossAnEditBesideIt`).
- Editing one paragraph re-encodes one paragraph; every other block comes back byte-identical
  (`TestParseMarkdownInto_ReparsesOnlyTheBlockThatChanged`).

Matching on the *rendering* rather than on the parsed shape is what makes this independent of how the
parser divides lines up: a heading holding a hard break is two blocks to markdown and one node to ADF,
and it still comes back as the node.

For a parse with no original, the property that does hold is a one-pass fixed point:
`Markdown(ParseMarkdown(Markdown(d))) == Markdown(d)` — what the author saw is what comes back.

## Every case where ADF → markdown is one-way

Enumerated deliberately rather than glossed. Each has a row in `TestParseMarkdown_CannotUndoTheseRenderings`
with the answer the parser actually gives, a matching entry in `ParseMarkdownDropsOnly()` (so a caller can
warn a user), and a matching row in `TestParseMarkdownInto_RestoresEveryOneWayCase` showing it costs
nothing when the original document is to hand.

| Construct | What is lost | Why it cannot be inverted |
|---|---|---|
| `mention` | account id | ADF requires `attrs.id`; markdown carries only the display text. Rebuilding one would mean inventing an id, i.e. @-ing a different person. |
| `status` | colour | `attrs.color` is required and has no spelling in `[Done]`. |
| `date` | the instant | rendered as a day in one timezone; the epoch millis are gone, and a bare `2026-03-02` in prose must not become a node. |
| `emoji` | `shortName`, `id` | only the character is written. |
| `media` | collection, width, height, layout | `![alt](media:<id>)` keeps the id and the type. |
| `table` | colspan, rowspan, background, layout, number column | a merged cell was written as one value plus empty columns; a multi-block cell was folded to one line. |
| `table` with `TableWidth` | **the cell text itself** | a bounded render truncates with an ellipsis. **P2.3/P2.4: render with `Options{}` when handing markdown to `$EDITOR`.** |
| `panel` | the case of an unknown `panelType` | rendered uppercased; comes back lowercased, which ADF's own types are. |
| empty `heading` | the node | the renderer writes nothing at all for it. |
| `hardBreak` opening a block, or in a heading, or before a line that reads as a marker | the break | markdown's block structure eats a leading blank line, ends a heading at the newline, and lets a list interrupt a paragraph. |
| prose beginning a line with `- `, `1. `, `> `, `#` | the distinction | the renderer does not escape prose, on purpose — a reader should see what the author typed. |
| neighbouring runs whose marks overlap | the split | an em run beside an em+code run spells the same characters as one run nested inside another. |
| trailing whitespace, control characters | themselves | trimmed and sanitised by the renderer. |
| mark order | itself | already documented in API-NOTES as byte-significant and meaningless. |

**No renderer change is proposed.** Escaping prose would defeat the renderer's stated reason for not
escaping it, and embedding an unknown node's JSON in the markdown would put raw ADF in front of a
reader. The reconciling parser is the fix, and it costs the caller one extra argument.

## Not drifting, which matters more than not being lossy

A lossy render is survivable. A parser that reads its own output back *differently each time* eats
somebody's formatting one save at a time — that is what the fuzzer found four times here (a paragraph
growing four asterisks per save, among others). So `inline` checks each reading against what it would
render, and falls back: full parse → emphasis markers as characters → the line as prose. The last
reading always reproduces the line, so the parser never answers something that would come out
different next time.

## Never invalid ADF

- No empty text node (`minLength: 1`) — `TestParseMarkdown_NeverWritesAnEmptyTextNode` over 19 degenerate inputs.
- Always `{"version":1,"type":"doc","content":[…]}`; a null field stays null.
- A container that must hold a block gets an empty paragraph rather than nothing.
- `orderedList` read from `0.` starts at one, because ADF numbers from one.
- A nesting ADF has no shape for — a table, heading or rule inside a quote or list item, a panel inside
  a panel — is `ErrNesting` with a line number, not a document the validator would silently repair.
- An `[unsupported: …]` marker with no original to restore from is `ErrUnsupportedMarker`, not a
  fabricated node Jira would reject or a silent deletion.
- A second `expand` inside one becomes `nestedExpand`, which is the node ADF has for it.

## Tests

- Table test over 46 shapes the renderer writes, asserting exact JSON, plus the sharp edges the packet
  named: a list marker inside a code fence, a link whose text holds brackets, an ordered list not
  starting at 1, an escaped pipe, CRLF and lone CR, trailing whitespace, empty and whitespace-only
  documents, a BOM, `snake_case`, `#hashtag`, an unclosed fence, ASCII vs Unicode markers.
- Round-trip properties over the renderer's own corpus (its goldens' source data plus
  `issue_rich_adf.json`, read not copied) × four option sets.
- Property test over 1,500 seeded generated documents (200 with `-short`); the seed is printed with any
  failure so it reproduces exactly.
- `FuzzParseMarkdown` with a 75-entry `f.Add` corpus and six regression seeds under
  `pkg/adf/testdata/fuzz/`, each one a real bug it found. Ran clean for **10.3M executions**.
- No golden file changed and none was added; the parser's output is asserted as JSON.

## Benchmarks

`go test -bench BenchmarkParse -benchmem ./pkg/adf` on an M2 Pro:

```
ParseMarkdown_RichFixture              11.3 µs/op    70 MB/s     20.5 kB    125 allocs
ParseMarkdown_Prose (13 kB)             113 µs/op   117 MB/s      173 kB    611 allocs
ParseMarkdown_LargeDocument (160 kB)   3.09 ms/op    52 MB/s     4.03 MB  22819 allocs
ParseMarkdownInto_Unchanged (184 kB)   2.25 ms/op    82 MB/s     3.51 MB  18498 allocs
ParseMarkdownInto_OneBlockEdited       2.31 ms/op    80 MB/s     3.51 MB  18512 allocs
ScalesWithTheText  1x / 10x / 100x     39.7 µs / 450 µs / 5.05 ms
```

Linear in the text — `BenchmarkParseMarkdown_ScalesWithTheText` is there so a future rewrite that
rescans a line per delimiter shows up as a hundredfold rather than a tenfold. A comment body is well
under a millisecond. Markup-heavy text costs about 3x plain prose, which is the reading-check; lines
with no marker character skip it, and the check's buffer is reused.

## Consumers

Nothing shared changed — this only adds new exported API to `pkg/adf`, and nothing outside the package
compiled against it before. `grep -rn "pkg/adf"` outside the package finds `pkg/jira`, `internal/ui/issue`
and `internal/arch`, none of which parse markdown today. The consumers are in flight in this same batch,
so, by name:

- **P2.3 (`internal/ui/issue/edit*.go`, #10)** — the `$EDITOR` handoff must call `ParseMarkdownInto` with
  the document it rendered, not `ParseMarkdown`. Calling `ParseMarkdown` compiles, passes a smoke test,
  and silently strips every mention id and unknown node in the description. It must also render with
  `Options{}` (no `TableWidth`) or an edit writes truncated table cells back.
- **P2.4 (`internal/ui/comment/**`, #11)** — a *new* comment has no original, so `ParseMarkdown` is right
  there; editing an existing one is `ParseMarkdownInto`.

`ParseMarkdownDropsOnly()` exists so both can tell the user what an edit will cost instead of finding
out afterwards.

## Docs

- `docs/API-NOTES.md` gains five ADF rows: which attributes have no markdown spelling and what follows
  from that, `orderedList` numbering from one, the nestings ADF has no shape for, and the `(item | list)+`
  content model for task lists.
- `docs/ROADMAP.md`: checkbox ticked, `owns` corrected, row rewritten to say what actually landed.

## Verification

`go mod tidy` clean · `go vet` clean · `golangci-lint run` **0 issues** · `go test -race -count=1 ./...`
green · stripped binary builds · `scripts/checkleak.py` clean · no `go.mod` change · no fixture touched.
