### PR TITLE
P2.4 — comments: read a thread, write, edit and delete one

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -16,6 +16,10 @@ here cost time to find out; read this before writing an adapter method.
 | The Plans API lives at `/rest/api/3/plans/plan` — the doubled segment is correct | `GET /rest/api/3/plans` does not exist. |
 | v3 requires **ADF** for description, environment, comments, worklog comments and multi-line custom fields | Single-line fields take plain strings. `pkg/adf` is not optional. |
 | `PUT /rest/agile/1.0/sprint/{id}` is a **full replace** — omitted fields become null | Never expose it. Use `POST /rest/agile/1.0/sprint/{id}` for partial updates. |
+| `PUT /rest/api/3/issue/{key}/comment/{id}` takes a whole comment, and `visibility` is one of its properties | A request that names only `body` is a request for a comment with no restriction on it, which publishes a comment one role could see. The port cannot carry the restriction — `EditComment` takes a body and nothing else — so the adapter reads the comment first and echoes its `visibility` object back verbatim. That is right whichever way the endpoint would have treated the omission, and it costs one `GET` per edit. |
+| A comment's `visibility` carries **`identifier`** beside `type` and `value`, and `value` is the localised display name of the role or group | Echo the object you were given rather than rebuilding one from `type` and `value`: on a German site the role name is German, and `identifier` is the half of it no translation moves. `jira.Visibility` has no slot for the identifier, which is the other reason an edit sends back the original bytes. |
+| `GET /rest/api/3/issue/{key}/comment` pages by `startAt`/`maxResults`/`total` — the Agile shape — while living on the platform API, and names its array **`comments`** rather than `values` | Neither shared envelope in `pkg/jira/cloud/paginate.go` reads it, so it decodes its own. It sends no `isLast`, so the walk ends on the total; an envelope that reports no total at all can only be ended by a page shorter than the `maxResults` the response itself echoes, because a site may cap the number asked for without saying so anywhere else. |
+| The order comments come back in is not documented | Send `orderBy=created` when oldest-first is what the caller was promised. |
 | Sprint state machine: `future → active → closed` only, start needs both dates set, `completeDate` is never writable, a closed sprint only accepts `name` and `goal` | Validate locally and return a real error instead of a 400. |
 | `POST /rest/agile/1.0/backlog/issue` caps at **50 issues** | Chunk, and report partial progress. |
 | Attachment upload needs `X-Atlassian-Token: no-check` and a multipart part named exactly `file` | Otherwise rejected by the XSRF guard. |
@@ -160,6 +164,9 @@ any poller on the first 429. Cost-based limits mean a burst of narrow requests b
 ## Still to confirm against live responses
 
 - The precise shape of `GET /rest/api/3/configuration`.
+- Whether `PUT /issue/{key}/comment/{id}` really clears a `visibility` the request omits. The
+  adapter re-sends it either way, because being wrong in that direction publishes somebody's
+  restricted comment and being wrong in the other direction costs a round trip.
 - Everything above is from the published OpenAPI schemas, not from a live site. `scripts/capture.sh`
   has not been run yet, so the fixtures in `pkg/jira/jiratest/fixtures/` are hand-authored to those
   schemas. Re-capture against a real instance before trusting a field name that only matters once.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -171,7 +171,14 @@ a thing Batch 2 would otherwise get quietly wrong.
   builds its patch from `Issue.Requested` and refuses a field outside it, saying so on the row.
   Create landed as the adapter method only — the create *form* is P2.2's schema-driven form, which is
   what will call it.
-- [ ] **P2.4 — Comments CRUD** · [#11](https://github.com/varijkapil13/saral/issues/11) · **owns** `internal/ui/comment/**`, `pkg/jira/cloud/comment.go`
+- [x] **P2.4 — Comments CRUD** · [#11](https://github.com/varijkapil13/saral/issues/11) · **owns** `internal/ui/comment/**`, `pkg/jira/cloud/comment.go`, its blank import line in `internal/ui/views.go`, `docs/API-NOTES.md`
+  A virtualized thread on one issue, with an editor for writing and editing a comment and a named
+  confirmation for deleting one. A new comment is parsed with `adf.ParseMarkdown`; an edit goes
+  through `adf.ParseMarkdownInto`, which is the only way a mention keeps its account id. `EditComment`
+  reads the comment before writing it so that a restriction the port cannot carry is echoed back
+  rather than dropped. Unsent text is kept on disk per issue and per comment being edited.
+  The thread is reached by being pushed with an issue; the detail pane cannot push it yet
+  ([#67](https://github.com/varijkapil13/saral/issues/67)).
 
 ## Batch 3 — Make it a daily driver · parallel ×5
 

--- a/internal/ui/comment/bench_test.go
+++ b/internal/ui/comment/bench_test.go
@@ -1,0 +1,145 @@
+package comment
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// thread builds a view holding n comments at a given size without touching the
+// network: the page arrives as the message a read would have produced.
+func thread(tb testing.TB, n, w, h int) *Model {
+	tb.Helper()
+
+	d := kernel.Deps{
+		Caps:  jira.Capabilities{TimeZone: time.UTC},
+		Theme: kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs()),
+		Site:  "bench.example.atlassian.net",
+		Now:   func() time.Time { return time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC) },
+	}
+	m := build(d, "PROJ-1")
+	next, _ := m.Update(kernel.SizeMsg{Width: w, Height: h})
+	m, _ = next.(*Model)
+
+	at := time.Date(2026, time.February, 11, 9, 38, 0, 0, time.UTC)
+	comments := make([]jira.Comment, 0, n)
+	for i := range n {
+		comments = append(comments, jira.Comment{
+			ID:      strconv.Itoa(20000 + i),
+			Author:  jira.User{DisplayName: "Another User"},
+			Body:    adf.NewDoc(adf.NewNode("paragraph", adf.NewText("comment number "+strconv.Itoa(i)))),
+			Created: at.Add(time.Duration(i) * time.Minute),
+			Updated: at.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	next, _ = m.Update(loadedMsg{gen: m.gen, page: jira.NewPage(comments, nil)})
+	m, _ = next.(*Model)
+	_ = m.View()
+	return m
+}
+
+func scroll(b *testing.B, m *Model) {
+	b.Helper()
+
+	var down, up tea.Msg = keyPress("j"), keyPress("k")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		key := down
+		if i%2 == 1 {
+			key = up
+		}
+		next, _ := m.Update(key)
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+}
+
+// BenchmarkThreadSteadyScroll10k and its twenty-comment twin are the pair that
+// matters: docs/PERFORMANCE.md asks that a long thread and a short one cost the
+// same per frame.
+func BenchmarkThreadSteadyScroll10k(b *testing.B) { scroll(b, thread(b, 10000, 120, 40)) }
+
+func BenchmarkThreadSteadyScroll20(b *testing.B) { scroll(b, thread(b, 20, 120, 40)) }
+
+// BenchmarkThreadWalk10k walks a fresh comment into view on every frame, which
+// is the worst case: every frame misses the memo by construction.
+func BenchmarkThreadWalk10k(b *testing.B) {
+	m := thread(b, 10000, 120, 40)
+	next, _ := m.Update(keyPress("g"))
+	m, _ = next.(*Model)
+	next, _ = m.Update(keyPress("g"))
+	m, _ = next.(*Model)
+
+	down := keyPress("j")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		next, _ := m.Update(down)
+		m, _ = next.(*Model)
+		_ = m.View()
+		if m.cursor >= len(m.comments)-1 {
+			next, _ = m.Update(keyPress("g"))
+			m, _ = next.(*Model)
+			next, _ = m.Update(keyPress("g"))
+			m, _ = next.(*Model)
+		}
+	}
+}
+
+func BenchmarkThreadRedraw200x60(b *testing.B) {
+	m := thread(b, 10000, 200, 60)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = m.View()
+	}
+}
+
+// BenchmarkThreadRenderBlock is the per-comment cost the memo protects.
+func BenchmarkThreadRenderBlock(b *testing.B) {
+	m := thread(b, 20, 120, 40)
+	c := &m.comments[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = renderBlock(c, 120, false, m.styles, m.deps.Theme, time.UTC)
+	}
+}
+
+func TestScrolling_CostsTheSameOnTenThousandCommentsAsOnTwenty(t *testing.T) {
+	t.Parallel()
+
+	big := testing.Benchmark(BenchmarkThreadSteadyScroll10k)
+	small := testing.Benchmark(BenchmarkThreadSteadyScroll20)
+
+	bigAllocs, smallAllocs := big.AllocsPerOp(), small.AllocsPerOp()
+	if bigAllocs > smallAllocs {
+		t.Errorf("a 10k-comment thread allocates %d per frame against %d for a 20-comment one; the render is not virtualized",
+			bigAllocs, smallAllocs)
+	}
+	// What is left is the frame string View has to return and the header joined
+	// onto it; every comment behind them is memoized.
+	if bigAllocs > 2 {
+		t.Errorf("a steady-state frame allocates %d times, want the memo to carry all but the frame itself", bigAllocs)
+	}
+}
+
+func TestBlockRendering_CostsNothingOnceMemoized(t *testing.T) {
+	t.Parallel()
+
+	m := thread(t, 200, 120, 40)
+	before := len(m.blocks.made)
+	for range 50 {
+		_ = m.blockLines(m.cursor)
+	}
+	if got := len(m.blocks.made); got != before {
+		t.Errorf("drawing one comment fifty times rendered it %d more times", got-before)
+	}
+}

--- a/internal/ui/comment/cmds.go
+++ b/internal/ui/comment/cmds.go
@@ -1,0 +1,102 @@
+package comment
+
+import (
+	"context"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// loadedMsg carries the first page of a thread, replacing whatever was held.
+type loadedMsg struct {
+	gen  int
+	page jira.Page[jira.Comment]
+}
+
+// pagedMsg carries the page after the one already in hand.
+type pagedMsg struct {
+	gen  int
+	page jira.Page[jira.Comment]
+}
+
+// savedMsg carries a comment the site stored. edited says which of the two
+// writes produced it, because only one of them moves the cursor.
+type savedMsg struct {
+	gen     int
+	comment jira.Comment
+	edited  bool
+}
+
+// deletedMsg carries the id of a comment the site no longer has.
+type deletedMsg struct {
+	gen int
+	id  string
+}
+
+// failedMsg is any request that produced no answer. The error travels whole so
+// that the status line can use the wording the error itself carries — a refusal
+// reaches the user as the sentence Jira wrote.
+type failedMsg struct {
+	gen int
+	err error
+}
+
+func load(ctx context.Context, client jira.Client, key string, gen int) tea.Cmd {
+	return func() tea.Msg {
+		page, err := client.Comments(ctx, key)
+		if err != nil {
+			return failedMsg{gen: gen, err: err}
+		}
+		return loadedMsg{gen: gen, page: page}
+	}
+}
+
+func more(ctx context.Context, page jira.Page[jira.Comment], gen int) tea.Cmd {
+	return func() tea.Msg {
+		next, err := page.Next(ctx)
+		if err != nil {
+			return failedMsg{gen: gen, err: err}
+		}
+		return pagedMsg{gen: gen, page: next}
+	}
+}
+
+func add(ctx context.Context, client jira.Client, key string, body adf.Doc, gen int) tea.Cmd {
+	return func() tea.Msg {
+		stored, err := client.AddComment(ctx, key, body)
+		if err != nil {
+			return failedMsg{gen: gen, err: err}
+		}
+		return savedMsg{gen: gen, comment: stored}
+	}
+}
+
+func edit(ctx context.Context, client jira.Client, key, id string, body adf.Doc, gen int) tea.Cmd {
+	return func() tea.Msg {
+		stored, err := client.EditComment(ctx, key, id, body)
+		if err != nil {
+			return failedMsg{gen: gen, err: err}
+		}
+		return savedMsg{gen: gen, comment: stored, edited: true}
+	}
+}
+
+func remove(ctx context.Context, client jira.Client, key, id string, gen int) tea.Cmd {
+	return func() tea.Msg {
+		if err := client.DeleteComment(ctx, key, id); err != nil {
+			return failedMsg{gen: gen, err: err}
+		}
+		return deletedMsg{gen: gen, id: id}
+	}
+}
+
+// withCancel makes a command release its context however it ends. The cancel is
+// also held on the model so that closing the view cuts the request short.
+func withCancel(cancel context.CancelFunc, cmd tea.Cmd) tea.Cmd {
+	return func() tea.Msg {
+		defer cancel()
+		return cmd()
+	}
+}

--- a/internal/ui/comment/comment.go
+++ b/internal/ui/comment/comment.go
@@ -1,0 +1,973 @@
+// Package comment is the comment thread on one issue: reading it, writing a
+// comment, editing one and deleting one.
+package comment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// ViewID is the name this view registers itself under and the scope its keys
+// are registered in.
+const ViewID = "comment"
+
+// lookahead is how close to the end of the loaded thread the cursor gets before
+// the next page is asked for.
+const lookahead = 5
+
+// blockCacheLimit is how many rendered comments are kept: a screenful and its
+// overscan, in both selected and unselected forms, several relayouts deep.
+const blockCacheLimit = 256
+
+// editorLines is the maximum number of logical lines the editor accepts. It is
+// the widget's own ceiling; a comment longer than this is not something a
+// terminal editor is the right place for.
+const editorLines = 10000
+
+// editorOptions is how a document is rendered for somebody to edit, and how the
+// edited markdown is read back. The two must be the same value or reconciling
+// the edit against the original matches nothing: a block that renders one way
+// and parses another reads as a block the author rewrote.
+//
+// TableWidth is deliberately zero. A width-bounded render truncates a table's
+// cells with an ellipsis, and an edit anywhere in that table would write the
+// truncation back.
+var editorOptions = adf.Options{}
+
+// zones are the click targets this view marks. Each is prefixed per instance so
+// that two of these views on one screen cannot answer for each other.
+const (
+	zoneWrite   = "write"
+	zoneEdit    = "edit"
+	zoneDelete  = "delete"
+	zoneConfirm = "confirm"
+	zoneRefuse  = "refuse"
+	zoneSend    = "send"
+	zoneCancel  = "cancel"
+	zoneComment = "comment:"
+)
+
+// mode is what the view is doing. Only browsing lets the kernel have the keys.
+type mode uint8
+
+const (
+	browsing mode = iota
+	writing
+	confirming
+)
+
+var (
+	_ kernel.View        = (*Model)(nil)
+	_ kernel.KeyCapturer = (*Model)(nil)
+	_ kernel.Blocker     = (*Model)(nil)
+)
+
+// ThreadMsg points the view at an issue's thread. It is exported so that a view
+// holding an issue can retarget this one without holding a pointer to it.
+type ThreadMsg struct{ Key string }
+
+// WriteMsg opens the editor on a new comment.
+type WriteMsg struct{}
+
+// EditMsg opens the editor on the comment under the cursor.
+type EditMsg struct{}
+
+// DeleteMsg starts the confirmation for the comment under the cursor. It starts
+// the confirmation and never the deletion: there is one path to removing a
+// comment and it goes through the sentence naming what will go.
+type DeleteMsg struct{}
+
+// Model is the comment thread.
+type Model struct {
+	deps    kernel.Deps
+	keys    keyMap
+	browse  map[string]action
+	confirm map[string]action
+	styles  *styles
+	blocks  *blocks
+	drafts  *drafts
+
+	issue    string
+	comments []jira.Comment
+	page     jira.Page[jira.Comment]
+	loaded   bool
+	loading  bool
+
+	// cursor is the comment under the selection; top and skip are the first
+	// comment drawn and how many of its lines are above the window. Scrolling
+	// is tracked this way so that drawing a screen never needs the height of a
+	// comment above it — a thread of a thousand costs the same as a thread of
+	// ten.
+	cursor int
+	top    int
+	skip   int
+
+	mode      mode
+	editor    textarea.Model
+	editing   string
+	original  adf.Doc
+	pending   jira.Comment
+	sending   bool
+	pendingGo bool
+
+	// draft is the text last written to disk, so that a keystroke that changes
+	// nothing does not rewrite the file.
+	draft       string
+	draftFailed bool
+
+	lines  []string
+	head   string
+	headAt headKey
+
+	width, height int
+	gen           int
+	cancel        context.CancelFunc
+	zonePrefix    string
+}
+
+// New builds the thread with no issue yet. It is the registry's constructor:
+// the view is reachable by name and from the palette, and is told which issue
+// it is about by a ThreadMsg.
+func New(d kernel.Deps) kernel.View { return build(d, "") }
+
+// Thread builds the thread for one issue, which is how a view holding an issue
+// opens it.
+func Thread(d kernel.Deps, key string) kernel.View { return build(d, key) }
+
+// Push returns the command that opens the thread for one issue on top of
+// whatever is on screen.
+func Push(d kernel.Deps, key string) tea.Cmd {
+	return kernel.Push(ViewID, key, Thread(d, key))
+}
+
+func build(d kernel.Deps, key string) *Model {
+	m := &Model{
+		deps:   d,
+		keys:   defaultKeys(),
+		blocks: newBlocks(blockCacheLimit),
+		drafts: openDrafts(),
+		issue:  strings.TrimSpace(key),
+		editor: newEditor(),
+	}
+	if m.deps.Theme == nil {
+		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
+	}
+	m.styles = newStyles(m.deps.Theme)
+	if d.Zones != nil {
+		m.zonePrefix = d.Zones.NewPrefix()
+	}
+	m.browse, m.confirm = m.keys.tables()
+	return m
+}
+
+func newEditor() textarea.Model {
+	ta := textarea.New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.Placeholder = "Markdown. Tables, lists, quotes and code fences all survive the round trip."
+	ta.MaxHeight = editorLines
+	// The widget's own cursor blink is a timer this view would then own for as
+	// long as the editor is open; dropping it costs a blinking block and keeps
+	// every frame reproducible.
+	ta.SetVirtualCursor(false)
+	return ta
+}
+
+// WantsRawKeys is true while the editor is open and while a delete is waiting
+// to be confirmed. Without it the kernel matches its own bindings first, so a
+// comment loses every q and esc it is typed with, and the key that answers a
+// confirmation would quit the program instead.
+func (m *Model) WantsRawKeys() bool { return m.mode != browsing }
+
+// BlocksClose refuses to let the view be discarded while it holds text nobody
+// has sent. The draft is on disk either way; the sentence is what stops a
+// click on the footer from looking like the text was thrown away.
+func (m *Model) BlocksClose() (string, bool) {
+	if m.mode == writing && strings.TrimSpace(m.editor.Value()) != "" {
+		return "this comment has not been sent — ctrl+s sends it, esc keeps it as a draft", true
+	}
+	return "", false
+}
+
+// Init reads the thread.
+func (m *Model) Init() tea.Cmd { return m.load() }
+
+// Update handles one message.
+func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case kernel.SizeMsg:
+		cmd = m.resize(msg.Width, msg.Height)
+
+	case kernel.FocusMsg:
+		m.focus(msg.Focused)
+
+	case kernel.ThemeMsg:
+		m.deps.Theme = msg.Theme
+		m.styles = newStyles(msg.Theme)
+		m.blocks.reset()
+
+	case kernel.CapabilitiesMsg:
+		m.deps.Caps = msg.Caps
+		m.blocks.reset()
+
+	case kernel.RefreshMsg:
+		cmd = m.load()
+
+	case ThreadMsg:
+		cmd = m.retarget(msg.Key)
+
+	case WriteMsg:
+		cmd = m.openEditor("", jira.Comment{})
+
+	case EditMsg:
+		cmd = m.editSelected()
+
+	case DeleteMsg:
+		cmd = m.askToDelete()
+
+	case loadedMsg:
+		cmd = m.loadedPage(msg)
+
+	case pagedMsg:
+		cmd = m.nextPage(msg)
+
+	case savedMsg:
+		cmd = m.saved(msg)
+
+	case deletedMsg:
+		cmd = m.deleted(msg)
+
+	case failedMsg:
+		cmd = m.failed(msg)
+
+	case tea.KeyPressMsg:
+		cmd = m.key(msg)
+
+	case tea.MouseClickMsg:
+		cmd = m.click(msg)
+
+	case tea.MouseWheelMsg:
+		cmd = m.wheel(msg)
+	}
+	return m, cmd
+}
+
+func (m *Model) location() *time.Location { return m.deps.Caps.Location() }
+
+func (m *Model) resize(w, h int) tea.Cmd {
+	if w == m.width && h == m.height {
+		return nil
+	}
+	m.width, m.height = w, h
+	m.blocks.reset()
+	m.editor.SetWidth(max(w-indent, 8))
+	m.editor.SetHeight(max(m.editorHeight(), 1))
+	m.ensureVisible()
+	return m.pageAheadIfNeeded()
+}
+
+// focus keeps the editor's cursor out of a pane nobody is looking at, and lets
+// go of a request nobody is waiting for.
+func (m *Model) focus(on bool) {
+	switch {
+	case on && m.mode == writing:
+		_ = m.editor.Focus()
+	case !on:
+		m.editor.Blur()
+		m.stop()
+	}
+}
+
+func (m *Model) retarget(key string) tea.Cmd {
+	key = strings.TrimSpace(key)
+	if key == "" || key == m.issue {
+		return nil
+	}
+	m.issue = key
+	m.comments, m.page = nil, jira.Page[jira.Comment]{}
+	m.cursor, m.top, m.skip = 0, 0, 0
+	m.loaded = false
+	m.mode, m.editing, m.sending = browsing, "", false
+	m.editor.Reset()
+	m.blocks.reset()
+	return m.load()
+}
+
+// --- fetching ---------------------------------------------------------------
+
+func (m *Model) begin() (ctx context.Context, gen int) {
+	m.stop()
+	m.gen++
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	return ctx, m.gen
+}
+
+func (m *Model) stop() {
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
+	m.loading = false
+}
+
+func (m *Model) current(gen int) bool { return gen == m.gen }
+
+func (m *Model) load() tea.Cmd {
+	if m.deps.Jira == nil || m.issue == "" {
+		return nil
+	}
+	ctx, gen := m.begin()
+	m.loading = true
+	return withCancel(m.cancel, load(ctx, m.deps.Jira, m.issue, gen))
+}
+
+func (m *Model) loadedPage(msg loadedMsg) tea.Cmd {
+	if !m.current(msg.gen) {
+		return nil
+	}
+	// A refresh must not throw the reader's place away: docs/UX.md principle 5.
+	// A first read has nothing under the cursor, so it lands on the newest.
+	under := ""
+	if c := m.selected(); c != nil {
+		under = c.ID
+	}
+	m.loading, m.loaded = false, true
+	m.comments = slices.Clone(msg.page.Items)
+	m.page = msg.page
+	m.blocks.reset()
+	m.cursor = max(len(m.comments)-1, 0)
+	if under != "" {
+		if at := slices.IndexFunc(m.comments, func(c jira.Comment) bool { return c.ID == under }); at >= 0 {
+			m.cursor = at
+		}
+	}
+	if m.cursor == len(m.comments)-1 {
+		m.scrollToBottom()
+	} else {
+		m.top, m.skip = m.cursor, 0
+	}
+	return m.pageAheadIfNeeded()
+}
+
+func (m *Model) nextPage(msg pagedMsg) tea.Cmd {
+	if !m.current(msg.gen) {
+		return nil
+	}
+	m.loading = false
+	m.comments = append(m.comments, msg.page.Items...)
+	m.page = msg.page
+	return m.pageAheadIfNeeded()
+}
+
+// pageAheadIfNeeded asks for the page after the one in hand when the cursor is
+// near the end of what is loaded. One request is in flight at a time, whatever
+// the cursor does.
+func (m *Model) pageAheadIfNeeded() tea.Cmd {
+	if m.loading || m.sending || !m.page.HasMore() {
+		return nil
+	}
+	if m.cursor < len(m.comments)-lookahead {
+		return nil
+	}
+	ctx, gen := m.begin()
+	m.loading = true
+	return withCancel(m.cancel, more(ctx, m.page, gen))
+}
+
+func (m *Model) failed(msg failedMsg) tea.Cmd {
+	if !m.current(msg.gen) {
+		return nil
+	}
+	m.loading, m.sending = false, false
+	return kernel.Fail(msg.err)
+}
+
+// --- writing ----------------------------------------------------------------
+
+func (m *Model) selected() *jira.Comment {
+	if m.cursor < 0 || m.cursor >= len(m.comments) {
+		return nil
+	}
+	return &m.comments[m.cursor]
+}
+
+func (m *Model) draftKey() draftKey {
+	return draftKey{site: m.deps.Site, issue: m.issue, comment: m.editing}
+}
+
+// openEditor puts the editor in front of the user, seeded with whatever is
+// already theirs: a draft they left, or the comment they are editing rendered
+// back into markdown.
+func (m *Model) openEditor(id string, c jira.Comment) tea.Cmd {
+	if m.issue == "" {
+		return kernel.Warn("open an issue first: a comment needs something to be about")
+	}
+	m.mode, m.editing, m.pending = writing, id, c
+	m.original = c.Body
+	m.sending = false
+
+	seeded := adf.MarkdownWith(c.Body, editorOptions)
+	restored := m.drafts.read(m.draftKey())
+	text := seeded
+	if restored != "" {
+		text = restored
+	}
+	m.draft = text
+	m.editor.SetValue(text)
+	m.editor.MoveToEnd()
+	m.editor.SetWidth(max(m.width-indent, 8))
+	m.editor.SetHeight(max(m.editorHeight(), 1))
+	_ = m.editor.Focus()
+
+	switch {
+	case restored != "" && restored != seeded:
+		return kernel.Warn("this is the draft you left, not what the site holds")
+	case id != "":
+		if lost := oneWay(c.Body); len(lost) > 0 {
+			return kernel.Warn("the " + list(lost) + " in this comment survive only in the parts you leave alone")
+		}
+	}
+	return nil
+}
+
+func (m *Model) editSelected() tea.Cmd {
+	c := m.selected()
+	if c == nil {
+		return kernel.Warn("there is no comment here to edit")
+	}
+	return m.openEditor(c.ID, *c)
+}
+
+// closeEditor puts the editor away and keeps what was typed, which is the whole
+// point of a draft: esc is not a way to lose an afternoon's wording.
+func (m *Model) closeEditor() tea.Cmd {
+	cmd := m.keepDraft(m.editor.Value())
+	m.mode, m.editing, m.sending = browsing, "", false
+	m.editor.Blur()
+	m.editor.Reset()
+	m.draft = ""
+	return cmd
+}
+
+// keepDraft writes the text to disk when it has changed. It runs on the
+// keystroke rather than on the way out, because docs/UX.md principle 6 counts a
+// crash among the things text has to survive.
+func (m *Model) keepDraft(text string) tea.Cmd {
+	if text == m.draft {
+		return nil
+	}
+	m.draft = text
+	var err error
+	if strings.TrimSpace(text) == "" {
+		m.drafts.discard(m.draftKey())
+	} else {
+		err = m.drafts.write(m.draftKey(), text)
+	}
+	if err == nil || m.draftFailed {
+		return nil
+	}
+	// Said once: a warning on every keystroke would bury whatever came before it.
+	m.draftFailed = true
+	return kernel.Warn("this draft is not being kept on disk: " + err.Error())
+}
+
+// send turns the markdown back into a document and writes it.
+//
+// A new comment has no original to reconcile against, so it is parsed on its
+// own. An edit goes through ParseMarkdownInto, which reuses the original node
+// for every block the author did not touch — the only way an account id behind
+// a mention, a lozenge's colour or a node type this client has never heard of
+// survives being edited.
+func (m *Model) send() tea.Cmd {
+	if m.deps.Jira == nil || m.sending {
+		return nil
+	}
+	text := m.editor.Value()
+	if strings.TrimSpace(text) == "" {
+		return kernel.Warn("there is nothing here to send yet")
+	}
+	var (
+		body adf.Doc
+		err  error
+	)
+	if m.editing == "" {
+		body, err = adf.ParseMarkdown(text)
+	} else {
+		body, err = adf.ParseMarkdownInto(m.original, text, editorOptions)
+	}
+	if err != nil {
+		return kernel.Fail(unreadable(err))
+	}
+	m.sending = true
+	ctx, gen := m.begin()
+	if m.editing == "" {
+		return withCancel(m.cancel, add(ctx, m.deps.Jira, m.issue, body, gen))
+	}
+	return withCancel(m.cancel, edit(ctx, m.deps.Jira, m.issue, m.editing, body, gen))
+}
+
+// unreadable turns a parse failure into the sentence a user reads: which line
+// stopped it, and what about that line.
+func unreadable(err error) error {
+	var pe *adf.ParseError
+	if errors.As(err, &pe) {
+		return fmt.Errorf("line %d: %w", pe.Line, pe.Err)
+	}
+	return err
+}
+
+func (m *Model) saved(msg savedMsg) tea.Cmd {
+	if !m.current(msg.gen) {
+		return nil
+	}
+	m.sending = false
+	m.drafts.discard(m.draftKey())
+	m.draft = ""
+	m.mode, m.editing = browsing, ""
+	m.editor.Blur()
+	m.editor.Reset()
+
+	if msg.edited {
+		at := slices.IndexFunc(m.comments, func(c jira.Comment) bool { return c.ID == msg.comment.ID })
+		if at >= 0 {
+			m.comments[at] = msg.comment
+			m.cursor = at
+		}
+	} else {
+		m.comments = append(m.comments, msg.comment)
+		m.cursor = len(m.comments) - 1
+	}
+	m.blocks.reset()
+	m.ensureVisible()
+	if msg.edited {
+		return kernel.Status("the comment has been changed")
+	}
+	return kernel.Status("the comment has been added")
+}
+
+// --- deleting ---------------------------------------------------------------
+
+// askToDelete puts the named confirmation up. Nothing else in this view calls
+// remove, so there is no path from a keystroke to a deleted comment that skips
+// the sentence saying which comment it is.
+func (m *Model) askToDelete() tea.Cmd {
+	c := m.selected()
+	if c == nil {
+		return kernel.Warn("there is no comment here to delete")
+	}
+	m.mode, m.pending = confirming, *c
+	return nil
+}
+
+func (m *Model) confirmDelete() tea.Cmd {
+	id := m.pending.ID
+	m.mode = browsing
+	if m.deps.Jira == nil || id == "" {
+		return nil
+	}
+	ctx, gen := m.begin()
+	m.loading = true
+	return withCancel(m.cancel, remove(ctx, m.deps.Jira, m.issue, id, gen))
+}
+
+func (m *Model) deleted(msg deletedMsg) tea.Cmd {
+	if !m.current(msg.gen) {
+		return nil
+	}
+	m.loading = false
+	at := slices.IndexFunc(m.comments, func(c jira.Comment) bool { return c.ID == msg.id })
+	if at >= 0 {
+		m.comments = slices.Delete(m.comments, at, at+1)
+	}
+	m.blocks.reset()
+	m.cursor = min(m.cursor, max(len(m.comments)-1, 0))
+	m.top = min(m.top, m.cursor)
+	m.skip = 0
+	m.ensureVisible()
+	return kernel.Status("the comment is gone")
+}
+
+// --- moving -----------------------------------------------------------------
+
+func (m *Model) threadHeight() int {
+	h := m.height - 2
+	if m.mode == confirming {
+		h--
+	}
+	return max(h, 1)
+}
+
+func (m *Model) editorHeight() int { return max(m.height-4, 1) }
+
+func (m *Model) blockLines(at int) []string {
+	if at < 0 || at >= len(m.comments) {
+		return nil
+	}
+	c := &m.comments[at]
+	k := blockKey{
+		id: c.ID, updated: c.Updated.UnixNano(), width: m.width,
+		gen: m.styles.gen, selected: at == m.cursor,
+	}
+	if lines, ok := m.blocks.get(k); ok {
+		return lines
+	}
+	lines := renderBlock(c, m.width, at == m.cursor, m.styles, m.deps.Theme, m.location())
+	if m.deps.Zones != nil && len(lines) > 0 {
+		// Marking the joined block and splitting it again puts the zone's start
+		// on the first line and its end on the last, so the rectangle the
+		// manager records is the whole comment rather than one line of it.
+		marked := m.deps.Zones.Mark(m.zonePrefix+zoneComment+c.ID, strings.Join(lines, "\n"))
+		lines = strings.Split(marked, "\n")
+	}
+	lines = append(lines, "")
+	m.blocks.put(k, lines)
+	return lines
+}
+
+func (m *Model) moveTo(at int) tea.Cmd {
+	if len(m.comments) == 0 {
+		m.cursor, m.top, m.skip = 0, 0, 0
+		return nil
+	}
+	next := min(max(at, 0), len(m.comments)-1)
+	if next == m.cursor {
+		return m.pageAheadIfNeeded()
+	}
+	m.cursor = next
+	m.ensureVisible()
+	return m.pageAheadIfNeeded()
+}
+
+// jumpTo puts the cursor on a comment and the window with it, without walking
+// what is in between: g g and G are the two moves whose distance is unbounded.
+func (m *Model) jumpTo(at int) tea.Cmd {
+	if len(m.comments) == 0 {
+		return nil
+	}
+	m.cursor = min(max(at, 0), len(m.comments)-1)
+	if m.cursor == len(m.comments)-1 {
+		m.scrollToBottom()
+	} else {
+		m.top, m.skip = m.cursor, 0
+	}
+	return m.pageAheadIfNeeded()
+}
+
+// scrollToBottom puts the end of the thread at the bottom of the window, which
+// is where a conversation is read from. It walks backwards from the newest
+// comment and stops as soon as the window is full, so it never touches a
+// comment nobody can see.
+func (m *Model) scrollToBottom() {
+	h := m.threadHeight()
+	used, at := 0, len(m.comments)-1
+	for at >= 0 {
+		n := len(m.blockLines(at))
+		if used+n > h {
+			break
+		}
+		used += n
+		at--
+	}
+	switch {
+	case at < 0:
+		m.top, m.skip = 0, 0
+	case used == 0:
+		// One comment taller than the whole window: show it from the top,
+		// because its first line is the one that says whose it is.
+		m.top, m.skip = at, 0
+	default:
+		m.top = at
+		m.skip = max(len(m.blockLines(at))-(h-used), 0)
+	}
+}
+
+// ensureVisible brings the cursor into the window by moving the window, and
+// only ever looks at the comments between the top and the cursor.
+func (m *Model) ensureVisible() {
+	if m.cursor < m.top {
+		m.top, m.skip = m.cursor, 0
+		return
+	}
+	h := m.threadHeight()
+	for m.top < m.cursor {
+		used := 0
+		for i := m.top; i <= m.cursor; i++ {
+			n := len(m.blockLines(i))
+			if i == m.top {
+				n -= m.skip
+			}
+			used += n
+		}
+		if used <= h {
+			return
+		}
+		m.top++
+		m.skip = 0
+	}
+	m.skip = min(m.skip, max(len(m.blockLines(m.top))-1, 0))
+}
+
+// pageStep is how far a page key moves: as many comments as the window holds,
+// counted from where the cursor is rather than from the top.
+func (m *Model) pageStep(dir int) int {
+	h, used, at := m.threadHeight(), 0, m.cursor
+	for {
+		next := at + dir
+		if next < 0 || next >= len(m.comments) {
+			return at
+		}
+		used += len(m.blockLines(next))
+		if used > h && next != m.cursor+dir {
+			return at
+		}
+		at = next
+		if used >= h {
+			return at
+		}
+	}
+}
+
+// scroll moves the window by lines without moving the selection, which is what
+// a wheel does everywhere else.
+func (m *Model) scroll(delta int) {
+	for ; delta > 0; delta-- {
+		if m.skip+1 < len(m.blockLines(m.top)) {
+			m.skip++
+			continue
+		}
+		if m.top+1 >= len(m.comments) {
+			return
+		}
+		m.top, m.skip = m.top+1, 0
+	}
+	for ; delta < 0; delta++ {
+		if m.skip > 0 {
+			m.skip--
+			continue
+		}
+		if m.top == 0 {
+			return
+		}
+		m.top--
+		m.skip = max(len(m.blockLines(m.top))-1, 0)
+	}
+}
+
+// --- input ------------------------------------------------------------------
+
+func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
+	switch m.mode {
+	case writing:
+		return m.editorKey(msg)
+	case confirming:
+		return m.confirmKey(msg.String())
+	case browsing:
+	}
+	return m.browseKey(msg.String())
+}
+
+func (m *Model) browseKey(stroke string) tea.Cmd {
+	if m.pendingGo {
+		m.pendingGo = false
+		switch stroke {
+		case "g":
+			return m.jumpTo(0)
+		case "e":
+			return m.jumpTo(len(m.comments) - 1)
+		}
+	}
+	switch m.browse[stroke] {
+	case actDown:
+		return m.moveTo(m.cursor + 1)
+	case actUp:
+		return m.moveTo(m.cursor - 1)
+	case actPageDown:
+		return m.moveTo(m.pageStep(1))
+	case actPageUp:
+		return m.moveTo(m.pageStep(-1))
+	case actHalfDown:
+		m.scroll(m.threadHeight() / 2)
+	case actHalfUp:
+		m.scroll(-m.threadHeight() / 2)
+	case actTop:
+		return m.jumpTo(0)
+	case actBottom:
+		return m.jumpTo(len(m.comments) - 1)
+	case actGo:
+		m.pendingGo = true
+	case actWrite:
+		return m.openEditor("", jira.Comment{})
+	case actEdit:
+		return m.editSelected()
+	case actDelete:
+		return m.askToDelete()
+	case actNone, actSend, actCancel, actConfirm:
+	}
+	return nil
+}
+
+func (m *Model) editorKey(msg tea.KeyPressMsg) tea.Cmd {
+	switch {
+	case kernel.Matches(msg, m.keys.Send):
+		return m.send()
+	case kernel.Matches(msg, m.keys.Cancel):
+		return m.closeEditor()
+	}
+	if m.sending {
+		return nil
+	}
+	var cmd tea.Cmd
+	m.editor, cmd = m.editor.Update(msg)
+	return tea.Batch(cmd, m.keepDraft(m.editor.Value()))
+}
+
+// confirmKey answers the delete confirmation. Only the key the prompt names
+// goes ahead; every other key keeps the comment, so there is no mode to guess a
+// way out of.
+func (m *Model) confirmKey(stroke string) tea.Cmd {
+	if m.confirm[stroke] == actConfirm {
+		return m.confirmDelete()
+	}
+	m.mode = browsing
+	return nil
+}
+
+func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
+	if msg.Button != tea.MouseLeft || m.deps.Zones == nil {
+		return nil
+	}
+	hit := func(name string) bool { return m.deps.Zones.Get(m.zonePrefix + name).InBounds(msg) }
+	switch m.mode {
+	case confirming:
+		switch {
+		case hit(zoneConfirm):
+			return m.confirmDelete()
+		case hit(zoneRefuse):
+			m.mode = browsing
+		}
+		return nil
+	case writing:
+		switch {
+		case hit(zoneSend):
+			return m.send()
+		case hit(zoneCancel):
+			return m.closeEditor()
+		}
+		return nil
+	case browsing:
+	}
+	switch {
+	case hit(zoneWrite):
+		return m.openEditor("", jira.Comment{})
+	case hit(zoneEdit):
+		return m.editSelected()
+	case hit(zoneDelete):
+		return m.askToDelete()
+	}
+	for i := m.top; i < len(m.comments); i++ {
+		if !hit(zoneComment + m.comments[i].ID) {
+			continue
+		}
+		if i == m.cursor {
+			return m.editSelected()
+		}
+		return m.moveTo(i)
+	}
+	return nil
+}
+
+func (m *Model) wheel(msg tea.MouseWheelMsg) tea.Cmd {
+	if m.mode != browsing {
+		return nil
+	}
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		m.scroll(-3)
+	case tea.MouseWheelDown:
+		m.scroll(3)
+	default:
+	}
+	return nil
+}
+
+// --- rendering --------------------------------------------------------------
+
+func (m *Model) mark(name, s string) string {
+	if m.deps.Zones == nil {
+		return s
+	}
+	return m.deps.Zones.Mark(m.zonePrefix+name, s)
+}
+
+// View draws the window and nothing else: a thread of a thousand comments and a
+// thread of ten do the same work here.
+func (m *Model) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+	if m.mode == writing {
+		return m.header() + "\n" + m.editorCaption() + "\n" + m.editor.View() + "\n" + m.editorHint()
+	}
+	lines := m.lines[:0]
+	h := m.threadHeight()
+	if len(m.comments) == 0 {
+		lines = m.appendEmpty(lines, h)
+	} else {
+		for i := m.top; i < len(m.comments) && len(lines) < h; i++ {
+			block := m.blockLines(i)
+			from := 0
+			if i == m.top {
+				from = min(m.skip, len(block))
+			}
+			for _, line := range block[from:] {
+				if len(lines) >= h {
+					break
+				}
+				lines = append(lines, line)
+			}
+		}
+		for len(lines) < h {
+			lines = append(lines, "")
+		}
+	}
+	if m.mode == confirming {
+		lines = append(lines, m.deletePrompt())
+	}
+	m.lines = lines
+	return m.header() + "\n" + strings.Join(lines, "\n")
+}
+
+func (m *Model) appendEmpty(lines []string, h int) []string {
+	at := len(lines)
+	switch {
+	case m.issue == "":
+		lines = append(lines,
+			m.styles.muted.Render("  This view comments on one issue, and has not been told which."),
+			m.styles.muted.Render("  Open an issue and come back."))
+	case m.deps.Jira == nil:
+		lines = append(lines, m.styles.muted.Render("  No Jira connection in this session yet."))
+	case !m.loaded:
+		lines = append(lines, m.styles.muted.Render("  Reading the thread"+m.deps.Theme.Glyphs.Ellipsis))
+	default:
+		lines = append(lines,
+			m.styles.muted.Render("  Nobody has commented on "+m.issue+" yet."),
+			m.styles.muted.Render("  Press a to write the first one."))
+	}
+	for len(lines)-at < h {
+		lines = append(lines, "")
+	}
+	return lines[:at+h]
+}

--- a/internal/ui/comment/comment_test.go
+++ b/internal/ui/comment/comment_test.go
@@ -1,0 +1,772 @@
+package comment
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+func TestThread_ReadsTheThreadAndLandsOnTheNewestComment(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "The first thing anybody said.")
+	comment(t, f, "PROJ-1", "The last thing anybody said.")
+
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	if got := len(dr.m.comments); got != 2 {
+		t.Fatalf("the thread holds %d comments, want 2", got)
+	}
+	if dr.m.cursor != 1 {
+		t.Errorf("the cursor landed on %d, want the newest comment", dr.m.cursor)
+	}
+	mustContain(t, dr.view(), "PROJ-1", "2 comments", "The last thing anybody said.", "Sam Tester")
+}
+
+func TestThread_WithoutAnIssueSaysSoRatherThanDrawingAnEmptyThread(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(t, newFake(3)), "", 100, 24)
+
+	mustContain(t, dr.view(), "has not been told which")
+	if dr.m.loaded {
+		t.Error("a view with no issue went and read something anyway")
+	}
+}
+
+func TestThread_PagesAsTheCursorReachesWhatIsLoaded(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3, jiratest.WithPageSize(5))
+	for i := range 23 {
+		comment(t, f, "PROJ-1", "comment number "+strconv.Itoa(i))
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	// Opening reads a page, and the cursor landing on its last comment is
+	// already inside the lookahead, so the page after it follows. Nothing more
+	// is read until the cursor asks for it.
+	if got := len(dr.m.comments); got != 10 {
+		t.Fatalf("opening the thread read %d comments, want a page and the one behind it", got)
+	}
+	for range 10 {
+		if !dr.m.page.HasMore() {
+			break
+		}
+		dr.key("G")
+	}
+	if got := len(dr.m.comments); got != 23 {
+		t.Fatalf("walking to the end stopped at %d comments, want all 23", got)
+	}
+	if dr.m.page.HasMore() {
+		t.Error("the last page still claims another one after it")
+	}
+	dr.key("G")
+	if dr.m.cursor != len(dr.m.comments)-1 {
+		t.Errorf("the cursor is on %d after paging, want the newest comment", dr.m.cursor)
+	}
+}
+
+func TestThread_MovesByCommentAndJumpsToEitherEnd(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	for i := range 8 {
+		comment(t, f, "PROJ-1", "comment number "+strconv.Itoa(i))
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("g", "g")
+	if dr.m.cursor != 0 || dr.m.top != 0 {
+		t.Errorf("g g left the cursor at %d and the window at %d", dr.m.cursor, dr.m.top)
+	}
+	dr.key("j")
+	if dr.m.cursor != 1 {
+		t.Errorf("j left the cursor at %d", dr.m.cursor)
+	}
+	dr.key("G")
+	if want := len(dr.m.comments) - 1; dr.m.cursor != want {
+		t.Errorf("G left the cursor at %d, want %d", dr.m.cursor, want)
+	}
+	dr.key("k")
+	if want := len(dr.m.comments) - 2; dr.m.cursor != want {
+		t.Errorf("k left the cursor at %d, want %d", dr.m.cursor, want)
+	}
+}
+
+func TestThread_DrawsOnlyTheCommentsTheWindowHolds(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	for i := range 60 {
+		comment(t, f, "PROJ-1", "comment number "+strconv.Itoa(i))
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+	dr.key("g", "g")
+	_ = dr.view()
+
+	// Opening the thread drew the newest screenful and g g drew the oldest, so
+	// two screens have been rendered out of sixty comments — and the third
+	// screen the assertion below draws costs nothing, because the window has
+	// not moved.
+	drawn := len(dr.m.blocks.made)
+	if drawn > 24 {
+		t.Errorf("two screens rendered %d comments out of %d", drawn, len(dr.m.comments))
+	}
+	_ = dr.view()
+	if got := len(dr.m.blocks.made); got != drawn {
+		t.Errorf("drawing the same screen again rendered %d more comments", got-drawn)
+	}
+	mustNotContain(t, dr.view(), "comment number 40")
+}
+
+func TestThread_WheelScrollsTheThreadWithoutMovingTheSelection(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	for i := range 30 {
+		comment(t, f, "PROJ-1", "comment number "+strconv.Itoa(i))
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+	dr.key("g", "g")
+	under := dr.m.cursor
+
+	dr.send(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	if dr.m.top == 0 && dr.m.skip == 0 {
+		t.Error("the wheel did not scroll")
+	}
+	if dr.m.cursor != under {
+		t.Errorf("the wheel moved the selection to %d, want it left on %d", dr.m.cursor, under)
+	}
+}
+
+// --- writing ----------------------------------------------------------------
+
+func TestThread_WritesACommentTheSiteThenHolds(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("a")
+	if dr.m.mode != writing {
+		t.Fatal("a did not open the editor")
+	}
+	if !dr.m.WantsRawKeys() {
+		t.Error("the editor does not claim the keyboard, so q would quit out from under the typing")
+	}
+	dr.typeText("Reproduced on staging.")
+	dr.key("ctrl+s")
+
+	stored, err := jira.Collect(t.Context(), mustComments(t, f, "PROJ-1"), 0)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("the site holds %d comments, want 1", len(stored))
+	}
+	if got := adf.Markdown(stored[0].Body); got != "Reproduced on staging." {
+		t.Errorf("the site holds %q", got)
+	}
+	if dr.m.mode != browsing {
+		t.Error("the editor is still open after the comment was sent")
+	}
+	if got := dr.m.cursor; got != 0 {
+		t.Errorf("the cursor is on %d, want the comment that was just written", got)
+	}
+	mustContain(t, dr.view(), "Reproduced on staging.")
+}
+
+func TestThread_RefusesToSendNothing(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("a")
+	dr.typeText("   ")
+	dr.key("ctrl+s")
+
+	if dr.m.mode != writing {
+		t.Error("the editor closed on a comment with nothing in it")
+	}
+	mustContain(t, dr.statusText(), "nothing here to send")
+	if calls := countCalls(f, "AddComment"); calls != 0 {
+		t.Errorf("the site was asked to store %d empty comments", calls)
+	}
+}
+
+func TestThread_EditKeepsWhatMarkdownCannotCarry(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	original := adf.NewDoc(
+		adf.NewNode("paragraph",
+			adf.NewText("thanks "),
+			adf.NewNode("mention").WithAttrs(adf.Attrs{"id": "acct-someone", "text": "@Someone"}),
+			adf.NewText(" for the fix"),
+		),
+		adf.NewNode("paragraph", adf.NewText("The second paragraph is the one being rewritten.")),
+	)
+	if _, err := f.AddComment(t.Context(), "PROJ-1", original); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("e")
+	if dr.m.mode != writing || dr.m.editing == "" {
+		t.Fatal("e did not open the editor on the comment under the cursor")
+	}
+	seeded := dr.m.editor.Value()
+	if !strings.Contains(seeded, "@Someone") {
+		t.Fatalf("the editor was seeded with %q", seeded)
+	}
+	dr.m.editor.SetValue(strings.Replace(seeded,
+		"The second paragraph is the one being rewritten.",
+		"The second paragraph has now been rewritten.", 1))
+	dr.key("ctrl+s")
+
+	stored, err := jira.Collect(t.Context(), mustComments(t, f, "PROJ-1"), 0)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("the site holds %d comments, want 1", len(stored))
+	}
+	if got := adf.Markdown(stored[0].Body); !strings.Contains(got, "has now been rewritten") {
+		t.Fatalf("the edit did not land: %q", got)
+	}
+
+	var mention adf.Node
+	stored[0].Body.Walk(func(n adf.Node) bool {
+		if n.Type == "mention" {
+			mention = n
+		}
+		return true
+	})
+	if mention.Type == "" {
+		t.Fatal("the mention was rewritten as prose by the edit")
+	}
+	if got := mention.Attrs["id"]; got != "acct-someone" {
+		t.Errorf("the mention came back with id %v; markdown has no room for one, so the original must supply it", got)
+	}
+}
+
+func TestThread_AnUntouchedEditGoesBackByteForByte(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	original := adf.NewDoc(
+		adf.NewNode("paragraph",
+			adf.NewText("a lozenge: "),
+			adf.NewNode("status").WithAttrs(adf.Attrs{"text": "DONE", "color": "green", "localId": "abc"}),
+		),
+		adf.NewNode("someNodeTypeThisClientHasNeverHeardOf").WithAttrs(adf.Attrs{"weight": 3}),
+	)
+	if _, err := f.AddComment(t.Context(), "PROJ-1", original); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	before, err := adf.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshalling the original: %v", err)
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("e")
+	dr.key("ctrl+s")
+
+	stored, err := jira.Collect(t.Context(), mustComments(t, f, "PROJ-1"), 0)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	after, err := adf.Marshal(stored[0].Body)
+	if err != nil {
+		t.Fatalf("marshalling what was stored: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("an edit that changed nothing rewrote the document\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+}
+
+func TestThread_SaysWhatAnEditWillOnlyKeepInThePartsNobodyTouches(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	body := adf.NewDoc(adf.NewNode("paragraph",
+		adf.NewText("ask "),
+		adf.NewNode("mention").WithAttrs(adf.Attrs{"id": "acct-someone", "text": "@Someone"}),
+	))
+	if _, err := f.AddComment(t.Context(), "PROJ-1", body); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("e")
+
+	if got := dr.statusText(); !strings.Contains(got, "mention") {
+		t.Errorf("opening the editor said %q, want a warning naming what markdown cannot carry", got)
+	}
+}
+
+func TestThread_SaysARestrictionSurvivesTheEdit(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(t, newFake(3)), "PROJ-1", 130, 24)
+	dr.send(loadedMsg{gen: dr.m.gen, page: jira.NewPage([]jira.Comment{{
+		ID:         "10701",
+		Author:     jira.User{DisplayName: "Another User"},
+		Body:       doc("Behind a flag."),
+		Created:    time.Date(2026, time.February, 11, 9, 38, 0, 0, time.UTC),
+		Updated:    time.Date(2026, time.February, 11, 9, 38, 0, 0, time.UTC),
+		Visibility: &jira.Visibility{Type: "role", Value: "Developers"},
+	}}, nil)})
+
+	mustContain(t, dr.view(), "only the Developers role")
+
+	dr.key("e")
+	mustContain(t, dr.view(), "only the Developers role, and it stays that way")
+}
+
+// --- deleting ---------------------------------------------------------------
+
+func TestThread_DeleteCannotBeReachedWithoutTheConfirmation(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "The one that must not vanish.")
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("d")
+	if dr.m.mode != confirming {
+		t.Fatal("d did not put the confirmation up")
+	}
+	if calls := countCalls(f, "DeleteComment"); calls != 0 {
+		t.Fatalf("d deleted the comment before anybody confirmed it")
+	}
+
+	// Every key that is not the one the prompt names keeps the comment, and
+	// leaves nothing to press twice by accident.
+	for _, stroke := range []string{"n", "esc", "enter", "d", "x", "Y", "j"} {
+		dr.key("d")
+		dr.key(stroke)
+		if got := countCalls(f, "DeleteComment"); got != 0 {
+			t.Fatalf("%q went through with the delete", stroke)
+		}
+		if dr.m.mode != browsing {
+			t.Fatalf("%q left the confirmation up", stroke)
+		}
+	}
+
+	dr.key("d", "y")
+	if got := countCalls(f, "DeleteComment"); got != 1 {
+		t.Fatalf("y after the confirmation deleted %d comments, want 1", got)
+	}
+	if len(dr.m.comments) != 0 {
+		t.Errorf("the thread still shows %d comments", len(dr.m.comments))
+	}
+}
+
+func TestThread_DeleteConfirmationNamesWhatWillGo(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "Reproduced on staging, then again on production.")
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.key("d")
+
+	mustContain(t, dr.view(), "delete Sam Tester's comment", "Reproduced on staging", "y deletes it")
+}
+
+func TestThread_DeleteThatIsRefusedSaysWhyAndKeepsTheComment(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "Somebody else wrote this.")
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	f.FailNext(&jira.CapabilityError{Reason: "you need Delete All Comments to remove somebody else's"})
+	dr.key("d", "y")
+
+	if got := dr.lastStatus(); got.Level != kernel.LevelError ||
+		!strings.Contains(got.Text, "Delete All Comments") {
+		t.Errorf("the refusal reached the user as %+v, want the site's own sentence", got)
+	}
+	if len(dr.m.comments) != 1 {
+		t.Errorf("a refused delete took the comment off the screen anyway")
+	}
+}
+
+// --- failure paths ----------------------------------------------------------
+
+func TestThread_EveryRequestReportsWhatWentWrongInItsOwnWords(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "a refusal",
+			err:  &jira.CapabilityError{Reason: "you may not edit somebody else's comment"},
+			want: "may not edit somebody else's comment",
+		},
+		{
+			name: "a rate limit",
+			err:  &jira.RateLimitError{RetryAfter: 30 * time.Second},
+			want: "retry in 30s",
+		},
+		{
+			name: "a transport failure",
+			err:  &jira.TransportError{Op: "POST /comment", Err: errors.New("connection reset")},
+			want: "connection reset",
+		},
+		{
+			name: "a conflict",
+			err:  &jira.ConflictError{Resource: "comment 10701", Detail: "somebody edited it first"},
+			want: "somebody edited it first",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(3)
+			comment(t, f, "PROJ-1", "The comment being written over.")
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+			dr.key("a")
+			dr.typeText("A comment that will not land.")
+			f.FailNext(tc.err)
+			dr.key("ctrl+s")
+
+			if got := dr.lastStatus(); !strings.Contains(got.Text, tc.want) {
+				t.Errorf("the status line says %q, want it to carry %q", got.Text, tc.want)
+			}
+			if dr.m.mode != writing {
+				t.Fatal("a failed send closed the editor, taking the text with it")
+			}
+			if got := dr.m.editor.Value(); got != "A comment that will not land." {
+				t.Errorf("the editor holds %q after the failure", got)
+			}
+		})
+	}
+}
+
+func TestThread_ReadingAThreadThatFailsSaysSoRatherThanShowingAnEmptyOne(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "unreachable")
+	f.FailNext(&jira.RateLimitError{RetryAfter: 12 * time.Second})
+
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	if got := dr.lastStatus(); got.Level != kernel.LevelError || !strings.Contains(got.Text, "retry in 12s") {
+		t.Errorf("reading a rate-limited thread reported %+v", got)
+	}
+	if dr.m.loaded {
+		t.Error("a thread that never arrived is marked as loaded")
+	}
+}
+
+// --- drafts -----------------------------------------------------------------
+
+func TestThread_KeepsTheTextWhenTheEditorIsPutAside(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	d := testDeps(t, f)
+	dr := newDriver(t, d, "PROJ-2", 100, 24)
+
+	dr.key("a")
+	dr.typeText("Half a thought.")
+	dr.key("esc")
+
+	if dr.m.mode != browsing {
+		t.Fatal("esc did not put the editor away")
+	}
+	dr.key("a")
+	if got := dr.m.editor.Value(); got != "Half a thought." {
+		t.Errorf("reopening the editor found %q", got)
+	}
+}
+
+func TestThread_ADraftOutlivesTheSessionThatTypedIt(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	d := testDeps(t, f)
+	first := newDriver(t, d, "PROJ-3", 100, 24)
+	first.key("a")
+	first.typeText("Typed just before the crash.")
+
+	// A second view of the same issue on the same site is what comes back after
+	// the program stops without anybody pressing anything.
+	second := newDriver(t, testDeps(t, f), "PROJ-3", 100, 24)
+	second.key("a")
+
+	if got := second.m.editor.Value(); got != "Typed just before the crash." {
+		t.Errorf("the new session found %q in the editor", got)
+	}
+	mustContain(t, second.statusText(), "the draft you left")
+}
+
+func TestThread_DraftsForTwoIssuesDoNotReachEachOther(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(4)
+	one := newDriver(t, testDeps(t, f), "PROJ-4", 100, 24)
+	one.key("a")
+	one.typeText("about four")
+
+	two := newDriver(t, testDeps(t, f), "PROJ-2", 100, 24)
+	two.key("a")
+
+	if got := two.m.editor.Value(); got != "" {
+		t.Errorf("the editor on another issue was seeded with %q", got)
+	}
+}
+
+func TestThread_ASentCommentLeavesNoDraftBehind(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(5)
+	dr := newDriver(t, testDeps(t, f), "PROJ-5", 100, 24)
+
+	dr.key("a")
+	dr.typeText("This one lands.")
+	dr.key("ctrl+s")
+
+	dr.key("a")
+	if got := dr.m.editor.Value(); got != "" {
+		t.Errorf("a comment that was sent came back as a draft: %q", got)
+	}
+}
+
+func TestThread_HoldsOntoTheViewWhileTextIsUnsent(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(t, newFake(3)), "PROJ-1", 100, 24)
+
+	if _, blocked := dr.m.BlocksClose(); blocked {
+		t.Error("the view blocks closing with nothing typed")
+	}
+	dr.key("a")
+	dr.typeText("unsent")
+
+	reason, blocked := dr.m.BlocksClose()
+	if !blocked {
+		t.Fatal("the view lets itself be closed over unsent text")
+	}
+	if !strings.Contains(reason, "ctrl+s") {
+		t.Errorf("the reason is %q, and does not say what to press", reason)
+	}
+}
+
+// --- rendering --------------------------------------------------------------
+
+func TestThread_RendersTheThreadAtSeveralWidths(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		width, height int
+	}{
+		{name: "thread_80x20.golden", width: 80, height: 20},
+		{name: "thread_120x30.golden", width: 120, height: 30},
+		{name: "thread_60x12.golden", width: 60, height: 12},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(3)
+			comment(t, f, "PROJ-1", "Reproduced on staging.", "The stack trace points at the total.")
+			comment(t, f, "PROJ-1", "Fix is behind a flag until the migration lands.")
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", tc.width, tc.height)
+
+			golden(t, tc.name, dr.view())
+		})
+	}
+}
+
+func TestThread_RendersTheEditorAndTheConfirmation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		keys []string
+	}{
+		{name: "editor_100x24.golden", keys: []string{"a"}},
+		{name: "confirm_100x24.golden", keys: []string{"d"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(3)
+			comment(t, f, "PROJ-1", "Reproduced on staging.")
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+			dr.key(tc.keys...)
+
+			golden(t, tc.name, dr.view())
+		})
+	}
+}
+
+func TestThread_DrawsNothingBeforeItHasBeenGivenASize(t *testing.T) {
+	t.Parallel()
+
+	view, ok := Thread(testDeps(t, newFake(3)), "PROJ-1").(*Model)
+	if !ok {
+		t.Fatal("Thread did not return a *Model")
+	}
+	if got := view.View(); got != "" {
+		t.Errorf("a view with no size drew %q", got)
+	}
+}
+
+func TestThread_KeepsEveryLineInsideTheWidthItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1",
+		"A paragraph long enough that no terminal this narrow could hold it on one line, which is the "+
+			"case a comment thread meets on the first day.")
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 40, 14)
+
+	for _, line := range strings.Split(dr.view(), "\n") {
+		if got := len([]rune(line)); got > 40 {
+			t.Errorf("a line is %d columns wide in a 40 column terminal: %q", got, line)
+		}
+	}
+}
+
+// --- registration -----------------------------------------------------------
+
+func TestRegistration_PutsTheViewItsKeysAndItsCommandsInTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	spec, ok := kernel.LookupView(ViewID)
+	if !ok {
+		t.Fatal("the comment view is not registered")
+	}
+	if spec.Slot != 0 {
+		t.Errorf("the comment view claims footer slot %d; docs/UX.md keeps the digits for root views", spec.Slot)
+	}
+	if kernel.KeysFor(ViewID).IsZero() {
+		t.Error("the comment view registered no keys, so the footer can say nothing about it")
+	}
+	want := map[string]bool{
+		"comments.open": false, "comments.write": false,
+		"comments.edit": false, "comments.delete": false,
+	}
+	for _, cmd := range kernel.Commands() {
+		if _, ours := want[cmd.ID]; ours {
+			want[cmd.ID] = true
+		}
+	}
+	for id, found := range want {
+		if !found {
+			t.Errorf("%s is not in the command palette", id)
+		}
+	}
+	for _, err := range kernel.RegistrationErrors() {
+		t.Errorf("registration: %v", err)
+	}
+}
+
+func TestRegistration_ThePaletteReachesTheSameGesturesTheKeysDo(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "The comment the palette acts on.")
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.send(WriteMsg{})
+	if dr.m.mode != writing || dr.m.editing != "" {
+		t.Error("the write command did not open the editor on a new comment")
+	}
+	dr.key("esc")
+
+	dr.send(EditMsg{})
+	if dr.m.mode != writing || dr.m.editing == "" {
+		t.Error("the edit command did not open the editor on the comment under the cursor")
+	}
+	dr.key("esc")
+
+	dr.send(DeleteMsg{})
+	if dr.m.mode != confirming {
+		t.Error("the delete command did not put the confirmation up")
+	}
+	if calls := countCalls(f, "DeleteComment"); calls != 0 {
+		t.Error("the delete command deleted a comment without a confirmation")
+	}
+}
+
+func TestThread_ARefreshKeepsTheReaderWhereTheyWere(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	for i := range 12 {
+		comment(t, f, "PROJ-1", "comment number "+strconv.Itoa(i))
+	}
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+	dr.key("g", "g")
+	dr.key("j", "j")
+	under := dr.m.comments[dr.m.cursor].ID
+
+	dr.send(kernel.RefreshMsg{})
+
+	if got := dr.m.comments[dr.m.cursor].ID; got != under {
+		t.Errorf("a refresh moved the cursor from comment %s to %s", under, got)
+	}
+}
+
+func TestThread_RetargetsAtAnotherIssueWithoutKeepingTheOldThread(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "about one")
+	comment(t, f, "PROJ-2", "about two")
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+	dr.send(ThreadMsg{Key: "PROJ-2"})
+
+	if dr.m.issue != "PROJ-2" {
+		t.Fatalf("the view is still on %s", dr.m.issue)
+	}
+	mustContain(t, dr.view(), "about two")
+	mustNotContain(t, dr.view(), "about one")
+}
+
+func mustComments(t *testing.T, f *jiratest.Fake, key string) jira.Page[jira.Comment] {
+	t.Helper()
+
+	page, err := f.Comments(t.Context(), key)
+	if err != nil {
+		t.Fatalf("Comments: %v", err)
+	}
+	return page
+}
+
+func countCalls(f *jiratest.Fake, name string) int {
+	n := 0
+	for _, call := range f.Calls() {
+		if call == name {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/ui/comment/draft.go
+++ b/internal/ui/comment/draft.go
@@ -1,0 +1,129 @@
+package comment
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/varijkapil13/saral/internal/config"
+)
+
+// draftDirName is where unsent comments live under the cache directory. They
+// are the user's own words rather than anything fetched, so nothing in the
+// program deletes one except sending it or clearing it by hand.
+const draftDirName = "drafts"
+
+// draftKey names one draft: a new comment on an issue, or an edit of one
+// comment. The two are separate drafts, because abandoning an edit must not
+// take the half-written new comment beside it with it.
+type draftKey struct {
+	site    string
+	issue   string
+	comment string
+}
+
+func (k draftKey) file() string {
+	name := k.comment
+	if name == "" {
+		name = "new"
+	}
+	return safeName(k.issue) + "." + safeName(name) + ".md"
+}
+
+// safeName keeps a path segment to characters that mean the same thing on every
+// filesystem, so an issue key or a comment id can never reach outside the
+// drafts directory.
+func safeName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "unnamed"
+	}
+	return b.String()
+}
+
+// drafts is where unsent text is kept between sessions. docs/UX.md principle 6
+// asks that anything typed survive a failed request, a conflict and a crash,
+// which means on disk rather than in the model.
+type drafts struct {
+	root string
+}
+
+// openDrafts finds the drafts directory. A session with nowhere to write —
+// no home directory, an unwritable cache — gets a store that keeps nothing
+// rather than a failure, because a comment nobody can save is still worth
+// typing.
+func openDrafts() *drafts {
+	dir, err := config.CacheDir()
+	if err != nil || strings.TrimSpace(dir) == "" {
+		return &drafts{}
+	}
+	return &drafts{root: filepath.Join(dir, draftDirName)}
+}
+
+func (d *drafts) path(k draftKey) string {
+	if d == nil || d.root == "" {
+		return ""
+	}
+	return filepath.Join(d.root, safeName(k.site), k.file())
+}
+
+// read returns the draft kept for this key, and "" when there is none.
+func (d *drafts) read(k draftKey) string {
+	path := d.path(k)
+	if path == "" {
+		return ""
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // the path is built from safeName segments under the cache directory
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// write keeps the text, replacing whatever was there. The file is written
+// beside its target and renamed over it, so a crash half way through leaves
+// the previous draft rather than a truncated one.
+func (d *drafts) write(k draftKey, text string) error {
+	path := d.path(k)
+	if path == "" {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".draft-*")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer func() { _ = os.Remove(name) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.WriteString(text); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(name, path)
+}
+
+// discard forgets a draft, which is what sending it does.
+func (d *drafts) discard(k draftKey) {
+	if path := d.path(k); path != "" {
+		_ = os.Remove(path)
+	}
+}

--- a/internal/ui/comment/draft_test.go
+++ b/internal/ui/comment/draft_test.go
@@ -1,0 +1,177 @@
+package comment
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDrafts_KeepsAndReturnsWhatWasTyped(t *testing.T) {
+	t.Parallel()
+
+	d := &drafts{root: t.TempDir()}
+	k := draftKey{site: "example.atlassian.net", issue: "PROJ-1"}
+
+	if got := d.read(k); got != "" {
+		t.Errorf("a draft nobody wrote came back as %q", got)
+	}
+	if err := d.write(k, "half a thought"); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	if got := d.read(k); got != "half a thought" {
+		t.Errorf("the draft came back as %q", got)
+	}
+	if err := d.write(k, "a whole one"); err != nil {
+		t.Fatalf("rewriting: %v", err)
+	}
+	if got := d.read(k); got != "a whole one" {
+		t.Errorf("the rewritten draft came back as %q", got)
+	}
+	d.discard(k)
+	if got := d.read(k); got != "" {
+		t.Errorf("a discarded draft came back as %q", got)
+	}
+}
+
+func TestDrafts_KeepsANewCommentApartFromAnEditOfAnExistingOne(t *testing.T) {
+	t.Parallel()
+
+	d := &drafts{root: t.TempDir()}
+	fresh := draftKey{site: "example.atlassian.net", issue: "PROJ-1"}
+	editing := draftKey{site: "example.atlassian.net", issue: "PROJ-1", comment: "10701"}
+
+	if err := d.write(fresh, "the new one"); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	if err := d.write(editing, "the edit"); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	d.discard(editing)
+
+	if got := d.read(fresh); got != "the new one" {
+		t.Errorf("abandoning an edit took the new comment with it: %q", got)
+	}
+}
+
+func TestDrafts_TwoSitesWithOneIssueKeyDoNotShareADraft(t *testing.T) {
+	t.Parallel()
+
+	d := &drafts{root: t.TempDir()}
+	here := draftKey{site: "one.atlassian.net", issue: "PROJ-1"}
+	there := draftKey{site: "two.atlassian.net", issue: "PROJ-1"}
+
+	if err := d.write(here, "about this site's PROJ-1"); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	if got := d.read(there); got != "" {
+		t.Errorf("the other site's PROJ-1 read %q", got)
+	}
+}
+
+func TestDrafts_APathCannotReachOutsideTheDraftsDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	d := &drafts{root: root}
+	k := draftKey{site: "../../etc", issue: "../../../passwd", comment: "/../.."}
+
+	if err := d.write(k, "not going anywhere"); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	path := d.path(k)
+	if !strings.HasPrefix(filepath.Clean(path), filepath.Clean(root)+string(filepath.Separator)) {
+		t.Fatalf("the draft went to %q, which is outside %q", path, root)
+	}
+	if got := d.read(k); got != "not going anywhere" {
+		t.Errorf("the draft came back as %q", got)
+	}
+}
+
+func TestDrafts_AreReadableOnlyByTheAccountThatWroteThem(t *testing.T) {
+	t.Parallel()
+
+	d := &drafts{root: t.TempDir()}
+	k := draftKey{site: "example.atlassian.net", issue: "PROJ-1"}
+	if err := d.write(k, "private until it is sent"); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	info, err := os.Stat(d.path(k))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("the draft is mode %o, want 600: it is somebody's unpublished words", perm)
+	}
+}
+
+func TestDrafts_WithNowhereToWriteKeepNothingRatherThanFailing(t *testing.T) {
+	t.Parallel()
+
+	d := &drafts{}
+	k := draftKey{site: "example.atlassian.net", issue: "PROJ-1"}
+
+	if err := d.write(k, "nowhere to put this"); err != nil {
+		t.Errorf("a store with no directory reported %v, want silence", err)
+	}
+	if got := d.read(k); got != "" {
+		t.Errorf("a store with no directory returned %q", got)
+	}
+	d.discard(k)
+}
+
+func TestDrafts_ReportsAWriteItCannotMake(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	// A file where the directory has to go: the store cannot create the tree,
+	// and has to say so rather than pretend the words are kept.
+	blocked := filepath.Join(root, "drafts")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("preparing: %v", err)
+	}
+	d := &drafts{root: blocked}
+
+	if err := d.write(draftKey{site: "example.atlassian.net", issue: "PROJ-1"}, "text"); err == nil {
+		t.Error("writing into a file reported success")
+	}
+}
+
+func TestThread_SaysWhenADraftIsNotBeingKept(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+	blocked := filepath.Join(t.TempDir(), "drafts")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("preparing: %v", err)
+	}
+	dr.m.drafts = &drafts{root: blocked}
+
+	dr.key("a")
+	dr.typeText("typed into a session that cannot keep it")
+
+	if got := dr.statusText(); !strings.Contains(got, "not being kept on disk") {
+		t.Errorf("the status line says %q, and does not say the draft is not being kept", got)
+	}
+	if got := dr.m.editor.Value(); got != "typed into a session that cannot keep it" {
+		t.Errorf("the text was lost as well: %q", got)
+	}
+}
+
+func TestSafeName_KeepsOnlyWhatEveryFilesystemMeansTheSameBy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ in, want string }{
+		{in: "PROJ-1", want: "PROJ-1"},
+		{in: "example.atlassian.net", want: "example_atlassian_net"},
+		{in: "../..", want: "_____"},
+		{in: "", want: "unnamed"},
+		{in: "a/b", want: "a_b"},
+	} {
+		if got := safeName(tc.in); got != tc.want {
+			t.Errorf("safeName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/comment/harness_test.go
+++ b/internal/ui/comment/harness_test.go
@@ -1,0 +1,279 @@
+package comment
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	zone "github.com/lrstanley/bubblezone/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files")
+
+// TestMain points the drafts at a directory of this run's own. Every test in
+// this package writes drafts through the real store, and none of them may reach
+// the machine's cache directory to do it.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "saral-comment-cache")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("SARAL_CACHE_DIR", dir); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+func fullCaps() jira.Capabilities {
+	ok := jira.Capability{OK: true}
+	return jira.Capabilities{
+		Plans: ok, BulkMove: ok, Boards: ok, Attachments: ok, DeleteIssues: ok,
+		TimeZone: time.UTC,
+	}
+}
+
+// testDeps gives every test a site of its own, because the site is half of the
+// key a draft is filed under and these tests run in parallel against one drafts
+// directory. Two tests writing a draft for PROJ-1 must not read each other's.
+func testDeps(t *testing.T, client jira.Client) kernel.Deps {
+	t.Helper()
+
+	return kernel.Deps{
+		Jira:    client,
+		Caps:    fullCaps(),
+		Project: "PROJ",
+		Theme:   kernel.NewTheme(kernel.ThemeNoColor, true, kernel.ASCIIGlyphs()),
+		Zones:   zone.New(),
+		Site:    t.Name() + ".example.atlassian.net",
+		Now:     func() time.Time { return time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC) },
+	}
+}
+
+func newFake(issues int, opts ...jiratest.Option) *jiratest.Fake {
+	return jiratest.New(append([]jiratest.Option{
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithIssues(jiratest.Gen(issues)),
+	}, opts...)...)
+}
+
+func doc(paragraphs ...string) adf.Doc {
+	nodes := make([]adf.Node, 0, len(paragraphs))
+	for _, p := range paragraphs {
+		nodes = append(nodes, adf.NewNode("paragraph", adf.NewText(p)))
+	}
+	return adf.NewDoc(nodes...)
+}
+
+// comment writes a comment onto an issue the way a person would, so the thread
+// under test is one the fake actually holds.
+func comment(t *testing.T, f *jiratest.Fake, key string, paragraphs ...string) jira.Comment {
+	t.Helper()
+
+	stored, err := f.AddComment(t.Context(), key, doc(paragraphs...))
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	return stored
+}
+
+type driver struct {
+	t        *testing.T
+	m        *Model
+	statuses []kernel.StatusMsg
+}
+
+func newDriver(t *testing.T, d kernel.Deps, key string, w, h int) *driver {
+	t.Helper()
+
+	view, ok := Thread(d, key).(*Model)
+	if !ok {
+		t.Fatal("Thread did not return a *Model")
+	}
+	dr := &driver{t: t, m: view}
+	dr.send(kernel.SizeMsg{Width: w, Height: h})
+	dr.run(dr.m.Init())
+	dr.send(kernel.FocusMsg{Focused: true})
+	return dr
+}
+
+func (d *driver) send(msg tea.Msg) {
+	d.t.Helper()
+
+	view, cmd := d.m.Update(msg)
+	model, ok := view.(*Model)
+	if !ok {
+		d.t.Fatal("Update did not return a *Model")
+	}
+	d.m = model
+	d.run(cmd)
+}
+
+func (d *driver) run(cmd tea.Cmd) {
+	d.t.Helper()
+
+	queue := []tea.Cmd{cmd}
+	for steps := 0; len(queue) > 0; steps++ {
+		if steps > 2000 {
+			d.t.Fatal("commands never settled")
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if cmds, ok := unwrapCmds(msg); ok {
+			queue = append(queue, cmds...)
+			continue
+		}
+		if status, ok := msg.(kernel.StatusMsg); ok {
+			d.statuses = append(d.statuses, status)
+			continue
+		}
+		view, follow := d.m.Update(msg)
+		model, ok := view.(*Model)
+		if !ok {
+			d.t.Fatal("Update did not return a *Model")
+		}
+		d.m = model
+		queue = append(queue, follow)
+	}
+}
+
+func (d *driver) key(keys ...string) {
+	d.t.Helper()
+
+	for _, k := range keys {
+		d.send(keyPress(k))
+	}
+}
+
+// typeText sends one key press per rune, which is what the editor and the draft
+// store actually see.
+func (d *driver) typeText(s string) {
+	d.t.Helper()
+
+	for _, r := range s {
+		if r == '\n' {
+			d.send(tea.KeyPressMsg{Code: tea.KeyEnter})
+			continue
+		}
+		d.send(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+}
+
+func (d *driver) view() string { return ansi.Strip(d.m.View()) }
+
+func (d *driver) lastStatus() kernel.StatusMsg {
+	if len(d.statuses) == 0 {
+		return kernel.StatusMsg{}
+	}
+	return d.statuses[len(d.statuses)-1]
+}
+
+func (d *driver) statusText() string { return d.lastStatus().Text }
+
+func unwrapCmds(msg tea.Msg) ([]tea.Cmd, bool) {
+	v := reflect.ValueOf(msg)
+	if v.Kind() != reflect.Slice || v.Type().Elem() != reflect.TypeOf(tea.Cmd(nil)) {
+		return nil, false
+	}
+	out := make([]tea.Cmd, 0, v.Len())
+	for i := range v.Len() {
+		cmd, _ := v.Index(i).Interface().(tea.Cmd)
+		out = append(out, cmd)
+	}
+	return out, true
+}
+
+func keyPress(s string) tea.KeyPressMsg {
+	switch s {
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "esc":
+		return tea.KeyPressMsg{Code: tea.KeyEscape}
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "home":
+		return tea.KeyPressMsg{Code: tea.KeyHome}
+	case "end":
+		return tea.KeyPressMsg{Code: tea.KeyEnd}
+	case "pgdown":
+		return tea.KeyPressMsg{Code: tea.KeyPgDown}
+	case "pgup":
+		return tea.KeyPressMsg{Code: tea.KeyPgUp}
+	case "ctrl+s":
+		return tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}
+	case "ctrl+d":
+		return tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
+	case "ctrl+u":
+		return tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl}
+	default:
+		r, _ := utf8.DecodeRuneInString(s)
+		return tea.KeyPressMsg{Code: r, Text: s}
+	}
+}
+
+func golden(t *testing.T, name, got string) {
+	t.Helper()
+
+	path := filepath.Join("testdata", name)
+	if *update {
+		if err := os.MkdirAll("testdata", 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // the path is a literal under testdata
+	if err != nil {
+		t.Fatalf("%v — run: go test ./internal/ui/comment -update", err)
+	}
+	if string(want) != got {
+		t.Errorf("frame differs from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}
+
+func mustContain(t *testing.T, got string, want ...string) {
+	t.Helper()
+
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("output does not contain %q:\n%s", w, got)
+		}
+	}
+}
+
+func mustNotContain(t *testing.T, got string, unwanted ...string) {
+	t.Helper()
+
+	for _, w := range unwanted {
+		if strings.Contains(got, w) {
+			t.Errorf("output still contains %q:\n%s", w, got)
+		}
+	}
+}

--- a/internal/ui/comment/keys.go
+++ b/internal/ui/comment/keys.go
@@ -1,0 +1,109 @@
+package comment
+
+import "github.com/varijkapil13/saral/internal/ui/kernel"
+
+type keyMap struct {
+	Up       kernel.Binding
+	Down     kernel.Binding
+	PageUp   kernel.Binding
+	PageDown kernel.Binding
+	HalfUp   kernel.Binding
+	HalfDown kernel.Binding
+	Go       kernel.Binding
+	Top      kernel.Binding
+	Bottom   kernel.Binding
+	Write    kernel.Binding
+	Edit     kernel.Binding
+	Delete   kernel.Binding
+	Send     kernel.Binding
+	Cancel   kernel.Binding
+	Confirm  kernel.Binding
+}
+
+func defaultKeys() keyMap {
+	return keyMap{
+		Up:       kernel.Bind([]string{"k", "up"}, "↑/k", "up"),
+		Down:     kernel.Bind([]string{"j", "down"}, "↓/j", "down"),
+		PageUp:   kernel.Bind([]string{"pgup", "ctrl+b"}, "pgup", "page up"),
+		PageDown: kernel.Bind([]string{"pgdown", "ctrl+f", "space"}, "pgdn", "page down"),
+		HalfUp:   kernel.Bind([]string{"ctrl+u"}, "ctrl+u", "half page up"),
+		HalfDown: kernel.Bind([]string{"ctrl+d"}, "ctrl+d", "half page down"),
+		Go:       kernel.Bind([]string{"g"}, "g", "go to"),
+		Top:      kernel.Bind([]string{"home"}, "g g", "oldest"),
+		Bottom:   kernel.Bind([]string{"G", "end"}, "G", "newest"),
+		Write:    kernel.Bind([]string{"a", "c"}, "a", "write a comment"),
+		Edit:     kernel.Bind([]string{"e"}, "e", "edit this one"),
+		Delete:   kernel.Bind([]string{"d"}, "d", "delete this one"),
+		Send:     kernel.Bind([]string{"ctrl+s"}, "ctrl+s", "send"),
+		Cancel:   kernel.Bind([]string{"esc"}, "esc", "put it aside"),
+		Confirm:  kernel.Bind([]string{"y"}, "y", "delete it"),
+	}
+}
+
+// keySet is what the footer and the help overlay show. It is derived from the
+// bindings above rather than written twice, so a key that moves cannot leave a
+// stale hint behind.
+func (k keyMap) keySet() kernel.KeySet {
+	return kernel.KeySet{
+		Short: []kernel.Binding{k.Down, k.Up, k.Write, k.Edit, k.Delete},
+		Full: [][]kernel.Binding{
+			{k.Down, k.Up, k.PageDown, k.PageUp},
+			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
+			{k.Write, k.Edit, k.Delete, k.Send, k.Cancel},
+		},
+	}
+}
+
+type action uint8
+
+const (
+	actNone action = iota
+	actDown
+	actUp
+	actPageDown
+	actPageUp
+	actHalfDown
+	actHalfUp
+	actGo
+	actTop
+	actBottom
+	actWrite
+	actEdit
+	actDelete
+	actSend
+	actCancel
+	actConfirm
+)
+
+// tables turn the bindings into a keystroke lookup, built once per model. The
+// bindings stay the one source of truth for what a key does and for what the
+// footer says it does.
+func (k keyMap) tables() (browse, confirm map[string]action) {
+	browse = table(
+		binding{k.Down, actDown}, binding{k.Up, actUp},
+		binding{k.PageDown, actPageDown}, binding{k.PageUp, actPageUp},
+		binding{k.HalfDown, actHalfDown}, binding{k.HalfUp, actHalfUp},
+		binding{k.Go, actGo}, binding{k.Top, actTop}, binding{k.Bottom, actBottom},
+		binding{k.Write, actWrite}, binding{k.Edit, actEdit}, binding{k.Delete, actDelete},
+	)
+	confirm = table(binding{k.Confirm, actConfirm})
+	return browse, confirm
+}
+
+type binding struct {
+	b kernel.Binding
+	a action
+}
+
+func table(entries ...binding) map[string]action {
+	out := make(map[string]action, len(entries)*2)
+	for _, e := range entries {
+		if !e.b.Enabled() {
+			continue
+		}
+		for _, stroke := range e.b.Keys() {
+			out[stroke] = e.a
+		}
+	}
+	return out
+}

--- a/internal/ui/comment/mouse_test.go
+++ b/internal/ui/comment/mouse_test.go
@@ -1,0 +1,130 @@
+package comment
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// clickOn presses the left button in the middle of a zone. Zones are recorded
+// on the manager's own goroutine as a side effect of scanning a drawn frame, so
+// the zone is looked for until it appears rather than assumed to be there.
+func clickOn(t *testing.T, d kernel.Deps, dr *driver, name string) {
+	t.Helper()
+
+	_ = d.Zones.Scan(dr.m.View())
+	id := dr.m.zonePrefix + name
+	eventually(t, "the zone "+id+" to be recorded", func() bool {
+		return !d.Zones.Get(id).IsZero()
+	})
+	at := d.Zones.Get(id)
+	dr.send(tea.MouseClickMsg{X: at.StartX, Y: at.StartY, Button: tea.MouseLeft})
+}
+
+func eventually(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		runtime.Gosched()
+	}
+}
+
+func TestThread_ClickingACommentSelectsItAndClickingItAgainEditsIt(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	first := comment(t, f, "PROJ-1", "The older one.")
+	comment(t, f, "PROJ-1", "The newer one.")
+	d := testDeps(t, f)
+	dr := newDriver(t, d, "PROJ-1", 100, 24)
+
+	if dr.m.cursor != 1 {
+		t.Fatalf("the cursor opened on %d, want the newest comment", dr.m.cursor)
+	}
+	clickOn(t, d, dr, zoneComment+first.ID)
+	if dr.m.cursor != 0 {
+		t.Fatalf("a click left the cursor on %d, want the comment that was clicked", dr.m.cursor)
+	}
+
+	clickOn(t, d, dr, zoneComment+first.ID)
+	if dr.m.mode != writing || dr.m.editing != first.ID {
+		t.Errorf("a second click on the selected comment did not open the editor on it")
+	}
+}
+
+func TestThread_ClickingWriteOpensTheEditorOnANewComment(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "Something to reply to.")
+	d := testDeps(t, f)
+	dr := newDriver(t, d, "PROJ-1", 100, 24)
+
+	clickOn(t, d, dr, zoneWrite)
+
+	if dr.m.mode != writing || dr.m.editing != "" {
+		t.Errorf("clicking write did not open the editor on a new comment")
+	}
+}
+
+func TestThread_ClickingDeleteAsksRatherThanDeletes(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "The one that must not vanish on a click.")
+	d := testDeps(t, f)
+	dr := newDriver(t, d, "PROJ-1", 100, 24)
+
+	clickOn(t, d, dr, zoneDelete)
+
+	if dr.m.mode != confirming {
+		t.Fatal("clicking delete did not put the confirmation up")
+	}
+	if got := countCalls(f, "DeleteComment"); got != 0 {
+		t.Fatalf("clicking delete removed %d comments without asking", got)
+	}
+
+	clickOn(t, d, dr, zoneConfirm)
+	if got := countCalls(f, "DeleteComment"); got != 1 {
+		t.Errorf("clicking the confirmation deleted %d comments, want 1", got)
+	}
+}
+
+func TestThread_ClickingTheEditorsOwnActionsSendsAndPutsAside(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	d := testDeps(t, f)
+	dr := newDriver(t, d, "PROJ-1", 100, 24)
+
+	dr.key("a")
+	dr.typeText("Sent with the mouse.")
+	clickOn(t, d, dr, zoneSend)
+
+	if dr.m.mode != browsing {
+		t.Fatal("clicking send left the editor open")
+	}
+	if got := countCalls(f, "AddComment"); got != 1 {
+		t.Fatalf("clicking send stored %d comments, want 1", got)
+	}
+
+	dr.key("a")
+	dr.typeText("Put aside with the mouse.")
+	clickOn(t, d, dr, zoneCancel)
+
+	if dr.m.mode != browsing {
+		t.Error("clicking the cancel hint left the editor open")
+	}
+	dr.key("a")
+	if got := dr.m.editor.Value(); got != "Put aside with the mouse." {
+		t.Errorf("the draft did not survive the click: %q", got)
+	}
+}

--- a/internal/ui/comment/register.go
+++ b/internal/ui/comment/register.go
@@ -1,0 +1,40 @@
+package comment
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// The thread claims no footer slot: docs/UX.md keeps the digits for the views a
+// session lives in, and this one is about whichever issue is being read. It is
+// reached by being pushed with an issue, by name, and from the palette.
+func init() {
+	kernel.RegisterView(kernel.ViewSpec{
+		ID:    ViewID,
+		Title: "Comments",
+		New:   New,
+	})
+	kernel.RegisterKeys(ViewID, defaultKeys().keySet())
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "comments.open",
+		Title: "Comments",
+		Group: "Go to",
+		Run:   func(kernel.Deps) tea.Cmd { return kernel.Open(ViewID) },
+	})
+	for _, c := range []struct {
+		id, title string
+		msg       tea.Msg
+	}{
+		{id: "comments.write", title: "Write a comment", msg: WriteMsg{}},
+		{id: "comments.edit", title: "Edit the comment you are on", msg: EditMsg{}},
+		{id: "comments.delete", title: "Delete the comment you are on", msg: DeleteMsg{}},
+	} {
+		kernel.RegisterCommand(kernel.Command{
+			ID:    c.id,
+			Title: c.title,
+			Group: "Comments",
+			Run:   func(kernel.Deps) tea.Cmd { return kernel.Broadcast(c.msg) },
+		})
+	}
+}

--- a/internal/ui/comment/render.go
+++ b/internal/ui/comment/render.go
@@ -1,0 +1,371 @@
+package comment
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const (
+	// marker is the gutter the selected comment's arrow sits in.
+	marker = 2
+	// indent is how far a comment's own words sit in from the gutter.
+	indent = 4
+)
+
+// styles are this view's styles, built once per theme generation because
+// constructing a lipgloss.Style is the expensive half of drawing a line.
+type styles struct {
+	gen      int
+	author   lipgloss.Style
+	muted    lipgloss.Style
+	title    lipgloss.Style
+	selected lipgloss.Style
+	danger   lipgloss.Style
+	warning  lipgloss.Style
+	action   lipgloss.Style
+	rule     lipgloss.Style
+}
+
+func newStyles(t *kernel.Theme) *styles {
+	return &styles{
+		gen:      t.Gen,
+		author:   t.Accent,
+		muted:    t.Muted,
+		title:    t.Title,
+		selected: t.Selected,
+		danger:   t.Danger,
+		warning:  t.Warning,
+		action:   t.HintKey,
+		rule:     t.Muted,
+	}
+}
+
+// asciiMode reports whether the theme's glyph set is the ASCII fallback, which
+// is what pkg/adf needs in order to pick its own markers. The theme carries the
+// glyphs rather than the name of the set they came from, so the set is
+// identified by one of its members.
+func asciiMode(t *kernel.Theme) bool {
+	return t.Glyphs.Ellipsis == kernel.ASCIIGlyphs().Ellipsis
+}
+
+// blockKey is everything one comment's rendering depends on, so that a block
+// memoized under it is invalidated by any change that would redraw it.
+type blockKey struct {
+	id       string
+	updated  int64
+	width    int
+	gen      int
+	selected bool
+}
+
+// blocks is a bounded memo of rendered comments. Past its limit it is emptied
+// rather than evicted one at a time: a scroll invalidates a screenful at once
+// anyway, and clearing keeps the map's capacity.
+type blocks struct {
+	made  map[blockKey][]string
+	limit int
+}
+
+func newBlocks(limit int) *blocks {
+	return &blocks{made: make(map[blockKey][]string, limit), limit: limit}
+}
+
+func (b *blocks) get(k blockKey) ([]string, bool) {
+	lines, ok := b.made[k]
+	return lines, ok
+}
+
+func (b *blocks) put(k blockKey, lines []string) {
+	if len(b.made) >= b.limit {
+		clear(b.made)
+	}
+	b.made[k] = lines
+}
+
+func (b *blocks) reset() { clear(b.made) }
+
+// renderBlock draws one comment: who wrote it and when, whatever restricts it,
+// and its body wrapped to the width it has been given. Every line is padded to
+// the full width so that the mouse zone around the block is the rectangle the
+// block occupies rather than the shape of its last line. The blank line that
+// separates one comment from the next is added outside, so that it falls
+// outside the zone.
+func renderBlock(c *jira.Comment, width int, selected bool, st *styles, t *kernel.Theme, loc *time.Location) []string {
+	body := adf.MarkdownWith(c.Body, adf.Options{
+		TableWidth: max(width-indent, 8),
+		ASCII:      asciiMode(t),
+		Location:   loc,
+	})
+	lines := make([]string, 0, 8)
+
+	head := metaLine(c, st, t, loc)
+	if selected {
+		head = st.selected.Render(pad(t.Glyphs.Collapsed+" "+head, width))
+	} else {
+		head = pad(strings.Repeat(" ", marker)+head, width)
+	}
+	lines = append(lines, head)
+
+	room := max(width-indent, 8)
+	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+		for _, wrapped := range strings.Split(ansi.Wrap(line, room, "-"), "\n") {
+			lines = append(lines, pad(strings.Repeat(" ", indent)+wrapped, width))
+		}
+	}
+	if len(lines) == 1 {
+		lines = append(lines, pad(strings.Repeat(" ", indent)+st.muted.Render("(empty)"), width))
+	}
+	return lines
+}
+
+// metaLine names the author, when the comment was written, whether it has been
+// edited since, and what restricts it — a restriction is the one property of a
+// comment that changes who else can read what is being written about them.
+func metaLine(c *jira.Comment, st *styles, t *kernel.Theme, loc *time.Location) string {
+	sep := " " + t.Glyphs.Separator + " "
+	parts := []string{st.author.Render(authorName(c))}
+	if when := formatWhen(c.Created, loc); when != "" {
+		parts = append(parts, st.muted.Render(when))
+	}
+	if edited := formatWhen(c.Updated, loc); edited != "" && !c.Updated.Equal(c.Created) {
+		parts = append(parts, st.muted.Render("edited "+edited))
+	}
+	if label := visibilityLabel(c.Visibility); label != "" {
+		parts = append(parts, st.warning.Render(label))
+	}
+	return strings.Join(parts, sep)
+}
+
+// visibilityLabel says who can read a restricted comment, and "" for one
+// anybody on the issue can read.
+func visibilityLabel(v *jira.Visibility) string {
+	if v == nil {
+		return ""
+	}
+	switch {
+	case v.Type == "" && v.Value == "":
+		return "restricted"
+	case v.Type == "":
+		return "only " + v.Value
+	case v.Value == "":
+		return "only one " + v.Type
+	default:
+		return "only the " + v.Value + " " + v.Type
+	}
+}
+
+func authorName(c *jira.Comment) string {
+	if strings.TrimSpace(c.Author.DisplayName) == "" {
+		return "Someone"
+	}
+	return c.Author.DisplayName
+}
+
+// formatWhen renders an instant in the Jira account's timezone rather than the
+// machine's, which is what Capabilities.Location carries it for.
+func formatWhen(t time.Time, loc *time.Location) string {
+	if t.IsZero() {
+		return ""
+	}
+	if loc == nil {
+		loc = time.UTC
+	}
+	return t.In(loc).Format("02 Jan 2006 15:04")
+}
+
+func pad(s string, width int) string {
+	if got := ansi.StringWidth(s); got < width {
+		return s + strings.Repeat(" ", width-got)
+	}
+	return s
+}
+
+// headKey is everything the header is built from, so that the line is rebuilt
+// when one of them moves and never once per frame.
+type headKey struct {
+	issue      string
+	width, gen int
+	comments   int
+	loaded     bool
+	more       bool
+	selected   bool
+}
+
+func (m *Model) headKey() headKey {
+	return headKey{
+		issue: m.issue, width: m.width, gen: m.styles.gen,
+		comments: len(m.comments), loaded: m.loaded,
+		more: m.page.HasMore(), selected: m.selected() != nil,
+	}
+}
+
+// header is the identity line above the thread and the rule under it. The
+// actions on the right are mouse zones, because docs/UX.md asks that nothing be
+// keyboard-only.
+func (m *Model) header() string {
+	key := m.headKey()
+	if m.head != "" && key == m.headAt {
+		return m.head
+	}
+	m.head, m.headAt = m.buildHeader(), key
+	return m.head
+}
+
+func (m *Model) buildHeader() string {
+	t := m.deps.Theme
+	actions := m.actionBar()
+	room := max(m.width-ansi.StringWidth(actions)-2, 8)
+
+	label := m.issue
+	if label == "" {
+		label = "Comments"
+	} else {
+		label += " " + t.Glyphs.Separator + " " + m.countLabel()
+	}
+	left := m.styles.title.Render(ansi.Truncate(label, room, t.Glyphs.Ellipsis))
+	gap := max(m.width-ansi.StringWidth(left)-ansi.StringWidth(actions), 1)
+	rule := m.styles.rule.Render(strings.Repeat(t.Glyphs.HLine, max(m.width, 1)))
+	return left + strings.Repeat(" ", gap) + actions + "\n" + rule
+}
+
+func (m *Model) countLabel() string {
+	switch {
+	case !m.loaded:
+		return "reading the thread" + m.deps.Theme.Glyphs.Ellipsis
+	case len(m.comments) == 0:
+		return "no comments"
+	case m.page.HasMore():
+		return strconv.Itoa(len(m.comments)) + "+ comments"
+	case len(m.comments) == 1:
+		return "1 comment"
+	default:
+		return strconv.Itoa(len(m.comments)) + " comments"
+	}
+}
+
+// actionBar is the three actions, each of them a click target. An action that
+// cannot be taken right now is not drawn, which is the same rule the footer
+// follows.
+func (m *Model) actionBar() string {
+	labels := []struct {
+		zone, text string
+	}{{zoneWrite, "write"}}
+	if m.selected() != nil {
+		labels = append(labels,
+			struct{ zone, text string }{zoneEdit, "edit"},
+			struct{ zone, text string }{zoneDelete, "delete"},
+		)
+	}
+	parts := make([]string, 0, len(labels))
+	for _, l := range labels {
+		parts = append(parts, m.mark(l.zone, m.styles.action.Render(l.text)))
+	}
+	return strings.Join(parts, "  ")
+}
+
+// deletePrompt is the confirmation docs/UX.md principle 4 asks for: it names
+// the comment that is about to go, in words, and says what answers it. Nothing
+// deletes a comment except the key this line names.
+func (m *Model) deletePrompt() string {
+	t := m.deps.Theme
+	c := m.pending
+	label := "delete " + authorName(&c) + "'s comment"
+	if when := formatWhen(c.Created, m.location()); when != "" {
+		label += " from " + when
+	}
+	if restricted := visibilityLabel(c.Visibility); restricted != "" {
+		label += ", " + restricted
+	}
+	if first := firstWords(c.Body, 40); first != "" {
+		label += ", " + strconv.Quote(first)
+	}
+	label += "?"
+	hint := "  " + m.mark(zoneConfirm, "y deletes it") + ", " + m.mark(zoneRefuse, "any other key keeps it")
+	room := max(m.width-ansi.StringWidth(hint), 8)
+	return m.styles.danger.Render(ansi.Truncate(label, room, t.Glyphs.Ellipsis)) + m.styles.muted.Render(hint)
+}
+
+// firstWords is the opening of a comment, on one line, so that a confirmation
+// names the comment the way the person who wrote it would recognise it.
+func firstWords(d adf.Doc, width int) string {
+	text := strings.TrimSpace(adf.Markdown(d))
+	if text == "" {
+		return ""
+	}
+	if at := strings.IndexByte(text, '\n'); at >= 0 {
+		text = text[:at]
+	}
+	return ansi.Truncate(strings.TrimSpace(text), width, "…")
+}
+
+// editorCaption says which comment the editor is on, so that an edit and a new
+// comment are never the same screen.
+func (m *Model) editorCaption() string {
+	if m.editing == "" {
+		return m.styles.title.Render("A new comment on " + m.issue)
+	}
+	label := "Editing " + authorName(&m.pending) + "'s comment"
+	if when := formatWhen(m.pending.Created, m.location()); when != "" {
+		label += " from " + when
+	}
+	if restricted := visibilityLabel(m.pending.Visibility); restricted != "" {
+		label += " " + m.deps.Theme.Glyphs.Separator + " " + restricted + ", and it stays that way"
+	}
+	return m.styles.title.Render(ansi.Truncate(label, max(m.width, 8), m.deps.Theme.Glyphs.Ellipsis))
+}
+
+// editorHint is the line under the editor. It names the keys that finish, since
+// the footer cannot: the registry holds one key set per view, not one per mode.
+func (m *Model) editorHint() string {
+	if m.sending {
+		return m.styles.muted.Render("  sending" + m.deps.Theme.Glyphs.Ellipsis)
+	}
+	return m.styles.muted.Render("  " + m.mark(zoneSend, "ctrl+s sends") + "  " +
+		m.mark(zoneCancel, "esc keeps it as a draft"))
+}
+
+// alwaysPresent are the entries in pkg/adf's list that name prose details
+// rather than a construct anybody would recognise on screen, and that every
+// document has. Warning about them would mean warning about every comment.
+var alwaysPresent = map[string]bool{"text": true, "marks": true}
+
+// oneWay names the constructs in a document that markdown alone cannot carry,
+// read out of pkg/adf's own list so that this view cannot end up warning about
+// something the parser has since learned to keep.
+func oneWay(d adf.Doc) []string {
+	types := d.NodeTypes()
+	if len(types) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(types))
+	out := make([]string, 0, 4)
+	for _, entry := range adf.ParseMarkdownDropsOnly() {
+		name, _, ok := strings.Cut(entry, ":")
+		if !ok || seen[name] || alwaysPresent[name] || types[name] == 0 {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+// list joins names the way a sentence does.
+func list(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+	}
+}

--- a/internal/ui/comment/render_test.go
+++ b/internal/ui/comment/render_test.go
@@ -1,0 +1,113 @@
+package comment
+
+import (
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+func TestVisibilityLabel_SaysWhoCanReadARestrictedComment(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   *jira.Visibility
+		want string
+	}{
+		{name: "nothing restricting it", in: nil, want: ""},
+		{name: "a role", in: &jira.Visibility{Type: "role", Value: "Developers"}, want: "only the Developers role"},
+		{name: "a group", in: &jira.Visibility{Type: "group", Value: "jira-developers"}, want: "only the jira-developers group"},
+		{name: "a restriction with no name", in: &jira.Visibility{Type: "role"}, want: "only one role"},
+		{name: "a name with no kind", in: &jira.Visibility{Value: "Developers"}, want: "only Developers"},
+		{name: "neither", in: &jira.Visibility{}, want: "restricted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := visibilityLabel(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOneWay_NamesOnlyTheConstructsTheDocumentActuallyHolds(t *testing.T) {
+	t.Parallel()
+
+	plain := adf.NewDoc(adf.NewNode("paragraph", adf.NewText("nothing special here")))
+	if got := oneWay(plain); len(got) != 0 {
+		t.Errorf("a paragraph of prose was reported as losing %v", got)
+	}
+
+	rich := adf.NewDoc(
+		adf.NewNode("paragraph",
+			adf.NewNode("mention").WithAttrs(adf.Attrs{"id": "acct-1", "text": "@Someone"}),
+			adf.NewNode("status").WithAttrs(adf.Attrs{"text": "DONE", "color": "green"}),
+		),
+		adf.NewNode("table"),
+	)
+	got := oneWay(rich)
+	want := map[string]bool{"mention": false, "status": false, "table": false}
+	for _, name := range got {
+		if _, ours := want[name]; !ours {
+			t.Errorf("%q is not in this document", name)
+		}
+		want[name] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("%q is in the document and was not named", name)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %v, which names something twice", got)
+	}
+}
+
+func TestList_ReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in   []string
+		want string
+	}{
+		{in: nil, want: ""},
+		{in: []string{"mention"}, want: "mention"},
+		{in: []string{"mention", "table"}, want: "mention and table"},
+		{in: []string{"mention", "status", "table"}, want: "mention, status and table"},
+	} {
+		if got := list(tc.in); got != tc.want {
+			t.Errorf("list(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFirstWords_TakesTheOpeningLineAndNoMore(t *testing.T) {
+	t.Parallel()
+
+	body := adf.NewDoc(
+		adf.NewNode("paragraph", adf.NewText("The first line of it.")),
+		adf.NewNode("paragraph", adf.NewText("The second, which nobody needs in a confirmation.")),
+	)
+	if got := firstWords(body, 40); got != "The first line of it." {
+		t.Errorf("got %q", got)
+	}
+	if got := firstWords(body, 10); got != "The first…" {
+		t.Errorf("a narrow confirmation got %q", got)
+	}
+	if got := firstWords(adf.Doc{}, 40); got != "" {
+		t.Errorf("an empty document got %q", got)
+	}
+}
+
+// The editor is seeded and read back with one value, and it must be the one
+// that does not truncate: a bounded render puts an ellipsis inside a table cell
+// and an edit anywhere in that table would write the truncation back.
+func TestEditorOptions_BoundNothingByWidth(t *testing.T) {
+	t.Parallel()
+
+	if editorOptions != (adf.Options{}) {
+		t.Errorf("the editor renders with %+v, want the zero options", editorOptions)
+	}
+}

--- a/internal/ui/comment/testdata/confirm_100x24.golden
+++ b/internal/ui/comment/testdata/confirm_100x24.golden
@@ -1,0 +1,24 @@
+PROJ-1 | 1 comment                                                               write  edit  delete
+----------------------------------------------------------------------------------------------------
+> Sam Tester | 02 Mar 2026 09:00                                                                    
+    Reproduced on staging.                                                                          
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+delete Sam Tester's comment from 02 Mar 2026 09:00, "Reprod...  y deletes it, any other key keeps it

--- a/internal/ui/comment/testdata/editor_100x24.golden
+++ b/internal/ui/comment/testdata/editor_100x24.golden
@@ -1,0 +1,24 @@
+PROJ-1 | 1 comment                                                               write  edit  delete
+----------------------------------------------------------------------------------------------------
+A new comment on PROJ-1
+Markdown. Tables, lists, quotes and code fences all survive the round trip.                     
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+  ctrl+s sends  esc keeps it as a draft

--- a/internal/ui/comment/testdata/thread_120x30.golden
+++ b/internal/ui/comment/testdata/thread_120x30.golden
@@ -1,0 +1,29 @@
+PROJ-1 | 2 comments                                                                                  write  edit  delete
+------------------------------------------------------------------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                                                                                        
+    Reproduced on staging.                                                                                              
+                                                                                                                        
+    The stack trace points at the total.                                                                                
+
+> Sam Tester | 02 Mar 2026 09:00                                                                                        
+    Fix is behind a flag until the migration lands.                                                                     
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/comment/testdata/thread_60x12.golden
+++ b/internal/ui/comment/testdata/thread_60x12.golden
@@ -1,0 +1,11 @@
+PROJ-1 | 2 comments                      write  edit  delete
+------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                            
+    Reproduced on staging.                                  
+                                                            
+    The stack trace points at the total.                    
+
+> Sam Tester | 02 Mar 2026 09:00                            
+    Fix is behind a flag until the migration lands.         
+
+

--- a/internal/ui/comment/testdata/thread_80x20.golden
+++ b/internal/ui/comment/testdata/thread_80x20.golden
@@ -1,0 +1,19 @@
+PROJ-1 | 2 comments                                          write  edit  delete
+--------------------------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                                                
+    Reproduced on staging.                                                      
+                                                                                
+    The stack trace points at the total.                                        
+
+> Sam Tester | 02 Mar 2026 09:00                                                
+    Fix is behind a flag until the migration lands.                             
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -7,6 +7,7 @@
 package ui
 
 import (
+	_ "github.com/varijkapil13/saral/internal/ui/comment"
 	_ "github.com/varijkapil13/saral/internal/ui/form"
 	_ "github.com/varijkapil13/saral/internal/ui/issue"
 	_ "github.com/varijkapil13/saral/internal/ui/list"

--- a/pkg/jira/cloud/comment.go
+++ b/pkg/jira/cloud/comment.go
@@ -1,0 +1,269 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// commentPageSize is how many comments one request asks for. The endpoint
+// defaults to fifty and caps what it will send anyway; asking explicitly is what
+// makes the offsets a test walks reproducible.
+const commentPageSize = 50
+
+// commentsPath is the collection under one issue.
+func commentsPath(key string) string {
+	return "/rest/api/3/issue/" + url.PathEscape(key) + "/comment"
+}
+
+// commentPath is one comment under one issue.
+func commentPath(key, id string) string {
+	return commentsPath(key) + "/" + url.PathEscape(id)
+}
+
+// apiCommentPage is the envelope GET /issue/{key}/comment answers with. It pages
+// by startAt like the Agile API does, but names its array comments rather than
+// values and sends no isLast, so neither of this package's shared envelopes
+// reads it.
+type apiCommentPage struct {
+	StartAt    int          `json:"startAt"`
+	MaxResults int          `json:"maxResults"`
+	Total      *int         `json:"total"`
+	Comments   []apiComment `json:"comments"`
+}
+
+func (p apiCommentPage) total() int {
+	if p.Total == nil {
+		return -1
+	}
+	return *p.Total
+}
+
+// last reports the end of the walk for an envelope that reported no total. That
+// shape carries no isLast either, so the only thing left to end on is a page
+// shorter than the one the server said it was serving — and it is the server's
+// own maxResults that says how long a full page is, because a site may cap the
+// number asked for without saying so anywhere else.
+func (p apiCommentPage) last() bool {
+	if p.Total != nil {
+		return false
+	}
+	asked := p.MaxResults
+	if asked <= 0 {
+		asked = commentPageSize
+	}
+	return len(p.Comments) < asked
+}
+
+// apiComment is one comment. The body is decoded into a document rather than
+// kept raw because that is the shape the port carries; a body that will not read
+// as ADF fails the call rather than arriving as an empty comment.
+type apiComment struct {
+	ID           string          `json:"id"`
+	Author       *apiUser        `json:"author"`
+	UpdateAuthor *apiUser        `json:"updateAuthor"`
+	Body         adf.Doc         `json:"body"`
+	Created      timestamp       `json:"created"`
+	Updated      timestamp       `json:"updated"`
+	Visibility   json.RawMessage `json:"visibility"`
+}
+
+func (c apiComment) domain() jira.Comment {
+	out := jira.Comment{
+		ID:      c.ID,
+		Body:    c.Body,
+		Created: c.Created.Time,
+		Updated: c.Updated.Time,
+	}
+	if c.Author != nil {
+		out.Author = c.Author.domain()
+	}
+	if c.UpdateAuthor != nil {
+		author := c.UpdateAuthor.domain()
+		out.UpdateAuthor = &author
+	}
+	out.Visibility = decodeVisibility(c.Visibility)
+	return out
+}
+
+// apiVisibility is a comment's restriction. identifier is the role or group id,
+// which is the half of this that is not localised; value is the display name,
+// which on a German site is German.
+type apiVisibility struct {
+	Type       string `json:"type"`
+	Value      string `json:"value"`
+	Identifier string `json:"identifier"`
+}
+
+// decodeVisibility reads the restriction a comment carries, and nil for one that
+// carries none. The domain type has no room for the identifier, which is why an
+// edit sends the original object back rather than rebuilding one from this.
+func decodeVisibility(raw json.RawMessage) *jira.Visibility {
+	if !hasVisibility(raw) {
+		return nil
+	}
+	var v apiVisibility
+	if err := json.Unmarshal(raw, &v); err != nil || v.Type == "" {
+		return nil
+	}
+	label := v.Value
+	if label == "" {
+		label = v.Identifier
+	}
+	return &jira.Visibility{Type: v.Type, Value: label}
+}
+
+func hasVisibility(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null" && trimmed != "{}"
+}
+
+// apiCommentBody is what a write sends. Visibility is echoed back exactly as the
+// site sent it, keys this client does not model included.
+type apiCommentBody struct {
+	Body       json.RawMessage `json:"body"`
+	Visibility json.RawMessage `json:"visibility,omitempty"`
+}
+
+// Comments lists an issue's comments, oldest first.
+//
+// The endpoint pages by startAt and reports a total, like the Agile API, while
+// living on the platform API and naming its array comments. It is asked for
+// created order explicitly: the default is documented nowhere and the port
+// promises oldest first.
+func (c *Client) Comments(ctx context.Context, key string) (jira.Page[jira.Comment], error) {
+	path := commentsPath(key)
+	query := url.Values{"orderBy": []string{"created"}}
+	build := func(startAt int) request {
+		return request{
+			method: http.MethodGet,
+			path:   path,
+			query:  pagedQuery(query, startAt, commentPageSize),
+			kind:   "issue",
+			id:     key,
+		}
+	}
+	op := http.MethodGet + " " + path
+	return offsetPages(ctx, c, build, func(resp *response) ([]jira.Comment, int, bool, error) {
+		var page apiCommentPage
+		if err := resp.decode(op, &page); err != nil {
+			return nil, -1, false, err
+		}
+		out := make([]jira.Comment, 0, len(page.Comments))
+		for i := range page.Comments {
+			out = append(out, page.Comments[i].domain())
+		}
+		return out, page.total(), page.last(), nil
+	})
+}
+
+// AddComment adds a comment.
+//
+// A new comment carries no restriction: Jira treats an absent visibility as
+// "everyone who can see the issue", which is what somebody writing a comment
+// with no further ceremony means.
+func (c *Client) AddComment(ctx context.Context, key string, body adf.Doc) (jira.Comment, error) {
+	encoded, err := encodeCommentBody(body)
+	if err != nil {
+		return jira.Comment{}, err
+	}
+	r := request{
+		method: http.MethodPost,
+		path:   commentsPath(key),
+		body:   apiCommentBody{Body: encoded},
+		kind:   "issue",
+		id:     key,
+	}
+	var out apiComment
+	if err := c.doJSON(ctx, r, &out); err != nil {
+		return jira.Comment{}, err
+	}
+	return out.domain(), nil
+}
+
+// EditComment replaces a comment's body and keeps whatever restriction the
+// comment already had.
+//
+// The PUT is a replace, so a request that names only a body is a request to
+// publish a comment that was restricted to one role. The restriction is not
+// something the port can carry — the only safe thing to send is the object the
+// site sent, so the comment is read back first and its visibility echoed
+// verbatim, identifier included.
+func (c *Client) EditComment(ctx context.Context, key, id string, body adf.Doc) (jira.Comment, error) {
+	encoded, err := encodeCommentBody(body)
+	if err != nil {
+		return jira.Comment{}, err
+	}
+	current, err := c.comment(ctx, key, id)
+	if err != nil {
+		return jira.Comment{}, err
+	}
+	payload := apiCommentBody{Body: encoded}
+	if hasVisibility(current.Visibility) {
+		payload.Visibility = current.Visibility
+	}
+	r := request{
+		method: http.MethodPut,
+		path:   commentPath(key, id),
+		body:   payload,
+		kind:   "comment",
+		id:     id,
+	}
+	var out apiComment
+	if err := c.doJSON(ctx, r, &out); err != nil {
+		return jira.Comment{}, err
+	}
+	return out.domain(), nil
+}
+
+// DeleteComment removes a comment.
+func (c *Client) DeleteComment(ctx context.Context, key, id string) error {
+	r := request{
+		method: http.MethodDelete,
+		path:   commentPath(key, id),
+		kind:   "comment",
+		id:     id,
+	}
+	_, err := c.do(ctx, r)
+	return err
+}
+
+// comment reads one comment, which is how an edit learns what it must not
+// discard.
+func (c *Client) comment(ctx context.Context, key, id string) (apiComment, error) {
+	r := request{
+		method: http.MethodGet,
+		path:   commentPath(key, id),
+		kind:   "comment",
+		id:     id,
+	}
+	var out apiComment
+	if err := c.doJSON(ctx, r, &out); err != nil {
+		return apiComment{}, err
+	}
+	return out, nil
+}
+
+// encodeCommentBody turns a document into the bytes a write sends, and refuses
+// an empty one here rather than spending a round trip on a 400.
+func encodeCommentBody(body adf.Doc) (json.RawMessage, error) {
+	if body.IsZero() || body.IsEmpty() {
+		return nil, &jira.ValidationError{Fields: []jira.FieldError{{
+			Field:   "body",
+			Message: "a comment needs something in it",
+		}}}
+	}
+	encoded, err := adf.Marshal(body)
+	if err != nil {
+		return nil, &jira.ValidationError{Fields: []jira.FieldError{{
+			Field:   "body",
+			Message: "this comment is not a document Jira can store: " + err.Error(),
+		}}}
+	}
+	return encoded, nil
+}

--- a/pkg/jira/cloud/comment_test.go
+++ b/pkg/jira/cloud/comment_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 const (
-	testIssueKey     = "EX-1"
 	testCommentID    = "10701"
 	testCommentsPath = "/rest/api/3/issue/{key}/comment"
 	// One comment is routed by its literal path: Go's mux rejects
 	// /issue/{key}/comment/{id} as ambiguous against the createmeta route the
 	// fixture server already carries, and neither pattern is more specific.
 	testCommentPath = "/rest/api/3/issue/" + testIssueKey + "/comment/" + testCommentID
+	testThreadPath  = "/rest/api/3/issue/" + testIssueKey + "/comment"
 )
 
 // paragraph is the smallest document a comment can be: one line of prose.
@@ -95,20 +95,6 @@ func commentClient(t *testing.T, opts ...jiratest.ServerOption) (*Client, *jirat
 	t.Cleanup(s.Close)
 	c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
 	return c, s
-}
-
-// sentTo returns the last request the server took on a path, which is what a
-// write assertion reads: an edit sends two requests and only the second is a PUT.
-func sentTo(t *testing.T, s *jiratest.Server, method string) jiratest.Request {
-	t.Helper()
-
-	for _, r := range s.Requests() {
-		if r.Method == method {
-			return r
-		}
-	}
-	t.Fatalf("the client sent no %s; it sent %v", method, s.Requests())
-	return jiratest.Request{}
 }
 
 func TestComments_ReadsAThreadOldestFirstWithWhateverRestrictsIt(t *testing.T) {
@@ -235,7 +221,7 @@ func TestAddComment_SendsTheDocumentAndNothingThatWouldRestrictIt(t *testing.T) 
 		t.Errorf("a comment nobody restricted came back restricted: %+v", *got.Visibility)
 	}
 
-	sent := sentBody(t, sentTo(t, s, http.MethodPost))
+	sent := sentBody(t, sentTo(t, s, http.MethodPost, testThreadPath))
 	if _, ok := sent["visibility"]; ok {
 		t.Error("a new comment sent a visibility key, which restricts it to whatever that names")
 	}
@@ -289,7 +275,7 @@ func TestEditComment_KeepsTheRestrictionTheCommentAlreadyHad(t *testing.T) {
 		t.Fatalf("the edited comment came back as %+v", got.Visibility)
 	}
 
-	sent := sentBody(t, sentTo(t, s, http.MethodPut))
+	sent := sentBody(t, sentTo(t, s, http.MethodPut, testCommentPath))
 	vis, ok := sent["visibility"].(map[string]any)
 	if !ok {
 		t.Fatalf("the edit sent no visibility, which publishes a comment one role could see: %v", sent)
@@ -313,7 +299,7 @@ func TestEditComment_LeavesAnUnrestrictedCommentUnrestricted(t *testing.T) {
 	if _, err := c.EditComment(t.Context(), testIssueKey, testCommentID, paragraph("Reworded.")); err != nil {
 		t.Fatalf("editing: %v", err)
 	}
-	sent := sentBody(t, sentTo(t, s, http.MethodPut))
+	sent := sentBody(t, sentTo(t, s, http.MethodPut, testCommentPath))
 	if _, ok := sent["visibility"]; ok {
 		t.Errorf("the edit invented a restriction on a comment that had none: %v", sent)
 	}
@@ -364,7 +350,7 @@ func TestDeleteComment_AcceptsTheEmptyAnswerTheEndpointGives(t *testing.T) {
 	if err := c.DeleteComment(t.Context(), testIssueKey, testCommentID); err != nil {
 		t.Fatalf("deleting: %v", err)
 	}
-	sent := sentTo(t, s, http.MethodDelete)
+	sent := sentTo(t, s, http.MethodDelete, testCommentPath)
 	if want := "/rest/api/3/issue/EX-1/comment/10701"; sent.Path != want {
 		t.Errorf("deleted %q, want %q", sent.Path, want)
 	}

--- a/pkg/jira/cloud/comment_test.go
+++ b/pkg/jira/cloud/comment_test.go
@@ -1,0 +1,596 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+const (
+	testIssueKey     = "EX-1"
+	testCommentID    = "10701"
+	testCommentsPath = "/rest/api/3/issue/{key}/comment"
+	// One comment is routed by its literal path: Go's mux rejects
+	// /issue/{key}/comment/{id} as ambiguous against the createmeta route the
+	// fixture server already carries, and neither pattern is more specific.
+	testCommentPath = "/rest/api/3/issue/" + testIssueKey + "/comment/" + testCommentID
+)
+
+// paragraph is the smallest document a comment can be: one line of prose.
+func paragraph(text string) adf.Doc {
+	return adf.NewDoc(adf.NewNode("paragraph", adf.NewText(text)))
+}
+
+// restricted is a comment the site answers with a role restriction on, carrying
+// the identifier that names the role in a way no translation moves.
+const restricted = `{
+  "id": "10701",
+  "author": {"accountId": "5b10ac8d82e05b22cc7d4ef5", "displayName": "Another User", "active": true},
+  "body": {"type": "doc", "version": 1, "content": [
+    {"type": "paragraph", "content": [{"type": "text", "text": "Behind a flag."}]}
+  ]},
+  "created": "2026-02-11T09:38:55.000+0000",
+  "updated": "2026-02-11T09:41:22.104+0000",
+  "visibility": {"type": "role", "value": "Entwickler", "identifier": "10002"}
+}`
+
+// unrestricted is the same comment with nothing hiding it.
+const unrestricted = `{
+  "id": "10701",
+  "author": {"accountId": "5b10ac8d82e05b22cc7d4ef5", "displayName": "Another User", "active": true},
+  "body": {"type": "doc", "version": 1, "content": [
+    {"type": "paragraph", "content": [{"type": "text", "text": "Behind a flag."}]}
+  ]},
+  "created": "2026-02-11T09:38:55.000+0000",
+  "updated": "2026-02-11T09:41:22.104+0000"
+}`
+
+// commentPageHandler answers the collection with a window over the comments it
+// is given, honouring startAt the way the endpoint does.
+func commentPageHandler(comments []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		startAt, _ := strconv.Atoi(r.URL.Query().Get("startAt"))
+		maxResults, err := strconv.Atoi(r.URL.Query().Get("maxResults"))
+		if err != nil || maxResults <= 0 {
+			maxResults = 50
+		}
+		start := min(max(startAt, 0), len(comments))
+		end := min(start+maxResults, len(comments))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"startAt":` + strconv.Itoa(start) +
+			`,"maxResults":` + strconv.Itoa(maxResults) +
+			`,"total":` + strconv.Itoa(len(comments)) +
+			`,"comments":[` + strings.Join(comments[start:end], ",") + `]}`))
+	}
+}
+
+// numbered builds n comments whose bodies say which one they are.
+func numbered(n int) []string {
+	out := make([]string, 0, n)
+	for i := range n {
+		id := strconv.Itoa(20000 + i)
+		out = append(out, `{"id":"`+id+`",`+
+			`"author":{"accountId":"5b10ac8d82e05b22cc7d4ef5","displayName":"Another User","active":true},`+
+			`"body":{"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"note `+strconv.Itoa(i)+`"}]}]},`+
+			`"created":"2026-02-11T09:38:55.000+0000","updated":"2026-02-11T09:38:55.000+0000"}`)
+	}
+	return out
+}
+
+func commentClient(t *testing.T, opts ...jiratest.ServerOption) (*Client, *jiratest.Server) {
+	t.Helper()
+
+	s := jiratest.NewServer(opts...)
+	t.Cleanup(s.Close)
+	c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+	return c, s
+}
+
+// sentTo returns the last request the server took on a path, which is what a
+// write assertion reads: an edit sends two requests and only the second is a PUT.
+func sentTo(t *testing.T, s *jiratest.Server, method string) jiratest.Request {
+	t.Helper()
+
+	for _, r := range s.Requests() {
+		if r.Method == method {
+			return r
+		}
+	}
+	t.Fatalf("the client sent no %s; it sent %v", method, s.Requests())
+	return jiratest.Request{}
+}
+
+func TestComments_ReadsAThreadOldestFirstWithWhateverRestrictsIt(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t)
+	page, err := c.Comments(t.Context(), testIssueKey)
+	if err != nil {
+		t.Fatalf("reading the thread: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("got %d comments, want the 2 the fixture holds", len(page.Items))
+	}
+	if got := page.Items[0].ID; got != "10700" {
+		t.Errorf("the first comment is %q, want the oldest one", got)
+	}
+	if got := page.Items[0].Author.DisplayName; got != "Another User" {
+		t.Errorf("the author is %q", got)
+	}
+	if got := adf.Markdown(page.Items[0].Body); !strings.Contains(got, "basketTotal()") {
+		t.Errorf("the body did not survive the decode: %q", got)
+	}
+	vis := page.Items[1].Visibility
+	if vis == nil {
+		t.Fatal("the restricted comment came back with no visibility, which reads as public")
+	}
+	if vis.Type != "role" || vis.Value != "Developers" {
+		t.Errorf("got visibility %+v, want the role the fixture names", *vis)
+	}
+	if page.Items[0].Visibility != nil {
+		t.Errorf("the unrestricted comment grew a restriction: %+v", *page.Items[0].Visibility)
+	}
+	if total, ok := page.Count(); !ok || total != 2 {
+		t.Errorf("got total %d (reported %v), want the 2 the envelope claims", total, ok)
+	}
+	if page.HasMore() {
+		t.Error("a thread the site said was 2 long claims another page")
+	}
+
+	sent, err := url.ParseQuery(s.Requests()[0].Query)
+	if err != nil {
+		t.Fatalf("reading the query sent: %v", err)
+	}
+	if got := sent.Get("orderBy"); got != "created" {
+		t.Errorf("orderBy is %q; the port promises oldest first and the default order is documented nowhere", got)
+	}
+	if got := sent.Get("maxResults"); got != strconv.Itoa(commentPageSize) {
+		t.Errorf("maxResults is %q, want an explicit page size", got)
+	}
+}
+
+func TestComments_WalksEveryPageAndStopsAtTheTotal(t *testing.T) {
+	t.Parallel()
+
+	all := numbered(120)
+	c, s := commentClient(t, jiratest.WithHandler(http.MethodGet, testCommentsPath, commentPageHandler(all)))
+
+	page, err := c.Comments(t.Context(), testIssueKey)
+	if err != nil {
+		t.Fatalf("reading the thread: %v", err)
+	}
+	got, err := jira.Collect(t.Context(), page, 0)
+	if err != nil {
+		t.Fatalf("walking the thread: %v", err)
+	}
+	if len(got) != len(all) {
+		t.Fatalf("got %d comments over the whole walk, want %d", len(got), len(all))
+	}
+	if got[0].ID != "20000" || got[len(got)-1].ID != "20119" {
+		t.Errorf("the walk lost its order: first %q, last %q", got[0].ID, got[len(got)-1].ID)
+	}
+	if want := 3; len(s.Requests()) != want {
+		t.Errorf("the walk took %d requests, want %d at %d a page", len(s.Requests()), want, commentPageSize)
+	}
+}
+
+func TestComments_StopsOnAnEmptyPageWhateverTheTotalClaims(t *testing.T) {
+	t.Parallel()
+
+	body := `{"startAt":0,"maxResults":50,"total":900,"comments":[]}`
+	c, _ := commentClient(t, jiratest.WithHandler(http.MethodGet, testCommentsPath, jsonHandler(http.StatusOK, body)))
+
+	page, err := c.Comments(t.Context(), testIssueKey)
+	if err != nil {
+		t.Fatalf("reading the thread: %v", err)
+	}
+	if page.HasMore() {
+		t.Error("an empty page left the walk open, which against a truncating endpoint never terminates")
+	}
+}
+
+func TestComments_ReadsAThreadWithNoTotalWithoutInventingOne(t *testing.T) {
+	t.Parallel()
+
+	body := `{"startAt":0,"maxResults":50,"comments":[` + unrestricted + `]}`
+	c, _ := commentClient(t, jiratest.WithHandler(http.MethodGet, testCommentsPath, jsonHandler(http.StatusOK, body)))
+
+	page, err := c.Comments(t.Context(), testIssueKey)
+	if err != nil {
+		t.Fatalf("reading the thread: %v", err)
+	}
+	if _, ok := page.Count(); ok {
+		t.Error("a page whose envelope carried no total reported one")
+	}
+	if page.HasMore() {
+		t.Error("a page with no total and nothing after it claims another page")
+	}
+}
+
+func TestAddComment_SendsTheDocumentAndNothingThatWouldRestrictIt(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t, jiratest.WithHandler(http.MethodPost, testCommentsPath,
+		jsonHandler(http.StatusCreated, unrestricted)))
+
+	got, err := c.AddComment(t.Context(), testIssueKey, paragraph("Behind a flag."))
+	if err != nil {
+		t.Fatalf("adding a comment: %v", err)
+	}
+	if got.ID != testCommentID {
+		t.Errorf("the comment came back as %q", got.ID)
+	}
+	if got.Visibility != nil {
+		t.Errorf("a comment nobody restricted came back restricted: %+v", *got.Visibility)
+	}
+
+	sent := sentBody(t, sentTo(t, s, http.MethodPost))
+	if _, ok := sent["visibility"]; ok {
+		t.Error("a new comment sent a visibility key, which restricts it to whatever that names")
+	}
+	body, ok := sent["body"].(map[string]any)
+	if !ok || body["type"] != "doc" {
+		t.Fatalf("the body sent is not an ADF document: %v", sent["body"])
+	}
+}
+
+func TestAddComment_RefusesAnEmptyDocumentWithoutAskingTheSite(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t)
+
+	for _, tc := range []struct {
+		name string
+		body adf.Doc
+	}{
+		{name: "a document nobody built", body: adf.Doc{}},
+		{name: "a document with no blocks in it", body: adf.NewDoc()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.AddComment(t.Context(), testIssueKey, tc.body)
+			var invalid *jira.ValidationError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("got %v, want a *jira.ValidationError", err)
+			}
+			if _, ok := invalid.For("body"); !ok {
+				t.Errorf("the failure does not name the body: %v", invalid)
+			}
+		})
+	}
+	if served := len(s.Requests()); served != 0 {
+		t.Errorf("the site served %d requests for a comment with nothing in it", served)
+	}
+}
+
+func TestEditComment_KeepsTheRestrictionTheCommentAlreadyHad(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t,
+		jiratest.WithHandler(http.MethodGet, testCommentPath, jsonHandler(http.StatusOK, restricted)),
+		jiratest.WithHandler(http.MethodPut, testCommentPath, jsonHandler(http.StatusOK, restricted)),
+	)
+
+	got, err := c.EditComment(t.Context(), testIssueKey, testCommentID, paragraph("Behind a flag, still."))
+	if err != nil {
+		t.Fatalf("editing: %v", err)
+	}
+	if got.Visibility == nil || got.Visibility.Type != "role" {
+		t.Fatalf("the edited comment came back as %+v", got.Visibility)
+	}
+
+	sent := sentBody(t, sentTo(t, s, http.MethodPut))
+	vis, ok := sent["visibility"].(map[string]any)
+	if !ok {
+		t.Fatalf("the edit sent no visibility, which publishes a comment one role could see: %v", sent)
+	}
+	if vis["type"] != "role" || vis["value"] != "Entwickler" {
+		t.Errorf("the edit rewrote the restriction: %v", vis)
+	}
+	if vis["identifier"] != "10002" {
+		t.Errorf("the edit dropped the identifier, which is the half of a role name no translation moves: %v", vis)
+	}
+}
+
+func TestEditComment_LeavesAnUnrestrictedCommentUnrestricted(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t,
+		jiratest.WithHandler(http.MethodGet, testCommentPath, jsonHandler(http.StatusOK, unrestricted)),
+		jiratest.WithHandler(http.MethodPut, testCommentPath, jsonHandler(http.StatusOK, unrestricted)),
+	)
+
+	if _, err := c.EditComment(t.Context(), testIssueKey, testCommentID, paragraph("Reworded.")); err != nil {
+		t.Fatalf("editing: %v", err)
+	}
+	sent := sentBody(t, sentTo(t, s, http.MethodPut))
+	if _, ok := sent["visibility"]; ok {
+		t.Errorf("the edit invented a restriction on a comment that had none: %v", sent)
+	}
+}
+
+// An edit is a read and then a write. A read that fails must not be followed by
+// a PUT built from what the client guessed instead.
+func TestEditComment_DoesNotWriteWhenItCannotReadWhatItWouldReplace(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t,
+		jiratest.WithStatus(http.MethodGet, testCommentPath, http.StatusForbidden, "plans_403.json"),
+		jiratest.WithHandler(http.MethodPut, testCommentPath, jsonHandler(http.StatusOK, unrestricted)),
+	)
+
+	_, err := c.EditComment(t.Context(), testIssueKey, testCommentID, paragraph("Reworded."))
+	var refused *jira.CapabilityError
+	if !errors.As(err, &refused) {
+		t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+	}
+	for _, r := range s.Requests() {
+		if r.Method == http.MethodPut {
+			t.Fatal("the edit wrote after failing to read what it was replacing")
+		}
+	}
+}
+
+func TestEditComment_RefusesAnEmptyDocumentBeforeReadingAnything(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t)
+
+	_, err := c.EditComment(t.Context(), testIssueKey, testCommentID, adf.NewDoc())
+	var invalid *jira.ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("got %v, want a *jira.ValidationError", err)
+	}
+	if served := len(s.Requests()); served != 0 {
+		t.Errorf("the site served %d requests for an edit that emptied the comment", served)
+	}
+}
+
+func TestDeleteComment_AcceptsTheEmptyAnswerTheEndpointGives(t *testing.T) {
+	t.Parallel()
+
+	c, s := commentClient(t, jiratest.WithStatus(http.MethodDelete, testCommentPath, http.StatusNoContent, ""))
+
+	if err := c.DeleteComment(t.Context(), testIssueKey, testCommentID); err != nil {
+		t.Fatalf("deleting: %v", err)
+	}
+	sent := sentTo(t, s, http.MethodDelete)
+	if want := "/rest/api/3/issue/EX-1/comment/10701"; sent.Path != want {
+		t.Errorf("deleted %q, want %q", sent.Path, want)
+	}
+}
+
+func TestDeleteComment_ReportsACommentThatIsNotThereAsNotThere(t *testing.T) {
+	t.Parallel()
+
+	c, _ := commentClient(t, jiratest.WithHandler(http.MethodDelete, testCommentPath,
+		jsonHandler(http.StatusNotFound, `{"errorMessages":["Comment does not exist."],"errors":{}}`)))
+
+	err := c.DeleteComment(t.Context(), testIssueKey, testCommentID)
+	var missing *jira.NotFoundError
+	if !errors.As(err, &missing) {
+		t.Fatalf("got %T (%v), want a *jira.NotFoundError", err, err)
+	}
+	if missing.Kind != "comment" || missing.ID != testCommentID {
+		t.Errorf("the failure names %s %s rather than the comment", missing.Kind, missing.ID)
+	}
+}
+
+// call is one adapter method under test, named so a subtest reads as prose.
+type commentCall struct {
+	name   string
+	method string
+	path   string
+	run    func(context.Context, *Client) error
+}
+
+func commentCalls() []commentCall {
+	return []commentCall{
+		{
+			name: "reading a thread", method: http.MethodGet, path: testCommentsPath,
+			run: func(ctx context.Context, c *Client) error {
+				_, err := c.Comments(ctx, testIssueKey)
+				return err
+			},
+		},
+		{
+			name: "adding a comment", method: http.MethodPost, path: testCommentsPath,
+			run: func(ctx context.Context, c *Client) error {
+				_, err := c.AddComment(ctx, testIssueKey, paragraph("hello"))
+				return err
+			},
+		},
+		{
+			name: "editing a comment", method: http.MethodGet, path: testCommentPath,
+			run: func(ctx context.Context, c *Client) error {
+				_, err := c.EditComment(ctx, testIssueKey, testCommentID, paragraph("hello"))
+				return err
+			},
+		},
+		{
+			name: "deleting a comment", method: http.MethodDelete, path: testCommentPath,
+			run: func(ctx context.Context, c *Client) error {
+				return c.DeleteComment(ctx, testIssueKey, testCommentID)
+			},
+		},
+	}
+}
+
+func TestComments_RefusalBecomesTheSentenceTheUserReads(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range commentCalls() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := `{"errorMessages":["You do not have permission to edit this comment."],"errors":{}}`
+			c, _ := commentClient(t, jiratest.WithHandler(tc.method, tc.path, jsonHandler(http.StatusForbidden, body)))
+
+			err := tc.run(t.Context(), c)
+			var refused *jira.CapabilityError
+			if !errors.As(err, &refused) {
+				t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+			}
+			if !strings.Contains(refused.Error(), "permission to edit this comment") {
+				t.Errorf("the reason lost the site's own wording: %q", refused.Error())
+			}
+		})
+	}
+}
+
+func TestComments_RateLimitCarriesTheWaitTheSiteAskedFor(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range commentCalls() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _ := commentClient(t, jiratest.WithRateLimit(tc.method, tc.path, 30*time.Second))
+
+			err := tc.run(t.Context(), c)
+			var limited *jira.RateLimitError
+			if !errors.As(err, &limited) {
+				t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+			}
+			if limited.RetryAfter != 30*time.Second {
+				t.Errorf("got a wait of %s, want the 30s the header asked for", limited.RetryAfter)
+			}
+		})
+	}
+}
+
+func TestComments_TransportFailureIsATransportFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range commentCalls() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _ := commentClient(t, jiratest.WithHandler(tc.method, tc.path,
+				jsonHandler(http.StatusBadGateway, `{"errorMessages":["upstream is unwell"]}`)))
+
+			err := tc.run(t.Context(), c)
+			var down *jira.TransportError
+			if !errors.As(err, &down) {
+				t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+			}
+			if down.Status != http.StatusBadGateway {
+				t.Errorf("the failure reports HTTP %d", down.Status)
+			}
+		})
+	}
+}
+
+func TestComments_ABodyThisClientCannotReadIsATransportFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "JSON that stops half way", body: `{"startAt":0,"comments":[`},
+		{name: "a comment body that is not a document", body: `{"total":1,"comments":[{"id":"1","body":"just a string"}]}`},
+		{name: "an envelope that is an array", body: `[]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _ := commentClient(t, jiratest.WithHandler(http.MethodGet, testCommentsPath,
+				jsonHandler(http.StatusOK, tc.body)))
+
+			_, err := c.Comments(t.Context(), testIssueKey)
+			var down *jira.TransportError
+			if !errors.As(err, &down) {
+				t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+			}
+		})
+	}
+}
+
+func TestComments_ReturnTheCallersOwnErrorWhenItCancels(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range commentCalls() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, s := commentClient(t)
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			if err := tc.run(ctx, c); !errors.Is(err, context.Canceled) {
+				t.Fatalf("got %v, want the context's own error", err)
+			}
+			if served := len(s.Requests()); served != 0 {
+				t.Errorf("the site served %d requests after the caller had already gone", served)
+			}
+		})
+	}
+}
+
+// A write must never be replayed by the retry loop or shared with another
+// caller's identical write: two identical comments are two comments.
+func TestAddComment_IsNeitherRetriedNorSharedWithAnIdenticalRequest(t *testing.T) {
+	t.Parallel()
+
+	r := request{method: http.MethodPost, path: commentsPath(testIssueKey), body: apiCommentBody{}}
+	if r.canRepeat() {
+		t.Error("adding a comment is marked repeatable, so a 5xx would post it twice")
+	}
+}
+
+func TestComments_EscapeAKeyAndAnIDThatWouldOtherwiseChangeThePath(t *testing.T) {
+	t.Parallel()
+
+	got := commentPath("EX 1/../..", "10 1")
+	if strings.Contains(got, " ") || strings.Contains(got, "/../") {
+		t.Errorf("the path is %q, which is not the comment that was asked for", got)
+	}
+}
+
+// decodeVisibility is the half of the read that decides whether a comment reads
+// as public, so its edge cases are worth naming.
+func TestDecodeVisibility_ReadsAbsenceAsPublicAndNothingElse(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		raw   string
+		want  *jira.Visibility
+		exact bool
+	}{
+		{name: "no key at all", raw: ``},
+		{name: "an explicit null", raw: `null`},
+		{name: "an empty object", raw: `{}`},
+		{name: "a role", raw: `{"type":"role","value":"Developers","identifier":"10002"}`,
+			want: &jira.Visibility{Type: "role", Value: "Developers"}, exact: true},
+		{name: "a group named only by its identifier", raw: `{"type":"group","identifier":"jira-developers"}`,
+			want: &jira.Visibility{Type: "group", Value: "jira-developers"}, exact: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := decodeVisibility(json.RawMessage(tc.raw))
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("got %+v, want nothing that would hide the comment", *got)
+			case tc.want == nil:
+				return
+			case got == nil:
+				t.Fatalf("got nothing, want %+v", *tc.want)
+			case tc.exact && *got != *tc.want:
+				t.Errorf("got %+v, want %+v", *got, *tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #11.

P2.4 — the comment thread on one issue, and the four adapter methods behind it.

## What is here

**`pkg/jira/cloud/comment.go`** — `Comments`, `AddComment`, `EditComment`, `DeleteComment`.

**`internal/ui/comment/**`** — a new view: a virtualized thread, an editor for writing and editing
a comment, and a named confirmation for deleting one. It registers itself, its keys, four palette
commands and its mouse zones.

## The decisions worth reviewing

### An edit preserves the restriction the comment already had

`PUT /issue/{key}/comment/{id}` takes a whole comment, and `visibility` is one of its properties. A
request that names only `body` is a request for a comment with no restriction on it — which
publishes a comment that one role could see. The port cannot carry the restriction (`EditComment`
takes a body and nothing else), so **the adapter reads the comment first and echoes its `visibility`
object back verbatim**, `identifier` included. That is right whichever way the endpoint would have
treated the omission, and it costs one `GET` per edit.

Echoing the object rather than rebuilding one from `type` and `value` matters twice over:
`visibility.value` is the *localised* display name of the role or group, and `visibility.identifier`
is the half of it no translation moves — and `jira.Visibility` has no slot for the identifier, so a
rebuilt object would lose it. Same principle as `pkg/adf`: send back what you were given wherever
you did not edit.

I could not confirm against a live site whether the endpoint really clears an omitted `visibility`.
That is noted in `docs/API-NOTES.md` under *Still to confirm*, along with why the adapter re-sends it
either way.

### ADF: which parse where, deliberately

Following the note P2.1's author left on the issue:

- **new comment** → `adf.ParseMarkdown(text)`. There is no original to reconcile against.
- **edit** → `adf.ParseMarkdownInto(original, text, editorOptions)`. `ParseMarkdown` alone compiles,
  passes a smoke test, and silently strips every mention's account id, every lozenge's colour and
  every attribute of a node type this client has never heard of.
- **`editorOptions` is the zero `adf.Options`**, used for *both* the render that seeds the editor and
  the parse that reads it back. It has to be one value on both sides or reconciliation matches
  nothing; and it has to be the unbounded one, because a `TableWidth` render truncates a table cell
  with an ellipsis and an edit anywhere in that table writes the truncation back. There is a test
  asserting the value is the zero one, so a later "let's bound this to the pane width" cannot land
  quietly.
- The read-only thread still renders with `TableWidth`, `ASCII` and `Location` — nobody edits it.
- `adf.ParseMarkdownDropsOnly()` drives the warning shown when the editor opens on a comment holding
  a mention, a lozenge, a table or an unknown node: *"the mention and table in this comment survive
  only in the parts you leave alone"*. The wording comes out of `pkg/adf`'s own list, filtered to
  the node types the document actually holds, so this view cannot end up warning about something the
  parser has since learned to keep.

`TestThread_AnUntouchedEditGoesBackByteForByte` opens the editor on a comment carrying a status
lozenge and an invented node type, saves without typing anything, and asserts the stored bytes are
identical. `TestThread_EditKeepsWhatMarkdownCannotCarry` rewrites one paragraph and asserts the
mention in the paragraph above still has its account id.

### Pagination — the offset model, and an envelope neither shared decoder reads

`GET /issue/{key}/comment` pages by `startAt`/`maxResults`/`total` — the Agile shape — while living
on the platform API and naming its array **`comments`** rather than `values`. Neither envelope in
`paginate.go` reads it, so it decodes its own and drives `jira.Offset`. It sends no `isLast`, so the
walk ends on the total; an envelope reporting *no* total can only be ended by a page shorter than
the `maxResults` the response itself echoes, since a site may cap the number asked for without
saying so anywhere else. `orderBy=created` is sent explicitly — the default order is documented
nowhere and the port promises oldest first.

The view pages lazily as the cursor approaches the end of what is loaded, like the issue list does.

### Delete is unskippable

`d` never deletes. It puts up a sentence naming the author, the time, the restriction if there is
one and the opening words of the comment; only `y` goes ahead and every other key keeps it.
`askToDelete` is the only caller of the delete command, so there is no path from a keystroke to a
removed comment that skips the sentence. `TestThread_DeleteCannotBeReachedWithoutTheConfirmation`
presses `d` followed by each of seven other keys and asserts the site was never asked.

**Delete is not pre-hidden by a capability probe**, which the issue's *Notes* suggest. There is no
comment-scoped capability key in `jira.Capabilities` — `CapDeleteIssues` is the *Delete Issues*
project permission, which is a different permission from *Delete Own Comments* / *Delete All
Comments*, and using it here would hide the action from people who can use it and show it to people
who cannot. So the refusal is answered at the point of use: the 403 becomes the sentence Jira wrote,
verbatim, and the comment stays on screen. Adding a capability for it means amending the frozen
port; that is a maintainer call rather than something to slip into a view packet. Noted on #11.

### Never lose the user's text

Unsent text is written to disk on the keystroke that changes it — temp file plus rename, mode 600,
under `<cache>/drafts/<site>/<issue>.<comment|new>.md`. `esc` puts the editor away and keeps the
draft; a failed request keeps the editor open *with* the text and the draft; reopening the editor in
a later process finds it and says so. A new comment and an edit of an existing one are separate
drafts, so abandoning an edit does not take the half-written new comment with it. The view also
implements `kernel.Blocker`, so a footer click cannot discard an open editor without a sentence.

The store degrades rather than fails: a session with nowhere to write keeps nothing, and a write it
cannot make is reported once rather than on every keystroke.

## Reaching it — one honest gap

The thread is pushed with an issue key:

```go
comment.Push(deps, key)   // or kernel.Push(comment.ViewID, key, comment.Thread(deps, key))
```

Nothing pushes it yet. The view that holds an issue is `internal/ui/issue`, which this packet does
not own, so per the brief I have said so rather than reached across: **#67** asks for the one key
there. Today the thread is reachable by name (`saral comment`) and from the palette, and in both it
opens with no issue and says so in words rather than drawing an empty frame. `comment.ThreadMsg`
retargets it, so joining the two up is a one-line change in a file I do not own.

## Owned paths

Declared on the issue and corrected in the roadmap row: the packet's own two paths plus its single
blank import line in `internal/ui/views.go` (alphabetical, first), `docs/API-NOTES.md` and
`docs/ROADMAP.md`. Nothing else.

## go.sum

`go.mod` is **unchanged** — no new dependency. `go.sum` gains two checksum lines for
`github.com/MakeNowJust/heredoc`, which is a test-only import of `charm.land/bubbles/v2/textarea`;
importing another package of an already-required module makes `go mod tidy` record it.
`go list -deps ./cmd/saral` does not mention it and it is not linked into the binary. The lines have
to be committed or `make check`'s `go mod tidy && git diff --exit-code` fails.

## Golden files

Five new, none changed: `thread_{80x20,120x30,60x12}`, `editor_100x24`, `confirm_100x24`. The narrow
one is the interesting one — at 60 columns the header keeps `PROJ-1 | 2 comments` and the action bar,
and the confirmation gives up the quoted opening of the comment before it gives up the author, the
time or the key that answers. Comment bodies are word-wrapped to the pane; there is a test asserting
no line exceeds the width at 40 columns.

## Tests

- **403 / 429 / transport on all four adapter methods**, table-driven, plus a malformed body (three
  shapes), cancellation on all four, a 404 mapped to the comment rather than the issue, and an empty
  document refused locally before any request is made.
- **Pagination**: a 120-comment walk over three requests, exhaustion, an empty page whatever the
  total claims, and an envelope with no total at all.
- **Visibility**: an edit that preserves a role restriction with its identifier, an edit that invents
  none on an unrestricted comment, and an edit refused at the read that never issues the write.
- **The view**: refusal / rate limit / transport / conflict each keeping the editor and its text,
  the unskippable confirmation, drafts across sessions and across issues, mouse zones (click to
  select, click again to edit, click write/delete/confirm/send/cancel), a refresh that keeps the
  reader's place, and registration.
- **Benchmarks**: `BenchmarkThreadSteadyScroll10k` and `…20` cost the same, 2 allocations a frame
  (the frame string and the header joined onto it), with a test asserting both.

## A note for whoever touches `jiratest` next

The fixture server cannot host a wildcard route for `/rest/api/3/issue/{key}/comment/{id}`: Go's mux
rejects it as ambiguous against the existing `/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes`
route, and neither pattern is more specific. These tests route the single-comment endpoint by its
literal path instead. It is not worth a change to a shared file for one packet, but the next packet
that needs a route under `/issue/{key}/…` will meet it too.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
