### PR TITLE
fix(session): remember the project you picked, and let it change without a restart

### DIFF
--- a/cmd/saral/main.go
+++ b/cmd/saral/main.go
@@ -2,11 +2,14 @@
 package main
 
 import (
+	"cmp"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"unicode"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -121,7 +124,11 @@ func build(opt options) (kernel.Deps, []kernel.Option, error) {
 		return deps, nil, perr
 	}
 	deps.Site = profile.Site
-	deps.Project = opt.project
+	project, err := sessionProject(opt.project, profile.Project)
+	if err != nil {
+		return deps, nil, err
+	}
+	deps.Project = project
 
 	saved, err := app.NewSavedQueries(profile.Queries...)
 	if err != nil {
@@ -155,6 +162,17 @@ func build(opt options) (kernel.Deps, []kernel.Option, error) {
 		kopts = append(kopts, kernel.WithInitialView(kernel.SetupViewID))
 	}
 	return deps, kopts, nil
+}
+
+// sessionProject scopes the session. The flag overrides the profile for one run
+// rather than replacing it, and reaches JQL the way a stored key does, so it is
+// held to the rule internal/config enforces on one.
+func sessionProject(fromFlag, stored string) (string, error) {
+	key := cmp.Or(strings.TrimSpace(fromFlag), stored)
+	if strings.ContainsFunc(key, unicode.IsSpace) {
+		return "", fmt.Errorf("--project %q is not a project key", key)
+	}
+	return key, nil
 }
 
 // queryWriter persists a changed set of saved queries back into the profile

--- a/cmd/saral/main_test.go
+++ b/cmd/saral/main_test.go
@@ -123,4 +123,52 @@ token = { env = "JIRA_TOKEN" }
 	}
 }
 
+func TestBuild_TheProjectFlagOverridesTheProfileRatherThanReplacingIt(t *testing.T) {
+	tests := map[string]struct {
+		stored string
+		flag   string
+		want   string
+		fails  bool
+	}{
+		"the profile alone scopes the session":   {stored: "EX", want: "EX"},
+		"the flag alone scopes the session":      {flag: "OTHER", want: "OTHER"},
+		"the flag wins over the profile":         {stored: "EX", flag: "OTHER", want: "OTHER"},
+		"neither leaves the session unscoped":    {},
+		"a blank flag falls back to the profile": {stored: "EX", flag: "   ", want: "EX"},
+		"a padded flag is taken trimmed":         {flag: "  OTHER  ", want: "OTHER"},
+		"a flag with a space in it is refused":   {flag: "two words", fails: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SARAL_CONFIG_DIR", dir)
+			cfg := "active = \"work\"\n\n[profiles.work]\nsite  = \"example.atlassian.net\"\n" +
+				"email = \"you@example.com\"\ntoken = { env = \"JIRA_TOKEN\" }\n"
+			if tc.stored != "" {
+				cfg += "project = " + strconv.Quote(tc.stored) + "\n"
+			}
+			if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(cfg), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			deps, _, err := build(options{project: tc.flag})
+			switch {
+			case tc.fails && err == nil:
+				t.Fatalf("--project %q was accepted and reached JQL", tc.flag)
+			case tc.fails:
+				if !strings.Contains(err.Error(), tc.flag) {
+					t.Errorf("error %q does not quote the offending value", err)
+				}
+				return
+			case err != nil:
+				t.Fatalf("build: %v", err)
+			}
+			if deps.Project != tc.want {
+				t.Errorf("the session is scoped to %q, want %q", deps.Project, tc.want)
+			}
+		})
+	}
+}
+
 func initialView(opts []kernel.Option) string { return kernel.InitialViewOf(opts...) }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,11 +106,25 @@ because it unblocks or blocks everyone. The other four run in parallel behind it
   a key with a confirmation when it is taking one, and the injection through `kernel.Deps` and
   `cmd/saral/main.go`. The owned paths grew to match: the digit dispatch, the footer and the memo key
   are all in `kernel.go`, and saved-query persistence was owned by nobody at all.
-- [ ] **PC.3 — Session project scope** · [#50](https://github.com/varijkapil13/saral/issues/50) · **owns** `cmd/saral/main.go`, `internal/ui/kernel/kernel.go`, `internal/ui/list/list.go`
-  Onboarding asks which project you work in, validates it, writes it to the profile, and nothing ever
-  reads it back: `deps.Project` comes only from `--project`. So the capability probe resolves
-  per-project permissions against an empty key and the list opens unscoped over the whole site.
-  Includes deciding what no-project-at-all means and how a project is changed mid-session.
+- [x] **PC.3 — Session project scope** · [#50](https://github.com/varijkapil13/saral/issues/50) · **owns** `cmd/saral/main.go`, `internal/ui/kernel/kernel.go`, `internal/ui/list/list.go` and their tests, `internal/ui/list/testdata/**`, `docs/ROADMAP.md`
+  Onboarding asked which project you work in, validated it, wrote it to the profile, and nothing ever
+  read it back: `deps.Project` came only from `--project`, which was itself validated nowhere, so
+  `--project "two words"` reached JQL. The flag now overrides the profile rather than replacing it,
+  and is held to the rule `internal/config` already enforces on a stored key.
+  Half of the issue's premise was stale. `cloud.Capabilities("")` was already right — it skips the
+  per-project probes and writes three sentences saying why those answers are unknown. The untested
+  denials were the kernel's *zero* `jira.Capabilities`, which is indistinguishable from a token that
+  may do nothing, so a session that had probed nothing still answered `open()` with "is not available
+  on this site" for a question never asked. The kernel now probes on `Init`, remembers whether a
+  probe has answered, and says which of the two it is.
+  A project can be changed mid-session with `kernel.SetProject`, which is as far into the gesture as
+  the kernel goes — the palette command belongs to P3.1. The kernel re-probes under a sequence
+  number so two switches cannot land out of order, tells every view including the roots parked off
+  screen, keeps the project being left answering until the new answers arrive, and names the scope in
+  the header. A view already open when a switch takes its capability away stays on screen and lets
+  its own actions refuse with the capability's `Reason`, per `docs/UX.md`. The list follows a switch
+  only while the search on screen is still the one it derived from the project, so a query the user
+  ran is never silently discarded.
 - [x] **PC.4 — Make the test rules enforceable** · [#33](https://github.com/varijkapil13/saral/issues/33), [#35](https://github.com/varijkapil13/saral/issues/35) · **owns** `.github/workflows/ci.yml`, `internal/arch/**`
   `AGENTS.md` and `docs/TESTING.md` both said CI fails a test that opens a non-loopback connection,
   and it did not. Now it does: the race suite runs inside a network namespace with only loopback up,

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -67,6 +67,7 @@ type chromeKey struct {
 	rootID    string
 	topID     string
 	title     string
+	project   string
 	status    string
 	help      bool
 	depth     int
@@ -104,6 +105,17 @@ type Model struct {
 	// chrome memoizes the header and footer, which are otherwise rebuilt on
 	// every frame and would put a few hundred allocations under every scroll.
 	chrome *chromeCache
+
+	// capsProbed records that a probe has actually answered. Without it the zero
+	// jira.Capabilities is indistinguishable from a site where the token may do
+	// nothing, and the kernel invents a denial for a question never asked.
+	capsProbed bool
+
+	// capsSeq tags each probe so that an answer overtaken by a newer one is
+	// dropped; scopeSeq is the probe a project switch is waiting on, zero when
+	// none is — which is also the sequence the startup probe carries.
+	capsSeq  int
+	scopeSeq int
 
 	// prefix holds the go-to key while it waits for the one that completes it.
 	// It is buffered rather than forwarded, because a view that spends g on its
@@ -226,8 +238,11 @@ func (m Model) available(spec ViewSpec) bool {
 
 // Init starts the model. It asks the terminal for its background colour so the
 // theme can settle before the second frame; the first frame is already drawn.
+//
+// It also asks the site what this token can do here: until that answers, every
+// capability-gated view is hidden with nothing to say about why.
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{tea.RequestBackgroundColor}
+	cmds := []tea.Cmd{tea.RequestBackgroundColor, m.probeAt(m.capsSeq)}
 	if len(m.stack) > 0 {
 		cmds = append(cmds, m.top().view.Init())
 	}
@@ -287,10 +302,24 @@ func (m Model) route(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.bindQuery(msg)
 
 	case CapabilitiesMsg:
-		m.deps.Caps = msg.Caps
-		m.roots = Views()
-		m.capsGen++
-		return m.forwardAll(msg)
+		return m.applyCaps(msg.Caps)
+
+	case capsProbedMsg:
+		if msg.seq != m.capsSeq {
+			return m, nil
+		}
+		return m.settle(msg.seq, msg.caps)
+
+	case capsFailedMsg:
+		if msg.seq != m.capsSeq {
+			return m, nil
+		}
+		text, _ := jira.Reason(msg.err)
+		m.status, m.statusLevel = text, LevelError
+		return m, nil
+
+	case ProjectMsg:
+		return m.setProject(msg.Project)
 
 	case BroadcastMsg:
 		return m.forwardAll(msg.Msg)
@@ -366,7 +395,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.forwardTop(RefreshMsg{})
 
 	case Matches(msg, m.keys.Purge):
-		return m.forwardTopWith(RefreshMsg{Purge: true}, m.probeCaps())
+		next, probe := m.probeCaps()
+		return next.forwardTopWith(RefreshMsg{Purge: true}, probe)
 	}
 	m.status = ""
 	return m.forwardTop(msg)
@@ -529,10 +559,7 @@ func (m Model) open(id string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if !m.available(spec) {
-		m.status, m.statusLevel = m.deps.Caps.Capability(spec.Requires).Reason, LevelWarn
-		if m.status == "" {
-			m.status = fmt.Sprintf("%s is not available on this site", spec.Title)
-		}
+		m.status, m.statusLevel = m.unavailable(spec), LevelWarn
 		return m, nil
 	}
 	if len(m.stack) == 1 && m.stack[0].spec.ID == id {
@@ -556,6 +583,19 @@ func (m Model) open(id string) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, view.Init())
 	}
 	return m, tea.Batch(cmds...)
+}
+
+// unavailable is why a view cannot be opened. A session that has probed nothing
+// knows nothing about this site, which is a different answer from a probe that
+// came back without the capability.
+func (m Model) unavailable(spec ViewSpec) string {
+	if reason := m.deps.Caps.Capability(spec.Requires).Reason; reason != "" {
+		return reason
+	}
+	if !m.capsProbed {
+		return fmt.Sprintf("nothing has been checked on this site yet, so whether %s works here is unknown", spec.Title)
+	}
+	return fmt.Sprintf("%s is not available on this site", spec.Title)
 }
 
 func (m Model) push(msg PushMsg) (tea.Model, tea.Cmd) {
@@ -691,9 +731,97 @@ func (m Model) forwardAll(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+// ProjectMsg carries the project the session is scoped to after a switch. An
+// empty key is the whole site, which is a scope of its own rather than the
+// absence of one.
+type ProjectMsg struct{ Project string }
+
+// SetProject returns a command that re-scopes the session to a project key, or
+// to the whole site when the key is empty.
+func SetProject(key string) tea.Cmd {
+	return func() tea.Msg { return ProjectMsg{Project: key} }
+}
+
+// capsProbedMsg is a probe answer tagged with the request that asked for it. Two
+// project switches in quick succession put two probes in flight, and without the
+// tag the slower one wins whichever project it was asked about.
+type capsProbedMsg struct {
+	seq  int
+	caps jira.Capabilities
+}
+
+// capsFailedMsg is a probe that never answered, tagged the same way.
+type capsFailedMsg struct {
+	seq int
+	err error
+}
+
+// setProject re-scopes the session. Every view hears it, including the roots
+// parked off screen, and the probe runs again because boards, Move and Delete
+// are per-project answers. What the last project answered stands until the new
+// answer lands, rather than the zero Capabilities standing in for it.
+func (m Model) setProject(key string) (tea.Model, tea.Cmd) {
+	key = strings.TrimSpace(key)
+	if key == m.deps.Project {
+		return m, nil
+	}
+	m.deps.Project = key
+	next, probe := m.probeCaps()
+	next.scopeSeq = next.capsSeq
+	told, cmd := next.forwardAll(ProjectMsg{Project: key})
+	model, ok := told.(Model)
+	if !ok {
+		return told, tea.Batch(cmd, probe)
+	}
+	model.status, model.statusLevel = scopeNote(key, probe != nil), LevelInfo
+	return model, tea.Batch(cmd, probe)
+}
+
+// scopeNote says what the session is scoped to now, and whether anything is
+// still being asked about it.
+func scopeNote(key string, probing bool) string {
+	note := "no project is selected, so per-project answers stay unknown"
+	if key != "" {
+		note = "this session is scoped to " + key
+	}
+	if !probing {
+		return note
+	}
+	return note + ", and Saral is re-checking what this token can do"
+}
+
+// settle installs a probe result and, when it is the one a switch was waiting
+// for, replaces the note that said it was still being checked.
+func (m Model) settle(seq int, caps jira.Capabilities) (tea.Model, tea.Cmd) {
+	awaited := m.scopeSeq != 0 && seq == m.scopeSeq
+	next, cmd := m.applyCaps(caps)
+	model, ok := next.(Model)
+	if !ok || !awaited {
+		return next, cmd
+	}
+	model.status, model.statusLevel = scopeNote(model.deps.Project, false), LevelInfo
+	return model, cmd
+}
+
+// applyCaps installs a probe result. Views hear one message whichever probe
+// answered, so a view has a single case to write.
+func (m Model) applyCaps(caps jira.Capabilities) (tea.Model, tea.Cmd) {
+	m.deps.Caps, m.capsProbed = caps, true
+	m.roots = Views()
+	m.capsGen++
+	return m.forwardAll(CapabilitiesMsg{Caps: caps})
+}
+
 // probeCaps re-runs the capability probe, which is what R means beyond a
-// refetch: permissions and instance settings can change under a session.
-func (m Model) probeCaps() tea.Cmd {
+// refetch: permissions and instance settings can change under a session, and a
+// project switch changes the answer outright. Only the newest question's answer
+// is applied.
+func (m Model) probeCaps() (Model, tea.Cmd) {
+	m.capsSeq++
+	return m, m.probeAt(m.capsSeq)
+}
+
+func (m Model) probeAt(seq int) tea.Cmd {
 	client, project := m.deps.Jira, m.deps.Project
 	if client == nil {
 		return nil
@@ -703,10 +831,9 @@ func (m Model) probeCaps() tea.Cmd {
 		defer cancel()
 		caps, err := client.Capabilities(ctx, project)
 		if err != nil {
-			text, _ := jira.Reason(err)
-			return StatusMsg{Text: text, Level: LevelError}
+			return capsFailedMsg{seq: seq, err: err}
 		}
-		return CapabilitiesMsg{Caps: caps}
+		return capsProbedMsg{seq: seq, caps: caps}
 	}
 }
 
@@ -755,7 +882,8 @@ func (m Model) chromeFor() (header, footer string) {
 	_, palette := LookupView(PaletteViewID)
 	key := chromeKey{
 		width: m.width, themeGen: m.deps.Theme.Gen, capsGen: m.capsGen,
-		savedGen: m.savedGen, status: m.status, help: m.showHelp,
+		savedGen: m.savedGen, project: m.deps.Project,
+		status: m.status, help: m.showHelp,
 		depth: len(m.stack), palette: palette,
 		capturing: m.capturing(), prefixed: m.prefixSet,
 	}
@@ -780,13 +908,26 @@ func (m Model) header() string {
 	if len(m.stack) > 0 && m.top().spec.Title != "" {
 		title = "saral " + t.Glyphs.Separator + " " + m.top().spec.Title
 	}
-	right := m.deps.Site
+	right := m.headerRight()
 	gap := m.width - lipgloss.Width(title) - lipgloss.Width(right) - 2
 	if gap < 1 {
 		gap = 1
 		right = ""
 	}
 	return t.Header.Width(m.width).Render(oneLine(title+strings.Repeat(" ", gap)+right, m.width-2, t.Glyphs.Ellipsis))
+}
+
+// headerRight names what the session is pointed at: the project it is scoped
+// to, when there is one, and the site it is talking to.
+func (m Model) headerRight() string {
+	switch {
+	case m.deps.Project == "":
+		return m.deps.Site
+	case m.deps.Site == "":
+		return m.deps.Project
+	default:
+		return m.deps.Project + " " + m.deps.Theme.Glyphs.Separator + " " + m.deps.Site
+	}
 }
 
 func (m Model) body() string {

--- a/internal/ui/kernel/project_test.go
+++ b/internal/ui/kernel/project_test.go
@@ -1,0 +1,450 @@
+package kernel
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// probeRecorder is the fake with the project key of every probe written down,
+// answering with capabilities that name the key it was asked about. Which probe
+// an answer came from is otherwise invisible, and that is the whole question a
+// project switch raises.
+type probeRecorder struct {
+	*jiratest.Fake
+
+	mu     sync.Mutex
+	probed []string
+}
+
+func newProbeRecorder(keys ...string) *probeRecorder {
+	opts := make([]jiratest.Option, 0, len(keys))
+	for _, key := range keys {
+		opts = append(opts, jiratest.WithProject(key, jiratest.Scrum))
+	}
+	return &probeRecorder{Fake: jiratest.New(opts...)}
+}
+
+func (p *probeRecorder) Capabilities(ctx context.Context, projectKey string) (jira.Capabilities, error) {
+	p.mu.Lock()
+	p.probed = append(p.probed, projectKey)
+	p.mu.Unlock()
+
+	caps, err := p.Fake.Capabilities(ctx, projectKey)
+	if err != nil {
+		return caps, err
+	}
+	caps.Plans = jira.Capability{Reason: answeredFor(projectKey)}
+	return caps, nil
+}
+
+func (p *probeRecorder) probes() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.probed)
+}
+
+func answeredFor(key string) string {
+	if key == "" {
+		return "answered for the whole site"
+	}
+	return "answered for " + key
+}
+
+// projectSpy is a root view that writes down the switches it is told about,
+// including the ones that arrive while it is parked off screen.
+type projectSpy struct {
+	stubView
+	projects []string
+}
+
+func (p *projectSpy) Update(msg tea.Msg) (View, tea.Cmd) {
+	if m, ok := msg.(ProjectMsg); ok {
+		p.projects = append(p.projects, m.Project)
+	}
+	_, cmd := p.stubView.Update(msg)
+	return p, cmd
+}
+
+// scopedDeps is a session pointed at a project, with a client that answers for
+// it and capabilities that have not been probed yet.
+func scopedDeps(rec *probeRecorder, project string) Deps {
+	d := testDeps()
+	d.Jira, d.Project, d.Caps = rec, project, jira.Capabilities{}
+	return d
+}
+
+// runCmd runs a command tree and returns the messages it produced without
+// feeding any of them back, so a test can choose the order they land in.
+func runCmd(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		out := make([]tea.Msg, 0, len(batch))
+		for _, c := range batch {
+			out = append(out, runCmd(c)...)
+		}
+		return out
+	}
+	if msg == nil {
+		return nil
+	}
+	return []tea.Msg{msg}
+}
+
+// deliver runs a command tree against the model the way the runtime would.
+func deliver(t *testing.T, m Model, cmd tea.Cmd) Model {
+	t.Helper()
+	for _, msg := range runCmd(cmd) {
+		next, follow := m.Update(msg)
+		m = next.(Model)
+		m = deliver(t, m, follow)
+	}
+	return m
+}
+
+// probeAnswer picks the probe's reply out of everything a command tree produced.
+func probeAnswer(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	for _, msg := range runCmd(cmd) {
+		switch msg.(type) {
+		case capsProbedMsg, capsFailedMsg:
+			return msg
+		}
+	}
+	t.Fatal("no probe was started")
+	return nil
+}
+
+func switchTo(t *testing.T, m Model, key string) (Model, tea.Cmd) {
+	t.Helper()
+	msg, ok := SetProject(key)().(ProjectMsg)
+	if !ok {
+		t.Fatal("SetProject did not produce a ProjectMsg")
+	}
+	next, cmd := m.Update(msg)
+	return next.(Model), cmd
+}
+
+func TestInit_AsksWhatTheTokenCanDoInTheSessionsProject(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	if m.capsProbed {
+		t.Fatal("a session claims to have probed before anything ran")
+	}
+
+	m = deliver(t, m, m.Init())
+
+	if got := rec.probes(); !slices.Equal(got, []string{"ONE"}) {
+		t.Errorf("startup probed %v, want one probe for ONE", got)
+	}
+	if !m.capsProbed {
+		t.Error("the probe answered and the session still says nothing has been checked")
+	}
+	if got := m.deps.Caps.Plans.Reason; got != answeredFor("ONE") {
+		t.Errorf("the session is holding %q, want the answer for ONE", got)
+	}
+}
+
+func TestOpen_ExplainsWhyAGatedViewWillNotOpen(t *testing.T) {
+	tests := map[string]struct {
+		probed  bool
+		caps    jira.Capabilities
+		want    string
+		refused string
+	}{
+		"nothing has been probed": {
+			want:    "nothing has been checked on this site yet",
+			refused: "is not available on this site",
+		},
+		"the probe gave a reason": {
+			probed: true,
+			caps:   jira.Capabilities{Plans: jira.Capability{Reason: "Plans need Administer Jira"}},
+			want:   "Plans need Administer Jira",
+		},
+		"the probe gave no reason": {
+			probed: true,
+			want:   "Plans is not available on this site",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+			RegisterView(spec("plans", 2, jira.CapPlans, &stubView{id: "plans"}))
+
+			d := testDeps()
+			d.Caps = jira.Capabilities{}
+			m := newAt(t, d, 120, 30)
+			if tc.probed {
+				next, _ := m.Update(CapabilitiesMsg{Caps: tc.caps})
+				m = next.(Model)
+			}
+
+			m, _ = press(m, "g", "2")
+			got := ansi.Strip(m.Frame())
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("the status does not say %q:\n%s", tc.want, got)
+			}
+			if tc.refused != "" && strings.Contains(got, tc.refused) {
+				t.Errorf("a probe that never ran was reported as a refusal:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestSetProject_ReprobesAgainstTheNewKeyAndSaysSo(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE", "TWO")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	m = deliver(t, m, m.Init())
+
+	m, cmd := switchTo(t, m, "TWO")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "TWO") || !strings.Contains(got, "re-checking") {
+		t.Errorf("a switch did not say it was re-checking:\n%s", got)
+	}
+	if got := m.deps.Caps.Plans.Reason; got != answeredFor("ONE") {
+		t.Errorf("the capabilities were blanked during the probe: %q", got)
+	}
+
+	m = deliver(t, m, cmd)
+	if got := rec.probes(); !slices.Equal(got, []string{"ONE", "TWO"}) {
+		t.Errorf("probed %v, want ONE then TWO", got)
+	}
+	if m.deps.Project != "TWO" {
+		t.Errorf("the session is scoped to %q, want TWO", m.deps.Project)
+	}
+	if got := m.deps.Caps.Plans.Reason; got != answeredFor("TWO") {
+		t.Errorf("the session is holding %q, want the answer for TWO", got)
+	}
+}
+
+func TestSetProject_SwitchingToNoProjectIsAScopeOfItsOwn(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	m = deliver(t, m, m.Init())
+
+	m, cmd := switchTo(t, m, "")
+	m = deliver(t, m, cmd)
+
+	if got := rec.probes(); !slices.Equal(got, []string{"ONE", ""}) {
+		t.Errorf("probed %v, want ONE then the whole site", got)
+	}
+	if m.deps.Project != "" {
+		t.Errorf("the session is scoped to %q, want no project", m.deps.Project)
+	}
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "no project is selected") {
+		t.Errorf("dropping the project did not say what the session is scoped to now:\n%s", got)
+	}
+}
+
+func TestSetProject_SwitchingToTheSameKeyChangesNothing(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	m = deliver(t, m, m.Init())
+
+	m, cmd := switchTo(t, m, "  ONE  ")
+	m = deliver(t, m, cmd)
+
+	if got := rec.probes(); !slices.Equal(got, []string{"ONE"}) {
+		t.Errorf("probed %v; switching to the project already open should not ask again", got)
+	}
+	if m.status != "" {
+		t.Errorf("a switch that changed nothing put %q on the status line", m.status)
+	}
+}
+
+func TestSetProject_TheAnswerToAnOvertakenProbeIsDropped(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE", "TWO", "THREE")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	m = deliver(t, m, m.Init())
+
+	m, first := switchTo(t, m, "TWO")
+	older := probeAnswer(t, first)
+	m, second := switchTo(t, m, "THREE")
+	newer := probeAnswer(t, second)
+
+	for _, msg := range []tea.Msg{newer, older} {
+		next, cmd := m.Update(msg)
+		m = deliver(t, next.(Model), cmd)
+	}
+
+	if got := m.deps.Caps.Plans.Reason; got != answeredFor("THREE") {
+		t.Errorf("the session is holding %q; the overtaken probe's answer won", got)
+	}
+}
+
+func TestSetProject_ReachesARootViewTheUserSwitchedAwayFrom(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &projectSpy{stubView: stubView{id: "board"}}
+	RegisterView(ViewSpec{ID: "board", Title: "Board", Slot: 1, New: func(Deps) View { return board }})
+	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+	rec := newProbeRecorder("ONE", "TWO")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	m, _ = press(m, "g", "2")
+
+	m, cmd := switchTo(t, m, "TWO")
+	_ = deliver(t, m, cmd)
+
+	if !slices.Equal(board.projects, []string{"TWO"}) {
+		t.Errorf("a parked root view was told %v about the switch, want TWO", board.projects)
+	}
+}
+
+func TestHeader_NamesTheProjectAndRebuildsWhenItChanges(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE", "TWO")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+
+	first := firstLine(ansi.Strip(m.Frame()))
+	if !strings.Contains(first, "ONE") || !strings.Contains(first, "example.atlassian.net") {
+		t.Fatalf("the header does not name what the session is pointed at:\n%s", first)
+	}
+
+	m, cmd := switchTo(t, m, "TWO")
+	m = deliver(t, m, cmd)
+
+	switched := firstLine(ansi.Strip(m.Frame()))
+	if strings.Contains(switched, "ONE") || !strings.Contains(switched, "TWO") {
+		t.Errorf("the memoized header survived a switch:\n%s", switched)
+	}
+}
+
+func TestHeader_IsNotMemoizedAcrossAProjectChange(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	rec := newProbeRecorder("ONE", "TWO")
+	m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+	if got := firstLine(ansi.Strip(m.Frame())); !strings.Contains(got, "ONE") {
+		t.Fatalf("the header does not name the project:\n%s", got)
+	}
+
+	// Nothing else the memo key holds moves here, so the project on its own has
+	// to be enough to rebuild the header.
+	m.deps.Project = "TWO"
+
+	if got := firstLine(ansi.Strip(m.Frame())); !strings.Contains(got, "TWO") {
+		t.Errorf("the memoized header outlived the project it names:\n%s", got)
+	}
+}
+
+func TestHeader_NamesOnlyTheSiteWhenNoProjectIsSelected(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	if got := firstLine(ansi.Strip(m.Frame())); strings.Count(got, "|") != 1 {
+		t.Errorf("an unscoped session drew a separator for a project it does not have:\n%s", got)
+	}
+}
+
+func TestSetProject_AFailedReprobeLeavesTheStandingAnswersAlone(t *testing.T) {
+	tests := map[string]error{
+		"403": &jira.CapabilityError{Capability: jira.CapBulkMove, Reason: "needs Bulk Change permission"},
+		"429": &jira.RateLimitError{RetryAfter: 30 * time.Second, Endpoint: "/rest/api/3/mypermissions"},
+		"transport": &jira.TransportError{
+			Op: "GET /rest/api/3/mypermissions", Err: errors.New("connection refused"),
+		},
+	}
+
+	for name, failure := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+			rec := newProbeRecorder("ONE", "TWO")
+			m := newAt(t, scopedDeps(rec, "ONE"), 120, 30)
+			m = deliver(t, m, m.Init())
+
+			rec.FailNext(failure)
+			m, cmd := switchTo(t, m, "TWO")
+			m = deliver(t, m, cmd)
+
+			want, _ := jira.Reason(failure)
+			if m.status != want {
+				t.Errorf("the status reads %q, want the error's own wording %q", m.status, want)
+			}
+			if m.statusLevel != LevelError {
+				t.Errorf("a failed probe was reported at level %v", m.statusLevel)
+			}
+			if got := m.deps.Caps.Plans.Reason; got != answeredFor("ONE") {
+				t.Errorf("a failed probe threw away what was already known: %q", got)
+			}
+			if m.deps.Project != "TWO" {
+				t.Errorf("the session is scoped to %q, want TWO whatever the probe did", m.deps.Project)
+			}
+		})
+	}
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(s, "\n")
+	return line
+}
+
+// BenchmarkFrameScopedToAProject holds the redraw budget for a header that
+// names a project as well as a site.
+func BenchmarkFrameScopedToAProject(b *testing.B) {
+	resetRegistry()
+	b.Cleanup(resetRegistry)
+	RegisterView(ViewSpec{ID: "board", Title: "Board", Slot: 1,
+		New: func(Deps) View { return &stubView{id: "board", content: strings.Repeat("row\n", 40)} }})
+	RegisterKeys("board", KeySet{Short: []Binding{Bind([]string{"enter"}, "enter", "open")}})
+
+	d := testDeps()
+	d.Project = "PROJ"
+	m, err := New(d, WithSize(200, 60), WithMouse(false))
+	if err != nil {
+		b.Fatal(err)
+	}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	m = next.(Model)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = m.Frame()
+	}
+}

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -79,6 +79,11 @@ type Model struct {
 	filter    textinput.Model
 	query     string
 
+	// defaulted records that the search on screen is still the one New derived
+	// from the session's project. A project switch retargets that search and
+	// leaves alone one the user asked for.
+	defaulted bool
+
 	// saved is the kernel's set of saved queries, as this view was built and as
 	// the kernel last changed it, kept so that binding a key can name what that
 	// key already runs.
@@ -136,6 +141,7 @@ func New(d kernel.Deps) kernel.View {
 	}
 	m.normal, m.inFilter = defaultKeys().tables()
 	m.jql, m.title = defaultQuery(d.Project)
+	m.defaulted = true
 	m.relayout()
 	return m
 }
@@ -194,6 +200,9 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case kernel.CapabilitiesMsg:
 		m.deps.Caps = msg.Caps
 		m.rows.reset()
+
+	case kernel.ProjectMsg:
+		cmd = m.reproject(msg.Project)
 
 	case kernel.RefreshMsg:
 		cmd = m.refresh(msg.Purge)
@@ -338,13 +347,32 @@ func (m *Model) refresh(purge bool) tea.Cmd {
 }
 
 func (m *Model) retarget(msg QueryMsg) tea.Cmd {
-	jql := strings.TrimSpace(msg.JQL)
+	return m.setQuery(msg.JQL, msg.Title, false)
+}
+
+// reproject follows a mid-session project switch. The key is taken whatever the
+// search is, because the detail pane is built from these deps; the search moves
+// only while it is the one this view chose, never one the user ran.
+func (m *Model) reproject(project string) tea.Cmd {
+	if project == m.deps.Project {
+		return nil
+	}
+	m.deps.Project = project
+	if !m.defaulted {
+		return nil
+	}
+	jql, title := defaultQuery(project)
+	return m.setQuery(jql, title, true)
+}
+
+func (m *Model) setQuery(jql, title string, byDefault bool) tea.Cmd {
+	jql = strings.TrimSpace(jql)
 	if jql == "" {
 		return nil
 	}
-	m.jql = jql
-	if msg.Title != "" {
-		m.title = msg.Title
+	m.jql, m.defaulted = jql, byDefault
+	if title != "" {
+		m.title = title
 	}
 	m.issues, m.page, m.missing, m.view, m.needles = nil, jira.Page[jira.Issue]{}, nil, nil, nil
 	m.cursor, m.top, m.loaded = 0, 0, false

--- a/internal/ui/list/list_test.go
+++ b/internal/ui/list/list_test.go
@@ -324,7 +324,11 @@ func TestList_EnterOnAnEmptyResultDoesNothing(t *testing.T) {
 func TestList_RendersWhenTheCapabilityProbeFoundNothing(t *testing.T) {
 	t.Parallel()
 
-	d := testDeps(newFake(12))
+	// The fake has to answer with nothing too: the kernel probes on Init, so a
+	// hand-built empty Caps would be replaced before the first frame.
+	d := testDeps(newFake(12, jiratest.WithCapabilities(
+		jiratest.NoPlans, jiratest.NoBulkMove, jiratest.NoBoards,
+		jiratest.NoAttachments, jiratest.NoDeleteIssues, jiratest.NoTimeZone)))
 	d.Caps = jira.Capabilities{}
 	m := startAll(t, d, 120, 30)
 

--- a/internal/ui/list/project_test.go
+++ b/internal/ui/list/project_test.go
@@ -1,0 +1,111 @@
+package list
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// twoProjects is a site the session can be re-scoped inside, with work of the
+// account's own in both so a switch has something to land on.
+func twoProjects() *jiratest.Fake {
+	ada := jira.User{AccountID: "acct-ada", DisplayName: "Ada Lovelace", Active: true, TimeZone: time.UTC}
+	return jiratest.New(
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithProject("OTHER", jiratest.Kanban),
+		jiratest.WithIssues(append(jiratest.Gen(12), jiratest.GenFor("OTHER", 12)...)),
+		jiratest.WithMe(ada),
+	)
+}
+
+func TestList_OpensOnTheWholeSiteWhenNoProjectIsSelected(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(12))
+	d.Project = ""
+	dr := newDriver(t, d, 120, 30)
+
+	if strings.Contains(dr.m.jql, "project =") {
+		t.Errorf("an unscoped session opened on %q, which names a project it was never given", dr.m.jql)
+	}
+	if !strings.Contains(dr.m.jql, "currentUser()") {
+		t.Errorf("the opening query is %q, want the account's own work", dr.m.jql)
+	}
+	if dr.m.title != "My issues" {
+		t.Errorf("the unscoped search is titled %q, want My issues", dr.m.title)
+	}
+}
+
+func TestList_AProjectSwitchRetargetsTheSearchItChoseItself(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(twoProjects()), 120, 30)
+	if !strings.Contains(dr.m.jql, `project = "PROJ"`) {
+		t.Fatalf("the list did not open scoped to the session's project: %q", dr.m.jql)
+	}
+
+	dr.send(kernel.ProjectMsg{Project: "OTHER"})
+
+	if !strings.Contains(dr.m.jql, `project = "OTHER"`) {
+		t.Errorf("the search is still %q after a switch to OTHER", dr.m.jql)
+	}
+	if dr.m.title != "My issues in OTHER" {
+		t.Errorf("the search is titled %q, want My issues in OTHER", dr.m.title)
+	}
+	if dr.m.deps.Project != "OTHER" {
+		t.Errorf("the view is still built for %q, so a pushed detail pane would be too", dr.m.deps.Project)
+	}
+	if len(dr.m.issues) == 0 {
+		t.Fatal("the retargeted search found nothing at all")
+	}
+	for i := range dr.m.issues {
+		if !strings.HasPrefix(dr.m.issues[i].Key, "OTHER-") {
+			t.Fatalf("%s is not in the project the session switched to", dr.m.issues[i].Key)
+		}
+	}
+}
+
+func TestList_AProjectSwitchDoesNotDiscardASearchTheUserRan(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(twoProjects()), 120, 30)
+	dr.send(QueryMsg{JQL: shippedJQL, Title: "Shipped"})
+
+	dr.send(kernel.ProjectMsg{Project: "OTHER"})
+
+	if dr.m.jql != shippedJQL {
+		t.Errorf("a switch replaced the query the user ran with %q", dr.m.jql)
+	}
+	if dr.m.title != "Shipped" {
+		t.Errorf("the search is titled %q, want the user's own title", dr.m.title)
+	}
+	if dr.m.deps.Project != "OTHER" {
+		t.Errorf("the view is still built for %q; the key travels even when the search does not", dr.m.deps.Project)
+	}
+}
+
+func TestList_ASwitchBackToTheSameProjectRefetchesNothing(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(twoProjects()), 120, 30)
+	before := dr.m.gen
+
+	dr.send(kernel.ProjectMsg{Project: "PROJ"})
+
+	if dr.m.gen != before {
+		t.Errorf("a switch to the project already open started another search (generation %d to %d)", before, dr.m.gen)
+	}
+}
+
+func TestList_GoldenAfterAProjectSwitch(t *testing.T) {
+	t.Parallel()
+
+	m := start(t, testDeps(twoProjects()), 120, 30)
+	m = send(t, m, kernel.ProjectMsg{Project: "OTHER"})
+
+	golden(t, "list_switched_120x30.golden", frame(m))
+}

--- a/internal/ui/list/testdata/list_100x30.golden
+++ b/internal/ui/list/testdata/list_100x30.golden
@@ -1,4 +1,4 @@
- saral | Issues                                                               example.atlassian.net 
+ saral | Issues                                                        PROJ | example.atlassian.net 
 All issues                                                                                 12 issues
   KEY      SUMMARY                           TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-1   Add the nightly export            Epic       Building      Grace Hopper      02 Mar 12:00

--- a/internal/ui/list/testdata/list_120x40.golden
+++ b/internal/ui/list/testdata/list_120x40.golden
@@ -1,4 +1,4 @@
- saral | Issues                                                                                   example.atlassian.net 
+ saral | Issues                                                                            PROJ | example.atlassian.net 
 All issues                                                                                                     12 issues
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00

--- a/internal/ui/list/testdata/list_80x20.golden
+++ b/internal/ui/list/testdata/list_80x20.golden
@@ -1,4 +1,4 @@
- saral | Issues                                           example.atlassian.net 
+ saral | Issues                                    PROJ | example.atlassian.net 
 All issues                                                             12 issues
   KEY      SUMMARY                                       TYPE       STATUS      
 > PROJ-1   Add the nightly export                        Epic       Building    

--- a/internal/ui/list/testdata/list_switched_120x30.golden
+++ b/internal/ui/list/testdata/list_switched_120x30.golden
@@ -1,18 +1,9 @@
- saral | Issues                                                                            PROJ | example.atlassian.net 
-All issues                                                                                                     12 issues
+ saral | Issues                                                                           OTHER | example.atlassian.net 
+My issues in OTHER                                                                                              3 issues
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
-> PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
-  PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
-  PROJ-3   Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
-  PROJ-4   Document CSV import                                   Defect     Building      unassigned        02 Mar 18:00
-  PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00
-  PROJ-6   Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
-  PROJ-7   Fix the search index                                  Defect     Building      Grace Hopper      03 Mar 00:00
-  PROJ-8   Add invoice rounding                                  Chore      Shipped       unassigned        03 Mar 02:00
-  PROJ-9   Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
-  PROJ-10  Investigate the release checklist                     Defect     Building      Grace Hopper      03 Mar 06:00
-  PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
-  PROJ-12  Retire the nightly export                             Story      Triage        unassigned        03 Mar 10:00
+> OTHER-9  Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
+  OTHER-6  Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
+  OTHER-3  Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -27,4 +18,13 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
                                                                                                                         
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ this session is scoped to OTHER                                                                                        
  g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit


### PR DESCRIPTION
Closes #50.

Onboarding asks which project you work in, validates it and writes it to the profile. Nothing read it back — `deps.Project` came from `--project` and nothing else — so the second launch, the first one that skips onboarding, was scoped to nothing at all.

## Two corrections to the issue body

Recon found half the issue's premise stale, so this PR does not rebuild what was already right.

1. **`cloud.Capabilities("")` already behaves correctly.** `pkg/jira/cloud/caps.go` skips `capsPermissions` and `capsBoards` entirely when the key is empty, and `capsWithoutProject` writes three explicit sentences ("no project is selected, and a board belongs to a project", etc.). The adapter does not report untested denials, and nothing in `pkg/jira` is touched here.
2. **The untested denials were the kernel's zero value.** `build()` never sets `deps.Jira`, because it cannot — `*cloud.Client` implements 2 of the port's 34 methods (#55). So every session ran on the zero `jira.Capabilities`, `available()` hid every gated view, and `open()` answered `"%s is not available on this site"` for a probe that never ran. **The wiring is not fixed here** — that is #55/#52 — only the fabricated sentence.

## What changed

**`cmd/saral/main.go`** — `sessionProject` resolves the scope: `cmp.Or(strings.TrimSpace(opt.project), profile.Project)`. The flag overrides the profile for one run rather than replacing it, which is exactly what the last onboarding screen promises ("Saral remembers the one you pick, and naming a project on the command line overrides it for that run"). The flag was validated nowhere, so `--project "two words"` reached JQL; it is now refused with the wording `internal/config` uses for a stored key.

**`internal/ui/kernel/kernel.go`**

- `capsProbed` records that a probe has actually answered. `available()` stays conservative — an unprobed session still hides gated views — but `open()` now says `"nothing has been checked on this site yet, so whether Plans works here is unknown"` instead of naming a capability as unavailable. A probe that came back *with* a reason still shows that reason verbatim.
- The kernel probes on `Init`. Without it `capsProbed` could only flip on `R`, and a session with a working client would hide every gated view forever. This is the one addition beyond the issue's letter; it is what @varijkapil13's comment on #50 asked for, and it is inside this packet's owned file.
- `kernel.SetProject(key)` / `ProjectMsg` re-scope a live session. `setProject` trims, no-ops when unchanged, updates `deps.Project`, forwards to the stack **and** to the parked roots via `forwardAll`, and re-probes.
- **The race is closed.** `probeCaps` captured the project but nothing tagged the answer, so two rapid switches could land out of order and the older one would win. Probe replies now carry a sequence number and a stale one is dropped. This is done with kernel-local unexported messages (`capsProbedMsg`, `capsFailedMsg`); **the public `CapabilitiesMsg` is unchanged**, and `list.go`'s existing handler for it keeps working untouched.
- The header names the project beside the site (`PROJ | example.atlassian.net`), and `project` joined `chromeKey` — without it the memoized header outlives the project it names. There is a test that fails if the key is dropped again.

**`internal/ui/list/list.go`** — a `defaulted` flag records whether the search on screen is still the one `New` derived from the project. `ProjectMsg` always updates `deps.Project` (the detail pane is constructed from `m.deps`, so a stale key would propagate into it) and recomputes the default query **only while it is still the default**, so a switch never discards a query the user retargeted. `defaultQuery` is unchanged: it already returns the right unscoped query for an empty key.

## Decisions, made rather than stumbled into

- **A view open when a switch takes its capability away stays on screen** and lets its own actions refuse with the capability's `Reason`, per `docs/UX.md`. `open()` checks `available()` on entry only; popping someone out of a view they are reading is worse than letting the next action explain itself.
- **The previous project's answers stand during the re-probe**, with a status line saying it is being re-checked, replaced by the settled scope once the answer lands. Blanking them would put five empty reasons and the fabricated "not available on this site" back on screen at a new moment — the bug this PR removes.
- **The gesture stays out of the kernel.** `Command.Run` already receives `Deps` and the palette does not exist yet, so `kernel.SetProject` is exported and stops there. Registering a command from inside the kernel package would make the registry its own client, which `AGENTS.md` and `docs/PARALLEL.md` forbid. Filed as a follow-up on #12.
- **"No project at all" is a scope, not a gap.** The adapter, config, onboarding and the list already handled it; what this PR fixes is `""` being the *accidental* value.

## Consumers

- `internal/ui/list/list.go` — handles `kernel.ProjectMsg`, tested. ✅
- `internal/ui/issue/issue.go` — consumes `kernel.CapabilitiesMsg`, whose shape and delivery are unchanged; it holds one issue key and has no project-scoped behaviour, so it needs no `ProjectMsg` case. ✅
- `internal/ui/list/register.go` — `scoped(d.Project, …)` in three palette commands. Nothing invokes `Command.Run` yet. Noted on #12: it follows a switch for free **only** if the palette calls `Run` with the kernel's live deps rather than a copy captured at construction.
- `cmd/saral/main.go` — sets `deps.Project`. ✅

## Tests

- `cmd/saral/main_test.go`: the precedence table — profile only, flag only, both, neither, a blank flag falling back to the profile, a padded flag taken trimmed, and a flag with a space refused.
- `internal/ui/kernel/project_test.go` (new): a `jiratest.Fake` in `Deps.Jira` wrapped in a recorder that writes down the key each probe was asked about and answers with capabilities naming it. Covers: startup probes with the session's project; the three `open()` wordings, tabled; a switch re-probing against the new key; a switch to no project; a switch to the same key doing nothing; **an overtaken probe's answer being dropped**; `ProjectMsg` reaching a root the user switched away from (mirrors the existing theme-change test); the header rebuilding when nothing else in the memo key moved; and a failed re-probe — **403, 429 and transport** — becoming a status carrying `jira.Reason` verbatim while the standing capabilities survive and the new scope sticks.
- `internal/ui/list/project_test.go` (new): unscoped default query, a switch retargeting the default search, a switch *not* clobbering a user-retargeted one while still taking the key, and a switch to the project already open refetching nothing.
- `BenchmarkFrameScopedToAProject` guards the redraw path the header widened: 297 allocs/op, same as `BenchmarkFrame`, ~117 µs at 200×60 against a 4 ms budget.

No test touches the network; everything runs against `pkg/jira/jiratest`.

## Golden files — read this bit

Five goldens moved, all of it the header change.

- `list_100x30`, `list_120x40`, `list_80x20`, `list_no_caps_120x30`: **one line each**, the header's right-hand side going from `example.atlassian.net` to `PROJ | example.atlassian.net`. Nothing else in any of the four frames differs.
- `list_switched_120x30.golden` is new: the frame after a mid-session switch, showing the header naming `OTHER`, the summary reading `My issues in OTHER`, only `OTHER-` rows, and the status line saying what the session is scoped to now.

`TestList_RendersWhenTheCapabilityProbeFoundNothing` also changed: with the kernel probing on `Init`, a hand-built empty `Caps` is replaced before the first frame, so the fake has to answer with nothing too. Its golden is otherwise unchanged apart from the header line. Left as-is, that test would have kept passing while testing nothing.

## Owned paths

The roadmap `owns` line is corrected in the same PR to `cmd/saral/main.go`, `internal/ui/kernel/kernel.go`, `internal/ui/list/list.go` **and their tests**, `internal/ui/list/testdata/**`, `docs/ROADMAP.md` — the widening the spec allows and no further. `pkg/jira/**`, `internal/config/**` and `internal/ui/onboarding/**` are untouched; `internal/ui/kernel/msg.go` is untouched too, so `ProjectMsg` and `SetProject` live in `kernel.go` beside `setProject`.

## Verification

`go mod tidy` clean · `go vet ./...` · `golangci-lint run` → 0 issues · `go test -race -count=1 ./...` green · stripped binary builds at 5.2 MiB · `scripts/checkleak.py` clean · no `go.mod` change.
