### PR TITLE
feat(chrome): show only the keys that work in the state you are in, and switch theme without restarting

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -234,7 +234,7 @@ Three registries, all with the same conflict-free property:
 |---|---|---|
 | `RegisterView` | each view package's `register.go` | footer, view stack, `saral <view>` |
 | `RegisterCommand` | any package | command palette (`ctrl+k`) |
-| `RegisterKeys` | each view, scoped to itself | help overlay, footer hints |
+| `RegisterKeys` | each view, scoped to itself | help overlay, footer hints — the view's resting state; `kernel.KeyReporter` is how a view answers for the state it is actually in |
 
 Slots are allocated, not picked: the table in `docs/UX.md` says which view holds which digit, and
 `RegisterView` refuses a second claim on one at startup. A bare digit runs a saved query in a root
@@ -282,6 +282,40 @@ A view holding something unsaved implements `kernel.Blocker`. Going back asks th
 quitting and switching root view ask **every** entry on the stack, because both throw all of it away
 and the entry holding the draft is usually not the top one — the palette is pushed over whatever it
 was opened from and holds nothing itself.
+
+A view whose keys move with its state implements `kernel.KeyReporter`:
+
+```go
+type KeyReporter interface {
+	LiveKeys() (set KeySet, gen int)
+}
+```
+
+`RegisterKeys` is init-time and refuses a second call, so what the registry holds is one set for the
+whole run: the view's resting state, and the whole answer for a view whose keys never move. The footer
+and the `?` overlay ask the focused view first and fall back to the registry, so a static view pays
+nothing. The registry entry stays the thing `internal/ui`'s command sweep holds a palette entry's key
+against, which is why it must not be empty.
+
+Two constraints come with it, and both fail silently:
+
+- **`gen` must change whenever the set does.** The chrome is memoized on a comparable key and a
+  `KeySet` holds slices, so the number is the only thing that can ask for a repaint. Returning the
+  index of the state the set belongs to is enough. A constant one gives a footer that is right on the
+  first frame and stale afterwards — and `capturing` is already in that key, so the states this
+  actually catches are the ones where a view keeps the keyboard on both sides of the change: picking
+  then confirming a number key, typing then confirming a save, one editor pane then another.
+- **The set must be stored, not built.** `chromeFor` asks on every frame. Each view builds one set per
+  state in a package-level `var` at start-up and indexes it; the tests assert `LiveKeys` allocates
+  nothing.
+
+The theme is the kernel's, so switching it is too: `theme.go` registers one palette command per mode,
+`ThemeMsg` rebuilds the styles and every view hears it, and the choice is written back by reading the
+whole config file and changing one field — `Config.Save` writes the profile it is handed and nothing
+else, so building a fresh `Profile` from what is on screen drops the saved queries, the timeline field
+names and the glyph set. The kernel is told the site it is talking to and never which profile was
+named on the command line, so a session whose site is not the active profile's says the choice was not
+saved rather than writing it onto the wrong profile.
 
 Because every registration lives in a file that exactly one packet owns, two agents adding two views
 never touch the same line. This is the single most important structural decision for parallel work.
@@ -389,6 +423,10 @@ Bubble Tea v2's renderer already diffs frames; our job is to not hand it work it
 - **Never style in a loop over all data.** Build `lipgloss` styles once at theme load, not per cell.
 - **No allocation per frame in the steady state.** Reuse row buffers; benchmarks assert `allocs/op`.
 - **Width-aware truncation** with grapheme-cluster awareness, cached per string.
+- **Do not quantise colour.** Bubble Tea detects the terminal's colour profile at start-up and its
+  renderer downsamples true colour to 256 or 16 on the way out, so `internal/ui/kernel/theme.go`
+  writes hex values once and nothing steps them. A no-colour theme is a separate build of the styles
+  rather than a downsample, because it is a decision about what the user asked for.
 
 Budgets and how they are measured live in `docs/PERFORMANCE.md`; CI enforces the binary-size one.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -270,9 +270,24 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
   It reads through the cache P3.2 defines, so it follows P3.2 rather than running beside it: two
   packets agreeing out of band on the kinds, the key format and the value codec is how the shape
   comes out wrong.
-- [ ] **P3.5 — Help, hints and theming** · [#16](https://github.com/varijkapil13/saral/issues/16) · **owns** `internal/ui/help/**`, `internal/ui/theme/**`
-  Contextual footer showing only valid keys, `?` overlay from the key registry, "you could have
-  pressed `s`" hints after a menu path is used repeatedly, light/dark/no-color themes.
+- [x] **P3.5a — The contextual footer, the `?` overlay and the theme switch** · [#16](https://github.com/varijkapil13/saral/issues/16) · **owns** `internal/ui/kernel/{theme,chrome_test,theme_test}.go`, the chrome functions in `internal/ui/kernel/kernel.go`, the `KeyReporter` lines in `internal/ui/kernel/{view,registry}.go`, `internal/ui/kernel/testdata/**`, the `keys*.go` and `testdata/keys.golden` of `internal/ui/{list,issue,form,comment,onboarding}`, `internal/ui/livekeys_test.go`, `docs/{UX,ARCHITECTURE,ROADMAP}.md`
+  Contextual footer showing only valid keys, `?` overlay from the key registry, light/dark/no-color
+  themes switchable while the program runs.
+  **This row used to claim `internal/ui/help/**` and `internal/ui/theme/**`.** Neither directory
+  exists and neither was created: the footer and the `?` overlay are chrome functions in `kernel.go`,
+  and the themes are `internal/ui/kernel/theme.go`. Lifting theming out of the kernel would touch ~25
+  files across six packages and is a refactor packet, not this one.
+  What was missing was not the rendering. `RegisterKeys` is init-time and refuses a second call, so
+  `KeysFor` returned one static set however the view's state changed, and six views were advertising
+  keys that do nothing in the state the user was in. `kernel.KeyReporter` is how a view answers for
+  the state it is in, and all six implement it. `ThemeMsg` existed and nothing sent it; there are now
+  four palette commands and the choice is written back without dropping the rest of the profile
+  ([#63](https://github.com/varijkapil13/saral/issues/63)). Colour stepping down to 256 and 16 was
+  never missing — bubbletea's renderer does it — so that was a doc correction.
+  **The hints bullet moved to P3.1** ([#12](https://github.com/varijkapil13/saral/issues/12)): "after
+  you reach an action through the palette three times, the status line notes its key" needs the
+  counter, the call site and the frecency table that packet already owns, and W0-b landed
+  `CommandRanMsg{ID, Keys}` as the signal. A second counter in the chrome would be a second answer.
 
 ## Batch 4 — Attachments · parallel ×3
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -29,7 +29,7 @@ The mechanisms that make familiarity pay off, in the order a user meets them:
 | First minute | Onboarding writes the profile, then drops you on your own issues. `?` explains the current view only. |
 | First hour | The footer teaches the six keys that matter here. Mouse works, so nothing is blocked on learning. |
 | First week | Frecency: projects, assignees, versions and labels reorder so your usual choices are first. |
-| | Hints: after you reach an action through the palette three times, the status line notes its key. |
+| | Hints: after you reach an action through the palette three times, the status line notes its key. Built in P3.1 ([#12](https://github.com/varijkapil13/saral/issues/12)) rather than with the footer: the count, the call site and the frecency table are one piece of data, and P3.1 already owns it. `kernel.CommandRanMsg{ID, Keys}` is the signal it hangs on. |
 | Ongoing | JQL history with fuzzy recall; saved queries bound to `1`–`9` and kept in the profile. |
 | | Local fuzzy index — typing a key or a few words of a summary finds it with no round trip. |
 | | Session resume: reopening lands exactly where you left, including scroll and filter. |
@@ -37,6 +37,26 @@ The mechanisms that make familiarity pay off, in the order a user meets them:
 
 Frecency is a plain local table of `(item, count, lastUsed)` scored `count * decay(lastUsed)`. No
 telemetry leaves the machine, ever.
+
+### What "only the keys that work" costs
+
+Principle 2 is not satisfied by a view registering its keys once. `kernel.RegisterKeys` runs in an
+`init()` and refuses a second call, so what it holds is the view's **resting state** — a list nobody
+is typing into, a thread being read. Half of what a user actually meets is some other state: a filter
+open, an editor over the field list, a deletion waiting for a `y`, an onboarding step with nothing
+behind it. Advertising the resting keys there names strokes that do nothing, which is the failure
+principle 2 describes rather than a smaller version of it.
+
+So a view whose keys move with its state implements `kernel.KeyReporter` and answers for the state it
+is in. `esc` is called *clear filter*, *put it aside*, *do not save yet* and *keep it* in four
+different places, and each of those is the one on screen at the time. A state with nothing of its own
+to offer — a save in flight, a site being asked — says so by advertising nothing, and the footer falls
+back to the globals rather than naming a key that is being refused. `docs/ARCHITECTURE.md` has the
+interface and the generation counter the memoized chrome needs.
+
+The theme is switched from the palette — *use the dark theme*, *follow the terminal's own colours* —
+and the choice is written back into the profile it came from. There is no key for it: every letter
+left is one somebody types into a field.
 
 ## Navigation model
 
@@ -119,7 +139,14 @@ overlay is covering it.
 ## Rendering rules for modern terminals
 
 - **True color when available, 256 and 16 as graceful steps down, and a real no-color mode** driven
-  by `NO_COLOR` and `TERM`.
+  by `NO_COLOR` and `TERM`. **The stepping down is the library's, not ours.** Bubble Tea detects the
+  terminal's colour profile at start-up with `colorprofile` and its renderer downsamples every colour
+  to what the terminal can show, so a theme is written once in true colour and arrives correctly on a
+  16-colour `xterm`. Nothing here quantises a colour, and a packet that adds a mechanism for it is
+  adding a second answer. What *is* ours is the no-colour mode, because that is a decision rather than
+  a capability: `kernel.ThemeModeFromEnv` reads `NO_COLOR` and `TERM`, both beat the configured theme
+  and the runtime switch, and the resulting theme keeps bold, faint and reverse — `NO_COLOR` asks for
+  colour to go away, not for emphasis to.
 - **Never assume a Nerd Font.** Icons come from a glyph set with an ASCII fallback selected by
   config or capability detection; the default set is plain Unicode box-drawing and geometric shapes.
 - **Grapheme-cluster-correct widths.** Emoji, CJK and combining marks must not shift columns. Use a

--- a/internal/ui/comment/keys.go
+++ b/internal/ui/comment/keys.go
@@ -2,6 +2,8 @@ package comment
 
 import "github.com/varijkapil13/saral/internal/ui/kernel"
 
+var _ kernel.KeyReporter = (*Model)(nil)
+
 type keyMap struct {
 	Up       kernel.Binding
 	Down     kernel.Binding
@@ -18,6 +20,10 @@ type keyMap struct {
 	Send     kernel.Binding
 	Cancel   kernel.Binding
 	Confirm  kernel.Binding
+	// Keep is the same key as Cancel and means something else: while a deletion
+	// waits, esc is the answer that leaves the comment where it is rather than a
+	// way out of an editor.
+	Keep kernel.Binding
 }
 
 func defaultKeys() keyMap {
@@ -37,10 +43,11 @@ func defaultKeys() keyMap {
 		Send:     kernel.Bind([]string{"ctrl+s"}, "ctrl+s", "send"),
 		Cancel:   kernel.Bind([]string{"esc"}, "esc", "put it aside"),
 		Confirm:  kernel.Bind([]string{"y"}, "y", "delete it"),
+		Keep:     kernel.Bind([]string{"esc"}, "esc", "keep it"),
 	}
 }
 
-// keySet is what the footer and the help overlay show. It is derived from the
+// keySet is the resting state: a thread being read. It is derived from the
 // bindings above rather than written twice, so a key that moves cannot leave a
 // stale hint behind.
 func (k keyMap) keySet() kernel.KeySet {
@@ -49,9 +56,33 @@ func (k keyMap) keySet() kernel.KeySet {
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
-			{k.Write, k.Edit, k.Delete, k.Send, k.Cancel},
+			{k.Write, k.Edit, k.Delete},
 		},
 	}
+}
+
+// liveSets is one set per mode, built once at start-up. LiveKeys is called on
+// every frame, so it hands back a stored value rather than assembling one.
+var liveSets = func() [3]kernel.KeySet {
+	k := defaultKeys()
+	return [3]kernel.KeySet{
+		browsing: k.keySet(),
+		writing: {
+			Short: []kernel.Binding{k.Send, k.Cancel},
+			Full:  [][]kernel.Binding{{k.Send, k.Cancel}},
+		},
+		confirming: {
+			Short: []kernel.Binding{k.Confirm, k.Keep},
+			Full:  [][]kernel.Binding{{k.Confirm, k.Keep}},
+		},
+	}
+}()
+
+// LiveKeys reports the keys that work in the mode the thread is actually in.
+// Reading it, writing into it and answering for a deletion have no key in
+// common, and the mode is the generation because it is what changes them.
+func (m *Model) LiveKeys() (set kernel.KeySet, gen int) {
+	return liveSets[m.mode], int(m.mode)
 }
 
 type action uint8

--- a/internal/ui/comment/keys_test.go
+++ b/internal/ui/comment/keys_test.go
@@ -1,0 +1,105 @@
+package comment
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// TestLiveKeys_EveryStateGolden holds every mode the footer and the help overlay
+// can be asked about. A mode nothing covers is a mode whose keys can change
+// without anybody noticing.
+func TestLiveKeys_EveryStateGolden(t *testing.T) {
+	t.Parallel()
+	named := []struct {
+		name string
+		mode mode
+	}{
+		{"reading the thread", browsing},
+		{"writing a comment", writing},
+		{"confirming a deletion", confirming},
+	}
+	if len(named) != len(liveSets) {
+		t.Fatalf("the thread has %d key states and this test names %d", len(liveSets), len(named))
+	}
+	var b strings.Builder
+	for _, s := range named {
+		fmt.Fprintf(&b, "%s\n", s.name)
+		writeKeySet(&b, liveSets[s.mode])
+	}
+	golden(t, "keys.golden", b.String())
+}
+
+func TestLiveKeys_FollowTheModeTheThreadIsIn(t *testing.T) {
+	t.Parallel()
+	m := build(testDeps(t, nil), "PROJ-1")
+	seen := map[int]string{}
+	for _, tc := range []struct {
+		name string
+		mode mode
+	}{
+		{"reading", browsing},
+		{"writing", writing},
+		{"confirming", confirming},
+	} {
+		m.mode = tc.mode
+		set, gen := m.LiveKeys()
+		if gen != int(tc.mode) {
+			t.Errorf("%s: generation %d, want %d", tc.name, gen, tc.mode)
+		}
+		if other, clash := seen[gen]; clash {
+			t.Errorf("%s and %s share generation %d, so the footer will not repaint between them",
+				tc.name, other, gen)
+		}
+		seen[gen] = tc.name
+		if len(set.Short) == 0 {
+			t.Errorf("%s advertises nothing at all", tc.name)
+		}
+	}
+}
+
+// The three modes have no key in common, so nothing an editor advertises may
+// appear while the thread is being read, and the other way round.
+func TestLiveKeys_TheModesShareNoAdvertisedKey(t *testing.T) {
+	t.Parallel()
+	read := shortOf(liveSets[browsing])
+	write := shortOf(liveSets[writing])
+	confirm := shortOf(liveSets[confirming])
+	for _, pair := range [][2]string{{read, write}, {read, confirm}, {write, confirm}} {
+		for _, label := range strings.Split(pair[0], " · ") {
+			if strings.Contains(pair[1], label) {
+				t.Errorf("%q is advertised in two modes at once: %q and %q", label, pair[0], pair[1])
+			}
+		}
+	}
+}
+
+// AllocsPerRun measures the whole process, so this one cannot run beside
+// anything else.
+func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
+	m := build(testDeps(t, nil), "PROJ-1")
+	if got := testing.AllocsPerRun(100, func() { _, _ = m.LiveKeys() }); got != 0 {
+		t.Errorf("asking for the live keys allocates %.0f times; chromeFor asks on every frame, so the sets must be stored", got)
+	}
+}
+
+func shortOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Short), " · ")
+}
+
+func labels(bindings []kernel.Binding) []string {
+	out := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, b.Help().Key+" "+b.Help().Desc)
+	}
+	return out
+}
+
+func writeKeySet(b *strings.Builder, set kernel.KeySet) {
+	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	for _, column := range set.Full {
+		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
+	}
+}

--- a/internal/ui/comment/testdata/keys.golden
+++ b/internal/ui/comment/testdata/keys.golden
@@ -1,0 +1,11 @@
+reading the thread
+  short  ↓/j down · ↑/k up · a write a comment · e edit this one · d delete this one
+  full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
+  full   [ctrl+d half page down, ctrl+u half page up, g g oldest, G newest]
+  full   [a write a comment, e edit this one, d delete this one]
+writing a comment
+  short  ctrl+s send · esc put it aside
+  full   [ctrl+s send, esc put it aside]
+confirming a deletion
+  short  y delete it · esc keep it
+  full   [y delete it, esc keep it]

--- a/internal/ui/form/keys.go
+++ b/internal/ui/form/keys.go
@@ -2,6 +2,8 @@ package form
 
 import "github.com/varijkapil13/saral/internal/ui/kernel"
 
+var _ kernel.KeyReporter = (*Model)(nil)
+
 type keyMap struct {
 	Up       kernel.Binding
 	Down     kernel.Binding
@@ -13,6 +15,13 @@ type keyMap struct {
 	Clear    kernel.Binding
 	Submit   kernel.Binding
 	Retype   kernel.Binding
+	// Choose is enter on the list of issue types, where it picks one rather than
+	// opening an editor.
+	Choose kernel.Binding
+	// DocDone is ctrl+d in the long-text pane, where enter is a newline. It is
+	// the same stroke Clear is on in the field list and means the opposite there,
+	// which is the whole reason a footer has to answer for one state at a time.
+	DocDone kernel.Binding
 
 	// The chooser takes typing, so it moves on the arrows and the readline
 	// keys only: j and k are values a filter has to be able to hold.
@@ -32,8 +41,8 @@ func defaultKeys() keyMap {
 		Down:     kernel.Bind([]string{"j", "down", "tab"}, "↓/j", "down"),
 		PageUp:   kernel.Bind([]string{"pgup", "ctrl+b"}, "pgup", "page up"),
 		PageDown: kernel.Bind([]string{"pgdown", "ctrl+f"}, "pgdn", "page down"),
-		Top:      kernel.Bind([]string{"home"}, "home", "first field"),
-		Bottom:   kernel.Bind([]string{"end"}, "end", "last field"),
+		Top:      kernel.Bind([]string{"home"}, "home", "first row"),
+		Bottom:   kernel.Bind([]string{"end"}, "end", "last row"),
 		Edit:     kernel.Bind([]string{"enter"}, "enter", "edit this field"),
 		Clear:    kernel.Bind([]string{"ctrl+d"}, "ctrl+d", "empty this field"),
 		Submit:   kernel.Bind([]string{"ctrl+s"}, "ctrl+s", "create the issue"),
@@ -43,20 +52,79 @@ func defaultKeys() keyMap {
 		Toggle:   kernel.Bind([]string{"tab"}, "tab", "pick or unpick"),
 		Accept:   kernel.Bind([]string{"enter"}, "enter", "take this value"),
 		Done:     kernel.Bind([]string{"esc"}, "esc", "close the editor, keeping what is typed"),
+		Choose:   kernel.Bind([]string{"enter"}, "enter", "use this issue type"),
+		DocDone:  kernel.Bind([]string{"ctrl+d"}, "ctrl+d", "finish this text"),
 	}
 }
 
-// keySet is what the footer and the help overlay show, built from the same
-// bindings the keystrokes are matched against so a hint cannot go stale.
+// keySet is the resting state: the field list with no editor over it. It is
+// built from the same bindings the keystrokes are matched against, so a hint
+// cannot go stale.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
 		Short: []kernel.Binding{k.Down, k.Up, k.Edit, k.Submit},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp, k.Top, k.Bottom},
 			{k.Edit, k.Clear, k.Submit, k.Retype},
-			{k.Accept, k.Toggle, k.Done},
 		},
 	}
+}
+
+// keyState is which of the form's five states the keys belong to: choosing an
+// issue type, the field list, and the three editors the list opens over itself.
+type keyState int
+
+const (
+	keysTypes keyState = iota
+	keysFields
+	keysText
+	keysDoc
+	keysChoosing
+	keyStates
+)
+
+// liveSets is one set per state, built once at start-up. LiveKeys is called on
+// every frame, so it hands back a stored value rather than assembling one.
+var liveSets = func() [keyStates]kernel.KeySet {
+	k := defaultKeys()
+	var sets [keyStates]kernel.KeySet
+	sets[keysTypes] = kernel.KeySet{
+		Short: []kernel.Binding{k.Down, k.Up, k.Choose},
+		Full:  [][]kernel.Binding{{k.Down, k.Up, k.Top, k.Bottom, k.Choose}},
+	}
+	sets[keysFields] = k.keySet()
+	sets[keysText] = kernel.KeySet{
+		Short: []kernel.Binding{k.Accept, k.Done},
+		Full:  [][]kernel.Binding{{k.Accept, k.Done}},
+	}
+	sets[keysDoc] = kernel.KeySet{
+		Short: []kernel.Binding{k.DocDone, k.Done},
+		Full:  [][]kernel.Binding{{k.DocDone, k.Done}},
+	}
+	sets[keysChoosing] = kernel.KeySet{
+		Short: []kernel.Binding{k.Next, k.Prev, k.Toggle, k.Accept, k.Done},
+		Full:  [][]kernel.Binding{{k.Next, k.Prev, k.PageDown, k.PageUp}, {k.Toggle, k.Accept, k.Done}},
+	}
+	return sets
+}()
+
+// LiveKeys reports the keys that work in the state the form is actually in.
+// ctrl+d empties a field in the list and finishes the text in the long-text
+// pane, and a footer that named one of those while the other was on screen is
+// the drift this answers.
+func (m *Model) LiveKeys() (set kernel.KeySet, gen int) {
+	state := keysFields
+	switch {
+	case m.edit == editText:
+		state = keysText
+	case m.edit == editDoc:
+		state = keysDoc
+	case m.edit == editChoose:
+		state = keysChoosing
+	case m.stage == stageTypes:
+		state = keysTypes
+	}
+	return liveSets[state], int(state)
 }
 
 type action uint8

--- a/internal/ui/form/keys_test.go
+++ b/internal/ui/form/keys_test.go
@@ -1,0 +1,112 @@
+package form
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// TestLiveKeys_EveryStateGolden holds every state the footer and the help
+// overlay can be asked about. A state nothing covers is a state whose keys can
+// change without anybody noticing.
+func TestLiveKeys_EveryStateGolden(t *testing.T) {
+	t.Parallel()
+	named := []struct {
+		name  string
+		state keyState
+	}{
+		{"choosing an issue type", keysTypes},
+		{"the field list", keysFields},
+		{"a one-line field open", keysText},
+		{"the long-text pane open", keysDoc},
+		{"the value chooser open", keysChoosing},
+	}
+	if len(named) != int(keyStates) {
+		t.Fatalf("the form has %d key states and this test names %d", keyStates, len(named))
+	}
+	var b strings.Builder
+	for _, s := range named {
+		fmt.Fprintf(&b, "%s\n", s.name)
+		writeKeySet(&b, liveSets[s.state])
+	}
+	golden(t, "keys.golden", b.String())
+}
+
+func TestLiveKeys_FollowWhatTheFormIsShowing(t *testing.T) {
+	t.Parallel()
+	m := newWith(testDeps(nil), newSchemaCache(schemaTTL, time.Now), newDraftStore())
+	seen := map[int]string{}
+	for _, tc := range []struct {
+		name  string
+		enter func()
+		state keyState
+	}{
+		{"issue types", func() { m.stage, m.edit = stageTypes, editNone }, keysTypes},
+		{"field list", func() { m.stage, m.edit = stageFields, editNone }, keysFields},
+		{"one-line field", func() { m.edit = editText }, keysText},
+		{"long text", func() { m.edit = editDoc }, keysDoc},
+		{"value chooser", func() { m.edit = editChoose }, keysChoosing},
+	} {
+		tc.enter()
+		set, gen := m.LiveKeys()
+		if gen != int(tc.state) {
+			t.Errorf("%s: generation %d, want %d", tc.name, gen, tc.state)
+		}
+		if other, clash := seen[gen]; clash {
+			t.Errorf("%s and %s share generation %d, so the footer will not repaint between them",
+				tc.name, other, gen)
+		}
+		seen[gen] = tc.name
+		if len(set.Short) == 0 {
+			t.Errorf("%s advertises nothing at all", tc.name)
+		}
+	}
+}
+
+// ctrl+d empties a field in the list and finishes the text in the long-text
+// pane. Whichever is on screen has to be the only one advertised, or the footer
+// is telling the user the stroke does something it does not.
+func TestLiveKeys_CtrlDIsNamedForWhatItDoesInThisState(t *testing.T) {
+	t.Parallel()
+	fields := shortOf(liveSets[keysFields]) + " " + strings.Join(labels(liveSets[keysFields].Full[1]), ", ")
+	doc := shortOf(liveSets[keysDoc])
+	switch {
+	case !strings.Contains(fields, "ctrl+d empty this field"):
+		t.Errorf("the field list stopped naming ctrl+d: %s", fields)
+	case !strings.Contains(doc, "ctrl+d finish this text"):
+		t.Errorf("the long-text pane does not name the key that closes it: %s", doc)
+	case strings.Contains(doc, "empty this field"):
+		t.Errorf("the long-text pane advertises the field list's ctrl+d: %s", doc)
+	}
+}
+
+// AllocsPerRun measures the whole process, so this one cannot run beside
+// anything else.
+func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
+	m := newWith(testDeps(nil), newSchemaCache(schemaTTL, time.Now), newDraftStore())
+	if got := testing.AllocsPerRun(100, func() { _, _ = m.LiveKeys() }); got != 0 {
+		t.Errorf("asking for the live keys allocates %.0f times; chromeFor asks on every frame, so the sets must be stored", got)
+	}
+}
+
+func shortOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Short), " · ")
+}
+
+func labels(bindings []kernel.Binding) []string {
+	out := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, b.Help().Key+" "+b.Help().Desc)
+	}
+	return out
+}
+
+func writeKeySet(b *strings.Builder, set kernel.KeySet) {
+	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	for _, column := range set.Full {
+		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
+	}
+}

--- a/internal/ui/form/testdata/keys.golden
+++ b/internal/ui/form/testdata/keys.golden
@@ -1,0 +1,17 @@
+choosing an issue type
+  short  ↓/j down · ↑/k up · enter use this issue type
+  full   [↓/j down, ↑/k up, home first row, end last row, enter use this issue type]
+the field list
+  short  ↓/j down · ↑/k up · enter edit this field · ctrl+s create the issue
+  full   [↓/j down, ↑/k up, pgdn page down, pgup page up, home first row, end last row]
+  full   [enter edit this field, ctrl+d empty this field, ctrl+s create the issue, ctrl+t change the issue type]
+a one-line field open
+  short  enter take this value · esc close the editor, keeping what is typed
+  full   [enter take this value, esc close the editor, keeping what is typed]
+the long-text pane open
+  short  ctrl+d finish this text · esc close the editor, keeping what is typed
+  full   [ctrl+d finish this text, esc close the editor, keeping what is typed]
+the value chooser open
+  short  ↓ next value · ↑ previous value · tab pick or unpick · enter take this value · esc close the editor, keeping what is typed
+  full   [↓ next value, ↑ previous value, pgdn page down, pgup page up]
+  full   [tab pick or unpick, enter take this value, esc close the editor, keeping what is typed]

--- a/internal/ui/issue/edit_keys.go
+++ b/internal/ui/issue/edit_keys.go
@@ -52,15 +52,54 @@ func defaultEditKeys() editKeyMap {
 	}
 }
 
+// keySet is the resting state: the row list with no field open and nothing
+// waiting to be answered.
 func (k editKeyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
 		Short: []kernel.Binding{k.Down, k.Up, k.Act, k.Save},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.Act, k.Clear},
-			{k.Prev, k.Next, k.Accept, k.Cancel},
-			{k.Save, k.Discard, k.Yes},
+			{k.Prev, k.Next},
+			{k.Save, k.Discard},
 		},
 	}
+}
+
+// editLiveSets is one set per stage, built once at start-up. LiveKeys is called
+// on every frame, so it hands back a stored value rather than assembling one.
+var editLiveSets = func() [5]kernel.KeySet {
+	k := defaultEditKeys()
+	// esc backs out of three different things here, and what it leaves behind is
+	// different each time, so each stage names it for itself.
+	reread := kernel.Bind([]string{"y"}, "y", "re-read it and put your edits back on top")
+	notYet := kernel.Bind([]string{"esc"}, "esc", "do not save yet")
+	asItIs := kernel.Bind([]string{"esc"}, "esc", "leave it as it is for now")
+	return [5]kernel.KeySet{
+		stageBrowse: k.keySet(),
+		stageTyping: {
+			Short: []kernel.Binding{k.Accept, k.Cancel},
+			Full:  [][]kernel.Binding{{k.Accept, k.Cancel}},
+		},
+		stageConfirm: {
+			Short: []kernel.Binding{k.Yes, notYet},
+			Full:  [][]kernel.Binding{{k.Yes, notYet}},
+		},
+		// A save in flight answers nothing of its own, and the footer then shows
+		// the globals alone, which is the truth.
+		stageSaving: {},
+		stageConflict: {
+			Short: []kernel.Binding{reread, asItIs},
+			Full:  [][]kernel.Binding{{reread, asItIs}},
+		},
+	}
+}()
+
+// LiveKeys reports the keys that work in the stage the pane is actually in.
+// enter commits a value while a field is open and opens one when none is, and y
+// answers two different questions — go ahead with the save, and re-read after a
+// conflict — so what the footer calls it has to come from the stage.
+func (m *editModel) LiveKeys() (set kernel.KeySet, gen int) {
+	return editLiveSets[m.stage], int(m.stage)
 }
 
 type moveKeyMap struct {
@@ -85,12 +124,42 @@ func defaultMoveKeys() moveKeyMap {
 	}
 }
 
+// keySet is the resting state: the list of moves this issue can make from here.
 func (k moveKeyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
 		Short: []kernel.Binding{k.Down, k.Up, k.Act},
-		Full: [][]kernel.Binding{
-			{k.Down, k.Up, k.Act},
-			{k.Prev, k.Next, k.Yes, k.Cancel},
-		},
+		Full:  [][]kernel.Binding{{k.Down, k.Up, k.Act}},
 	}
 }
+
+// moveLiveSets is one set per stage, built once at start-up.
+var moveLiveSets = func() [4]kernel.KeySet {
+	k := defaultMoveKeys()
+	// enter takes the move under the cursor in the list and finishes the screen
+	// once it is filled in, so it is named for whichever of those is on screen.
+	filled := kernel.Bind([]string{"enter"}, "enter", "use these values")
+	return [4]kernel.KeySet{
+		moveList: k.keySet(),
+		moveScreen: {
+			Short: []kernel.Binding{k.Down, k.Up, k.Prev, k.Next, filled},
+			Full:  [][]kernel.Binding{{k.Down, k.Up, k.Prev, k.Next}, {filled, k.Cancel}},
+		},
+		moveConfirm: {
+			Short: []kernel.Binding{k.Yes, k.Cancel},
+			Full:  [][]kernel.Binding{{k.Yes, k.Cancel}},
+		},
+		moveDoing: {},
+	}
+}()
+
+// LiveKeys reports the keys that work in the stage the picker is actually in. A
+// transition screen moves between its fields and cycles their values; the list
+// of moves does neither.
+func (m *moveModel) LiveKeys() (set kernel.KeySet, gen int) {
+	return moveLiveSets[m.stage], int(m.stage)
+}
+
+var (
+	_ kernel.KeyReporter = (*editModel)(nil)
+	_ kernel.KeyReporter = (*moveModel)(nil)
+)

--- a/internal/ui/issue/keys.go
+++ b/internal/ui/issue/keys.go
@@ -42,3 +42,8 @@ func (k keyMap) keySet() kernel.KeySet {
 		},
 	}
 }
+
+// The detail pane implements no kernel.KeyReporter: it scrolls a document, and
+// every one of its keys works whatever it is showing, so the registry's answer
+// is already the live one. The two panes it opens are a different matter, and
+// answer for themselves in edit_keys.go.

--- a/internal/ui/issue/keys_test.go
+++ b/internal/ui/issue/keys_test.go
@@ -1,0 +1,182 @@
+package issue
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// TestLiveKeys_EveryStateGolden holds every stage of the two panes the detail
+// view opens. A stage nothing covers is a stage whose keys can change without
+// anybody noticing.
+func TestLiveKeys_EveryStateGolden(t *testing.T) {
+	t.Parallel()
+	editStages := []struct {
+		name  string
+		stage editStage
+	}{
+		{"the field list", stageBrowse},
+		{"a field taking typing", stageTyping},
+		{"waiting for the go-ahead to save", stageConfirm},
+		{"saving", stageSaving},
+		{"somebody else changed it first", stageConflict},
+	}
+	moveStages := []struct {
+		name  string
+		stage moveStage
+	}{
+		{"the moves this issue can make", moveList},
+		{"the transition screen", moveScreen},
+		{"waiting for the go-ahead to move", moveConfirm},
+		{"moving", moveDoing},
+	}
+	if len(editStages) != len(editLiveSets) || len(moveStages) != len(moveLiveSets) {
+		t.Fatalf("the panes have %d and %d stages; this test names %d and %d",
+			len(editLiveSets), len(moveLiveSets), len(editStages), len(moveStages))
+	}
+
+	var b strings.Builder
+	b.WriteString("editing an issue's fields\n")
+	for _, s := range editStages {
+		fmt.Fprintf(&b, "  %s\n", s.name)
+		writeKeySet(&b, editLiveSets[s.stage])
+	}
+	b.WriteString("changing an issue's status\n")
+	for _, s := range moveStages {
+		fmt.Fprintf(&b, "  %s\n", s.name)
+		writeKeySet(&b, moveLiveSets[s.stage])
+	}
+	golden(t, "keys.golden", b.String())
+}
+
+func TestLiveKeys_FollowTheStageTheEditorIsIn(t *testing.T) {
+	t.Parallel()
+	m, ok := NewEdit(testDeps(nil), jira.Issue{Key: "PROJ-1"}).(*editModel)
+	if !ok {
+		t.Fatal("NewEdit no longer builds an *editModel")
+	}
+	seen := map[int]string{}
+	for _, tc := range []struct {
+		name  string
+		stage editStage
+	}{
+		{"browsing", stageBrowse},
+		{"typing", stageTyping},
+		{"confirming", stageConfirm},
+		{"saving", stageSaving},
+		{"conflicted", stageConflict},
+	} {
+		m.stage = tc.stage
+		set, gen := m.LiveKeys()
+		if gen != int(tc.stage) {
+			t.Errorf("%s: generation %d, want %d", tc.name, gen, tc.stage)
+		}
+		if other, clash := seen[gen]; clash {
+			t.Errorf("%s and %s share generation %d, so the footer will not repaint between them",
+				tc.name, other, gen)
+		}
+		seen[gen] = tc.name
+		if tc.stage == stageSaving && !set.IsZero() {
+			t.Errorf("a save in flight advertises %s, none of which answers", shortOf(set))
+		}
+	}
+}
+
+func TestLiveKeys_FollowTheStageThePickerIsIn(t *testing.T) {
+	t.Parallel()
+	m, ok := NewMove(testDeps(nil), jira.Issue{Key: "PROJ-1"}).(*moveModel)
+	if !ok {
+		t.Fatal("NewMove no longer builds a *moveModel")
+	}
+	seen := map[int]string{}
+	for _, tc := range []struct {
+		name  string
+		stage moveStage
+	}{
+		{"choosing a move", moveList},
+		{"filling the screen in", moveScreen},
+		{"confirming", moveConfirm},
+		{"moving", moveDoing},
+	} {
+		m.stage = tc.stage
+		_, gen := m.LiveKeys()
+		if gen != int(tc.stage) {
+			t.Errorf("%s: generation %d, want %d", tc.name, gen, tc.stage)
+		}
+		if other, clash := seen[gen]; clash {
+			t.Errorf("%s and %s share generation %d, so the footer will not repaint between them",
+				tc.name, other, gen)
+		}
+		seen[gen] = tc.name
+	}
+	if !strings.Contains(shortOf(moveLiveSets[moveScreen]), "next value") {
+		t.Error("the transition screen does not advertise the key that fills a field in")
+	}
+	if strings.Contains(shortOf(moveLiveSets[moveList]), "next value") {
+		t.Error("the list of moves advertises a key that only the screen answers")
+	}
+}
+
+// y means go ahead with the save in one stage and re-read the issue in another.
+// The label has to come from the stage, or one of the two is a lie.
+func TestLiveKeys_YIsNamedForTheQuestionItIsAnswering(t *testing.T) {
+	t.Parallel()
+	confirm := shortOf(editLiveSets[stageConfirm])
+	conflict := shortOf(editLiveSets[stageConflict])
+	switch {
+	case !strings.Contains(confirm, "y go ahead"):
+		t.Errorf("a save waiting to be confirmed does not name y: %s", confirm)
+	case !strings.Contains(conflict, "re-read"):
+		t.Errorf("a conflict does not say what y would do: %s", conflict)
+	case confirm == conflict:
+		t.Errorf("both questions are advertised the same way: %s", confirm)
+	}
+}
+
+// AllocsPerRun measures the whole process, so this one cannot run beside
+// anything else.
+func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
+	edit, ok := NewEdit(testDeps(nil), jira.Issue{Key: "PROJ-1"}).(*editModel)
+	if !ok {
+		t.Fatal("NewEdit no longer builds an *editModel")
+	}
+	move, ok := NewMove(testDeps(nil), jira.Issue{Key: "PROJ-1"}).(*moveModel)
+	if !ok {
+		t.Fatal("NewMove no longer builds a *moveModel")
+	}
+	for name, ask := range map[string]func(){
+		"the field editor":      func() { _, _ = edit.LiveKeys() },
+		"the transition picker": func() { _, _ = move.LiveKeys() },
+	} {
+		if got := testing.AllocsPerRun(100, ask); got != 0 {
+			t.Errorf("%s allocates %.0f times to report its keys; chromeFor asks on every frame, so the sets must be stored",
+				name, got)
+		}
+	}
+}
+
+func shortOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Short), " · ")
+}
+
+func labels(bindings []kernel.Binding) []string {
+	out := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, b.Help().Key+" "+b.Help().Desc)
+	}
+	return out
+}
+
+func writeKeySet(b *strings.Builder, set kernel.KeySet) {
+	if set.IsZero() {
+		b.WriteString("    nothing of its own; the globals are all that answer\n")
+		return
+	}
+	fmt.Fprintf(b, "    short  %s\n", shortOf(set))
+	for _, column := range set.Full {
+		fmt.Fprintf(b, "    full   [%s]\n", strings.Join(labels(column), ", "))
+	}
+}

--- a/internal/ui/issue/testdata/keys.golden
+++ b/internal/ui/issue/testdata/keys.golden
@@ -1,0 +1,30 @@
+editing an issue's fields
+  the field list
+    short  ↓/j down · ↑/k up · enter change this field · ctrl+s save
+    full   [↓/j down, ↑/k up, enter change this field, del empty this field]
+    full   [←/h previous value, →/l next value]
+    full   [ctrl+s save, X discard changes]
+  a field taking typing
+    short  enter keep this value · esc leave the value alone
+    full   [enter keep this value, esc leave the value alone]
+  waiting for the go-ahead to save
+    short  y go ahead · esc do not save yet
+    full   [y go ahead, esc do not save yet]
+  saving
+    nothing of its own; the globals are all that answer
+  somebody else changed it first
+    short  y re-read it and put your edits back on top · esc leave it as it is for now
+    full   [y re-read it and put your edits back on top, esc leave it as it is for now]
+changing an issue's status
+  the moves this issue can make
+    short  ↓/j down · ↑/k up · enter choose
+    full   [↓/j down, ↑/k up, enter choose]
+  the transition screen
+    short  ↓/j down · ↑/k up · ←/h previous value · →/l next value · enter use these values
+    full   [↓/j down, ↑/k up, ←/h previous value, →/l next value]
+    full   [enter use these values, esc back]
+  waiting for the go-ahead to move
+    short  y go ahead · esc back
+    full   [y go ahead, esc back]
+  moving
+    nothing of its own; the globals are all that answer

--- a/internal/ui/kernel/chrome_test.go
+++ b/internal/ui/kernel/chrome_test.go
@@ -1,0 +1,203 @@
+package kernel
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// reporterView is a view whose keys move with its state, which is what every
+// real view in the program does. It stays capturing throughout, so a footer that
+// follows it can only be following the generation.
+type reporterView struct {
+	id    string
+	state int
+	sets  []KeySet
+}
+
+func (r *reporterView) Init() tea.Cmd { return nil }
+
+func (r *reporterView) Update(msg tea.Msg) (View, tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok && key.String() == "n" {
+		r.state = (r.state + 1) % len(r.sets)
+	}
+	return r, nil
+}
+
+func (r *reporterView) View() string       { return r.id + " body" }
+func (r *reporterView) WantsRawKeys() bool { return true }
+func (r *reporterView) LiveKeys() (set KeySet, gen int) {
+	return r.sets[r.state], r.state
+}
+
+func twoStateReporter(id string) *reporterView {
+	return &reporterView{id: id, sets: []KeySet{
+		{
+			Short: []Binding{Bind([]string{"enter"}, "enter", "open"), Bind([]string{"/"}, "/", "filter")},
+			Full:  [][]Binding{{Bind([]string{"enter"}, "enter", "open"), Bind([]string{"/"}, "/", "filter")}},
+		},
+		{
+			Short: []Binding{Bind([]string{"enter"}, "enter", "keep filter"), Bind([]string{"esc"}, "esc", "clear filter")},
+			Full:  [][]Binding{{Bind([]string{"enter"}, "enter", "keep filter"), Bind([]string{"esc"}, "esc", "clear filter")}},
+		},
+	}}
+}
+
+func reporterSpec(id string, slot int, v *reporterView) ViewSpec {
+	return ViewSpec{ID: id, Title: strings.ToUpper(id[:1]) + id[1:], Slot: slot,
+		New: func(Deps) View { return v }}
+}
+
+func TestFooter_ShowsWhatTheViewSaysWorksRatherThanWhatItRegistered(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	view := twoStateReporter("board")
+	RegisterView(reporterSpec("board", 1, view))
+	RegisterKeys("board", KeySet{Short: []Binding{Bind([]string{"x"}, "x", "registered at start-up")}})
+
+	m := newAt(t, testDeps(), 120, 30)
+	first := ansi.Strip(m.Frame())
+	if !strings.Contains(first, "filter") {
+		t.Errorf("the footer does not show what the view says works:\n%s", first)
+	}
+	if strings.Contains(first, "registered at start-up") {
+		t.Errorf("the footer fell back to the registered set for a view that reports:\n%s", first)
+	}
+
+	m, _ = press(m, "n")
+	second := ansi.Strip(m.Frame())
+	if !strings.Contains(second, "keep filter") || !strings.Contains(second, "clear filter") {
+		t.Errorf("the footer did not follow the view into its second state:\n%s", second)
+	}
+}
+
+// The chrome is memoized on a comparable key and a KeySet holds slices, so the
+// generation is the only thing that can tell it to repaint. This view captures
+// keys in both states and never changes its title, depth, width or theme, so a
+// footer that repaints here is repainting on the generation and nothing else.
+func TestChrome_RepaintsWhenNothingButTheViewsKeysChanged(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	view := twoStateReporter("board")
+	RegisterView(reporterSpec("board", 1, view))
+
+	m := newAt(t, testDeps(), 120, 30)
+	before := ansi.Strip(m.Frame())
+	m, _ = press(m, "n")
+	after := ansi.Strip(m.Frame())
+
+	if before == after {
+		t.Errorf("the footer is memoized past a change in the view's keys:\n%s", before)
+	}
+	if !m.capturing() {
+		t.Fatal("the view stopped capturing, so this test proves nothing about the generation")
+	}
+}
+
+func TestHelpOverlay_ListsWhatTheViewSaysWorksNow(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	view := &reporterView{id: "board", sets: []KeySet{{
+		Short: []Binding{Bind([]string{"a"}, "a", "write a comment")},
+		Full:  [][]Binding{{Bind([]string{"a"}, "a", "write a comment")}},
+	}}}
+	RegisterView(reporterSpec("board", 1, view))
+	RegisterKeys("board", KeySet{Full: [][]Binding{{Bind([]string{"z"}, "z", "registered at start-up")}}})
+
+	m := newAt(t, testDeps(), 120, 30)
+	m.showHelp = true
+	got := ansi.Strip(m.Frame())
+	if !strings.Contains(got, "write a comment") {
+		t.Errorf("the help overlay does not list the live keys:\n%s", got)
+	}
+	if strings.Contains(got, "registered at start-up") {
+		t.Errorf("the help overlay listed the registered set for a view that reports:\n%s", got)
+	}
+}
+
+func TestViewKeys_AnswersFromTheRegistryForAViewThatDoesNotReport(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+	RegisterKeys("board", KeySet{Short: []Binding{Bind([]string{"enter"}, "enter", "open")}})
+
+	m := newAt(t, testDeps(), 120, 30)
+	set, gen := m.viewKeys()
+	if len(set.Short) != 1 || set.Short[0].Help().Desc != "open" {
+		t.Errorf("a view that does not report should get the registered set, got %+v", set)
+	}
+	if gen != 0 {
+		t.Errorf("the registry answer carries generation %d, so the chrome would repaint for nothing", gen)
+	}
+	if !strings.Contains(ansi.Strip(m.Frame()), "open") {
+		t.Error("the footer of a view that does not report lost its keys")
+	}
+}
+
+// A golden per state as well as per width: the states are what this packet
+// changed, and the narrow one is where the footer has to give something up.
+func TestFrame_GoldenPerState(t *testing.T) {
+	for name, state := range map[string]int{"resting": 0, "filtering": 1} {
+		for _, size := range []struct {
+			label string
+			w, h  int
+		}{{"120x30", 120, 30}, {"80x20", 80, 20}} {
+			t.Run(name+" at "+size.label, func(t *testing.T) {
+				resetRegistry()
+				t.Cleanup(resetRegistry)
+				view := twoStateReporter("board")
+				view.state = state
+				RegisterView(reporterSpec("board", 1, view))
+				RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+				m := newAt(t, testDeps(), size.w, size.h)
+				golden(t, "chrome_"+name+"_"+size.label+".golden", ansi.Strip(m.Frame()))
+			})
+		}
+	}
+}
+
+func TestFrame_GoldenOfTheHelpOverlayPerState(t *testing.T) {
+	for name, state := range map[string]int{"resting": 0, "filtering": 1} {
+		t.Run(name, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			view := twoStateReporter("board")
+			view.state = state
+			RegisterView(reporterSpec("board", 1, view))
+
+			m := newAt(t, testDeps(), 120, 30)
+			m.showHelp = true
+			golden(t, "help_"+name+".golden", ansi.Strip(m.Frame()))
+		})
+	}
+}
+
+// A KeySet built per call would put its allocations under every keystroke,
+// because chromeFor asks for one on every frame. The comparison is against a
+// view that answers from the registry rather than against a fixed number, so
+// this measures the cost the interface added and nothing else.
+func TestFrame_AskingAViewForItsLiveKeysCostsNothingPerFrame(t *testing.T) {
+	allocs := func(build func() ViewSpec) float64 {
+		resetRegistry()
+		t.Cleanup(resetRegistry)
+		RegisterView(build())
+		RegisterKeys("board", KeySet{Short: []Binding{Bind([]string{"enter"}, "enter", "open")}})
+		m, err := New(testDeps(), WithSize(200, 60), WithMouse(false))
+		if err != nil {
+			t.Fatal(err)
+		}
+		next, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+		model := next.(Model)
+		return testing.AllocsPerRun(200, func() { _ = model.Frame() })
+	}
+
+	static := allocs(func() ViewSpec { return spec("board", 1, "", &stubView{id: "board"}) })
+	live := allocs(func() ViewSpec { return reporterSpec("board", 1, twoStateReporter("board")) })
+	if live > static+2 {
+		t.Errorf("reporting live keys costs %.0f allocations a frame against %.0f for the registry answer; "+
+			"a KeySet is being built per call rather than stored", live, static)
+	}
+}

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -64,10 +64,14 @@ type stackEntry struct {
 }
 
 type chromeKey struct {
-	width     int
-	themeGen  int
-	capsGen   int
-	savedGen  int
+	width    int
+	themeGen int
+	capsGen  int
+	savedGen int
+	// keysGen is what the focused view answers when asked which of its keys work
+	// right now. It is a number rather than the set because this key is compared
+	// with ==, and a KeySet holds slices.
+	keysGen   int
 	rootID    string
 	topID     string
 	title     string
@@ -979,9 +983,10 @@ func (m Model) Frame() string {
 // they depend on has changed.
 func (m Model) chromeFor() (header, footer string) {
 	_, palette := LookupView(PaletteViewID)
+	_, keysGen := m.viewKeys()
 	key := chromeKey{
 		width: m.width, themeGen: m.deps.Theme.Gen, capsGen: m.capsGen,
-		savedGen: m.savedGen, project: m.deps.Project,
+		savedGen: m.savedGen, keysGen: keysGen, project: m.deps.Project,
 		status: m.status, help: m.showHelp,
 		depth: len(m.stack), palette: palette,
 		capturing: m.capturing(), prefixed: m.prefixSet,
@@ -1063,11 +1068,23 @@ func (m Model) emptyState() string {
 		"Views self-register from their own package; see docs/ARCHITECTURE.md.")
 }
 
-func (m Model) helpView() string {
-	view := KeySet{}
-	if len(m.stack) > 0 {
-		view = KeysFor(m.top().spec.ID)
+// viewKeys is what the focused view says works right now, and a number that
+// changes when that changes. A view whose keys move with its state implements
+// KeyReporter; one whose keys never move is answered from the registry, which
+// costs it nothing.
+func (m Model) viewKeys() (set KeySet, gen int) {
+	if len(m.stack) == 0 {
+		return KeySet{}, 0
 	}
+	top := m.top()
+	if reporter, ok := top.view.(KeyReporter); ok {
+		return reporter.LiveKeys()
+	}
+	return KeysFor(top.spec.ID), 0
+}
+
+func (m Model) helpView() string {
+	view, _ := m.viewKeys()
 	h := m.deps.Theme.HelpModel
 	h.ShowAll = true
 	h.SetWidth(m.width)
@@ -1160,10 +1177,7 @@ func (m Model) hintLine(width int) string {
 			Bind(m.keys.Back.Keys(), "esc", "cancel"),
 		}})
 	}
-	set := KeySet{}
-	if len(m.stack) > 0 {
-		set = KeysFor(m.top().spec.ID)
-	}
+	set, _ := m.viewKeys()
 	if m.capturing() {
 		// The globals are unreachable while the view has the keyboard, bar the
 		// one key it is not allowed to swallow, and docs/UX.md asks the footer to

--- a/internal/ui/kernel/registry.go
+++ b/internal/ui/kernel/registry.go
@@ -140,11 +140,26 @@ func LookupCommand(id string) (Command, bool) {
 	return cmd, ok
 }
 
-// KeysFor returns the keys registered for a view.
+// KeysFor returns the keys registered for a view: its resting state, and the
+// whole answer for a view that does not implement KeyReporter.
 func KeysFor(viewID string) KeySet {
 	reg.mu.RLock()
 	defer reg.mu.RUnlock()
 	return reg.keys[viewID]
+}
+
+// KeyScopes names every view that registered keys, sorted. It is how the sweep
+// above the views checks that each of them was held to the same rule: the kernel
+// cannot, because it may not import one.
+func KeyScopes() []string {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	out := make([]string, 0, len(reg.keys))
+	for id := range reg.keys {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // RegistrationErrors returns everything wrong with the registrations that ran.

--- a/internal/ui/kernel/testdata/chrome_filtering_120x30.golden
+++ b/internal/ui/kernel/testdata/chrome_filtering_120x30.golden
@@ -1,0 +1,30 @@
+ saral | Board                                                                                    example.atlassian.net 
+board body                                                                                                              
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ g1 Board  g2 Backlog                                                               enter keep filter | esc clear filter

--- a/internal/ui/kernel/testdata/chrome_filtering_80x20.golden
+++ b/internal/ui/kernel/testdata/chrome_filtering_80x20.golden
@@ -1,0 +1,20 @@
+ saral | Board                                            example.atlassian.net 
+board body                                                                      
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+ g1 Board  g2 Backlog                       enter keep filter | esc clear filter

--- a/internal/ui/kernel/testdata/chrome_resting_120x30.golden
+++ b/internal/ui/kernel/testdata/chrome_resting_120x30.golden
@@ -1,0 +1,30 @@
+ saral | Board                                                                                    example.atlassian.net 
+board body                                                                                                              
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ g1 Board  g2 Backlog                                                                              enter open | / filter

--- a/internal/ui/kernel/testdata/chrome_resting_80x20.golden
+++ b/internal/ui/kernel/testdata/chrome_resting_80x20.golden
@@ -1,0 +1,20 @@
+ saral | Board                                            example.atlassian.net 
+board body                                                                      
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+ g1 Board  g2 Backlog                                      enter open | / filter

--- a/internal/ui/kernel/testdata/help_filtering.golden
+++ b/internal/ui/kernel/testdata/help_filtering.golden
@@ -1,0 +1,30 @@
+ saral | Board                                                                                    example.atlassian.net 
+enter keep filter     1-9   saved query           ctrl+k commands                                                       
+esc   clear filter    g 1-9 switch view           ?      help                                                           
+                      esc   back                  q      quit                                                           
+                      r     refresh                                                                                     
+                      R     refetch everything                                                                          
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ g1 Board                                                                                                   ? close help

--- a/internal/ui/kernel/testdata/help_resting.golden
+++ b/internal/ui/kernel/testdata/help_resting.golden
@@ -1,0 +1,30 @@
+ saral | Board                                                                                    example.atlassian.net 
+enter open      1-9   saved query           ctrl+k commands                                                             
+/     filter    g 1-9 switch view           ?      help                                                                 
+                esc   back                  q      quit                                                                 
+                r     refresh                                                                                           
+                R     refetch everything                                                                                
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ g1 Board                                                                                                   ? close help

--- a/internal/ui/kernel/theme.go
+++ b/internal/ui/kernel/theme.go
@@ -1,12 +1,17 @@
 package kernel
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync/atomic"
 
 	"charm.land/bubbles/v2/help"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/varijkapil13/saral/internal/config"
 )
 
 // ThemeMode is how colours are chosen.
@@ -281,4 +286,133 @@ func (t *Theme) colored() {
 		FullDesc:       t.Muted,
 		FullSeparator:  t.Muted,
 	}
+}
+
+// The theme is switchable while the program runs. It registers commands rather
+// than keys: there is no letter left that would not also be a letter somebody
+// types into a field, and docs/UX.md points at the palette for everything that
+// has no key of its own.
+func init() { registerThemeCommands() }
+
+func registerThemeCommands() {
+	for _, mode := range []ThemeMode{ThemeAuto, ThemeDark, ThemeLight, ThemeNoColor} {
+		RegisterCommand(Command{
+			ID:    "theme." + mode.String(),
+			Title: mode.title(),
+			Group: "Appearance",
+			Run:   func(d Deps) tea.Cmd { return SwitchTheme(d, mode) },
+		})
+	}
+}
+
+// title is how the palette offers the mode.
+func (m ThemeMode) title() string {
+	switch m {
+	case ThemeDark:
+		return "Use the dark theme"
+	case ThemeLight:
+		return "Use the light theme"
+	case ThemeNoColor:
+		return "Turn colour off"
+	default:
+		return "Follow the terminal's own colours"
+	}
+}
+
+// SwitchTheme rebuilds the styles in a new mode and keeps the choice. The glyph
+// set comes along unchanged: it answers a question about the font rather than
+// about colour, and a session that fell back to ASCII must not quietly get box
+// drawing back.
+//
+// Auto asks the terminal for its background again rather than reusing the answer
+// the old theme settled on, because that is the whole of what auto means and a
+// terminal that has been changed since is the likely reason for switching to it.
+func SwitchTheme(d Deps, mode ThemeMode) tea.Cmd {
+	if forced, why := noColorForced(); forced && mode != ThemeNoColor {
+		return func() tea.Msg { return StatusMsg{Text: why, Level: LevelWarn} }
+	}
+	dark, glyphs := true, UnicodeGlyphs()
+	if d.Theme != nil {
+		dark, glyphs = d.Theme.Dark, d.Theme.Glyphs
+	}
+	next := NewTheme(mode, dark, glyphs)
+	cmds := []tea.Cmd{
+		func() tea.Msg { return ThemeMsg{Theme: next} },
+		saveTheme(d.Site, mode),
+	}
+	if mode == ThemeAuto {
+		cmds = append(cmds, tea.RequestBackgroundColor)
+	}
+	return tea.Batch(cmds...)
+}
+
+// noColorForced reports whether the environment has already said no colour, in
+// which case a mode with colour in it is refused rather than quietly overriding
+// what the user exported. ThemeModeFromEnv is asked with nothing configured, so
+// only the environment can answer no-colour here.
+func noColorForced() (forced bool, why string) {
+	if ThemeModeFromEnv(os.Environ(), "") != ThemeNoColor {
+		return false, ""
+	}
+	return true, "this environment asks for no colour — NO_COLOR or TERM says so, and that beats a theme"
+}
+
+// saveTheme writes the mode into the profile it came from. The theme has already
+// changed by the time this runs, so a failure is reported rather than undoing
+// the switch.
+func saveTheme(site string, mode ThemeMode) tea.Cmd {
+	return func() tea.Msg {
+		switch err := writeTheme(site, mode); {
+		case err == nil:
+			return nil
+		case errors.Is(err, config.ErrNoConfig), errors.Is(err, config.ErrNoProfile):
+			return StatusMsg{
+				Text:  "the theme changed for this session; there is no profile to save it to",
+				Level: LevelInfo,
+			}
+		default:
+			return StatusMsg{
+				Text:  "the theme changed for this session, but saving it failed: " + err.Error(),
+				Level: LevelWarn,
+			}
+		}
+	}
+}
+
+// writeTheme reads the whole file and writes it back with one field changed.
+// Save writes the profile it is handed and nothing else, so a fresh Profile
+// built from what is on screen would drop the saved queries, the timeline field
+// names and the glyph set.
+func writeTheme(site string, mode ThemeMode) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		return err
+	}
+	profile, err := cfg.Current()
+	if err != nil {
+		return err
+	}
+	// The kernel is told which site it is talking to and never which profile was
+	// named on the command line, so a session started with --profile would
+	// otherwise write the choice onto whichever profile is active instead.
+	if site != "" && profile.Site != site {
+		return fmt.Errorf("this session is on %s and the active profile %q is on %s, so nothing was written",
+			site, profile.Name, profile.Site)
+	}
+	// Auto is the absence of a theme in the file rather than a value, so that a
+	// profile that never chose and a profile that chose auto read the same.
+	value := mode.String()
+	if mode == ThemeAuto {
+		value = ""
+	}
+	if profile.Theme == value {
+		return nil
+	}
+	profile.Theme = value
+	cfg.Profiles[profile.Name] = profile
+	return cfg.Save(path)
 }

--- a/internal/ui/kernel/theme_test.go
+++ b/internal/ui/kernel/theme_test.go
@@ -1,11 +1,17 @@
 package kernel
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/config"
 )
 
 func TestParseThemeMode(t *testing.T) {
@@ -112,6 +118,298 @@ func TestGlyphs_ASCIIFallbackIsPlain(t *testing.T) {
 	if GlyphsFor("").Bullet != UnicodeGlyphs().Bullet {
 		t.Error("the default glyph set should be unicode")
 	}
+}
+
+// colourfulEnv puts the environment back to one that allows colour, so that a
+// machine with TERM unset or NO_COLOR exported does not turn a test about
+// switching themes into a test about refusing to.
+func colourfulEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+}
+
+// writeConfig puts a config file where config.Path will find it and returns the
+// path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("SARAL_CONFIG_DIR", dir)
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const profileWithEverything = `active = "work"
+mouse = true
+
+[profiles.work]
+site   = "example.atlassian.net"
+email  = "you@example.com"
+glyphs = "ascii"
+token  = { env = "JIRA_TOKEN" }
+
+[profiles.work.timeline]
+start = ["Target start"]
+end   = ["Target end"]
+
+[[profiles.work.queries]]
+name = "Blockers"
+jql  = "resolution = EMPTY ORDER BY updated DESC"
+key  = 2
+`
+
+func TestThemeCommands_AreInThePaletteOnePerMode(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	registerThemeCommands()
+
+	want := map[string]bool{"theme.auto": false, "theme.dark": false, "theme.light": false, "theme.no-color": false}
+	for _, cmd := range Commands() {
+		if _, ours := want[cmd.ID]; !ours {
+			continue
+		}
+		want[cmd.ID] = true
+		if cmd.Title == "" || cmd.Run == nil {
+			t.Errorf("%s is registered with nothing to show or nothing to run", cmd.ID)
+		}
+		if len(cmd.Keys) != 0 {
+			t.Errorf("%s teaches keys %v; no view shows a key for the theme, so the palette must not claim one",
+				cmd.ID, cmd.Keys)
+		}
+	}
+	for id, found := range want {
+		if !found {
+			t.Errorf("%s is not registered, so the palette cannot reach it", id)
+		}
+	}
+}
+
+func TestSwitchTheme_RebuildsTheStylesAndKeepsTheGlyphSet(t *testing.T) {
+	colourfulEnv(t)
+	writeConfig(t, profileWithEverything)
+
+	d := Deps{Theme: NewTheme(ThemeNoColor, true, ASCIIGlyphs()), Site: "example.atlassian.net"}
+	msg := firstMsgOfType[ThemeMsg](t, SwitchTheme(d, ThemeLight))
+	switch {
+	case msg.Theme == nil:
+		t.Fatal("no theme came back")
+	case msg.Theme.Mode != ThemeLight:
+		t.Errorf("got mode %v want light", msg.Theme.Mode)
+	case msg.Theme.Dark:
+		t.Error("the light theme reports itself dark")
+	case msg.Theme.Glyphs.Bullet != ASCIIGlyphs().Bullet:
+		t.Error("the glyph set was replaced; it answers a question about the font, not about colour")
+	case !hasColour(msg.Theme.Accent.Render("x")):
+		t.Error("switching away from no-color left the styles colourless")
+	}
+}
+
+func TestSwitchTheme_AsksTheTerminalAgainWhenItIsToldToFollowIt(t *testing.T) {
+	colourfulEnv(t)
+	writeConfig(t, profileWithEverything)
+
+	d := Deps{Theme: NewTheme(ThemeDark, true, UnicodeGlyphs()), Site: "example.atlassian.net"}
+	if !asksBackgroundColour(SwitchTheme(d, ThemeAuto)) {
+		t.Error("auto did not ask the terminal for its background, so it would follow the old answer")
+	}
+	if asksBackgroundColour(SwitchTheme(d, ThemeLight)) {
+		t.Error("an explicit theme asked the terminal for its background, which cannot change it")
+	}
+}
+
+func TestSwitchTheme_RefusesColourWhenTheEnvironmentAlreadySaidNo(t *testing.T) {
+	for name, env := range map[string][2]string{
+		"NO_COLOR is set":         {"NO_COLOR", "1"},
+		"the terminal is dumb":    {"TERM", "dumb"},
+		"there is no TERM at all": {"TERM", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TERM", "xterm-256color")
+			t.Setenv("NO_COLOR", "")
+			t.Setenv(env[0], env[1])
+
+			d := Deps{Theme: NewTheme(ThemeNoColor, true, UnicodeGlyphs())}
+			status := firstMsgOfType[StatusMsg](t, SwitchTheme(d, ThemeDark))
+			if !strings.Contains(status.Text, "no colour") {
+				t.Errorf("unhelpful refusal: %q", status.Text)
+			}
+			if got := collect(SwitchTheme(d, ThemeDark)); len(got) != 1 {
+				t.Errorf("the refusal still did other things: %#v", got)
+			}
+			if _, ok := firstOfType[ThemeMsg](collect(SwitchTheme(d, ThemeNoColor))); !ok {
+				t.Error("no-color was refused in an environment that asked for exactly that")
+			}
+		})
+	}
+}
+
+func TestWriteTheme_ChangesTheThemeAndNothingElseInTheProfile(t *testing.T) {
+	path := writeConfig(t, profileWithEverything)
+
+	if err := writeTheme("example.atlassian.net", ThemeDark); err != nil {
+		t.Fatalf("writeTheme: %v", err)
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := cfg.Get("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch {
+	case got.Theme != "dark":
+		t.Errorf("theme is %q, want dark", got.Theme)
+	case got.Glyphs != "ascii":
+		t.Errorf("the glyph set went from ascii to %q", got.Glyphs)
+	case len(got.Queries) != 1 || got.Queries[0].Slot != 2:
+		t.Errorf("the saved queries did not survive: %+v", got.Queries)
+	case len(got.Timeline.Start) != 1 || len(got.Timeline.End) != 1:
+		t.Errorf("the timeline fields did not survive: %+v", got.Timeline)
+	case got.Token.Env != "JIRA_TOKEN":
+		t.Errorf("the token source changed to %+v", got.Token)
+	case cfg.Active != "work" || !cfg.Mouse:
+		t.Errorf("the file's own settings changed: active=%q mouse=%v", cfg.Active, cfg.Mouse)
+	}
+}
+
+func TestWriteTheme_WritesAutoAsNoThemeAtAll(t *testing.T) {
+	path := writeConfig(t, strings.Replace(profileWithEverything, `glyphs = "ascii"`, `theme = "dark"`, 1))
+
+	if err := writeTheme("example.atlassian.net", ThemeAuto); err != nil {
+		t.Fatalf("writeTheme: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "theme") {
+		t.Errorf("auto was written as a value rather than as an absence:\n%s", body)
+	}
+}
+
+func TestWriteTheme_RefusesWhenTheSessionIsNotOnTheActiveProfilesSite(t *testing.T) {
+	writeConfig(t, profileWithEverything)
+
+	err := writeTheme("other.atlassian.net", ThemeDark)
+	if err == nil {
+		t.Fatal("the theme was written onto a profile this session is not running as")
+	}
+	if !strings.Contains(err.Error(), "other.atlassian.net") || !strings.Contains(err.Error(), "work") {
+		t.Errorf("the refusal does not say which session and which profile: %v", err)
+	}
+}
+
+func TestSaveTheme_SaysSoWhenThereIsNoProfileToSaveTo(t *testing.T) {
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+
+	status := firstMsgOfType[StatusMsg](t, saveTheme("example.atlassian.net", ThemeDark))
+	if !strings.Contains(status.Text, "no profile") {
+		t.Errorf("unhelpful message with nowhere to save: %q", status.Text)
+	}
+	if status.Level != LevelInfo {
+		t.Errorf("a first run with no profile is reported at level %v, which reads as a failure", status.Level)
+	}
+}
+
+func TestRunCommand_ThemeSwitchReachesTheFrameAndTheProfile(t *testing.T) {
+	colourfulEnv(t)
+	path := writeConfig(t, profileWithEverything)
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	registerThemeCommands()
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	d := testDeps()
+	d.Site = "example.atlassian.net"
+	m := newAt(t, d, 120, 30)
+	if hasColour(m.Frame()) {
+		t.Fatal("the test session did not start colourless, so this proves nothing")
+	}
+
+	next, cmd := m.Update(RunCommandMsg{ID: "theme.dark"})
+	m = next.(Model)
+	theme, ok := firstOfType[ThemeMsg](collect(cmd))
+	if !ok {
+		t.Fatal("running the command produced no theme")
+	}
+	next, _ = m.Update(theme)
+	m = next.(Model)
+
+	if m.deps.Theme.Mode != ThemeDark {
+		t.Errorf("the kernel is on %v after switching to dark", m.deps.Theme.Mode)
+	}
+	if !hasColour(m.Frame()) {
+		t.Error("the frame is still colourless after switching to the dark theme")
+	}
+	if saw := ansi.Strip(m.Frame()); !strings.Contains(saw, "board body") {
+		t.Errorf("the view stopped drawing after a theme switch:\n%s", saw)
+	}
+
+	eventually(t, func() bool {
+		cfg, err := config.LoadFile(path)
+		if err != nil {
+			return false
+		}
+		p, err := cfg.Get("work")
+		return err == nil && p.Theme == "dark"
+	})
+}
+
+// collect runs a command and flattens whatever it produced, because tea.Batch
+// hands back a message holding more commands rather than a list of messages.
+func collect(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	switch msg := cmd().(type) {
+	case nil:
+		return nil
+	case tea.BatchMsg:
+		var out []tea.Msg
+		for _, c := range msg {
+			out = append(out, collect(c)...)
+		}
+		return out
+	default:
+		return []tea.Msg{msg}
+	}
+}
+
+func firstOfType[T tea.Msg](msgs []tea.Msg) (T, bool) {
+	for _, msg := range msgs {
+		if want, ok := msg.(T); ok {
+			return want, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+func firstMsgOfType[T tea.Msg](t *testing.T, cmd tea.Cmd) T {
+	t.Helper()
+	got, ok := firstOfType[T](collect(cmd))
+	if !ok {
+		var zero T
+		t.Fatalf("no %T came back", zero)
+	}
+	return got
+}
+
+// asksBackgroundColour reports whether the command asks the terminal what colour
+// it is. bubbletea keeps the request message unexported, so it is recognised by
+// comparing against what the request command itself produces.
+func asksBackgroundColour(cmd tea.Cmd) bool {
+	want := tea.RequestBackgroundColor()
+	for _, msg := range collect(cmd) {
+		if msg == want {
+			return true
+		}
+	}
+	return false
 }
 
 // hasColour reports whether a rendered string carries an SGR colour parameter.

--- a/internal/ui/kernel/view.go
+++ b/internal/ui/kernel/view.go
@@ -116,3 +116,21 @@ type KeySet struct {
 
 // IsZero reports whether the set carries no bindings.
 func (k KeySet) IsZero() bool { return len(k.Short) == 0 && len(k.Full) == 0 }
+
+// KeyReporter is the optional interface a view implements when the keys that
+// work in it depend on what it is doing. RegisterKeys is init-time and refuses a
+// second call, so the registry holds one set per view for the whole run: the
+// resting state. A list with its filter open, a comment being written, a
+// transition waiting to be confirmed and an onboarding step all answer
+// differently, and docs/UX.md asks the footer to show only what works right now.
+//
+// Gen must change whenever the set does. The chrome is memoized on a comparable
+// key and a KeySet holds slices, so the number is what tells the footer to
+// repaint; a view that returns a constant one is right on the first frame and
+// stale forever. Returning the index of the state the set belongs to is enough.
+//
+// The set must be stored rather than built: this is called on every frame, and
+// a KeySet assembled per call puts its allocations under every keystroke.
+type KeyReporter interface {
+	LiveKeys() (set KeySet, gen int)
+}

--- a/internal/ui/list/keys.go
+++ b/internal/ui/list/keys.go
@@ -2,6 +2,8 @@ package list
 
 import "github.com/varijkapil13/saral/internal/ui/kernel"
 
+var _ kernel.KeyReporter = (*Model)(nil)
+
 type keyMap struct {
 	Up       kernel.Binding
 	Down     kernel.Binding
@@ -17,6 +19,13 @@ type keyMap struct {
 	Save     kernel.Binding
 	Accept   kernel.Binding
 	Clear    kernel.Binding
+	// Slot, Take and Drop answer the gesture that binds the search on screen to
+	// a number key. bindKey reads the digit and the y itself, because every other
+	// key ends the gesture and a table would have to enumerate the alphabet to
+	// say so.
+	Slot kernel.Binding
+	Take kernel.Binding
+	Drop kernel.Binding
 }
 
 func defaultKeys() keyMap {
@@ -35,21 +44,76 @@ func defaultKeys() keyMap {
 		Save:     kernel.Bind([]string{"s"}, "s", "save this query to a key"),
 		Accept:   kernel.Bind([]string{"enter"}, "enter", "keep filter"),
 		Clear:    kernel.Bind([]string{"esc", "ctrl+g"}, "esc", "clear filter"),
+		Slot:     kernel.Bind(digits, "1-9", "the key to bind it to"),
+		Take:     kernel.Bind([]string{"y"}, "y", "take the key"),
+		Drop:     kernel.Bind([]string{"esc"}, "esc", "leave it alone"),
 	}
 }
 
-// keySet is what the footer and the help overlay show. Nothing here is a second
-// copy of the bindings above: both come from the same value, so a key that
-// moves cannot leave a stale hint behind.
+var digits = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}
+
+// keySet is the resting state: a list nobody is typing into. Nothing here is a
+// second copy of the bindings above — both come from the same value, so a key
+// that moves cannot leave a stale hint behind.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
 		Short: []kernel.Binding{k.Down, k.Up, k.Open, k.Filter},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
-			{k.Open, k.Filter, k.Save, k.Accept, k.Clear},
+			{k.Open, k.Filter, k.Save},
 		},
 	}
+}
+
+// keyState is which of the view's four states the keys belong to. It doubles as
+// the generation the chrome memoizes on, so a state that is added has to be
+// added here to be drawn.
+type keyState int
+
+const (
+	keysBrowsing keyState = iota
+	keysFiltering
+	keysPickingSlot
+	keysConfirmingSlot
+	keyStates
+)
+
+// liveSets is one set per state, built once at start-up. LiveKeys is called on
+// every frame, so it hands back a stored value rather than assembling one.
+var liveSets = func() [keyStates]kernel.KeySet {
+	k := defaultKeys()
+	var sets [keyStates]kernel.KeySet
+	sets[keysBrowsing] = k.keySet()
+	sets[keysFiltering] = kernel.KeySet{
+		Short: []kernel.Binding{k.Accept, k.Clear},
+		Full:  [][]kernel.Binding{{k.Accept, k.Clear}},
+	}
+	sets[keysPickingSlot] = kernel.KeySet{
+		Short: []kernel.Binding{k.Slot, k.Drop},
+		Full:  [][]kernel.Binding{{k.Slot, k.Drop}},
+	}
+	sets[keysConfirmingSlot] = kernel.KeySet{
+		Short: []kernel.Binding{k.Take, k.Drop},
+		Full:  [][]kernel.Binding{{k.Take, k.Drop}},
+	}
+	return sets
+}()
+
+// LiveKeys reports the keys that work in the state the list is actually in. An
+// open filter answers enter and esc and nothing else; the gesture that binds a
+// number key answers a digit, then a y.
+func (m *Model) LiveKeys() (set kernel.KeySet, gen int) {
+	state := keysBrowsing
+	switch {
+	case m.filtering:
+		state = keysFiltering
+	case m.bind == bindPick:
+		state = keysPickingSlot
+	case m.bind == bindConfirm:
+		state = keysConfirmingSlot
+	}
+	return liveSets[state], int(state)
 }
 
 type action uint8

--- a/internal/ui/list/keys_test.go
+++ b/internal/ui/list/keys_test.go
@@ -1,0 +1,120 @@
+package list
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// TestLiveKeys_EveryStateGolden holds every state the footer and the help
+// overlay can be asked about. A state nothing covers is a state whose keys can
+// change without anybody noticing, which is the drift this file exists to stop.
+func TestLiveKeys_EveryStateGolden(t *testing.T) {
+	t.Parallel()
+	named := []struct {
+		name  string
+		state keyState
+	}{
+		{"browsing", keysBrowsing},
+		{"filter open", keysFiltering},
+		{"picking the number key", keysPickingSlot},
+		{"confirming a number key that is taken", keysConfirmingSlot},
+	}
+	if len(named) != int(keyStates) {
+		t.Fatalf("the list has %d key states and this test names %d", keyStates, len(named))
+	}
+	var b strings.Builder
+	for _, s := range named {
+		fmt.Fprintf(&b, "%s\n", s.name)
+		writeKeySet(&b, liveSets[s.state])
+	}
+	golden(t, "keys.golden", b.String())
+}
+
+func TestLiveKeys_FollowWhatTheListIsDoing(t *testing.T) {
+	t.Parallel()
+	m := newModel(t)
+	seen := map[int]string{}
+	for _, tc := range []struct {
+		name  string
+		enter func()
+		state keyState
+	}{
+		{"browsing", func() { m.filtering, m.bind = false, bindNone }, keysBrowsing},
+		{"filter open", func() { m.filtering = true }, keysFiltering},
+		{"picking a key", func() { m.filtering, m.bind = false, bindPick }, keysPickingSlot},
+		{"confirming a key", func() { m.bind = bindConfirm }, keysConfirmingSlot},
+	} {
+		tc.enter()
+		set, gen := m.LiveKeys()
+		if gen != int(tc.state) {
+			t.Errorf("%s: generation %d, want %d", tc.name, gen, tc.state)
+		}
+		if other, clash := seen[gen]; clash {
+			t.Errorf("%s and %s share generation %d, so the footer will not repaint between them",
+				tc.name, other, gen)
+		}
+		seen[gen] = tc.name
+		if len(set.Short) == 0 {
+			t.Errorf("%s advertises nothing at all", tc.name)
+		}
+	}
+}
+
+// The filter is opened with the key rather than by setting the field, so that
+// what the footer says is held against what the dispatcher actually does.
+func TestLiveKeys_TheFilterKeyChangesWhatIsAdvertised(t *testing.T) {
+	t.Parallel()
+	m := newModel(t)
+	before, _ := m.LiveKeys()
+	m.key(keyPress("/"))
+	after, gen := m.LiveKeys()
+	if gen != int(keysFiltering) {
+		t.Fatalf("pressing / left the keys in state %d", gen)
+	}
+	if shortOf(before) == shortOf(after) {
+		t.Errorf("the same keys are advertised with the filter open and closed: %s", shortOf(after))
+	}
+	if !strings.Contains(shortOf(after), "clear filter") {
+		t.Errorf("an open filter does not advertise the key that closes it: %s", shortOf(after))
+	}
+}
+
+// AllocsPerRun measures the whole process, so this one cannot run beside
+// anything else.
+func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
+	m := newModel(t)
+	if got := testing.AllocsPerRun(100, func() { _, _ = m.LiveKeys() }); got != 0 {
+		t.Errorf("asking for the live keys allocates %.0f times; chromeFor asks on every frame, so the sets must be stored", got)
+	}
+}
+
+func newModel(t *testing.T) *Model {
+	t.Helper()
+	m, ok := New(testDeps(nil)).(*Model)
+	if !ok {
+		t.Fatal("New no longer builds a *Model")
+	}
+	return m
+}
+
+func shortOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Short), " · ")
+}
+
+func labels(bindings []kernel.Binding) []string {
+	out := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, b.Help().Key+" "+b.Help().Desc)
+	}
+	return out
+}
+
+func writeKeySet(b *strings.Builder, set kernel.KeySet) {
+	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	for _, column := range set.Full {
+		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
+	}
+}

--- a/internal/ui/list/testdata/keys.golden
+++ b/internal/ui/list/testdata/keys.golden
@@ -1,0 +1,14 @@
+browsing
+  short  ↓/j down · ↑/k up · enter open · / filter
+  full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
+  full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
+  full   [enter open, / filter, s save this query to a key]
+filter open
+  short  enter keep filter · esc clear filter
+  full   [enter keep filter, esc clear filter]
+picking the number key
+  short  1-9 the key to bind it to · esc leave it alone
+  full   [1-9 the key to bind it to, esc leave it alone]
+confirming a number key that is taken
+  short  y take the key · esc leave it alone
+  full   [y take the key, esc leave it alone]

--- a/internal/ui/livekeys_test.go
+++ b/internal/ui/livekeys_test.go
@@ -1,0 +1,143 @@
+package ui
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	zone "github.com/lrstanley/bubblezone/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/comment"
+	"github.com/varijkapil13/saral/internal/ui/form"
+	"github.com/varijkapil13/saral/internal/ui/issue"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/list"
+	"github.com/varijkapil13/saral/internal/ui/onboarding"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// keyReporters names the model that answers for each registered key scope. The
+// kernel cannot hold the views to this — it may not import one — and a view
+// checking itself is the drift, so the sweep lives here, above every view and
+// below nothing.
+//
+// Every scope in the key registry has to appear, so a seventh view fails this
+// until somebody has decided which half of the table it belongs in.
+var keyReporters = map[string]func(kernel.Deps) kernel.View{
+	list.ViewID:       list.New,
+	form.ViewID:       form.New,
+	comment.ViewID:    comment.New,
+	onboarding.ViewID: onboarding.New,
+	issue.EditViewID:  func(d kernel.Deps) kernel.View { return issue.NewEdit(d, seed()) },
+	issue.MoveViewID:  func(d kernel.Deps) kernel.View { return issue.NewMove(d, seed()) },
+}
+
+// staticKeys are the scopes whose view deliberately reports nothing, each with
+// the reason. A view lands here because its keys genuinely do not move, not
+// because nobody got round to it.
+var staticKeys = map[string]struct {
+	build func(kernel.Deps) kernel.View
+	why   string
+}{
+	issue.ViewID: {
+		build: func(d kernel.Deps) kernel.View { return issue.New(d, seed()) },
+		why:   "the detail pane scrolls a document and every one of its keys works whatever it is showing",
+	},
+}
+
+func TestLiveKeys_EveryViewWhoseKeysMoveReportsThem(t *testing.T) {
+	sweepEnv(t)
+	scopes := kernel.KeyScopes()
+	if len(scopes) == 0 {
+		t.Fatal("no view registered any keys, so this sweep is checking nothing")
+	}
+
+	for _, scope := range scopes {
+		build, reports := keyReporters[scope]
+		static, isStatic := staticKeys[scope]
+		switch {
+		case reports && isStatic:
+			t.Errorf("%s is in both halves of the table", scope)
+			continue
+		case !reports && !isStatic:
+			t.Errorf("%s registers keys and this sweep does not know whether they move with its state; "+
+				"add it to keyReporters, or to staticKeys with the reason its keys never move", scope)
+			continue
+		case isStatic:
+			build = static.build
+			if static.why == "" {
+				t.Errorf("%s is exempt with no reason given", scope)
+			}
+		}
+
+		view := build(depsFor(t))
+		_, implements := view.(kernel.KeyReporter)
+		switch {
+		case reports && !implements:
+			t.Errorf("%s is listed as reporting its live keys and does not implement kernel.KeyReporter, "+
+				"so its footer is whatever it registered at start-up", scope)
+		case isStatic && implements:
+			t.Errorf("%s implements kernel.KeyReporter but is listed as static: %s", scope, static.why)
+		}
+		if kernel.KeysFor(scope).IsZero() {
+			t.Errorf("%s registered an empty key set; it is the resting record and what the command sweep "+
+				"holds a palette entry's key against", scope)
+		}
+	}
+
+	for scope := range keyReporters {
+		if !known(scopes, scope) {
+			t.Errorf("keyReporters names %q, which registers no keys any more", scope)
+		}
+	}
+	for scope := range staticKeys {
+		if !known(scopes, scope) {
+			t.Errorf("staticKeys names %q, which registers no keys any more", scope)
+		}
+	}
+}
+
+// A view that reports has to say something in the state it is built in, or the
+// footer of a freshly opened view is the globals and nothing else.
+func TestLiveKeys_AFreshlyBuiltViewAdvertisesSomething(t *testing.T) {
+	sweepEnv(t)
+	for scope, build := range keyReporters {
+		reporter, ok := build(depsFor(t)).(kernel.KeyReporter)
+		if !ok {
+			continue
+		}
+		if set, _ := reporter.LiveKeys(); set.IsZero() {
+			t.Errorf("%s advertises nothing in the state it opens in", scope)
+		}
+	}
+}
+
+// seed is the row a list would have handed over: a key and nothing else, which
+// is all these panes need to be built.
+func seed() jira.Issue {
+	return jira.Issue{ID: "10001", Key: "PROJ-1", Summary: "Something to look at"}
+}
+
+func sweepEnv(t *testing.T) {
+	t.Helper()
+	// Two of these views locate a drafts directory when they are built. Pointing
+	// the lookup at a temporary directory keeps the sweep off whatever the person
+	// running it has configured.
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
+}
+
+func depsFor(t *testing.T) kernel.Deps {
+	t.Helper()
+	return kernel.Deps{
+		Theme: kernel.NewTheme(kernel.ThemeNoColor, true, kernel.ASCIIGlyphs()),
+		Zones: zone.New(),
+		Site:  "example.atlassian.net",
+		Now:   func() time.Time { return time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC) },
+	}
+}
+
+func known(scopes []string, want string) bool {
+	at := sort.SearchStrings(scopes, want)
+	return at < len(scopes) && scopes[at] == want
+}

--- a/internal/ui/onboarding/keys.go
+++ b/internal/ui/onboarding/keys.go
@@ -1,0 +1,126 @@
+package onboarding
+
+import "github.com/varijkapil13/saral/internal/ui/kernel"
+
+var _ kernel.KeyReporter = Model{}
+
+type keyMap struct {
+	Continue kernel.Binding
+	Back     kernel.Binding
+	Choose   kernel.Binding
+	Write    kernel.Binding
+	Finish   kernel.Binding
+	Retry    kernel.Binding
+}
+
+// defaultKeys is the flow's keymap. enter is spelt three ways because it does
+// three different things — take this step, write the file, leave — and a screen
+// that called all three "continue" would be telling the user the least at the
+// two moments it matters most.
+func defaultKeys() keyMap {
+	return keyMap{
+		Continue: kernel.Bind([]string{"enter", "tab"}, "enter", "continue"),
+		Back:     kernel.Bind([]string{"shift+tab"}, "shift+tab", "back a step"),
+		Choose:   kernel.Bind([]string{"up", "down"}, "↑/↓", "choose"),
+		Write:    kernel.Bind([]string{"enter", "tab"}, "enter", "write the profile"),
+		Finish:   kernel.Bind([]string{"enter", "tab"}, "enter", "start using it"),
+		Retry:    kernel.Bind([]string{"ctrl+r"}, "ctrl+r", "try that again"),
+	}
+}
+
+// keySet is the resting state: a step with a field in it, part way through.
+func (k keyMap) keySet() kernel.KeySet {
+	return kernel.KeySet{
+		Short: []kernel.Binding{k.Continue, k.Back},
+		Full:  [][]kernel.Binding{{k.Continue, k.Back, k.Retry}},
+	}
+}
+
+// keyState is which of the flow's states the keys belong to. It doubles as the
+// generation the chrome memoizes on, so a state that is added has to be added
+// here to be drawn.
+type keyState int
+
+const (
+	keysFirstStep keyState = iota
+	keysFirstStepFailed
+	keysTyping
+	keysChoosing
+	keysReview
+	keysDone
+	keysFailed
+	keysBusy
+	keyStates
+)
+
+// liveSets is one set per state, built once at start-up. LiveKeys is called on
+// every frame, so it hands back a stored value rather than assembling one.
+var liveSets = func() [keyStates]kernel.KeySet {
+	k := defaultKeys()
+	var sets [keyStates]kernel.KeySet
+	// The first step has nowhere to go back to, and back() knows it, so the
+	// footer says so by leaving the key out.
+	sets[keysFirstStep] = kernel.KeySet{
+		Short: []kernel.Binding{k.Continue},
+		Full:  [][]kernel.Binding{{k.Continue}},
+	}
+	// A site that could not be reached is the commonest way this flow fails, and
+	// it fails on the one step with nothing behind it.
+	sets[keysFirstStepFailed] = kernel.KeySet{
+		Short: []kernel.Binding{k.Retry, k.Continue},
+		Full:  [][]kernel.Binding{{k.Retry, k.Continue}},
+	}
+	sets[keysTyping] = k.keySet()
+	sets[keysChoosing] = kernel.KeySet{
+		Short: []kernel.Binding{k.Choose, k.Continue, k.Back},
+		Full:  [][]kernel.Binding{{k.Choose, k.Continue, k.Back, k.Retry}},
+	}
+	sets[keysReview] = kernel.KeySet{
+		Short: []kernel.Binding{k.Write, k.Back},
+		Full:  [][]kernel.Binding{{k.Write, k.Back}},
+	}
+	sets[keysDone] = kernel.KeySet{
+		Short: []kernel.Binding{k.Finish},
+		Full:  [][]kernel.Binding{{k.Finish}},
+	}
+	sets[keysFailed] = kernel.KeySet{
+		Short: []kernel.Binding{k.Retry, k.Back},
+		Full:  [][]kernel.Binding{{k.Retry, k.Back, k.Continue}},
+	}
+	// Nothing this view offers works while it is waiting on a site: enter and
+	// shift+tab are both refused until the answer comes back, so the footer
+	// falls back to the globals rather than naming a key that does nothing.
+	sets[keysBusy] = kernel.KeySet{}
+	return sets
+}()
+
+// LiveKeys reports the keys that work on the step the user is actually on. The
+// steps differ in more than their prompt: the first has no way back, two of them
+// have something to choose with the arrows, the last two spend enter on writing
+// the file and leaving, and none of them answers anything while a site is being
+// asked.
+func (m Model) LiveKeys() (set kernel.KeySet, gen int) {
+	state := m.keyState()
+	return liveSets[state], int(state)
+}
+
+func (m Model) keyState() keyState {
+	switch {
+	case m.busy != busyNone:
+		return keysBusy
+	case m.problem != "" && m.step == stepSite:
+		return keysFirstStepFailed
+	case m.problem != "":
+		return keysFailed
+	case m.step == stepStorage, m.step == stepProject && len(m.suggested) > 0:
+		return keysChoosing
+	case m.step == stepReview:
+		return keysReview
+	case m.step >= stepDone:
+		return keysDone
+	case m.step == stepSite:
+		return keysFirstStep
+	default:
+		return keysTyping
+	}
+}

--- a/internal/ui/onboarding/keys_test.go
+++ b/internal/ui/onboarding/keys_test.go
@@ -1,0 +1,146 @@
+package onboarding
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// TestLiveKeys_EveryStateGolden holds every state the footer and the help
+// overlay can be asked about. A state nothing covers is a state whose keys can
+// change without anybody noticing.
+func TestLiveKeys_EveryStateGolden(t *testing.T) {
+	t.Parallel()
+	named := []struct {
+		name  string
+		state keyState
+	}{
+		{"the first step", keysFirstStep},
+		{"the first step, after it failed", keysFirstStepFailed},
+		{"a step with something to type", keysTyping},
+		{"a step with something to choose", keysChoosing},
+		{"the review", keysReview},
+		{"the summary", keysDone},
+		{"after a step failed", keysFailed},
+		{"waiting on the site", keysBusy},
+	}
+	if len(named) != int(keyStates) {
+		t.Fatalf("the flow has %d key states and this test names %d", keyStates, len(named))
+	}
+	var b strings.Builder
+	for _, s := range named {
+		fmt.Fprintf(&b, "%s\n", s.name)
+		writeKeySet(&b, liveSets[s.state])
+	}
+	golden(t, "keys.golden", b.String())
+}
+
+func TestLiveKeys_FollowTheStepTheUserIsOn(t *testing.T) {
+	t.Parallel()
+	base, ok := NewWith(testDeps(), nil).(Model)
+	if !ok {
+		t.Fatal("NewWith no longer builds a Model")
+	}
+	seen := map[int]keyState{}
+	for _, tc := range []struct {
+		name  string
+		enter func(Model) Model
+		state keyState
+	}{
+		{"the site", func(m Model) Model { return m }, keysFirstStep},
+		{"the site, unreachable", func(m Model) Model { m.problem = "no such host"; return m }, keysFirstStepFailed},
+		{"the email", func(m Model) Model { m.step = stepEmail; return m }, keysTyping},
+		{"the token store", func(m Model) Model { m.step = stepStorage; return m }, keysChoosing},
+		{"a project with suggestions", func(m Model) Model {
+			m.step, m.suggested = stepProject, []string{"PROJ"}
+			return m
+		}, keysChoosing},
+		{"a project with none", func(m Model) Model { m.step = stepProject; return m }, keysTyping},
+		{"the review", func(m Model) Model { m.step = stepReview; return m }, keysReview},
+		{"the summary", func(m Model) Model { m.step = stepDone; return m }, keysDone},
+		{"the token refused", func(m Model) Model {
+			m.step, m.problem = stepToken, "that token is not for this account"
+			return m
+		}, keysFailed},
+		{"asking the site", func(m Model) Model { m.step, m.busy = stepToken, busyConnect; return m }, keysBusy},
+	} {
+		set, gen := tc.enter(base).LiveKeys()
+		if gen != int(tc.state) {
+			t.Errorf("%s: generation %d, want %d", tc.name, gen, tc.state)
+		}
+		if other, clash := seen[gen]; clash && other != tc.state {
+			t.Errorf("%s reports generation %d, which belongs to %d", tc.name, gen, other)
+		}
+		seen[gen] = tc.state
+		if tc.state == keysBusy && !set.IsZero() {
+			t.Errorf("a step waiting on the site advertises %s, none of which answers", shortOf(set))
+		}
+	}
+}
+
+// The first step has nowhere to go back to — back() returns nothing there — so
+// naming the key would be advertising a stroke that does nothing at the one
+// moment a first-time user is most likely to try it.
+func TestLiveKeys_TheFirstStepDoesNotOfferAWayBack(t *testing.T) {
+	t.Parallel()
+	for _, state := range []keyState{keysFirstStep, keysFirstStepFailed} {
+		if got := shortOf(liveSets[state]); strings.Contains(got, "back") {
+			t.Errorf("the first step offers a way back: %s", got)
+		}
+	}
+	if got := shortOf(liveSets[keysTyping]); !strings.Contains(got, "back") {
+		t.Errorf("a later step lost its way back: %s", got)
+	}
+}
+
+// enter does three different things across the flow, and the last two are the
+// ones a user has never seen before.
+func TestLiveKeys_EnterIsNamedForWhatItDoesOnThisStep(t *testing.T) {
+	t.Parallel()
+	for state, want := range map[keyState]string{
+		keysTyping: "continue",
+		keysReview: "write the profile",
+		keysDone:   "start using it",
+	} {
+		if got := shortOf(liveSets[state]); !strings.Contains(got, want) {
+			t.Errorf("state %d does not say enter %q: %s", state, want, got)
+		}
+	}
+}
+
+// AllocsPerRun measures the whole process, so this one cannot run beside
+// anything else.
+func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
+	m, ok := NewWith(testDeps(), nil).(Model)
+	if !ok {
+		t.Fatal("NewWith no longer builds a Model")
+	}
+	if got := testing.AllocsPerRun(100, func() { _, _ = m.LiveKeys() }); got != 0 {
+		t.Errorf("asking for the live keys allocates %.0f times; chromeFor asks on every frame, so the sets must be stored", got)
+	}
+}
+
+func shortOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Short), " · ")
+}
+
+func labels(bindings []kernel.Binding) []string {
+	out := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, b.Help().Key+" "+b.Help().Desc)
+	}
+	return out
+}
+
+func writeKeySet(b *strings.Builder, set kernel.KeySet) {
+	if set.IsZero() {
+		b.WriteString("  nothing of its own; the globals are all that answer\n")
+		return
+	}
+	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	for _, column := range set.Full {
+		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
+	}
+}

--- a/internal/ui/onboarding/register.go
+++ b/internal/ui/onboarding/register.go
@@ -16,18 +16,7 @@ func init() {
 		New:   New,
 	})
 
-	kernel.RegisterKeys(ViewID, kernel.KeySet{
-		Short: []kernel.Binding{
-			kernel.Bind([]string{"enter"}, "enter", "continue"),
-			kernel.Bind([]string{"shift+tab"}, "shift+tab", "back a step"),
-		},
-		Full: [][]kernel.Binding{{
-			kernel.Bind([]string{"enter", "tab"}, "enter", "continue"),
-			kernel.Bind([]string{"shift+tab"}, "shift+tab", "back a step"),
-			kernel.Bind([]string{"up", "down"}, "up/down", "choose"),
-			kernel.Bind([]string{"ctrl+r"}, "ctrl+r", "try that again"),
-		}},
-	})
+	kernel.RegisterKeys(ViewID, defaultKeys().keySet())
 
 	kernel.RegisterCommand(kernel.Command{
 		ID:    "onboarding.run",

--- a/internal/ui/onboarding/testdata/keys.golden
+++ b/internal/ui/onboarding/testdata/keys.golden
@@ -1,0 +1,23 @@
+the first step
+  short  enter continue
+  full   [enter continue]
+the first step, after it failed
+  short  ctrl+r try that again · enter continue
+  full   [ctrl+r try that again, enter continue]
+a step with something to type
+  short  enter continue · shift+tab back a step
+  full   [enter continue, shift+tab back a step, ctrl+r try that again]
+a step with something to choose
+  short  ↑/↓ choose · enter continue · shift+tab back a step
+  full   [↑/↓ choose, enter continue, shift+tab back a step, ctrl+r try that again]
+the review
+  short  enter write the profile · shift+tab back a step
+  full   [enter write the profile, shift+tab back a step]
+the summary
+  short  enter start using it
+  full   [enter start using it]
+after a step failed
+  short  ctrl+r try that again · shift+tab back a step
+  full   [ctrl+r try that again, shift+tab back a step, enter continue]
+waiting on the site
+  nothing of its own; the globals are all that answer


### PR DESCRIPTION
Closes #16.

## The roadmap row was wrong, and is corrected

It claimed **`owns internal/ui/help/**`, `internal/ui/theme/**`**. Neither directory exists and
neither was created. The footer and the `?` overlay are chrome functions in
`internal/ui/kernel/kernel.go`; the themes are `internal/ui/kernel/theme.go`, 284 lines of it. Moving
theming out of the kernel would touch ~25 files across six packages, two of which other agents are
editing this wave — it is a refactor packet, not this one. The row now names where the work actually
lives, and says why.

## Most of the packet was already built. What was actually missing

Reconnaissance found theming ~85% done and the footer's hard-won half — `liveGlobals()`, the derived
and clickable slots, the capturing footer keeping `ctrl+k`, the bespoke line for the buffered `g` —
already right. All of it is kept.

**1. A view's advertised keys were frozen at registration.** `RegisterKeys` runs in an `init()` and
refuses a second call, so `KeysFor(id)` returned one set however the view's state changed. Six views
have states whose keys are completely different, and were advertising the wrong ones:

| view | what the footer said | what actually worked |
|---|---|---|
| list, filter open | `↓/j down · ↑/k up · enter open · / filter` | `enter keep filter · esc clear filter` |
| list, binding a number key | the same again | a digit, then `y` |
| comment, writing | `a write a comment · e edit this one · d delete this one` | `ctrl+s send · esc put it aside` |
| comment, confirming a delete | the same again | `y delete it · esc keep it` |
| form, long-text pane | `ctrl+d empty this field` | `ctrl+d finish this text` — the opposite |
| form, choosing an issue type | `ctrl+s create the issue · ctrl+t change the issue type` | neither |
| issue editor, conflict | `y go ahead` | `y re-read it and put your edits back on top` |
| transition screen | `enter choose` | `enter use these values` |
| onboarding, first step | `shift+tab back a step` | nothing; `back()` returns nil there |
| onboarding, waiting on the site | `enter continue · shift+tab back a step` | neither; both are refused while busy |

`kernel.KeyReporter` is the optional interface a view implements to answer for the state it is in —
the same shape as `KeyCapturer` and `Blocker`, so a view that does not implement it costs nothing.
**All six implement it**, and the registry entry becomes the view's *resting* state, which is still
what `internal/ui/keys_test.go` holds a palette entry's key against.

The three traps in the packet brief are all handled, and each has a test:

- **`chromeKey` memoization.** `keysGen` joined the key. It is load-bearing rather than belt-and-
  braces: `capturing` was already in that key, so the transitions it actually catches are the ones
  where the view keeps the keyboard on both sides — pick-then-confirm a number key, type-then-confirm
  a save, one editor pane to another. `TestChrome_RepaintsWhenNothingButTheViewsKeysChanged` uses a
  stub that captures in both states so it can only be passing on the generation.
- **Per-frame cost.** Every view builds one `KeySet` per state in a package-level `var` at start-up
  and indexes it. Each view package asserts `testing.AllocsPerRun(100, LiveKeys) == 0`, and
  `BenchmarkFrame` / `BenchmarkKeyToFrame` are **297 / 310 allocs/op, unchanged**.
- **A golden per state.** Each view package has `testdata/keys.golden` listing every state and what it
  advertises, plus a guard that the number of states named equals the number that exist — so a sixth
  form state or a fourth comment mode fails until it is covered. The kernel's chrome goldens are per
  state *and* per width.

**2. Nothing sent `ThemeMsg`.** `theme.go` registers four palette commands (dark, light, follow the
terminal, colour off). No key: every letter left is one somebody types into a field, and
`internal/ui/keys_test.go` would rightly reject a command teaching a key no view shows.

**3. Colour stepping was never missing** — bubbletea calls `colorprofile.Detect` at start-up and its
renderer downsamples. `docs/UX.md` and `docs/ARCHITECTURE.md` now say the library does it and warn the
next packet off writing a second one. `tea.ColorProfileMsg` is not handled and does not need to be:
the renderer acts on the profile itself, and nothing here quantises a colour.

## #63 is not made worse

`writeTheme` reads the whole file and changes one field. `Config.Save` writes the profile it is handed
and nothing else, so a fresh `Profile` would drop the queries, the timeline field names and the glyph
set — which is exactly the bug in #63. `TestWriteTheme_ChangesTheThemeAndNothingElseInTheProfile`
writes a profile with a saved query on key `2`, a timeline pair, `glyphs = "ascii"` and an env token,
switches the theme and asserts every one of them survives, plus `active` and `mouse`.

Three smaller decisions in the same area:

- **Auto is written as the absence of a theme**, so a profile that never chose and a profile that
  chose auto read the same.
- **A `--profile` session refuses rather than guessing.** The kernel is told `Deps.Site` and never
  which profile was named on the command line, so it compares the two and says *"this session is on X
  and the active profile Y is on Z, so nothing was written"* rather than putting the choice on a
  profile the user cannot see. The clean fix is a `Deps.SaveTheme` wired at the composition root, the
  way `SaveQueries` is — `cmd/saral/main.go` belongs to another agent this wave, so it is a follow-up
  rather than a widened diff.
- **`NO_COLOR` still wins.** `docs/UX.md` says a user who exported it meant it everywhere, so a switch
  to a colour mode is refused with the reason. `TERM=dumb` and an empty `TERM` behave the same.

## Consumers adopted, by name

```
$ grep -rn KeyReporter internal/ | grep -v _test
internal/ui/list/keys.go:5:       var _ kernel.KeyReporter = (*Model)(nil)
internal/ui/comment/keys.go:5:    var _ kernel.KeyReporter = (*Model)(nil)
internal/ui/form/keys.go:5:       var _ kernel.KeyReporter = (*Model)(nil)
internal/ui/onboarding/keys.go:5: var _ kernel.KeyReporter = Model{}
internal/ui/issue/edit_keys.go:   _ kernel.KeyReporter = (*editModel)(nil)
internal/ui/issue/edit_keys.go:   _ kernel.KeyReporter = (*moveModel)(nil)
internal/ui/issue/keys.go:46:     // the detail pane implements no KeyReporter, and why
```

A hit per view package, not just the definition and its test. And it is enforced rather than counted
by hand: `internal/ui/livekeys_test.go` walks `kernel.KeyScopes()` and fails on any registered key
scope that is in neither `keyReporters` nor `staticKeys` — so **a seventh view fails this until
somebody decides which half it belongs in**, and a static exemption has to carry its reason. Verified
by breaking it: renaming `list.LiveKeys` fails with *"list is listed as reporting its live keys and
does not implement kernel.KeyReporter, so its footer is whatever it registered at start-up"*.

## The hints bullet moved to P3.1 (#12)

*"After you reach an action through the palette three times, the status line notes its key"* needs the
counter, the call site and the frecency table P3.1 already owns — one piece of data, and W0-b landed
`CommandRanMsg{ID, Keys}` as the signal. Building a second counter in the chrome is how a project
ends up with two answers. Noted on #16, on #12, and in `docs/UX.md` and the roadmap row.

## Golden files changed — what the diff shows

- `internal/ui/kernel/testdata/chrome_{resting,filtering}_{120x30,80x20}.golden` (new): the footer
  following a view between two states, at a comfortable and a narrow width. The state pair is what the
  footer line differs on; the slots and header are identical.
- `internal/ui/kernel/testdata/help_{resting,filtering}.golden` (new): `?` built from the live set
  rather than the registered one.
- `internal/ui/{list,comment,form,issue,onboarding}/testdata/keys.golden` (new): every state of every
  view and what it advertises. This is the artifact to read in review — it is the whole behaviour
  change in five files.
- `internal/ui/form/testdata/*.golden` (updated): `home`/`end` are labelled "first row" / "last row"
  rather than "first field" / "last field", because the same two strokes also move over the list of
  issue types, where there is no field.

## Deviations from the owned-paths list, all additive

The list in the packet brief is followed, with four new files it implies but does not name. None
touches a line another packet owns.

1. **`internal/ui/kernel/chrome_test.go`** — the chrome is this packet's and `kernel_test.go` is not
   granted, so the chrome's tests land in a new file beside it rather than inside someone else's.
2. **`internal/ui/livekeys_test.go`** — the completeness sweep has to import every view, and the
   kernel may not. `docs/ARCHITECTURE.md` already puts the sibling sweep (a command's key against what
   its view renders) in `internal/ui` for exactly this reason. `internal/ui/keys_test.go` is
   untouched.
3. **`keys_test.go` + `testdata/keys.golden` in the five view packages** — a state table is testable
   only from inside the package that owns the state; from `internal/ui` the fields are unreachable and
   the states data-dependent. New files, so nothing to conflict with. **`internal/ui/list/**` is
   otherwise untouched**, as asked: `list/keys.go` alone carries the implementation, which is why the
   sets are package-level rather than fields on `Model`.
4. **`internal/ui/issue/edit_keys.go`** — the issue package splits its keymaps across `keys.go` and
   `edit_keys.go`, and the two pushed panes' keys live in the latter. Putting their state tables
   anywhere else would separate them from the `editKeyMap` they are built from.

Plus one small addition inside a granted file: **`kernel.KeyScopes()`** in `registry.go`, which is
what makes the sweep total rather than a hand-maintained list.

`cmd/saral/main.go` and `internal/ui/list/**` beyond `keys.go` are untouched.

## Verification

```
go mod tidy && git diff --exit-code go.mod go.sum   clean (no dependency change)
go vet ./... && golangci-lint run                   0 issues
go test -race -count=1 ./...                        all packages ok
go build -trimpath -ldflags "-s -w"                 10M, under the 15 MiB budget
python3 scripts/checkleak.py                        clean
BenchmarkFrame                                      297 allocs/op (was 297)
BenchmarkKeyToFrame                                 310 allocs/op (was 310)
```

No instance data in the diff: the only new fixtures are key labels and the invented
`example.atlassian.net` profile the theme round-trip test writes into a `t.TempDir()`.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
