### PR TITLE
fix(saral): talk to the site the profile names

### DIFF
--- a/cmd/saral/main.go
+++ b/cmd/saral/main.go
@@ -111,7 +111,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	if opt.benchPaint {
-		return benchFirstPaint(stdout, deps, kopts)
+		return benchFirstPaint(stdout, stderr, deps, kopts, notice)
 	}
 	return start(deps, kopts, notice)
 }
@@ -271,7 +271,14 @@ func profileFor(cfg config.Config, name string) (config.Profile, error) {
 // benchFirstPaint measures the budget in docs/PERFORMANCE.md that is otherwise
 // unmeasurable: how long it takes to put the first frame on the screen from
 // what is already on disk.
-func benchFirstPaint(stdout io.Writer, deps kernel.Deps, kopts []kernel.Option) error {
+//
+// There is no status line on this path, so the startup notice goes to stderr
+// instead: a run measuring a session with no client is measuring something else,
+// and stdout stays the single number a script reads.
+func benchFirstPaint(stdout, stderr io.Writer, deps kernel.Deps, kopts []kernel.Option, notice string) error {
+	if notice != "" {
+		_, _ = fmt.Fprintln(stderr, "saral: "+notice)
+	}
 	took, _, err := kernel.FirstPaint(deps, 120, 40, kopts...)
 	if err != nil {
 		return err

--- a/cmd/saral/main.go
+++ b/cmd/saral/main.go
@@ -3,12 +3,14 @@ package main
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
@@ -17,7 +19,17 @@ import (
 	"github.com/varijkapil13/saral/internal/config"
 	_ "github.com/varijkapil13/saral/internal/ui"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/onboarding"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/cloud"
 )
+
+// tokenTimeout bounds resolving the token, which happens before the first frame
+// and cannot be cancelled by anyone watching it. internal/config gives a command
+// source 15s plus a 2s wait delay of its own, so this sits above that and lets
+// the resolver's better-worded failure win; what it really caps is a keychain
+// prompt nobody is at the machine to answer.
+const tokenTimeout = 20 * time.Second
 
 var (
 	version = "dev"
@@ -94,45 +106,50 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("%d view(s) failed to register: %w", len(errs), errors.Join(errs...))
 	}
 
-	deps, kopts, err := build(opt)
+	deps, kopts, notice, err := build(opt)
 	if err != nil {
 		return err
 	}
 	if opt.benchPaint {
 		return benchFirstPaint(stdout, deps, kopts)
 	}
-	return start(deps, kopts)
+	return start(deps, kopts, notice)
 }
 
 // build turns flags and config into the kernel's dependencies. A missing config
 // file is not an error: there is nothing to onboard with yet, so the UI opens
 // with no site and says so.
-func build(opt options) (kernel.Deps, []kernel.Option, error) {
+//
+// The third result is a sentence to put in front of the user once the program is
+// running. Resolving a token can fail for reasons that are nobody's mistake — a
+// locked keychain, a helper command that is not installed on this machine — and
+// none of them is a reason to refuse to open.
+func build(opt options) (kernel.Deps, []kernel.Option, string, error) {
 	deps := kernel.Deps{}
 	cfg, err := config.Load()
 	switch {
 	case errors.Is(err, config.ErrNoConfig):
 		cfg = config.Config{Mouse: true}
 	case err != nil:
-		return deps, nil, err
+		return deps, nil, "", err
 	}
 
 	// A config file that exists but points nowhere is a mistake worth naming: the
 	// alternative is a session that silently talks to no site at all.
 	profile, perr := profileFor(cfg, opt.profile)
 	if perr != nil && (opt.profile != "" || len(cfg.Profiles) > 0) {
-		return deps, nil, perr
+		return deps, nil, "", perr
 	}
 	deps.Site = profile.Site
 	project, err := sessionProject(opt.project, profile.Project)
 	if err != nil {
-		return deps, nil, err
+		return deps, nil, "", err
 	}
 	deps.Project = project
 
 	saved, err := app.NewSavedQueries(profile.Queries...)
 	if err != nil {
-		return deps, nil, err
+		return deps, nil, "", err
 	}
 	deps.Saved = saved
 	deps.SaveQueries = queryWriter(profile.Name)
@@ -142,6 +159,20 @@ func build(opt options) (kernel.Deps, []kernel.Option, error) {
 	// first footer slot, and setup is reachable only by someone who already
 	// knows its name — which is nobody on their first run.
 	firstRun := perr != nil || profile.Site == ""
+
+	// A first run is exactly the path with no token yet, and onboarding is what
+	// gets one, so this goes on whether or not there is a profile to open with.
+	onboarding.SetConnector(connect)
+
+	var notice string
+	if !firstRun {
+		client, cerr := clientFor(profile)
+		if cerr != nil {
+			notice = cerr.Error()
+		} else {
+			deps.Jira = client
+		}
+	}
 
 	theme := opt.theme
 	if theme == "" {
@@ -161,7 +192,37 @@ func build(opt options) (kernel.Deps, []kernel.Option, error) {
 	case firstRun:
 		kopts = append(kopts, kernel.WithInitialView(kernel.SetupViewID))
 	}
-	return deps, kopts, nil
+	return deps, kopts, notice, nil
+}
+
+// connect opens a client for credentials the caller already holds, which is what
+// onboarding does with three fields that have never been saved.
+//
+// The error path returns a nil interface deliberately. cloud.New returns a
+// *cloud.Client, and returning that straight into the result would hand back a
+// non-nil jira.SessionClient wrapping a nil pointer — every `== nil` check
+// downstream would pass and the first call would panic.
+func connect(site, email, token string) (jira.SessionClient, error) {
+	client, err := cloud.New(site, email, token, cloud.WithUserAgent("saral/"+version))
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// clientFor resolves the profile's token and opens a client with it.
+//
+// Nothing is probed here. The kernel probes on Init once deps.Jira is set, so
+// the first frame is drawn from what is already on disk (docs/UX.md).
+func clientFor(p config.Profile) (jira.SessionClient, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tokenTimeout)
+	defer cancel()
+
+	token, err := p.ResolveToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return connect(p.Site, p.Email, token)
 }
 
 // sessionProject scopes the session. The flag overrides the profile for one run
@@ -219,13 +280,28 @@ func benchFirstPaint(stdout io.Writer, deps kernel.Deps, kopts []kernel.Option) 
 	return err
 }
 
-func start(deps kernel.Deps, kopts []kernel.Option) error {
+func start(deps kernel.Deps, kopts []kernel.Option, notice string) error {
 	m, err := kernel.New(deps, kopts...)
 	if err != nil {
 		return err
 	}
-	if _, err := tea.NewProgram(m).Run(); err != nil {
+	if _, err := tea.NewProgram(withNotice(m, notice)).Run(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// withNotice puts a startup message on the status line before the program runs.
+//
+// The alt screen wipes anything printed ahead of it, so the status line is the
+// only surface left, and Update is a pure function on a value, so the message
+// goes onto the model rather than into a running event loop. The resize command
+// it returns is dropped: no size is known yet, and the WindowSizeMsg that
+// arrives at startup does the same work.
+func withNotice(m kernel.Model, notice string) tea.Model {
+	if notice == "" {
+		return m
+	}
+	next, _ := m.Update(kernel.StatusMsg{Text: notice, Level: kernel.LevelWarn})
+	return next
 }

--- a/cmd/saral/main_test.go
+++ b/cmd/saral/main_test.go
@@ -40,6 +40,22 @@ func TestRun_BenchFirstPaintPrintsMicroseconds(t *testing.T) {
 	}
 }
 
+func TestRun_BenchFirstPaintStillSaysWhyThereIsNoClient(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "")
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"--bench-first-paint"}, &out, &errOut); err != nil {
+		t.Fatalf("run: %v (stderr %q)", err, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "SARAL_TEST_TOKEN") {
+		t.Errorf("stderr is %q, want the reason the session has no client", errOut.String())
+	}
+	if _, err := strconv.Atoi(strings.TrimSpace(out.String())); err != nil {
+		t.Errorf("stdout is %q, want only the microsecond count", out.String())
+	}
+}
+
 func TestRun_UnknownProfileIsAnError(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
 

--- a/cmd/saral/main_test.go
+++ b/cmd/saral/main_test.go
@@ -8,7 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/onboarding"
+	"github.com/varijkapil13/saral/pkg/jira"
 )
 
 func TestRun_Version(t *testing.T) {
@@ -48,7 +52,7 @@ func TestRun_UnknownProfileIsAnError(t *testing.T) {
 func TestRun_MissingConfigStillStarts(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
 
-	deps, opts, err := build(options{benchPaint: true})
+	deps, opts, _, err := build(options{benchPaint: true})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -64,7 +68,7 @@ func TestBuild_NoColorEnvironmentWinsOverTheFlag(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
 	t.Setenv("NO_COLOR", "1")
 
-	deps, _, err := build(options{theme: "dark"})
+	deps, _, _, err := build(options{theme: "dark"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -79,7 +83,7 @@ func TestBuild_AFirstRunStartsAtSetup(t *testing.T) {
 	// Nothing configured. The kernel would otherwise open whichever view claimed
 	// the first footer slot, leaving setup reachable only by someone who already
 	// knows its name — which is nobody on their first run.
-	_, opts, err := build(options{})
+	_, opts, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -91,7 +95,7 @@ func TestBuild_AFirstRunStartsAtSetup(t *testing.T) {
 func TestBuild_AnExplicitViewStillWinsOnAFirstRun(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
 
-	_, opts, err := build(options{view: "board"})
+	_, opts, _, err := build(options{view: "board"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -114,7 +118,7 @@ token = { env = "JIRA_TOKEN" }
 		t.Fatal(err)
 	}
 
-	_, opts, err := build(options{})
+	_, opts, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -152,7 +156,7 @@ func TestBuild_TheProjectFlagOverridesTheProfileRatherThanReplacingIt(t *testing
 				t.Fatal(err)
 			}
 
-			deps, _, err := build(options{project: tc.flag})
+			deps, _, _, err := build(options{project: tc.flag})
 			switch {
 			case tc.fails && err == nil:
 				t.Fatalf("--project %q was accepted and reached JQL", tc.flag)
@@ -172,3 +176,148 @@ func TestBuild_TheProjectFlagOverridesTheProfileRatherThanReplacingIt(t *testing
 }
 
 func initialView(opts []kernel.Option) string { return kernel.InitialViewOf(opts...) }
+
+// writeProfile puts a config file naming an env-resolved token in a temporary
+// config directory. Nothing here reaches a keychain: a test that prompted for
+// one would hang on somebody's machine and pass on nobody's.
+func writeProfile(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("SARAL_CONFIG_DIR", dir)
+	cfg := "active = \"work\"\n\n[profiles.work]\nsite  = \"example.atlassian.net\"\n" +
+		"email = \"you@example.com\"\ntoken = { env = \"SARAL_TEST_TOKEN\" }\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuild_AResolvableTokenProducesAClientTheSessionCanUse(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "a-token")
+
+	deps, _, notice, err := build(options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if deps.Jira == nil {
+		t.Fatal("the session has no Jira client, so every read in it is dead on arrival")
+	}
+	if notice != "" {
+		t.Errorf("a resolvable token still produced the notice %q", notice)
+	}
+	// Nothing was asked of the site. A probe before the first frame is the one
+	// thing docs/UX.md rules out, and the kernel runs its own on Init.
+	if deps.Caps != (jira.Capabilities{}) {
+		t.Errorf("capabilities read %+v at build time, so something probed before the first frame", deps.Caps)
+	}
+}
+
+func TestBuild_AnUnresolvableTokenStillStartsAndSaysWhy(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "")
+
+	deps, opts, notice, err := build(options{})
+	if err != nil {
+		t.Fatalf("a token that would not resolve stopped the program: %v", err)
+	}
+	if deps.Jira != nil {
+		t.Error("a client was built from a token that does not exist")
+	}
+	if !strings.Contains(notice, "SARAL_TEST_TOKEN") {
+		t.Errorf("the notice is %q, want the resolver's own sentence naming what it looked for", notice)
+	}
+
+	// The program opens, and the sentence is on the status line rather than
+	// behind the alt screen that would have wiped it.
+	m, err := kernel.New(deps, append(opts, kernel.WithSize(100, 30))...)
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	started, ok := withNotice(m, notice).(kernel.Model)
+	if !ok {
+		t.Fatal("the notice replaced the kernel model with something else")
+	}
+	if !strings.Contains(started.Frame(), "SARAL_TEST_TOKEN") {
+		t.Errorf("the first frame does not carry the reason:\n%s", started.Frame())
+	}
+}
+
+func TestWithNotice_LeavesTheModelAloneWhenThereIsNothingToSay(t *testing.T) {
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+
+	deps, opts, _, err := build(options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	m, err := kernel.New(deps, append(opts, kernel.WithSize(100, 30))...)
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	plain, ok := withNotice(m, "").(kernel.Model)
+	if !ok {
+		t.Fatal("an empty notice replaced the kernel model with something else")
+	}
+	if plain.Frame() != m.Frame() {
+		t.Error("an empty notice still changed what the first frame says")
+	}
+}
+
+func TestConnect_ReturnsANilInterfaceRatherThanANilPointerInOne(t *testing.T) {
+	t.Parallel()
+
+	client, err := connect("", "you@example.com", "a-token")
+	if err == nil {
+		t.Fatal("a site of nothing was accepted")
+	}
+	if client != nil {
+		t.Errorf("the failure came back as a non-nil %T, which passes every == nil check downstream", client)
+	}
+}
+
+func TestConnect_BuildsAClientForCredentialsThatWereNeverSaved(t *testing.T) {
+	t.Parallel()
+
+	client, err := connect("example.atlassian.net", "you@example.com", "a-token")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if client == nil {
+		t.Fatal("no client came back and no error did either")
+	}
+}
+
+// A first run has no token and no profile, and onboarding is the path that gets
+// one. The connector has to be registered before the view opens, or the flow
+// refuses the credentials it has just collected.
+func TestBuild_AFirstRunWiresTheConnectorBeforeOnboardingOpens(t *testing.T) {
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+
+	deps, _, _, err := build(options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	// Built through onboarding.New, which takes whatever this build registered.
+	// NewWith would prove nothing about it.
+	view := onboarding.New(deps)
+	view, _ = view.Update(kernel.SizeMsg{Width: 100, Height: 30})
+
+	// The commands that come back are dropped rather than run. Reaching the
+	// connect attempt is the whole assertion; running it would put a request on
+	// the wire, and the site typed here is not one this test may talk to.
+	for _, typed := range []string{"example.atlassian.net", "you@example.com", "a-token"} {
+		for _, r := range typed {
+			view, _ = view.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		}
+		view, _ = view.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	}
+
+	frame := view.View()
+	if strings.Contains(frame, "onboarding.SetConnector") {
+		t.Fatalf("the flow still refuses to open a connection:\n%s", frame)
+	}
+	if !strings.Contains(frame, "Checking the site, the email and the token") {
+		t.Errorf("the flow did not reach a connection attempt:\n%s", frame)
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,6 +109,44 @@ Rules for the port:
 - **Every method takes `context.Context`** and must honour cancellation — views cancel in-flight
   work when they close.
 
+### Roles: what a caller asks for
+
+`Client` is what an adapter grows into. It is **not** what a caller takes. A view that runs a search
+needs a search, and an adapter that cannot yet do the other thirty-three should not have to pretend —
+the reasoning `internal/app.Counter` was already written with, generalised.
+
+So `pkg/jira/roles.go` declares one interface per job, and callers take those:
+
+```go
+type Prober         interface{ Capabilities(ctx, projectKey) (Capabilities, error) }
+type Identifier     interface{ Me(ctx) (User, error) }
+type Searcher       interface{ Search(ctx, Query) (Page[Issue], error) }
+type FieldCatalogue interface{ Fields(ctx) ([]Field, error) }
+// … SchemaReader, IssueWriter, Mover, CommentReader, Commenter
+
+// SessionClient is the union of every role the views in this build call.
+type SessionClient interface { Prober; Identifier; Searcher; … }
+```
+
+`kernel.Deps.Jira` and `onboarding.Connector` take `SessionClient`. A batch that lands the adapter
+method its own view needs adds that role to the union in the same PR; nothing that already compiled
+stops compiling, and the diff says which capability the batch added.
+
+A role restates a signature `Client` already carries, which is drift a reader cannot see. The
+compiler can: one type cannot hold two methods of a name, so a role that drifts from the port makes
+the assertions in `pkg/jira/jiratest` fail to build.
+
+**Every adapter states what it satisfies, in its own built source:**
+
+```go
+var _ jira.Prober = (*Client)(nil)
+```
+
+Not in a `_test.go` file — an assertion there fails `go test` and not `go build`. `internal/arch`
+fails an adapter package under `pkg/jira/**` that carries none at all. Their absence is exactly how
+`pkg/jira/cloud` implemented 12 of 34 methods for two batches while passing CI, lint, race and a
+cross-build: nothing outside the package ever assigned a `*Client` to anything, so nothing asked.
+
 ## Two pagination models, one type
 
 The platform API pages by opaque cursor and returns no total; the Agile API pages by `startAt` and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -170,6 +170,15 @@ PC.2 and PC.3 also edit.
   line through `kernel.StatusMsg`, applied to the model before the program starts because the alt
   screen wipes anything printed ahead of it. No probe runs before the first frame; PC.3's `Init`
   probe does it once a client exists.
+  Verification then found the thing the role assertions cannot catch: two types satisfying one
+  interface and disagreeing about the answer. `cloud.Me` refuses a 200 that names nobody, because
+  onboarding reads a success there as proof the three fields go together; `jiratest.Fake.Me` returned
+  it as an account, so the guard was unreachable from a suite that runs on the fake. The fake now
+  refuses the same state — `WithMe(jira.User{})` is how a test asks for it — and `fakeDefaultMe`
+  carries the avatar `cloud.Me` populates. `pkg/jira/cloud/conformance_test.go` is the durable half:
+  one table of cases run over both adapters through `jira.Identifier`, so the next divergence in `Me`
+  fails on the adapter that has it. Generalising that to the rest of the port is
+  [#74](https://github.com/varijkapil13/saral/issues/74).
 
 ## Batch 2 — Change your work · parallel ×4
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,7 +67,7 @@ instance from day one.
 - [x] **P1.6 — First-run onboarding** · [#7](https://github.com/varijkapil13/saral/issues/7) · **owns** `internal/ui/onboarding/**`
   Site, email, token, project picker; writes the profile; explains what the probe found.
 
-## Batch 1.5 — Corrections · **PC.1 serial, then parallel ×4** · blocks Batch 2
+## Batch 1.5 — Corrections · **PC.1 serial, then parallel ×4, then PC.6 serial** · blocks Batch 2
 
 Batch 1 shipped and left the project asserting several things that are not true. None of them is a
 feature and none was worth stopping Batch 1 for; all of them are load-bearing for **Batch 2, which is
@@ -77,11 +77,15 @@ someone's ticket.
 
 The claims being made good on: that CI keeps tests off the network; that the layer diagram is
 enforced; that `Capabilities` gives a reason for every negative; that an `Issue` means what its zero
-values say; that the session knows its project; that the fixture server replays the right shape; and
-that the number keys have exactly one owner.
+values say; that the session knows its project; that the fixture server replays the right shape; that
+the number keys have exactly one owner; and — the largest of them, found while doing PC.6 and settled
+on [#55](https://github.com/varijkapil13/saral/issues/55) — that the shipped binary can talk to a Jira
+site at all.
 
 **PC.1 lands first and alone** — it amends the port, which `docs/PARALLEL.md` makes a serial change
-because it unblocks or blocks everyone. The other four run in parallel behind it.
+because it unblocks or blocks everyone. PC.2 to PC.5 run in parallel behind it. **PC.6 lands last and
+alone**, because it narrows what every view asks of the port and holds the composition root, which
+PC.2 and PC.3 also edit.
 
 - [x] **PC.1 — Port amendments** · [#46](https://github.com/varijkapil13/saral/issues/46), [#37](https://github.com/varijkapil13/saral/issues/37) · **owns** `pkg/jira/{port,types}.go`, `pkg/jira/cloud/{caps,search}.go`, `pkg/jira/jiratest/{jiratest,fake}.go`, `internal/ui/onboarding/render.go`, `docs/{ARCHITECTURE,API-NOTES}.md`
   Two additive amendments, one PR, because two agents editing the frozen port is the one guaranteed
@@ -142,6 +146,30 @@ because it unblocks or blocks everyone. The other four run in parallel behind it
   found one more: the paged `versions.json` was served at `/project/{key}/versions`, which answers a
   bare array, so the route moved to the paged `/project/{key}/version` the capture script already
   used.
+- [x] **PC.6 — Make the Cloud adapter constructible, and construct it** · [#55](https://github.com/varijkapil13/saral/issues/55), [#52](https://github.com/varijkapil13/saral/issues/52) · **owns** `pkg/jira/roles.go`, `pkg/jira/port.go` (package doc), `pkg/jira/cloud/{me,field,assert}.go` and their tests, `pkg/jira/jiratest/jiratest.go` (assertions), `internal/ui/kernel/view.go`, `internal/ui/onboarding/{onboarding,commands}.go` and their tests, `internal/app/search.go`, `internal/ui/{issue,form,comment}/*cmds.go` (parameter types), `cmd/saral/main.go`, `internal/arch/**`, `docs/{ARCHITECTURE,ROADMAP,TESTING}.md`
+  Nothing in the shipped binary ever built a Cloud client, and it could not have: `pkg/jira/cloud`
+  implemented 12 of the port's 34 methods, so `*cloud.Client` was not a `jira.Client` and nothing that
+  wanted one — `kernel.Deps.Jira`, `onboarding.Connector`, `app.NewSearch` — could hold it. The only
+  type in the tree that satisfied the port was `jiratest.Fake`. Everything Batches 1 and 2 shipped
+  worked, against the fake.
+  Settled on #55 as **role interfaces**, generalising `app.Counter`'s existing "a client that cannot
+  make it should not have to pretend". `jira.Client` is untouched and stays the whole port; callers
+  now take a role named for their job — `Prober`, `Identifier`, `Searcher`, `FieldCatalogue`,
+  `SchemaReader`, `IssueWriter`, `Mover`, `CommentReader`, `Commenter` — and `Deps.Jira` takes
+  `SessionClient`, the union of exactly what the views in this build call. Later batches widen that
+  union as they land the adapter methods their own views need, which is additive.
+  Two of the thirteen methods in the union were missing, not one. `Me` was known. `Fields` was not:
+  `app.Search` has called it since P1.2 to resolve a field named in configuration to this site's ID
+  for it, and no packet owned the adapter half. Both are implemented here rather than stubbed.
+  Both adapters now assert what they satisfy in a non-test file, and `internal/arch` fails an adapter
+  package under `pkg/jira/**` that never says. That absence is why a package implementing a minority
+  of the port passed CI, lint, race and a cross-build for two whole batches.
+  `cmd/saral` registers the connector unconditionally — a first run is exactly the path with no token
+  — and resolves the profile's token under a 20s bound when there is one. A resolution failure is not
+  fatal: `deps.Jira` stays nil, the program opens, and the resolver's own sentence reaches the status
+  line through `kernel.StatusMsg`, applied to the model before the program starts because the alt
+  screen wipes anything printed ahead of it. No probe runs before the first frame; PC.3's `Init`
+  probe does it once a client exists.
 
 ## Batch 2 — Change your work · parallel ×4
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -127,8 +127,25 @@ writes down which of its interfaces it satisfies:
 var _ jira.Prober = (*Client)(nil)
 ```
 
-The test only checks the line exists, in a file that is part of the build rather than in a `_test.go`
-— the compiler checks that it is *true*, and does so at `go build` time. Nobody had written one for
-`pkg/jira/cloud`, so it implemented 12 of the port's 34 methods for two whole batches while passing
-lint, vet, race and a cross-build. Nothing outside the package assigned a `*Client` to anything, so
-nothing ever asked.
+The test checks the lines exist, in a file that is part of the build rather than in a `_test.go` —
+the compiler checks that they are *true*, and does so at `go build` time. One of them has to be
+`jira.SessionClient`, the composite a session is built with, so that an adapter cannot shed its
+single-role claims one at a time and still pass. Nobody had written one for `pkg/jira/cloud`, so it
+implemented 12 of the port's 34 methods for two whole batches while passing lint, vet, race and a
+cross-build. Nothing outside the package assigned a `*Client` to anything, so nothing ever asked.
+
+## Adapters answer the same question the same way
+
+An assertion is only worth what it is run against. Everything above the port is tested against the
+fake, so a rule the cloud adapter enforces and the fake does not is a rule no test ever meets — and
+the suite stays green while the binary fails against a site. That has happened twice: the fake
+accepted a whitespace-only field list the site refuses, and the fake accepted a 200 naming nobody
+that the cloud adapter refuses, which is the answer onboarding reads as proof a credential works.
+
+`pkg/jira/cloud/conformance_test.go` runs one table of cases over both adapters through the port role
+that names the method — `jira.Identifier` for `Me`. Each case builds a site in each adapter's own
+terms (a replay server for `cloud`, an option for `jiratest`) and then asserts the same thing about
+the answer, so a divergence fails on the adapter that has it.
+
+It covers `Me`. A new adapter method is a new table beside that one; a harness over all 34 port
+methods is [#74](https://github.com/varijkapil13/saral/issues/74) and deliberately not this.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -117,3 +117,18 @@ The rules only see imports within this module. "No IO libs in `internal/app`" is
 can check this way — a `net/http` import there is invisible to the walk.
 
 This catches the most common way a modular design quietly stops being modular.
+
+## Adapters say what they satisfy
+
+A third test in `internal/arch` fails any package under `pkg/jira/**` that adapts the port and never
+writes down which of its interfaces it satisfies:
+
+```go
+var _ jira.Prober = (*Client)(nil)
+```
+
+The test only checks the line exists, in a file that is part of the build rather than in a `_test.go`
+— the compiler checks that it is *true*, and does so at `go build` time. Nobody had written one for
+`pkg/jira/cloud`, so it implemented 12 of the port's 34 methods for two whole batches while passing
+lint, vet, race and a cross-build. Nothing outside the package assigned a `*Client` to anything, so
+nothing ever asked.

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -29,6 +29,15 @@ type Counter interface {
 	ApproximateCount(ctx context.Context, jql string) (int, error)
 }
 
+// SearchClient is what a search runs on: JQL, and the field catalogue that turns
+// a field named in a profile into the ID to ask this site for. It is the pair of
+// port roles this use case needs, and asking for the pair rather than for the
+// whole port is what lets an adapter run a list before it can do anything else.
+type SearchClient interface {
+	jira.Searcher
+	jira.FieldCatalogue
+}
+
 // Projection is the narrow set of fields one view needs.
 //
 // It is split in two because only half of it can be written down. IDs are the
@@ -114,7 +123,7 @@ type Result struct {
 // collapsing of identical searches that a cursor moving down a list produces.
 // A Search is safe to share between goroutines.
 type Search struct {
-	client jira.Client
+	client SearchClient
 	saved  SavedQueries
 
 	flight singleflight.Group
@@ -134,7 +143,7 @@ func WithSavedQueries(q SavedQueries) Option {
 }
 
 // NewSearch builds the search use case over a Jira client.
-func NewSearch(client jira.Client, opts ...Option) *Search {
+func NewSearch(client SearchClient, opts ...Option) *Search {
 	s := &Search{client: client}
 	for _, o := range opts {
 		if o != nil {

--- a/internal/arch/adapters_test.go
+++ b/internal/arch/adapters_test.go
@@ -16,12 +16,19 @@ import (
 // portDir is the package the adapters under it adapt.
 const portDir = "pkg/jira"
 
-// An adapter package has to say which of the port's interfaces it satisfies.
+// unionRole is the composite a session is built with, and the one line an
+// adapter may not be without.
+const unionRole = "SessionClient"
+
+// An adapter package has to say which of the port's interfaces it satisfies, and
+// one of them has to be the composite.
 //
-// Only the presence of the line is checked here. Whether it is true is the
-// compiler's job, and one `var _ jira.Prober = (*Client)(nil)` fails the build
-// the moment the type stops satisfying the role. What nothing checked before was
-// whether anybody had written one.
+// Whether an assertion is true is the compiler's job: one
+// `var _ jira.Prober = (*Client)(nil)` fails the build the moment the type stops
+// satisfying the role. What no compiler checks is whether anybody wrote one, and
+// presence alone would let a package drop nine of ten claims and still pass —
+// which is why the composite is required by name. Nothing that satisfies it can
+// have dropped a role inside it.
 //
 // The scan skips _test.go files: an assertion only a test file carries fails
 // `go test` and not `go build`.
@@ -37,6 +44,10 @@ func TestAdapters_StateWhichPortRolesTheySatisfy(t *testing.T) {
 	}
 	if !slices.Contains(roles, "Client") {
 		t.Errorf("the port declares no Client interface; roles found: %v", roles)
+	}
+	if !slices.Contains(roles, unionRole) {
+		t.Fatalf("the port declares no %s interface, so there is no composite to require; roles found: %v",
+			unionRole, roles)
 	}
 
 	adapters := adapterPackages(t, root)
@@ -62,6 +73,13 @@ func TestAdapters_StateWhichPortRolesTheySatisfy(t *testing.T) {
 					t.Errorf("%s asserts it satisfies jira.%s, which %s does not declare; it declares %v",
 						dir, name, portDir, roles)
 				}
+			}
+			if !slices.Contains(asserted, unionRole) {
+				t.Errorf("%s asserts %v and not jira.%s.\n"+
+					"the composite is what a session is built with, so an adapter that does not claim it "+
+					"cannot be wired in, and claiming it is what stops the single-role lines from being "+
+					"quietly dropped one at a time",
+					dir, asserted, unionRole)
 			}
 		})
 	}

--- a/internal/arch/adapters_test.go
+++ b/internal/arch/adapters_test.go
@@ -1,0 +1,290 @@
+package arch
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// portDir is the package the adapters under it adapt.
+const portDir = "pkg/jira"
+
+// An adapter package has to say which of the port's interfaces it satisfies.
+//
+// Only the presence of the line is checked here. Whether it is true is the
+// compiler's job, and one `var _ jira.Prober = (*Client)(nil)` fails the build
+// the moment the type stops satisfying the role. What nothing checked before was
+// whether anybody had written one.
+//
+// The scan skips _test.go files: an assertion only a test file carries fails
+// `go test` and not `go build`.
+func TestAdapters_StateWhichPortRolesTheySatisfy(t *testing.T) {
+	t.Parallel()
+
+	root := moduleRoot(t)
+	modPath := modulePath(t, root)
+
+	roles := portInterfaces(t, root)
+	if len(roles) == 0 {
+		t.Fatalf("no exported interface found in %s, so this check proves nothing", portDir)
+	}
+	if !slices.Contains(roles, "Client") {
+		t.Errorf("the port declares no Client interface; roles found: %v", roles)
+	}
+
+	adapters := adapterPackages(t, root)
+	if len(adapters) == 0 {
+		t.Fatalf("no adapter package found under %s, so this check proves nothing", portDir)
+	}
+
+	for _, dir := range adapters {
+		t.Run(dir, func(t *testing.T) {
+			t.Parallel()
+
+			asserted := assertedRoles(t, filepath.Join(root, filepath.FromSlash(dir)), modPath)
+			if len(asserted) == 0 {
+				t.Fatalf("%s adapts %s and never says what it satisfies.\n"+
+					"add one line per role in a non-test file of the package, e.g.\n"+
+					"\tvar _ jira.Prober = (*Client)(nil)\n"+
+					"without it the package compiles while implementing none of the port, "+
+					"and the first thing to notice is whatever tries to use it",
+					dir, portDir)
+			}
+			for _, name := range asserted {
+				if !slices.Contains(roles, name) {
+					t.Errorf("%s asserts it satisfies jira.%s, which %s does not declare; it declares %v",
+						dir, name, portDir, roles)
+				}
+			}
+		})
+	}
+}
+
+func TestAssertionsIn_FindsThePortRolesAPackageClaimsAndNothingElse(t *testing.T) {
+	t.Parallel()
+
+	const modPath = "example.com/mod"
+
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "one assertion under the usual import name",
+			src: `package cloud
+import "example.com/mod/pkg/jira"
+var _ jira.Prober = (*Client)(nil)`,
+			want: []string{"Prober"},
+		},
+		{
+			name: "a grouped var block",
+			src: `package cloud
+import "example.com/mod/pkg/jira"
+var (
+	_ jira.Prober = (*Client)(nil)
+	_ jira.Searcher = (*Client)(nil)
+)`,
+			want: []string{"Prober", "Searcher"},
+		},
+		{
+			name: "an aliased import",
+			src: `package cloud
+import port "example.com/mod/pkg/jira"
+var _ port.Commenter = (*Client)(nil)`,
+			want: []string{"Commenter"},
+		},
+		{
+			name: "a package that never mentions the port",
+			src: `package cloud
+var _ error = (*Client)(nil)`,
+			want: nil,
+		},
+		{
+			name: "a named variable rather than a blank assertion",
+			src: `package cloud
+import "example.com/mod/pkg/jira"
+var fallback jira.Prober = (*Client)(nil)`,
+			want: nil,
+		},
+		{
+			name: "a selector on something that merely shares the name",
+			src: `package cloud
+import "example.com/mod/pkg/jira"
+import jira2 "example.com/other/jira"
+var _ jira2.Prober = (*Client)(nil)`,
+			want: nil,
+		},
+		{
+			name: "an unexported interface is not a role",
+			src: `package cloud
+import "example.com/mod/pkg/jira"
+var _ jira.prober = (*Client)(nil)`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "src.go", tt.src, 0)
+			if err != nil {
+				t.Fatalf("parsing the fixture: %v", err)
+			}
+			got := assertionsIn(file, modPath)
+			slices.Sort(got)
+			want := slices.Clone(tt.want)
+			slices.Sort(want)
+			if !slices.Equal(got, want) {
+				t.Errorf("assertionsIn = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// portInterfaces lists the exported interfaces the port declares, which is the
+// set an adapter may claim to satisfy.
+func portInterfaces(t *testing.T, root string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	var out []string
+	for _, file := range goFiles(t, filepath.Join(root, filepath.FromSlash(portDir))) {
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", file, err)
+		}
+		for _, decl := range parsed.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				typ, ok := spec.(*ast.TypeSpec)
+				if !ok || !typ.Name.IsExported() {
+					continue
+				}
+				if _, isInterface := typ.Type.(*ast.InterfaceType); isInterface {
+					out = append(out, typ.Name.Name)
+				}
+			}
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// adapterPackages lists the module-relative directories directly under the port
+// that hold Go code. Those are the packages whose whole job is to be the port.
+func adapterPackages(t *testing.T, root string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(root, filepath.FromSlash(portDir)))
+	if err != nil {
+		t.Fatalf("reading %s: %v", portDir, err)
+	}
+	var out []string
+	for _, entry := range entries {
+		if !entry.IsDir() || skipDir(entry.Name()) {
+			continue
+		}
+		dir := path.Join(portDir, entry.Name())
+		if len(goFiles(t, filepath.Join(root, filepath.FromSlash(dir)))) > 0 {
+			out = append(out, dir)
+		}
+	}
+	return out
+}
+
+func assertedRoles(t *testing.T, dir, modPath string) []string {
+	t.Helper()
+
+	files := goFiles(t, dir)
+	fset := token.NewFileSet()
+	out := make([]string, 0, len(files))
+	for _, file := range files {
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", file, err)
+		}
+		out = append(out, assertionsIn(parsed, modPath)...)
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+// assertionsIn reads the port roles a file claims through `var _ jira.X = ...`.
+// A named variable is not a claim — only the blank one is unmistakably written
+// to be checked and never read.
+func assertionsIn(file *ast.File, modPath string) []string {
+	alias, ok := portAlias(file, modPath)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue || len(value.Names) != 1 || value.Names[0].Name != "_" {
+				continue
+			}
+			selector, isSelector := value.Type.(*ast.SelectorExpr)
+			if !isSelector {
+				continue
+			}
+			pkg, isIdent := selector.X.(*ast.Ident)
+			if !isIdent || pkg.Name != alias || !selector.Sel.IsExported() {
+				continue
+			}
+			out = append(out, selector.Sel.Name)
+		}
+	}
+	return out
+}
+
+// portAlias is the name the port is imported under in this file, if it is.
+func portAlias(file *ast.File, modPath string) (string, bool) {
+	want := modPath + "/" + portDir
+	for _, spec := range file.Imports {
+		imported, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || imported != want {
+			continue
+		}
+		if spec.Name != nil {
+			return spec.Name.Name, spec.Name.Name != "_" && spec.Name.Name != "."
+		}
+		return path.Base(imported), true
+	}
+	return "", false
+}
+
+func goFiles(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	var out []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		out = append(out, filepath.Join(dir, name))
+	}
+	return out
+}

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -33,7 +33,7 @@ var importRules = []importRule{
 		name:   "ui-must-not-import-the-cloud-adapter",
 		from:   "internal/ui",
 		forbid: "pkg/jira/cloud",
-		why:    "views take the jira.Client port so they can be driven by pkg/jira/jiratest",
+		why:    "views take the pkg/jira port so they can be driven by pkg/jira/jiratest",
 	},
 	{
 		name:   "only-cmd-and-config-construct-the-cloud-adapter",

--- a/internal/ui/comment/cmds.go
+++ b/internal/ui/comment/cmds.go
@@ -43,7 +43,7 @@ type failedMsg struct {
 	err error
 }
 
-func load(ctx context.Context, client jira.Client, key string, gen int) tea.Cmd {
+func load(ctx context.Context, client jira.CommentReader, key string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		page, err := client.Comments(ctx, key)
 		if err != nil {
@@ -63,7 +63,7 @@ func more(ctx context.Context, page jira.Page[jira.Comment], gen int) tea.Cmd {
 	}
 }
 
-func add(ctx context.Context, client jira.Client, key string, body adf.Doc, gen int) tea.Cmd {
+func add(ctx context.Context, client jira.Commenter, key string, body adf.Doc, gen int) tea.Cmd {
 	return func() tea.Msg {
 		stored, err := client.AddComment(ctx, key, body)
 		if err != nil {
@@ -73,7 +73,7 @@ func add(ctx context.Context, client jira.Client, key string, body adf.Doc, gen 
 	}
 }
 
-func edit(ctx context.Context, client jira.Client, key, id string, body adf.Doc, gen int) tea.Cmd {
+func edit(ctx context.Context, client jira.Commenter, key, id string, body adf.Doc, gen int) tea.Cmd {
 	return func() tea.Msg {
 		stored, err := client.EditComment(ctx, key, id, body)
 		if err != nil {
@@ -83,7 +83,7 @@ func edit(ctx context.Context, client jira.Client, key, id string, body adf.Doc,
 	}
 }
 
-func remove(ctx context.Context, client jira.Client, key, id string, gen int) tea.Cmd {
+func remove(ctx context.Context, client jira.Commenter, key, id string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		if err := client.DeleteComment(ctx, key, id); err != nil {
 			return failedMsg{gen: gen, err: err}

--- a/internal/ui/form/cmds.go
+++ b/internal/ui/form/cmds.go
@@ -94,7 +94,7 @@ func distinctTypes(issues []jira.Issue) []jira.IssueType {
 }
 
 // loadSchema reads a create screen, from the cache when it is still fresh.
-func loadSchema(ctx context.Context, client jira.Client, cache *schemaCache, key screen, gen int) tea.Cmd {
+func loadSchema(ctx context.Context, client jira.SchemaReader, cache *schemaCache, key screen, gen int) tea.Cmd {
 	return func() tea.Msg {
 		if schema, ok := cache.get(key); ok {
 			return schemaLoadedMsg{gen: gen, screen: key, schema: schema}
@@ -110,7 +110,7 @@ func loadSchema(ctx context.Context, client jira.Client, cache *schemaCache, key
 
 // loadAccount reads the authenticated account. A failure is not reported: it
 // costs a person picker one candidate, and there is nothing the user can do.
-func loadAccount(ctx context.Context, client jira.Client, gen int) tea.Cmd {
+func loadAccount(ctx context.Context, client jira.Identifier, gen int) tea.Cmd {
 	return func() tea.Msg {
 		user, err := client.Me(ctx)
 		if err != nil {
@@ -121,7 +121,7 @@ func loadAccount(ctx context.Context, client jira.Client, gen int) tea.Cmd {
 }
 
 // create asks Jira to store the issue.
-func create(ctx context.Context, client jira.Client, in jira.IssueInput, gen int) tea.Cmd {
+func create(ctx context.Context, client jira.IssueWriter, in jira.IssueInput, gen int) tea.Cmd {
 	return func() tea.Msg {
 		issue, err := client.CreateIssue(ctx, in)
 		if err != nil {

--- a/internal/ui/issue/cmds.go
+++ b/internal/ui/issue/cmds.go
@@ -51,7 +51,7 @@ func load(ctx context.Context, search *app.Search, key string, gen int) tea.Cmd 
 	}
 }
 
-func comments(ctx context.Context, client jira.Client, key string, gen int) tea.Cmd {
+func comments(ctx context.Context, client jira.CommentReader, key string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		page, err := client.Comments(ctx, key)
 		if err != nil {

--- a/internal/ui/issue/edit_cmds.go
+++ b/internal/ui/issue/edit_cmds.go
@@ -69,7 +69,7 @@ func loadForEdit(ctx context.Context, search *app.Search, key string, gen int) t
 	}
 }
 
-func loadEditSchema(ctx context.Context, client jira.Client, project, issueTypeID string, gen int) tea.Cmd {
+func loadEditSchema(ctx context.Context, client jira.SchemaReader, project, issueTypeID string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		schema, err := client.CreateMeta(ctx, project, issueTypeID)
 		if err != nil {
@@ -79,7 +79,7 @@ func loadEditSchema(ctx context.Context, client jira.Client, project, issueTypeI
 	}
 }
 
-func saveEdit(ctx context.Context, client jira.Client, key string, patch jira.IssuePatch, gen int) tea.Cmd {
+func saveEdit(ctx context.Context, client jira.IssueWriter, key string, patch jira.IssuePatch, gen int) tea.Cmd {
 	return func() tea.Msg {
 		if err := client.UpdateIssue(ctx, key, patch); err != nil {
 			return editFailedMsg{gen: gen, err: err}
@@ -91,7 +91,7 @@ func saveEdit(ctx context.Context, client jira.Client, key string, patch jira.Is
 // loadMoves reads the transitions this issue can make right now. They are never
 // cached: which ones exist depends on the status the issue is in at the moment
 // of asking, and on conditions the workflow evaluates against this issue.
-func loadMoves(ctx context.Context, client jira.Client, key string, gen int) tea.Cmd {
+func loadMoves(ctx context.Context, client jira.Mover, key string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		moves, err := client.Transitions(ctx, key)
 		if err != nil {
@@ -101,7 +101,7 @@ func loadMoves(ctx context.Context, client jira.Client, key string, gen int) tea
 	}
 }
 
-func applyMove(ctx context.Context, client jira.Client, key, transitionID string, patch jira.IssuePatch, gen int) tea.Cmd {
+func applyMove(ctx context.Context, client jira.Mover, key, transitionID string, patch jira.IssuePatch, gen int) tea.Cmd {
 	return func() tea.Msg {
 		if err := client.Transition(ctx, key, transitionID, patch); err != nil {
 			return editFailedMsg{gen: gen, err: err}

--- a/internal/ui/kernel/view.go
+++ b/internal/ui/kernel/view.go
@@ -64,8 +64,11 @@ type Command struct {
 // a view affects the rest of the program by returning one of this package's
 // commands, never by reaching for another model.
 type Deps struct {
-	// Jira is the port. It is never a concrete adapter here.
-	Jira jira.Client
+	// Jira is the port, narrowed to the roles the views in this build call. It
+	// is never a concrete adapter here, and it is deliberately not the whole
+	// jira.Client: an adapter that can serve every view that exists is wired in
+	// now rather than when it can serve the ones that do not.
+	Jira jira.SessionClient
 	// Caps is the probe result, already resolved for Project.
 	Caps jira.Capabilities
 	// Project is the project this session is scoped to. Several capabilities

--- a/internal/ui/onboarding/commands.go
+++ b/internal/ui/onboarding/commands.go
@@ -45,7 +45,7 @@ type configLoadedMsg struct {
 
 type connectedMsg struct {
 	seq     int
-	client  jira.Client
+	client  jira.SessionClient
 	account jira.User
 }
 

--- a/internal/ui/onboarding/harness_test.go
+++ b/internal/ui/onboarding/harness_test.go
@@ -68,8 +68,8 @@ func newDriver(t *testing.T, client jira.Client, opts ...func(*kernel.Deps)) *dr
 	return newDriverWith(t, connectorFor(client), opts...)
 }
 
-func connectorFor(client jira.Client) Connector {
-	return func(string, string, string) (jira.Client, error) { return client, nil }
+func connectorFor(client jira.SessionClient) Connector {
+	return func(string, string, string) (jira.SessionClient, error) { return client, nil }
 }
 
 func newDriverWith(t *testing.T, connect Connector, opts ...func(*kernel.Deps)) *driver {

--- a/internal/ui/onboarding/kernel_test.go
+++ b/internal/ui/onboarding/kernel_test.go
@@ -28,7 +28,7 @@ func TestKernel_RunsTheWholeFlowThroughTheRegisteredView(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", dir)
 
 	fake := testFake()
-	SetConnector(func(string, string, string) (jira.Client, error) { return fake, nil })
+	SetConnector(func(string, string, string) (jira.SessionClient, error) { return fake, nil })
 	t.Cleanup(func() { SetConnector(nil) })
 
 	if errs := kernel.RegistrationErrors(); len(errs) > 0 {
@@ -85,7 +85,7 @@ func TestKernel_RunsTheWholeFlowThroughTheRegisteredView(t *testing.T) {
 // re-enter one that was already correct.
 func TestKernel_TheFormReceivesEveryCharacterOfACredential(t *testing.T) {
 	var got struct{ site, email, token string }
-	SetConnector(func(site, email, token string) (jira.Client, error) {
+	SetConnector(func(site, email, token string) (jira.SessionClient, error) {
 		got.site, got.email, got.token = site, email, token
 		return testFake(), nil
 	})
@@ -128,7 +128,7 @@ func TestKernel_TheFormReceivesEveryCharacterOfACredential(t *testing.T) {
 // A view holding the keyboard must still be quittable by the one key that always
 // means it.
 func TestKernel_CtrlCStillQuitsWhileTheFormHasTheKeyboard(t *testing.T) {
-	SetConnector(func(string, string, string) (jira.Client, error) { return testFake(), nil })
+	SetConnector(func(string, string, string) (jira.SessionClient, error) { return testFake(), nil })
 	t.Cleanup(func() { SetConnector(nil) })
 
 	root, err := kernel.New(testDeps(), kernel.WithSize(100, 30), kernel.WithInitialView(ViewID), kernel.WithMouse(false))

--- a/internal/ui/onboarding/onboarding.go
+++ b/internal/ui/onboarding/onboarding.go
@@ -37,10 +37,11 @@ const opTimeout = 30 * time.Second
 
 // Connector opens a client for credentials that have not been saved yet.
 //
-// The view cannot build one itself: internal/ui takes the jira.Client port and
-// never an adapter, so the composition root registers the adapter this build
-// uses with SetConnector.
-type Connector func(site, email, token string) (jira.Client, error)
+// The view cannot build one itself: internal/ui takes the port and never an
+// adapter, so the composition root registers the adapter this build uses with
+// SetConnector. What comes back is the same narrowed client a session runs on,
+// because this view hands it straight to one.
+type Connector func(site, email, token string) (jira.SessionClient, error)
 
 var registered struct {
 	mu sync.RWMutex
@@ -125,7 +126,7 @@ type Model struct {
 	problem string
 	note    string
 
-	client  jira.Client
+	client  jira.SessionClient
 	search  *app.Search
 	account jira.User
 	caps    jira.Capabilities

--- a/internal/ui/onboarding/onboarding_test.go
+++ b/internal/ui/onboarding/onboarding_test.go
@@ -132,7 +132,7 @@ func TestFlow_AnUnreachableSiteReturnsToTheSiteFieldAndSaysWhichProblemItIs(t *t
 func TestFlow_AConnectorThatCannotBuildAClientIsReportedOnTheTokenStep(t *testing.T) {
 	t.Parallel()
 
-	d := newDriverWith(t, func(string, string, string) (jira.Client, error) {
+	d := newDriverWith(t, func(string, string, string) (jira.SessionClient, error) {
 		return nil, errors.New("cloud: an API token is required")
 	})
 	d.credentials()

--- a/internal/ui/onboarding/onboarding_test.go
+++ b/internal/ui/onboarding/onboarding_test.go
@@ -129,6 +129,26 @@ func TestFlow_AnUnreachableSiteReturnsToTheSiteFieldAndSaysWhichProblemItIs(t *t
 	d.noTokenAnywhere()
 }
 
+// The whole point of asking who the token belongs to is that an answer proves
+// the three fields go together. An answer that names nobody proves nothing, so
+// it has to stop the flow rather than reach the review screen as an account with
+// no name.
+func TestFlow_AnAnswerThatNamesNobodyIsNotProofTheCredentialsGoTogether(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake(jiratest.WithMe(jira.User{})))
+
+	d.credentials()
+
+	d.atStep(stepSite)
+	d.mustContain("names no account")
+	if strings.Contains(d.frame(), "verified") {
+		t.Errorf("an answer naming nobody read as a verified credential:\n%s", d.frame())
+	}
+	d.nothingWritten()
+	d.noTokenAnywhere()
+}
+
 func TestFlow_AConnectorThatCannotBuildAClientIsReportedOnTheTokenStep(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/jira/cloud/assert.go
+++ b/pkg/jira/cloud/assert.go
@@ -1,0 +1,27 @@
+package cloud
+
+import "github.com/varijkapil13/saral/pkg/jira"
+
+// What this adapter can be asked for.
+//
+// These belong in the built package and not in a test: a package that claims to
+// adapt something and does not should fail `go build`, not a suite somebody has
+// to run.
+//
+// The list is what the adapter satisfies today. A packet landing the rest of an
+// area adds its role here in the same PR; jira.Client joins the list when the
+// last of the port's methods arrives.
+var (
+	_ jira.Prober         = (*Client)(nil)
+	_ jira.Identifier     = (*Client)(nil)
+	_ jira.Searcher       = (*Client)(nil)
+	_ jira.FieldCatalogue = (*Client)(nil)
+	_ jira.SchemaReader   = (*Client)(nil)
+	_ jira.IssueWriter    = (*Client)(nil)
+	_ jira.Mover          = (*Client)(nil)
+	_ jira.CommentReader  = (*Client)(nil)
+	_ jira.Commenter      = (*Client)(nil)
+
+	// The composite a session is built with.
+	_ jira.SessionClient = (*Client)(nil)
+)

--- a/pkg/jira/cloud/conformance_test.go
+++ b/pkg/jira/cloud/conformance_test.go
@@ -1,0 +1,170 @@
+package cloud
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// One set of assertions, run against both adapters. A rule that lives in only
+// one of them is a rule no test meets: everything above the port is tested
+// against the fake, so the suite stays green while the binary fails against a
+// site. It has happened twice — a field list the fake accepted and the site
+// refuses, and a 200 naming nobody the fake accepted and the cloud adapter
+// refuses.
+//
+// This covers Me. Another method is another table beside this one, driven over
+// the port role that names it.
+
+// meBuilder opens one adapter in that adapter's own terms. The role is what
+// makes a single table runnable twice.
+type meBuilder func(*testing.T) jira.Identifier
+
+type meCase struct {
+	name   string
+	cloud  meBuilder
+	fake   meBuilder
+	assert func(*testing.T, jira.User, error)
+}
+
+func TestMe_BothAdaptersAnswerTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	const namedNobody = `{"displayName":"Example User","active":true}`
+	const unloadableZone = `{"accountId":"5b10a2844c20165700ede21g","displayName":"Example User",
+		"emailAddress":"user@example.com","active":true,"avatarUrls":{"48x48":"https://example.atlassian.net/avatar"},
+		"timeZone":"Mars/Olympus_Mons"}`
+
+	cases := []meCase{
+		{
+			name:   "an account the site names in full",
+			cloud:  func(t *testing.T) jira.Identifier { return meFromSite(t) },
+			fake:   func(*testing.T) jira.Identifier { return jiratest.New() },
+			assert: func(t *testing.T, got jira.User, err error) { assertWholeAccount(t, got, err) },
+		},
+		{
+			name:  "a 200 that names nobody",
+			cloud: func(t *testing.T) jira.Identifier { return meFromSite(t, meAnswering(namedNobody)) },
+			fake: func(*testing.T) jira.Identifier {
+				return jiratest.New(jiratest.WithMe(jira.User{DisplayName: "Example User", Active: true}))
+			},
+			assert: assertRefusedNobody,
+		},
+		{
+			name:  "an account whose timezone this machine cannot load",
+			cloud: func(t *testing.T) jira.Identifier { return meFromSite(t, meAnswering(unloadableZone)) },
+			// A zone no database has reaches a caller as no zone at all, which is
+			// the only form the in-memory fake can hold it in.
+			fake: func(*testing.T) jira.Identifier {
+				return jiratest.New(jiratest.WithMe(jira.User{
+					AccountID:   "5b10a2844c20165700ede21g",
+					DisplayName: "Example User",
+					Email:       "user@example.com",
+					Active:      true,
+					AvatarURL:   "https://example.atlassian.net/avatar",
+				}))
+			},
+			assert: assertAccountWithoutAZone,
+		},
+	}
+
+	for _, tt := range cases {
+		for _, adapter := range []struct {
+			name string
+			open meBuilder
+		}{
+			{name: "cloud", open: tt.cloud},
+			{name: "fake", open: tt.fake},
+		} {
+			t.Run(tt.name+"/"+adapter.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, err := adapter.open(t).Me(t.Context())
+				tt.assert(t, got, err)
+			})
+		}
+	}
+}
+
+// assertWholeAccount names the fields that came back empty rather than the first
+// one, because a divergence is usually one field and the name of it is the
+// finding. The avatar is the field that was missing from the fake.
+func assertWholeAccount(t *testing.T, got jira.User, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("reading the account: %v", err)
+	}
+	unset := make([]string, 0, 6)
+	if got.AccountID == "" {
+		unset = append(unset, "AccountID")
+	}
+	if got.DisplayName == "" {
+		unset = append(unset, "DisplayName")
+	}
+	if got.Email == "" {
+		unset = append(unset, "Email")
+	}
+	if got.TimeZone == nil {
+		unset = append(unset, "TimeZone")
+	}
+	if !got.Active {
+		unset = append(unset, "Active")
+	}
+	if got.AvatarURL == "" {
+		unset = append(unset, "AvatarURL")
+	}
+	if len(unset) > 0 {
+		t.Errorf("the account came back with %v unset: %+v", unset, got)
+	}
+}
+
+func assertRefusedNobody(t *testing.T, got jira.User, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("an answer naming nobody read as the account %+v, and onboarding takes that for proof", got)
+	}
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+	}
+	if got != (jira.User{}) {
+		t.Errorf("the refusal came back with %+v attached, want no account at all", got)
+	}
+}
+
+func assertAccountWithoutAZone(t *testing.T, got jira.User, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("an unusable zone failed the whole read: %v", err)
+	}
+	if got.TimeZone != nil {
+		t.Errorf("the timezone is %s, want none", got.TimeZone)
+	}
+	if got.AccountID == "" || got.DisplayName == "" || got.Email == "" || !got.Active {
+		t.Errorf("the account reads as %+v, want everything but the zone", got)
+	}
+}
+
+// meFromSite is the cloud adapter pointed at a replay server, which is as close
+// to a site as a test is allowed to get.
+func meFromSite(t *testing.T, opts ...jiratest.ServerOption) jira.Identifier {
+	t.Helper()
+
+	s := jiratest.NewServer(opts...)
+	t.Cleanup(s.Close)
+	c, _ := testClient(t, s.URL())
+	return c
+}
+
+func meAnswering(body string) jiratest.ServerOption {
+	return jiratest.WithHandler(http.MethodGet, mePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+}

--- a/pkg/jira/cloud/field.go
+++ b/pkg/jira/cloud/field.go
@@ -1,0 +1,67 @@
+package cloud
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const fieldPath = "/rest/api/3/field"
+
+// Fields returns the site's field catalogue.
+//
+// It is what turns a field written down by name — in a profile, a saved query, a
+// board's estimation setting — into the ID to ask this site for. A custom field
+// ID is site-specific, so there is no other way to reach one that does not mean
+// writing a customfield_NNNNN into the source and being wrong on every other
+// site.
+//
+// The endpoint returns every field the site defines in one unpaged array, which
+// on a large site is a few hundred entries. Callers cache it; it changes when
+// somebody edits the site's configuration.
+func (c *Client) Fields(ctx context.Context) ([]jira.Field, error) {
+	var body []apiField
+	err := c.doJSON(ctx, request{
+		method: http.MethodGet,
+		path:   fieldPath,
+		kind:   "the field catalogue",
+		id:     fieldPath,
+	}, &body)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]jira.Field, len(body))
+	for i := range body {
+		out[i] = body[i].domain()
+	}
+	return out, nil
+}
+
+type apiField struct {
+	ID               string         `json:"id"`
+	Key              string         `json:"key"`
+	Name             string         `json:"name"`
+	UntranslatedName string         `json:"untranslatedName"`
+	Custom           bool           `json:"custom"`
+	Navigable        bool           `json:"navigable"`
+	Searchable       bool           `json:"searchable"`
+	Orderable        bool           `json:"orderable"`
+	ClauseNames      []string       `json:"clauseNames"`
+	Schema           apiFieldSchema `json:"schema"`
+}
+
+func (f apiField) domain() jira.Field {
+	return jira.Field{
+		ID:               f.ID,
+		Key:              f.Key,
+		Name:             f.Name,
+		UntranslatedName: f.UntranslatedName,
+		Custom:           f.Custom,
+		Navigable:        f.Navigable,
+		Searchable:       f.Searchable,
+		Orderable:        f.Orderable,
+		ClauseNames:      f.ClauseNames,
+		Schema:           f.Schema.domain(),
+	}
+}

--- a/pkg/jira/cloud/field_test.go
+++ b/pkg/jira/cloud/field_test.go
@@ -1,0 +1,153 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+func TestFields_ReadsTheCatalogueASiteSpecificIDIsResolvedThrough(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Fields(t.Context())
+	if err != nil {
+		t.Fatalf("reading the catalogue: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("the catalogue is empty, so no field name can be resolved on this site")
+	}
+
+	summary, ok := jira.FieldByName(got, "Summary")
+	if !ok {
+		t.Fatalf("no field is called Summary: %v", fieldNames(got))
+	}
+	if summary.ID != "summary" || summary.Custom {
+		t.Errorf("Summary reads as %+v, want the system field", summary)
+	}
+	if summary.Schema.System != "summary" || summary.Schema.Type != "string" {
+		t.Errorf("Summary's schema reads as %+v, want the one the site states", summary.Schema)
+	}
+
+	// The whole reason this endpoint is called: the ID is site-specific and the
+	// name is the only stable handle onto it.
+	points, ok := jira.FieldByName(got, "Story Points")
+	if !ok {
+		t.Fatalf("no field is called Story Points: %v", fieldNames(got))
+	}
+	switch {
+	case !points.Custom:
+		t.Errorf("Story Points reads as a system field: %+v", points)
+	case points.ID == "" || points.ID == points.Name:
+		t.Errorf("Story Points resolved to %q, want the site's own customfield ID", points.ID)
+	case points.Schema.CustomID == 0:
+		t.Errorf("Story Points carries no customId: %+v", points.Schema)
+	case len(points.ClauseNames) == 0:
+		t.Error("Story Points carries no clause names, and JQL is written with those")
+	}
+}
+
+func TestFields_ReportsARefusalRateLimitAndTransportFailureAsThemselves(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		opt    jiratest.ServerOption
+		assert func(*testing.T, error)
+	}{
+		{
+			name: "the token may not ask",
+			opt:  jiratest.WithStatus(http.MethodGet, fieldPath, http.StatusForbidden, ""),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var refused *jira.CapabilityError
+				if !errors.As(err, &refused) {
+					t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+				}
+			},
+		},
+		{
+			name: "the site is rate limiting",
+			opt:  jiratest.WithRateLimit(http.MethodGet, fieldPath, 30*time.Second),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var limited *jira.RateLimitError
+				if !errors.As(err, &limited) {
+					t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+				}
+			},
+		},
+		{
+			name: "the site broke",
+			opt:  jiratest.WithStatus(http.MethodGet, fieldPath, http.StatusInternalServerError, ""),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var broken *jira.TransportError
+				if !errors.As(err, &broken) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+			},
+		},
+		{
+			name: "the answer is not the array this expects",
+			opt: jiratest.WithHandler(http.MethodGet, fieldPath, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"values":[]}`))
+			}),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var broken *jira.TransportError
+				if !errors.As(err, &broken) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(tt.opt)
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			got, err := c.Fields(t.Context())
+			if err == nil {
+				t.Fatalf("the failure came back as %d fields", len(got))
+			}
+			tt.assert(t, err)
+		})
+	}
+}
+
+func TestFields_HonoursACancelledContext(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.Fields(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the cancellation the caller asked for", err)
+	}
+}
+
+func fieldNames(fields []jira.Field) []string {
+	out := make([]string, 0, len(fields))
+	for i := range fields {
+		out = append(out, fields[i].Name)
+	}
+	return out
+}

--- a/pkg/jira/cloud/me.go
+++ b/pkg/jira/cloud/me.go
@@ -1,0 +1,42 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// Me returns the account the token authenticates as.
+//
+// It is the cheapest proof that a site, an email and a token belong together,
+// which is why onboarding asks it first, and the account it names is the one a
+// create screen offers as the default assignee.
+//
+// The capability probe reads the same endpoint and keeps its own decode. It owes
+// the user a sentence about a zone it could not load; here the same zone is a
+// rendering detail on an otherwise complete account and is dropped silently. One
+// decode cannot do both without being told which was wanted.
+func (c *Client) Me(ctx context.Context) (jira.User, error) {
+	r := request{
+		method: http.MethodGet,
+		path:   capsMyselfPath,
+		kind:   "account",
+		id:     "the authenticated account",
+	}
+	var body apiUser
+	if err := c.doJSON(ctx, r, &body); err != nil {
+		return jira.User{}, err
+	}
+	// Onboarding reads a successful answer here as proof the credentials go
+	// together, so a 200 that names nobody must not read as one.
+	if body.AccountID == "" {
+		return jira.User{}, &jira.TransportError{
+			Op:     r.op(),
+			Status: http.StatusOK,
+			Err:    errors.New("the answer names no account"),
+		}
+	}
+	return body.domain(), nil
+}

--- a/pkg/jira/cloud/me_test.go
+++ b/pkg/jira/cloud/me_test.go
@@ -1,0 +1,264 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+const mePath = "/rest/api/3/myself"
+
+func TestMe_ReadsTheWholeAccountAndNotJustTheZone(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Me(t.Context())
+	if err != nil {
+		t.Fatalf("reading the account: %v", err)
+	}
+
+	if got.AccountID == "" {
+		t.Error("the account has no ID, which is the one field that says a token belongs to somebody")
+	}
+	if got.DisplayName == "" || got.Email == "" {
+		t.Errorf("the account reads as %+v, want the name and email the site states", got)
+	}
+	if !got.Active {
+		t.Error("the account reads as inactive, and the site says it is active")
+	}
+	if got.AvatarURL == "" {
+		t.Error("no avatar was picked, and the site offers four sizes")
+	}
+	if got.TimeZone == nil {
+		t.Fatal("the account has no timezone, which is the zone Jira renders its own dates in")
+	}
+	if got.TimeZone.String() == time.UTC.String() {
+		t.Errorf("the timezone is %s, want the one the site states rather than a fallback", got.TimeZone)
+	}
+}
+
+func TestMe_AndTheCapabilityProbeAgreeAboutTheZone(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	account, err := c.Me(t.Context())
+	if err != nil {
+		t.Fatalf("reading the account: %v", err)
+	}
+	caps, err := c.Capabilities(t.Context(), "")
+	if err != nil {
+		t.Fatalf("probing: %v", err)
+	}
+
+	if caps.TimeZone == nil {
+		t.Fatalf("the probe found no timezone and said %q", caps.TimeZoneReason)
+	}
+	if account.TimeZone.String() != caps.TimeZone.String() {
+		t.Errorf("Me says %s and the probe says %s; they read one endpoint and must not disagree",
+			account.TimeZone, caps.TimeZone)
+	}
+}
+
+// The two read the same endpoint and decode it differently on purpose: the probe
+// owes the user a sentence about a zone it could not use, and an account is
+// still an account without one.
+func TestMe_SurvivesAZoneThisMachineHasNoDatabaseFor(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"accountId":"5b10a2844c20165700ede21g","displayName":"Example User",
+		"emailAddress":"user@example.com","active":true,"timeZone":"Mars/Olympus_Mons"}`
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, mePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Me(t.Context())
+	if err != nil {
+		t.Fatalf("an unknown zone failed the whole read: %v", err)
+	}
+	if got.AccountID == "" || got.DisplayName == "" {
+		t.Errorf("the account reads as %+v, want everything but the zone", got)
+	}
+	if got.TimeZone != nil {
+		t.Errorf("the timezone is %s, want none: this machine has no entry for it", got.TimeZone)
+	}
+
+	caps, err := c.Capabilities(t.Context(), "")
+	if err != nil {
+		t.Fatalf("probing: %v", err)
+	}
+	if caps.TimeZone != nil || !strings.Contains(caps.TimeZoneReason, "Mars/Olympus_Mons") {
+		t.Errorf("the probe said %q, want a reason naming the zone it could not load", caps.TimeZoneReason)
+	}
+}
+
+func TestMe_RefusesAnAnswerThatNamesNobody(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"an empty object":          `{}`,
+		"a body with no accountId": `{"displayName":"Example User","active":true}`,
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, mePath, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL())
+			got, err := c.Me(t.Context())
+			if err == nil {
+				t.Fatalf("a 200 naming nobody read as the account %+v, and onboarding takes that for proof", got)
+			}
+			var broken *jira.TransportError
+			if !errors.As(err, &broken) {
+				t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+			}
+		})
+	}
+}
+
+func TestMe_ReportsARefusalRateLimitAndTransportFailureAsThemselves(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		opt    jiratest.ServerOption
+		assert func(*testing.T, error)
+	}{
+		{
+			name: "the token may not ask",
+			opt:  jiratest.WithStatus(http.MethodGet, mePath, http.StatusForbidden, ""),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var refused *jira.CapabilityError
+				if !errors.As(err, &refused) {
+					t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+				}
+			},
+		},
+		{
+			name: "the credentials were rejected",
+			opt:  jiratest.WithStatus(http.MethodGet, mePath, http.StatusUnauthorized, ""),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var rejected *jira.AuthError
+				if !errors.As(err, &rejected) {
+					t.Fatalf("got %T (%v), want a *jira.AuthError", err, err)
+				}
+			},
+		},
+		{
+			name: "the site is rate limiting",
+			opt:  jiratest.WithRateLimit(http.MethodGet, mePath, 30*time.Second),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var limited *jira.RateLimitError
+				if !errors.As(err, &limited) {
+					t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+				}
+				if limited.RetryAfter != 30*time.Second {
+					t.Errorf("RetryAfter = %s, want the 30s the site asked for", limited.RetryAfter)
+				}
+			},
+		},
+		{
+			name: "the site broke",
+			opt:  jiratest.WithStatus(http.MethodGet, mePath, http.StatusInternalServerError, ""),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var broken *jira.TransportError
+				if !errors.As(err, &broken) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+			},
+		},
+		{
+			name: "the answer is not JSON",
+			opt: jiratest.WithHandler(http.MethodGet, mePath, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("<html>a proxy answered instead</html>"))
+			}),
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var broken *jira.TransportError
+				if !errors.As(err, &broken) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(tt.opt)
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			got, err := c.Me(t.Context())
+			if err == nil {
+				t.Fatalf("the failure came back as the account %+v", got)
+			}
+			tt.assert(t, err)
+		})
+	}
+}
+
+func TestMe_HonoursACancelledContext(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	arrived := make(chan struct{})
+	var once sync.Once
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, mePath, func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(arrived) })
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	c, _ := testClient(t, s.URL())
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.Me(ctx)
+		errs <- err
+	}()
+
+	<-arrived
+	cancel()
+
+	err := <-errs
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the cancellation the caller asked for", err)
+	}
+}

--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -49,13 +50,22 @@ func (f *Fake) Capabilities(ctx context.Context, projectKey string) (jira.Capabi
 	return caps, nil
 }
 
-// Me returns the authenticated account.
+// Me returns the authenticated account, and refuses an account with no ID the
+// way a real site's answer is refused: a caller that reads a success here as
+// proof a credential works must not be able to get that proof from nobody.
+// WithMe is how a test asks for the refusal.
 func (f *Fake) Me(ctx context.Context) (jira.User, error) {
 	if err := f.fakeBegin(ctx, "Me"); err != nil {
 		return jira.User{}, err
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.me.AccountID == "" {
+		return jira.User{}, &jira.TransportError{
+			Op:  "read the authenticated account",
+			Err: errors.New("the answer names no account"),
+		}
+	}
 	return f.me, nil
 }
 

--- a/pkg/jira/jiratest/gen.go
+++ b/pkg/jira/jiratest/gen.go
@@ -59,6 +59,7 @@ var fakeDefaultMe = jira.User{
 	Email:       "sam@example.invalid",
 	TimeZone:    time.UTC,
 	Active:      true,
+	AvatarURL:   fakeBaseURL + "/avatar/me",
 }
 
 var fakeDefaultFields = []jira.Field{

--- a/pkg/jira/jiratest/jiratest.go
+++ b/pkg/jira/jiratest/jiratest.go
@@ -261,7 +261,8 @@ func WithFields(fields []jira.Field) Option {
 	return func(f *Fake) { f.fields = fakeCloneFields(fields) }
 }
 
-// WithMe sets the authenticated account.
+// WithMe sets the authenticated account. A user with no AccountID is the site
+// that answers 200 and names nobody, which Me refuses rather than returns.
 func WithMe(u jira.User) Option {
 	return func(f *Fake) { f.me = u }
 }

--- a/pkg/jira/jiratest/jiratest.go
+++ b/pkg/jira/jiratest/jiratest.go
@@ -31,7 +31,26 @@ import (
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
-var _ jira.Client = (*Fake)(nil)
+// What the fake can be asked for.
+//
+// Both the port and the roles are named on purpose. A role restates a signature
+// Client already carries, and one type cannot hold two methods of a name, so a
+// role that drifts from the port makes these lines stop compiling. Nothing else
+// catches that drift.
+var (
+	_ jira.Client = (*Fake)(nil)
+
+	_ jira.Prober         = (*Fake)(nil)
+	_ jira.Identifier     = (*Fake)(nil)
+	_ jira.Searcher       = (*Fake)(nil)
+	_ jira.FieldCatalogue = (*Fake)(nil)
+	_ jira.SchemaReader   = (*Fake)(nil)
+	_ jira.IssueWriter    = (*Fake)(nil)
+	_ jira.Mover          = (*Fake)(nil)
+	_ jira.CommentReader  = (*Fake)(nil)
+	_ jira.Commenter      = (*Fake)(nil)
+	_ jira.SessionClient  = (*Fake)(nil)
+)
 
 // BoardKind is what WithProject builds alongside a project.
 type BoardKind int

--- a/pkg/jira/port.go
+++ b/pkg/jira/port.go
@@ -13,6 +13,11 @@
 // Everything in this package is safe for concurrent use by definition: every
 // method takes a context and must honour its cancellation, because views cancel
 // their in-flight work when they close.
+//
+// Client is what an adapter grows into, not what a caller asks for. Callers take
+// one of the role interfaces in roles.go — Prober, Searcher, Commenter and the
+// rest — each named for a job, so that a holder's signature says which part of
+// Jira it needs and an adapter is usable for that job before it is complete.
 package jira
 
 import (

--- a/pkg/jira/roles.go
+++ b/pkg/jira/roles.go
@@ -1,0 +1,102 @@
+package jira
+
+import (
+	"context"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// The roles below are what a holder asks of an adapter; Client is what an
+// adapter grows into. A caller takes the role its own job is named after.
+//
+// Each role restates a signature Client already carries. Keep them identical: no
+// type can hold two methods of one name, so a role that drifts from the port
+// makes the assertions in pkg/jira/jiratest stop compiling, and nothing else
+// catches it.
+
+// Prober reports what a site, a token and a project can do. The kernel holds one
+// to run the capability probe behind the first frame, and onboarding holds one
+// to show a token's real permissions before anything is written to disk.
+type Prober interface {
+	Capabilities(ctx context.Context, projectKey string) (Capabilities, error)
+}
+
+// Identifier reports who a token belongs to. It is the first thing asked of a
+// credential that has just been typed in — an answer is proof the three fields
+// go together — and the account it names is the one a create screen defaults to.
+type Identifier interface {
+	Me(ctx context.Context) (User, error)
+}
+
+// Searcher runs JQL. Query.Fields must be an explicit narrow list.
+type Searcher interface {
+	Search(ctx context.Context, q Query) (Page[Issue], error)
+}
+
+// FieldCatalogue reads the site's field definitions. It is how a field written
+// down by name becomes the ID to ask this site for, and it is the only way:
+// custom field IDs differ per site, so a name is resolved at runtime or the
+// field is not asked for at all.
+type FieldCatalogue interface {
+	Fields(ctx context.Context) ([]Field, error)
+}
+
+// SchemaReader reports what a project and issue type require. A create or edit
+// screen is built from the answer rather than from a fixed list of fields,
+// because which fields exist, which are required and which are on the screen at
+// all are site configuration.
+type SchemaReader interface {
+	CreateMeta(ctx context.Context, projectKey, issueTypeID string) (Schema, error)
+}
+
+// IssueWriter creates issues and applies sparse patches to them. It cannot move
+// one through the workflow: that is Mover, because a transition is a separate
+// permission, has its own screen, and can be refused on an issue the same token
+// may otherwise edit.
+type IssueWriter interface {
+	CreateIssue(ctx context.Context, in IssueInput) (Issue, error)
+	UpdateIssue(ctx context.Context, key string, in IssuePatch) error
+}
+
+// Mover lists the workflow moves available on one issue right now and applies
+// one of them. The list is per issue and per token and expires: it is asked for
+// when the mover opens, never cached across issues.
+type Mover interface {
+	Transitions(ctx context.Context, key string) ([]Transition, error)
+	Transition(ctx context.Context, key, transitionID string, in IssuePatch) error
+}
+
+// CommentReader reads an issue's thread. It is separate from Commenter because
+// the detail pane shows a thread it has no business writing to, and asking only
+// for the read makes that visible in the signature.
+type CommentReader interface {
+	Comments(ctx context.Context, key string) (Page[Comment], error)
+}
+
+// Commenter reads and writes an issue's thread.
+type Commenter interface {
+	CommentReader
+	AddComment(ctx context.Context, key string, body adf.Doc) (Comment, error)
+	EditComment(ctx context.Context, key, id string, body adf.Doc) (Comment, error)
+	DeleteComment(ctx context.Context, key, id string) error
+}
+
+// SessionClient is every role a view in this build actually calls, and nothing
+// else. It is what a session is built with.
+//
+// It exists so an adapter can be wired in once it serves the views that exist,
+// rather than once it serves the whole port — which is the difference between a
+// binary that talks to Jira and one that cannot. A batch that lands the adapter
+// method its own view needs widens this in the same PR. Widening is additive:
+// nothing that compiled stops compiling, and the diff says which capability the
+// batch added.
+type SessionClient interface {
+	Prober
+	Identifier
+	Searcher
+	FieldCatalogue
+	SchemaReader
+	IssueWriter
+	Mover
+	Commenter
+}


### PR DESCRIPTION
**PC.6** — closes [#55](https://github.com/varijkapil13/saral/issues/55) and [#52](https://github.com/varijkapil13/saral/issues/52). One packet, as the decision on #55 says: a type change with no consumer and a composition root that does not compile are not two PRs.

**The shipped binary could not reach a Jira site.** Nothing ever built a Cloud client, and nothing could have. Everything Batches 1 and 2 shipped works — against `jiratest.Fake`, which was the only type in the tree that satisfied the port.

## Before and after

The proof, before this branch:

```
$ cat > pkg/jira/cloud/zz_scratch_assert.go <<'GO'
package cloud
import "github.com/varijkapil13/saral/pkg/jira"
var _ jira.Client = (*Client)(nil)
GO
$ go vet ./pkg/jira/cloud/
vet: cannot use (*Client)(nil) (value of type *Client) as jira.Client value in
variable declaration: *Client does not implement jira.Client (missing method Attachments)
```

**Implemented before (12 of 34):** `AddComment` · `Capabilities` · `Comments` · `CreateIssue` · `CreateMeta` · `DeleteComment` · `EditComment` · `Issue` · `Search` · `Transition` · `Transitions` · `UpdateIssue`. Plus `ApproximateCount`, deliberately off the port.

**Missing before (22):** `Attachments` · `BoardConfig` · `Boards` · `BulkMove` · `CompleteSprint` · `CreateSprint` · `DeleteAttachment` · `Download` · **`Fields`** · **`Me`** · `MoveToBacklog` · `MoveToSprint` · `Plans` · `ReleaseVersion` · `SaveVersion` · `Sprints` · `StartSprint` · `Task` · `UnresolvedCount` · `UpdateSprint` · `Upload` · `Versions`.

**Implemented after (14 of 34):** the twelve, plus `Me` and `Fields`. The other twenty stay missing and stay owned by the packets that will need them — P4.1, P5.1, P6.1, P6.2, P7.1, P8.3. `*cloud.Client` is still not a `jira.Client` and is not meant to be yet. It **is** a `jira.SessionClient`, which is what the program needs.

(#55's census said 2 of 34. Batch 2 landed `issue.go`, `comment.go` and `meta.go` in the meantime.)

## The roles, and why each one exists

`jira.Client` is **untouched** — same methods, same signatures, same doc comment. Only `port.go`'s *package* doc gained a paragraph pointing at the new file. What changed is what consumers ask for. This generalises a decision already made in this repo: `internal/app.Counter` exists because "a client that cannot make it should not have to pretend" (`internal/app/search.go:20-29`).

`pkg/jira/roles.go`:

| role | why it exists |
|---|---|
| `Prober` | The kernel probes behind the first frame; onboarding shows a token's real permissions before anything is written to disk. Neither needs anything else. |
| `Identifier` | The first question asked of a credential just typed in — an answer *is* the proof the three fields go together — and the account a create screen defaults to. |
| `Searcher` | Runs JQL. Half of what a search use case needs. |
| `FieldCatalogue` | The other half: a field written down by name becomes this site's ID for it. There is no other way — custom field IDs differ per site. |
| `SchemaReader` | A create or edit screen is built from what the site says the project requires, not from a fixed list. |
| `IssueWriter` | Creates and patches. Deliberately **not** transitions: a transition is a separate permission, has its own screen, and can be refused on an issue the same token may otherwise edit. |
| `Mover` | Lists the moves available on one issue right now, and applies one. |
| `CommentReader` | The detail pane shows a thread it has no business writing to. Asking only for the read puts that in the signature. |
| `Commenter` | Embeds `CommentReader` and adds the three writes. |
| `SessionClient` | The union of the roles the views in **this build** call. What `kernel.Deps.Jira` and `onboarding.Connector` take. |

A role restates a signature `Client` already carries, which is drift a reader cannot see. The compiler can: one type cannot hold two methods of a name, so a role that drifts from the port makes the `pkg/jira/jiratest` assertions stop compiling. That is the only guard the duplication has, and it is stated in both files.

## The union, derived from the consumers

Not guessed — grepped, then followed into the function each one is passed to.

| method | consumer, by file:line |
|---|---|
| `Capabilities` | `internal/ui/kernel/kernel.go:832` · `internal/ui/onboarding/commands.go:274` |
| `Me` | `internal/ui/onboarding/commands.go:155` · `internal/ui/form/cmds.go:115` |
| `Search` | `internal/app/search.go:243` |
| `Fields` | `internal/app/search.go:161` |
| `CreateMeta` | `internal/ui/form/cmds.go:102` · `internal/ui/issue/edit_cmds.go:74` |
| `CreateIssue` | `internal/ui/form/cmds.go:126` |
| `UpdateIssue` | `internal/ui/issue/edit_cmds.go:84` |
| `Transitions` · `Transition` | `internal/ui/issue/edit_cmds.go:96,106` |
| `Comments` | `internal/ui/comment/cmds.go:48` · `internal/ui/issue/cmds.go:56` |
| `AddComment` · `EditComment` · `DeleteComment` | `internal/ui/comment/cmds.go:68,78,88` |

Thirteen methods. `Issue` is **not** one of them: the detail pane reads one issue through search, because only search takes a field set (`internal/ui/issue/cmds.go:34-38`).

Two of the thirteen were missing, not one.

- **`Me`** is the one #55 named. New `pkg/jira/cloud/me.go`. `caps.go` is untouched: `capsTimeZone` keeps its own decode, and that is deliberate — the probe owes the user a sentence about a zone it could not load, while here the same zone is a rendering detail on an otherwise complete account and is dropped silently. One decode cannot do both without being told which was wanted. They do share the wire struct (`apiUser`) and the endpoint constant. A test asserts the two agree about the zone when it loads, and disagree correctly when it does not.
- **`Fields`** was not in anyone's blast radius. `app.Search` has called it since **P1.2** to resolve a configured field name to an ID — the mechanism the "never write a `customfield_NNNNN`" rule stands on — and no packet in `docs/ROADMAP.md` ever owned the adapter half. Nothing calls it at runtime today only because no shipped projection names a field; `app.NewSearch` is on the static path from `Deps.Jira` either way. Took the first of the three options the packet allows and implemented it: a flat unpaged `GET /rest/api/3/field`, with `field.json` and a `jiratest` route already in place and `apiFieldSchema.domain()` already written. The alternative — making the catalogue optional in `app` the way `Counter` is — would have a saved query naming a real field report it as missing from a site that has it, which is exactly the invented sentence this batch exists to delete.

## The assertion whose absence let this ship

`pkg/jira/cloud/assert.go` and the block in `pkg/jira/jiratest/jiratest.go`: one line per role, in **built** source, not a `_test.go`. An assertion a test file carries fails `go test` and not `go build`.

And a mechanical guard, in `internal/arch/adapters_test.go`: every package under `pkg/jira/**` must carry at least one `var _ jira.X = ...`, and every `X` it names must be an interface the port declares. The test checks only that the line exists — whether it is *true* is the compiler's job, which is the honest division of labour here. Verified by deleting `assert.go` and watching it fail:

```
--- FAIL: TestAdapters_StateWhichPortRolesTheySatisfy/pkg/jira/cloud
    pkg/jira/cloud adapts pkg/jira and never says what it satisfies.
    add one line per role in a non-test file of the package, e.g.
    	var _ jira.Prober = (*Client)(nil)
```

The extractor has its own table test (aliased imports, grouped `var` blocks, a named variable that is not a claim, a selector on a package that merely shares the name).

## How the resolver's sentence reaches the user

The previous attempt found a real obstacle, and it turned out to have an answer that needs no kernel change. `kernel.Model.Update` is a pure function on a value and `StatusMsg` only sets two fields (`kernel.go:296-298`), so `withNotice` applies the message to the model **before** `tea.NewProgram` — no fourth `kernel.Option`, no new `Deps` field, no `go p.Send` racing the event loop. The resize command it returns is dropped: no size is known yet and the startup `WindowSizeMsg` does the same work. It is testable without running a program — build the model, apply the notice, read `Frame()` back.

`build()` gains a notice result, a signature change to an unexported function in `package main`.

## The wiring

1. `onboarding.SetConnector(connect)` **unconditionally**, before the first-run decision. `connect` returns `nil, err` explicitly, because `cloud.New` returns a `*cloud.Client` and returning that straight into an interface result would hand back a non-nil `jira.SessionClient` wrapping a nil pointer — every `== nil` check downstream would pass. There is a test for exactly that.
2. When the profile names a site, resolve and set `deps.Jira`. Failure is **not** fatal: `deps.Jira` stays nil, the program opens, the sentence is on the status line.
3. **20s bound.** `internal/config` gives a `command` source 15s plus a 2s `WaitDelay`, so 20s sits above its own limit and lets its better-worded error win. Onboarding's 30s is the wrong number to copy: that one is watched by a spinner the user can cancel; this one holds the first frame and nobody can.
4. **No synchronous probe.** Checked rather than assumed: PC.3 landed, `Model.Init` batches `m.probeAt(m.capsSeq)` (`kernel.go:244-249`), and `probeAt` returns nil while `deps.Jira == nil` (`:824-828`). So a wired client probes itself, after the first frame, and `deps.Caps` is asserted to be the zero value at build time.

## Blast radius

Changing `Deps.Jira`'s type touches everything that holds it. It came to **type names only** — no view logic moved:

- `internal/ui/{comment,issue,form}/*cmds.go`: twelve parameter types, `jira.Client` → the role each function actually uses.
- `internal/app/search.go`: two lines. `SearchClient` is `Searcher` + `FieldCatalogue`, declared next to `Counter` because it is the same idea.
- `internal/ui/onboarding`: the `Connector` type and two struct fields, plus the connector literals in its tests.
- **`internal/ui/list` needed no edit at all** — it hands `d.Jira` straight to `app.NewSearch`. That is the design working.
- Every view harness still takes `jira.Client` and still compiles: a wider interface assigns to a narrower one, and the fake satisfies both.

Every new symbol has a consumer, not just a definition and its own test — grepping the ten role names hits a real call site for each.

## Owned paths, declared wider than the brief

A composition root is cross-cutting. Declared on both issues and written into the roadmap row: `pkg/jira/roles.go` (new) · `pkg/jira/port.go` (package doc only) · `pkg/jira/cloud/{me,field,assert}.go` + tests · `pkg/jira/jiratest/jiratest.go` (assertions) · `internal/ui/kernel/view.go` · `internal/ui/onboarding/{onboarding,commands}.go` + tests · `internal/app/search.go` · `internal/ui/{issue,form,comment}/*cmds.go` · `cmd/saral/main.go` + test · `internal/arch/**` · `docs/{ARCHITECTURE,ROADMAP,TESTING}.md`.

`docs/ROADMAP.md` gains the PC.6 row, ticked, and the Batch 1.5 preamble no longer says five packets or claims a set that no longer matches.

## What still cannot be done against a real site

Named rather than hidden:

- **The other twenty port methods.** Attachments, versions, boards, sprints, bulk move and plans are still Batch 4 to 8. A view needing one widens `SessionClient` in its own PR.
- **Onboarding still quits rather than continuing into the session.** A run that started with no client cannot use the profile it has just written, because nothing hands a running kernel a new one — `onboarding.finish()` already says so at `onboarding.go:544-549` and calls `tea.Quit`. Giving the kernel a seam for that is `internal/ui/kernel/**` and not this packet.
- **Token resolution is synchronous, before the first frame.** An `env` source is free and a keychain read is milliseconds, but a `command` source shelling out to a password manager is charged to the `< 60 ms` cold-start budget in `docs/PERFORMANCE.md`. The alternative is resolving in the background and installing the client later, which needs the same kernel seam as the point above.
- **No live-site verification.** Every test here runs against `jiratest`; nothing in this branch has been pointed at a real Jira Cloud instance.

## Checks

`go mod tidy` clean (no `go.mod` change) · `go vet ./...` · `golangci-lint run` → 0 issues · `go test -race -count=1 ./...` all green · `make build` · `scripts/checkleak.py` clean. No fixture was added or edited.
