### PR TITLE
feat(store): open the cache file, and say when another copy holds it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,10 +37,10 @@ Three constraints drive every decision below:
 Dependencies point **downward only**. `pkg/*` must never import `internal/*`; `internal/ui` must
 never import `pkg/jira/cloud` directly — it takes the port interface; only `cmd/*` and
 `internal/config` construct a concrete adapter; `internal/app` must never import `internal/ui`,
-because a use case is driven by a view and never reaches back up into one; and `pkg/adf` must never
-import `pkg/jira`, because the document library does not know about issues. All five are enforced in
-CI by an import-boundary test (see `docs/TESTING.md`). The sixth the diagram implies —
-`internal/store` must not import `internal/ui` — lands with the package, in P3.2.
+because a use case is driven by a view and never reaches back up into one; `pkg/adf` must never
+import `pkg/jira`, because the document library does not know about issues; and `internal/store` must
+never import `internal/ui`, because the cache is written to and read by the layers above it and never
+renders anything. All six are enforced in CI by an import-boundary test (see `docs/TESTING.md`).
 
 The "no IO libs" on `internal/app` is the one line above that no test can hold you to: the
 import-boundary test only sees imports within this module, so a `net/http` in a use case is invisible

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -230,6 +230,10 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
   consumer of PC.1's field-presence answer. **Adds the `internal/store` must-not-import-`internal/ui`
   rule to `internal/arch` in the same PR** — PC.4 adds its sibling and cannot add this one, because
   the package does not exist yet.
+  The dependency landed first and on its own, alongside the smallest `internal/store` that keeps it —
+  opening the file, closing it, naming buckets — and the import rule. CI runs `go mod tidy` before
+  anything else and that strips a `require` line nothing imports, so the package is what makes the
+  dependency real. The cache is what is left.
 - [ ] **P3.3 — Mouse** · [#14](https://github.com/varijkapil13/saral/issues/14) · **owns** `internal/ui/widget/zone*.go` + zone wiring in own files
   Click, double-click, wheel-under-pointer, drag-to-resize, clickable chips and footer.
 - [ ] **P3.4 — Local fuzzy index** · [#15](https://github.com/varijkapil13/saral/issues/15) · **owns** `internal/app/index.go`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,7 +97,7 @@ Bubble Tea's `teatest` drives full programs where an interaction sequence matter
 
 ## Import boundaries
 
-A test in `internal/arch` asserts the layering from `docs/ARCHITECTURE.md`. Five rules, one table
+A test in `internal/arch` asserts the layering from `docs/ARCHITECTURE.md`. Six rules, one table
 entry each:
 
 - `pkg/**` must not import `internal/**`
@@ -105,9 +105,7 @@ entry each:
 - only `cmd/**` and `internal/config` may construct a concrete adapter
 - `internal/app` must not import `internal/ui`
 - `pkg/adf` must not import `pkg/jira`
-
-The sixth rule the layer diagram implies — `internal/store` must not import `internal/ui` — waits for
-P3.2 to create the package; its case is already in the table, expecting nothing.
+- `internal/store` must not import `internal/ui`
 
 A second test reads the table itself, because a rule can be wrong in a way that only ever shows up as
 green: a duplicated name, a missing `why`, an exemption that no package the rule covers could match,

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/lrstanley/bubblezone/v2 v2.0.0
 	github.com/zalando/go-keyring v0.2.8
+	go.etcd.io/bbolt v1.5.0
 	golang.org/x/sync v0.22.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
+go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
+go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -55,6 +55,12 @@ var importRules = []importRule{
 		forbid: "pkg/jira",
 		why:    "pkg/adf is an independent document library; the dependency runs the other way",
 	},
+	{
+		name:   "store-must-not-import-the-ui",
+		from:   "internal/store",
+		forbid: "internal/ui",
+		why:    "the cache is written to and read by the layers above it and never renders anything",
+	},
 }
 
 func underPath(p, prefix string) bool {
@@ -293,6 +299,12 @@ func TestBrokenRules_MatchTheOffendingPackagesAndNothingElse(t *testing.T) {
 			name:    "the store importing the ui",
 			pkgDir:  "internal/store",
 			imports: "internal/ui/kernel",
+			want:    []string{"store-must-not-import-the-ui"},
+		},
+		{
+			name:    "the store taking the port",
+			pkgDir:  "internal/store",
+			imports: "pkg/jira",
 			want:    nil,
 		},
 		{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,88 @@
+// Package store holds Saral's cache file. This package owns the file itself —
+// opening it, closing it, and naming the buckets inside it so that two profiles
+// cannot read each other's rows. What goes in the buckets, and for how long, is
+// the cache's business and not this file's.
+package store
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
+)
+
+const (
+	dirPerm  fs.FileMode = 0o700
+	filePerm fs.FileMode = 0o600
+
+	defaultLockTimeout = 2 * time.Second
+)
+
+// ErrLocked reports that another process has the cache open. bbolt holds an
+// exclusive lock on the file for as long as it is open, so a second copy of
+// Saral gets this rather than a second cache.
+var ErrLocked = errors.New("the cache is open in another process")
+
+// DB is an open cache file.
+type DB struct {
+	bolt *bbolt.DB
+}
+
+// Option adjusts how Open opens the file.
+type Option func(*bbolt.Options)
+
+// WithLockTimeout sets how long Open waits for another process to let go of the
+// file before giving up with ErrLocked. Zero waits for as long as it takes.
+func WithLockTimeout(d time.Duration) Option {
+	return func(o *bbolt.Options) { o.Timeout = d }
+}
+
+// Open opens the cache at path, creating the file and the directory holding it
+// if they are not there yet. It reports ErrLocked when another process holds the
+// file. The caller closes what it opens.
+func Open(path string, opts ...Option) (*DB, error) {
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return nil, fmt.Errorf("making the directory for %s: %w", path, err)
+	}
+
+	options := bbolt.Options{Timeout: defaultLockTimeout}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	bolt, err := bbolt.Open(path, filePerm, &options)
+	if err != nil {
+		if errors.Is(err, bolterrors.ErrTimeout) {
+			return nil, fmt.Errorf("opening %s: %w", path, ErrLocked)
+		}
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	return &DB{bolt: bolt}, nil
+}
+
+// Close releases the file and the lock on it.
+func (db *DB) Close() error {
+	if err := db.bolt.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", db.bolt.Path(), err)
+	}
+	return nil
+}
+
+// Scope is whose cache a bucket holds: one account on one site. Two accounts on
+// one site, and one account on two sites, are different scopes.
+type Scope struct {
+	Site    string
+	Account string
+}
+
+// Bucket names the bucket holding one kind of cached data for this scope. The
+// three parts are joined with a NUL, which no hostname, account ID or kind of
+// ours contains, so no two scopes can name the same bucket.
+func (s Scope) Bucket(kind string) []byte {
+	return []byte(s.Site + "\x00" + s.Account + "\x00" + kind)
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,193 @@
+package store
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpen_CreatesTheFileAndTheDirectoryHoldingIt(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "saral", "cache.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("the database is not on disk: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("the database is empty, so bbolt never wrote its meta pages")
+	}
+	if perm := info.Mode().Perm(); perm != filePerm {
+		t.Errorf("the cache is mode %v, want %v: it holds issues from a private site", perm, filePerm)
+	}
+}
+
+func TestOpen_ReopensADatabaseItAlreadyWrote(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cache.db")
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after the first close: %v", err)
+	}
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopening: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after the second close: %v", err)
+	}
+	if after.Size() != before.Size() {
+		t.Errorf("reopening changed the file from %d to %d bytes, so it was not reused",
+			before.Size(), after.Size())
+	}
+}
+
+func TestOpen_FailsWhenThePathCannotBeCreated(t *testing.T) {
+	t.Parallel()
+
+	blocker := filepath.Join(t.TempDir(), "saral")
+	if err := os.WriteFile(blocker, []byte("not a directory"), filePerm); err != nil {
+		t.Fatalf("writing the blocking file: %v", err)
+	}
+
+	db, err := Open(filepath.Join(blocker, "cache.db"))
+	if err == nil {
+		t.Fatalf("Open succeeded below a regular file; closing: %v", db.Close())
+	}
+	if errors.Is(err, ErrLocked) {
+		t.Errorf("a path that cannot be created was reported as another process holding it: %v", err)
+	}
+}
+
+func TestOpen_FailsWhenTheFileIsNotADatabase(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cache.db")
+	if err := os.WriteFile(path, []byte("this was never a bbolt file"), filePerm); err != nil {
+		t.Fatalf("writing the impostor: %v", err)
+	}
+
+	db, err := Open(path, WithLockTimeout(time.Second))
+	if err == nil {
+		t.Fatalf("Open accepted a file that is not a database; closing: %v", db.Close())
+	}
+}
+
+func TestOpen_ReportsThatAnotherCopyOfSaralHasTheFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cache.db")
+	held, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := held.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+
+	second, err := Open(path, WithLockTimeout(100*time.Millisecond))
+	if err == nil {
+		t.Fatalf("a second opener took the locked file; closing: %v", second.Close())
+	}
+	if !errors.Is(err, ErrLocked) {
+		t.Fatalf("a second opener got %v, want it to report ErrLocked", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("the error %q does not name the file the other copy is holding", err)
+	}
+}
+
+func TestOpen_TakesTheFileOnceTheFirstOpenerHasClosed(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cache.db")
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+
+	second, err := Open(path, WithLockTimeout(100*time.Millisecond))
+	if err != nil {
+		t.Fatalf("the lock outlived the close: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestScopeBucket_KeepsProfilesAndKindsApart(t *testing.T) {
+	t.Parallel()
+
+	const (
+		site    = "example.atlassian.net"
+		account = "5b10a2844c20165700ede21g"
+	)
+	work := Scope{Site: site, Account: account}
+
+	tests := map[string]struct {
+		scope        Scope
+		kind         string
+		sameAsTheRef bool
+	}{
+		"the same site, account and kind": {
+			scope:        Scope{Site: site, Account: account},
+			kind:         "issue",
+			sameAsTheRef: true,
+		},
+		"another kind for one account": {scope: work, kind: "search"},
+		"another account on one site":  {scope: Scope{Site: site, Account: account + "h"}, kind: "issue"},
+		"the same account on another site": {
+			scope: Scope{Site: "other.atlassian.net", Account: account},
+			kind:  "issue",
+		},
+		"a kind that continues where the account ends": {
+			scope: Scope{Site: site, Account: account[:len(account)-1]},
+			kind:  account[len(account)-1:] + "issue",
+		},
+	}
+
+	reference := work.Bucket("issue")
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.scope.Bucket(tc.kind)
+			if slices.Equal(got, reference) != tc.sameAsTheRef {
+				t.Errorf("%+v under %q names %q against %q, want the same name = %t",
+					tc.scope, tc.kind, got, reference, tc.sameAsTheRef)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The foundation half of P3.2 ([#13](https://github.com/varijkapil13/saral/issues/13)): the bbolt
dependency, the smallest `internal/store` that makes it real, and the sixth import rule. The cache
itself — TTLs, stale-while-revalidate, cursor-preserving row patching, the LRU bound, the stale badge
— is the next PR on top of this one, and P3.2's roadmap checkbox stays unticked until it lands.

## Why this is not a dependency-only PR

`AGENTS.md` says `go.mod` changes go in their own PR, merged before the work that needs them. This is
that PR, with one exception worth stating rather than leaving to be discovered in review.

A `require` line that nothing imports does not survive `go mod tidy`, and tidy is the first step of
the test job in `.github/workflows/ci.yml` (`go mod tidy && git diff --exit-code`); `make tidy` does
the same locally. A genuinely dependency-only PR would therefore be red the moment it was opened. So
the smallest honest package that imports bbolt travels with the dependency. The rule is satisfied in
substance: no cache behaviour rides along, and the diff outside `go.mod`/`go.sum` is a file that
opens a database, closes it, and names buckets.

## What is in `internal/store`

- `Open(path string, opts ...Option) (*DB, error)` — creates the directory around the file if it is
  not there, opens the database `0600`, and maps bbolt's lock timeout onto a package sentinel.
- `Close() error`.
- `WithLockTimeout(d)` — the one option, and the reason there is one at all is below.
- `Scope{Site, Account}` with `Bucket(kind string) []byte` — the naming scheme that keeps two
  profiles from reading each other's rows, which `docs/ARCHITECTURE.md` requires of the cache. The
  three parts are joined with a NUL so no two scopes can name one bucket.

No TTLs, no stale-while-revalidate, no row patching, no LRU, no buckets created.

### The lock is a real failure mode, so it has a real error

bbolt holds an exclusive lock on the file for as long as it is open, and `Options.Timeout` defaults
to zero, which waits forever. Left alone, a user who starts a second copy of Saral gets a process
that hangs on startup with nothing on screen and no way to tell why. `Open` waits two seconds and
then reports `ErrLocked`, naming the file, so the caller can say "another copy of Saral has the
cache" instead of appearing to be broken.

## The sixth arch rule

`internal/arch/imports_test.go` had five `importRule` entries and a placeholder case expecting
nothing, left by PC.4 because the package did not exist yet. This adds
`store-must-not-import-the-ui` (`internal/store` must not import `internal/ui`) and flips the
placeholder to expect it, plus a `internal/store` → `pkg/jira` case that must stay clean.

Verified live rather than by reading: dropping a file into `internal/store` that imports
`internal/ui/kernel` fails `TestImports_ObeyTheLayeringInTheArchitectureDoc` with the new rule's name
and reason.

`internal/arch/adapters_test.go`, added by PC.6, does not apply here and I checked rather than
assumed: `adapterPackages` reads the directories directly under `pkg/jira`, so its subtests are
`pkg/jira/cloud` and `pkg/jira/jiratest` and nothing else. `internal/store` is not under the port and
adapts nothing, so it neither trips the test nor owes a `var _ jira.SessionClient` line.

## Docs

Only the claims this PR makes false:

- `docs/TESTING.md` — "Five rules" becomes "Six rules", the sixth joins the bullet list, and the
  paragraph saying it "waits for P3.2 to create the package; its case is already in the table,
  expecting nothing" is gone.
- `docs/ARCHITECTURE.md` — the sixth rule joins the sentence that lists the others, "All five are
  enforced in CI" becomes "All six", and the "lands with the package, in P3.2" clause is gone.
- `docs/ROADMAP.md` — P3.2's row notes that the dependency landed separately and why. The checkbox is
  deliberately still unticked.

## Which bbolt, and why

`go.etcd.io/bbolt v1.5.0` — the current stable release, checked against the proxy rather than
assumed (`go list -m -versions` puts v1.5.0 after v1.5.0-rc.0 as the newest non-prerelease, and
`@latest` resolves to it). Its own `go.mod` asks for go 1.25.0, under this module's 1.26.

One thing v1.5.0 changes that is worth knowing before the cache is written on top of it: the
top-level error variables are deprecated in favour of `go.etcd.io/bbolt/errors`. `staticcheck` fails
the build on `bbolt.ErrTimeout`, so this imports `go.etcd.io/bbolt/errors` for the comparison.

## Verification

```
go mod tidy && git diff --exit-code go.mod go.sum   clean on the committed tree
go vet ./...                                        clean
golangci-lint run                                   0 issues
go test -race -count=1 ./...                        all packages ok
go build -trimpath -ldflags "-s -w"                 10,349,314 bytes
python3 scripts/checkleak.py                        clean (no capture in this tree)
```

No test opens a socket: the store's tests all work on a bbolt file in `t.TempDir()`.

### Binary size against the 15 MiB budget

**9.87 MiB (10,349,314 bytes)** — byte-identical to `main`, because nothing under `cmd/saral`
imports `internal/store` yet, so bbolt is in the module graph but not in the link
(`go list -deps ./cmd/saral` does not mention it).

That number would be misleading on its own for a PR whose whole point is a new dependency, so I
measured what it will cost when the cache is wired in: a temporary `cmd/saral` file that actually
calls `store.Open` builds at 10,602,546 bytes, so bbolt adds **about 247 KiB**, landing the binary
near 10.11 MiB. Comfortably inside the budget in `docs/PERFORMANCE.md`, and the number the cache PR
should expect to see appear.

Those are darwin/arm64 figures from my machine. The budget CI actually enforces is on linux/amd64,
where this build reports 11,059,465 bytes (10.55 MiB) — unchanged from `main` for the same reason,
and roughly 10.79 MiB once bbolt is linked.

## Tests

Opening and creating the directory around the file, the file's mode, reopening a database the package
already wrote (and not growing it), a path that cannot be created, a file that is not a database, a
second opener getting `ErrLocked` with the path in the message, the lock being released by `Close`,
and the bucket scheme keeping sites, accounts and kinds apart — including a kind that begins exactly
where an account ends, which is the case a scheme without a separator would get wrong.
