### PR TITLE
feat(cache): draw yesterday's rows before asking Jira anything

### DIFF
--- a/cmd/saral/main.go
+++ b/cmd/saral/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
@@ -17,12 +18,17 @@ import (
 
 	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/store"
 	_ "github.com/varijkapil13/saral/internal/ui"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/list"
 	"github.com/varijkapil13/saral/internal/ui/onboarding"
 	"github.com/varijkapil13/saral/pkg/jira"
 	"github.com/varijkapil13/saral/pkg/jira/cloud"
 )
+
+// cacheFile is the bbolt database inside config.CacheDir().
+const cacheFile = "cache.db"
 
 // tokenTimeout bounds resolving the token, which happens before the first frame
 // and cannot be cancelled by anyone watching it. internal/config gives a command
@@ -58,6 +64,7 @@ type options struct {
 	project    string
 	view       string
 	theme      string
+	poll       time.Duration
 	mouse      bool
 	mouseSet   bool
 	benchPaint bool
@@ -71,6 +78,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fs.StringVar(&opt.project, "project", "", "project key to scope the session to; several capabilities are per-project")
 	fs.StringVar(&opt.profile, "profile", "", "profile to use (default: the active one)")
 	fs.StringVar(&opt.theme, "theme", "", "auto, dark, light or no-color")
+	fs.DurationVar(&opt.poll, "poll", 0, "re-read the focused view this often; off by default, and pauses when Jira rate-limits")
 	fs.BoolVar(&opt.mouse, "mouse", true, "enable mouse reporting")
 	fs.BoolVar(&opt.benchPaint, "bench-first-paint", false, "render one frame, print how long it took, and exit")
 	fs.BoolVar(&opt.showVer, "version", false, "print the version and exit")
@@ -106,10 +114,11 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("%d view(s) failed to register: %w", len(errs), errors.Join(errs...))
 	}
 
-	deps, kopts, notice, err := build(opt)
+	deps, kopts, notice, closeCache, err := build(opt)
 	if err != nil {
 		return err
 	}
+	defer closeCache()
 	if opt.benchPaint {
 		return benchFirstPaint(stdout, stderr, deps, kopts, notice)
 	}
@@ -124,32 +133,36 @@ func run(args []string, stdout, stderr io.Writer) error {
 // running. Resolving a token can fail for reasons that are nobody's mistake — a
 // locked keychain, a helper command that is not installed on this machine — and
 // none of them is a reason to refuse to open.
-func build(opt options) (kernel.Deps, []kernel.Option, string, error) {
-	deps := kernel.Deps{}
+//
+// The fourth releases the cache file. bbolt holds an exclusive lock on it for as
+// long as it is open, so the run that took it gives it back rather than leaving
+// the next copy of Saral without one.
+func build(opt options) (deps kernel.Deps, kopts []kernel.Option, notice string, releaseCache func(), err error) {
+	releaseCache = func() {}
 	cfg, err := config.Load()
 	switch {
 	case errors.Is(err, config.ErrNoConfig):
 		cfg = config.Config{Mouse: true}
 	case err != nil:
-		return deps, nil, "", err
+		return deps, nil, notice, releaseCache, err
 	}
 
 	// A config file that exists but points nowhere is a mistake worth naming: the
 	// alternative is a session that silently talks to no site at all.
 	profile, perr := profileFor(cfg, opt.profile)
 	if perr != nil && (opt.profile != "" || len(cfg.Profiles) > 0) {
-		return deps, nil, "", perr
+		return deps, nil, notice, releaseCache, perr
 	}
 	deps.Site = profile.Site
 	project, err := sessionProject(opt.project, profile.Project)
 	if err != nil {
-		return deps, nil, "", err
+		return deps, nil, notice, releaseCache, err
 	}
 	deps.Project = project
 
 	saved, err := app.NewSavedQueries(profile.Queries...)
 	if err != nil {
-		return deps, nil, "", err
+		return deps, nil, notice, releaseCache, err
 	}
 	deps.Saved = saved
 	deps.SaveQueries = queryWriter(profile.Name)
@@ -164,7 +177,6 @@ func build(opt options) (kernel.Deps, []kernel.Option, string, error) {
 	// gets one, so this goes on whether or not there is a profile to open with.
 	onboarding.SetConnector(connect)
 
-	var notice string
 	if !firstRun {
 		client, cerr := clientFor(profile)
 		if cerr != nil {
@@ -172,7 +184,16 @@ func build(opt options) (kernel.Deps, []kernel.Option, string, error) {
 		} else {
 			deps.Jira = client
 		}
+		// Opened whether or not the client was: rows from the last session are
+		// worth drawing even in a session that cannot reach the site at all.
+		var cacheNote string
+		deps.Cache, releaseCache, cacheNote = openCache(profile)
+		if notice == "" {
+			notice = cacheNote
+		}
 	}
+
+	list.SetPollInterval(opt.poll)
 
 	theme := opt.theme
 	if theme == "" {
@@ -185,14 +206,38 @@ func build(opt options) (kernel.Deps, []kernel.Option, string, error) {
 	if opt.mouseSet {
 		mouse = opt.mouse
 	}
-	kopts := []kernel.Option{kernel.WithMouse(mouse)}
+	kopts = []kernel.Option{kernel.WithMouse(mouse)}
 	switch {
 	case opt.view != "":
 		kopts = append(kopts, kernel.WithInitialView(opt.view))
 	case firstRun:
 		kopts = append(kopts, kernel.WithInitialView(kernel.SetupViewID))
 	}
-	return deps, kopts, notice, nil
+	return deps, kopts, notice, releaseCache, nil
+}
+
+// openCache opens the profile's cache, and says in words when it could not.
+//
+// Nothing here is fatal: a session that keeps no cache fetches everything it
+// shows, which still works. Another copy of Saral holding the file is the
+// ordinary way that happens, not a mistake, and so is an unwritable home.
+func openCache(p config.Profile) (cache app.Cache, release func(), notice string) {
+	release = func() {}
+	dir, err := config.CacheDir()
+	if err != nil {
+		return nil, release, "nothing will be cached this session: " + err.Error()
+	}
+	db, err := store.Open(filepath.Join(dir, cacheFile))
+	switch {
+	case errors.Is(err, store.ErrLocked):
+		return nil, release, "another copy of Saral has the cache open, so this session keeps none of its own"
+	case err != nil:
+		return nil, release, "nothing will be cached this session: " + err.Error()
+	}
+	// The account is the profile's email rather than its Jira account ID: the ID
+	// takes a round trip to learn, the first frame is drawn before one could have
+	// answered, and two profiles on one site differ by email anyway.
+	return app.NewCache(db, store.Scope{Site: p.Site, Account: p.Email}), func() { _ = db.Close() }, ""
 }
 
 // connect opens a client for credentials the caller already holds, which is what

--- a/cmd/saral/main_test.go
+++ b/cmd/saral/main_test.go
@@ -7,12 +7,18 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/store"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/list"
 	"github.com/varijkapil13/saral/internal/ui/onboarding"
 	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
 )
 
 func TestRun_Version(t *testing.T) {
@@ -29,6 +35,7 @@ func TestRun_Version(t *testing.T) {
 
 func TestRun_BenchFirstPaintPrintsMicroseconds(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
 	var out, errOut bytes.Buffer
 	if err := run([]string{"--bench-first-paint"}, &out, &errOut); err != nil {
@@ -58,6 +65,7 @@ func TestRun_BenchFirstPaintStillSaysWhyThereIsNoClient(t *testing.T) {
 
 func TestRun_UnknownProfileIsAnError(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
 	var out, errOut bytes.Buffer
 	if err := run([]string{"--profile", "nope", "--bench-first-paint"}, &out, &errOut); err == nil {
@@ -67,8 +75,9 @@ func TestRun_UnknownProfileIsAnError(t *testing.T) {
 
 func TestRun_MissingConfigStillStarts(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
-	deps, opts, _, err := build(options{benchPaint: true})
+	deps, opts, _, _, err := build(options{benchPaint: true})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -82,9 +91,10 @@ func TestRun_MissingConfigStillStarts(t *testing.T) {
 
 func TestBuild_NoColorEnvironmentWinsOverTheFlag(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 	t.Setenv("NO_COLOR", "1")
 
-	deps, _, _, err := build(options{theme: "dark"})
+	deps, _, _, _, err := build(options{theme: "dark"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -95,11 +105,12 @@ func TestBuild_NoColorEnvironmentWinsOverTheFlag(t *testing.T) {
 
 func TestBuild_AFirstRunStartsAtSetup(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
 	// Nothing configured. The kernel would otherwise open whichever view claimed
 	// the first footer slot, leaving setup reachable only by someone who already
 	// knows its name — which is nobody on their first run.
-	_, opts, _, err := build(options{})
+	_, opts, _, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -110,8 +121,9 @@ func TestBuild_AFirstRunStartsAtSetup(t *testing.T) {
 
 func TestBuild_AnExplicitViewStillWinsOnAFirstRun(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
-	_, opts, _, err := build(options{view: "board"})
+	_, opts, _, _, err := build(options{view: "board"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -123,6 +135,7 @@ func TestBuild_AnExplicitViewStillWinsOnAFirstRun(t *testing.T) {
 func TestBuild_AConfiguredProfileDoesNotStartAtSetup(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SARAL_CONFIG_DIR", dir)
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 	const cfg = `active = "work"
 
 [profiles.work]
@@ -134,7 +147,7 @@ token = { env = "JIRA_TOKEN" }
 		t.Fatal(err)
 	}
 
-	_, opts, _, err := build(options{})
+	_, opts, _, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -163,6 +176,8 @@ func TestBuild_TheProjectFlagOverridesTheProfileRatherThanReplacingIt(t *testing
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
 			t.Setenv("SARAL_CONFIG_DIR", dir)
+			t.Setenv("SARAL_CACHE_DIR", t.TempDir())
+			t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 			cfg := "active = \"work\"\n\n[profiles.work]\nsite  = \"example.atlassian.net\"\n" +
 				"email = \"you@example.com\"\ntoken = { env = \"JIRA_TOKEN\" }\n"
 			if tc.stored != "" {
@@ -172,7 +187,7 @@ func TestBuild_TheProjectFlagOverridesTheProfileRatherThanReplacingIt(t *testing
 				t.Fatal(err)
 			}
 
-			deps, _, _, err := build(options{project: tc.flag})
+			deps, _, _, _, err := build(options{project: tc.flag})
 			switch {
 			case tc.fails && err == nil:
 				t.Fatalf("--project %q was accepted and reached JQL", tc.flag)
@@ -201,6 +216,7 @@ func writeProfile(t *testing.T) {
 
 	dir := t.TempDir()
 	t.Setenv("SARAL_CONFIG_DIR", dir)
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 	cfg := "active = \"work\"\n\n[profiles.work]\nsite  = \"example.atlassian.net\"\n" +
 		"email = \"you@example.com\"\ntoken = { env = \"SARAL_TEST_TOKEN\" }\n"
 	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(cfg), 0o600); err != nil {
@@ -212,7 +228,7 @@ func TestBuild_AResolvableTokenProducesAClientTheSessionCanUse(t *testing.T) {
 	writeProfile(t)
 	t.Setenv("SARAL_TEST_TOKEN", "a-token")
 
-	deps, _, notice, err := build(options{})
+	deps, _, notice, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -233,7 +249,7 @@ func TestBuild_AnUnresolvableTokenStillStartsAndSaysWhy(t *testing.T) {
 	writeProfile(t)
 	t.Setenv("SARAL_TEST_TOKEN", "")
 
-	deps, opts, notice, err := build(options{})
+	deps, opts, notice, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("a token that would not resolve stopped the program: %v", err)
 	}
@@ -261,8 +277,9 @@ func TestBuild_AnUnresolvableTokenStillStartsAndSaysWhy(t *testing.T) {
 
 func TestWithNotice_LeavesTheModelAloneWhenThereIsNothingToSay(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
-	deps, opts, _, err := build(options{})
+	deps, opts, _, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -308,8 +325,9 @@ func TestConnect_BuildsAClientForCredentialsThatWereNeverSaved(t *testing.T) {
 // refuses the credentials it has just collected.
 func TestBuild_AFirstRunWiresTheConnectorBeforeOnboardingOpens(t *testing.T) {
 	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
 
-	deps, _, _, err := build(options{})
+	deps, _, _, _, err := build(options{})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -335,5 +353,198 @@ func TestBuild_AFirstRunWiresTheConnectorBeforeOnboardingOpens(t *testing.T) {
 	}
 	if !strings.Contains(frame, "Checking the site, the email and the token") {
 		t.Errorf("the flow did not reach a connection attempt:\n%s", frame)
+	}
+}
+
+func TestBuild_OpensTheCacheForAConfiguredProfile(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "a-token")
+
+	deps, _, notice, closeCache, err := build(options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	defer closeCache()
+
+	if deps.Cache == nil {
+		t.Fatal("a configured session has nowhere to keep what it reads")
+	}
+	if notice != "" {
+		t.Errorf("opening the cache said %q", notice)
+	}
+	dir, err := config.CacheDir()
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, cacheFile)); err != nil {
+		t.Errorf("the cache file is not on disk: %v", err)
+	}
+}
+
+func TestBuild_AFirstRunHasNoCacheToOpen(t *testing.T) {
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+	cacheDir := t.TempDir()
+	t.Setenv("SARAL_CACHE_DIR", cacheDir)
+
+	deps, _, _, closeCache, err := build(options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	defer closeCache()
+
+	if deps.Cache != nil {
+		t.Error("a run with no profile opened a cache for a site it does not know")
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, cacheFile)); err == nil {
+		t.Error("a first run took the cache file's lock before it knew whose cache it was")
+	}
+}
+
+// A second copy of Saral cannot have the cache file, because bbolt holds it
+// exclusively. It has to run without one rather than refuse to start.
+func TestBuild_AnotherCopyHoldingTheCacheStillStarts(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "a-token")
+
+	dir, err := config.CacheDir()
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+	held, err := store.Open(filepath.Join(dir, cacheFile))
+	if err != nil {
+		t.Fatalf("taking the cache first: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := held.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+
+	deps, opts, notice, closeCache, err := build(options{})
+	if err != nil {
+		t.Fatalf("build refused to start with the cache held elsewhere: %v", err)
+	}
+	defer closeCache()
+
+	if deps.Cache != nil {
+		t.Error("two copies of Saral both hold the cache")
+	}
+	if deps.Jira == nil {
+		t.Error("a session with no cache also lost its connection to the site")
+	}
+	if !strings.Contains(notice, "another copy of Saral") {
+		t.Errorf("the run says %q, want it to say why nothing is being cached", notice)
+	}
+	if _, _, err := kernel.FirstPaint(deps, 100, 30, opts...); err != nil {
+		t.Errorf("FirstPaint with no cache: %v", err)
+	}
+}
+
+func TestBuild_ACacheFileThatCannotBeOpenedIsNotFatal(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "a-token")
+
+	dir, err := config.CacheDir()
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+	// A directory where the file goes is the portable way to make opening it
+	// fail; a read-only parent does not stop root, which is who CI runs as.
+	if err := os.MkdirAll(filepath.Join(dir, cacheFile), 0o700); err != nil {
+		t.Fatalf("blocking the cache file: %v", err)
+	}
+
+	deps, _, notice, closeCache, err := build(options{})
+	if err != nil {
+		t.Fatalf("build refused to start without a usable cache: %v", err)
+	}
+	defer closeCache()
+
+	if deps.Cache != nil {
+		t.Error("a cache was built over a file that could not be opened")
+	}
+	if !strings.Contains(notice, "nothing will be cached") {
+		t.Errorf("the run says %q, want it to say that nothing is being cached", notice)
+	}
+}
+
+func TestBuild_ThePollFlagIsOffUnlessItIsGiven(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "a-token")
+	t.Cleanup(func() { list.SetPollInterval(0) })
+
+	_, _, _, closeCache, err := build(options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	closeCache()
+	if got := list.PollInterval(); got != 0 {
+		t.Errorf("a run nobody asked to poll polls every %s", got)
+	}
+
+	_, _, _, closeCache, err = build(options{poll: 90 * time.Second})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	closeCache()
+	if got := list.PollInterval(); got != 90*time.Second {
+		t.Errorf("--poll 90s produced %s", got)
+	}
+}
+
+// TestFirstPaint_DrawsRowsOutOfTheRealCacheFile is the one test that runs the
+// whole path: bbolt on disk, through app.Cache, onto kernel.Deps, into the list's
+// constructor, and out as a frame. Everything above the store is otherwise tested
+// against a cache in a map, because internal/ui may not import internal/store.
+func TestFirstPaint_DrawsRowsOutOfTheRealCacheFile(t *testing.T) {
+	writeProfile(t)
+	t.Setenv("SARAL_TEST_TOKEN", "a-token")
+
+	// The query the list opens on, which is internal/ui/list's own default for a
+	// session scoped to a project. Nothing exports it, so if it changes this test
+	// stops finding rows and says so rather than passing on a different question.
+	const opensOn = `project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC`
+
+	deps, _, _, releaseCache, err := build(options{project: "PROJ"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	defer releaseCache()
+	if deps.Cache == nil {
+		t.Fatal("there is no cache to write into")
+	}
+
+	rows := jiratest.Gen(5)
+	mask := jira.NewFieldMask(app.ListProjection().IDs)
+	for i := range rows {
+		rows[i].Requested = mask
+	}
+	if err := deps.Cache.PutRows(opensOn, rows, false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	// A second session over the same file, which is what the next run of the
+	// program is. The first has to let the lock go for this to open at all.
+	releaseCache()
+	deps, opts, _, releaseCache, err := build(options{project: "PROJ"})
+	if err != nil {
+		t.Fatalf("second build: %v", err)
+	}
+	defer releaseCache()
+
+	took, frame, err := kernel.FirstPaint(deps, 120, 40, opts...)
+	if err != nil {
+		t.Fatalf("FirstPaint: %v", err)
+	}
+	for i := range rows {
+		if !strings.Contains(frame, rows[i].Key) {
+			t.Fatalf("the first frame does not show %s, so it was not drawn from the file:\n%s", rows[i].Key, frame)
+		}
+		if !strings.Contains(frame, rows[i].Summary) {
+			t.Errorf("%s was drawn without its summary", rows[i].Key)
+		}
+	}
+	if took > 60*time.Millisecond {
+		t.Errorf("the first paint took %s, want under the 60ms in docs/PERFORMANCE.md", took)
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,8 +23,9 @@ Three constraints drive every decision below:
 │    widget/            shared table, form, pager, zones      │
 ├─────────────────────────────────────────────────────────────┤
 │  internal/app         use cases — orchestration, no IO libs │
+│                       cache policy: kinds, TTLs, the codec  │
 ├─────────────────────────────────────────────────────────────┤
-│  internal/store       bbolt cache, stale-while-revalidate   │
+│  internal/store       bbolt: the file, buckets, records     │
 ├─────────────────────────────────────────────────────────────┤
 │  pkg/jira  (PORT)     interfaces + domain types             │
 │    ├── cloud/         adapter: Jira Cloud REST v3 + Agile   │
@@ -38,13 +39,17 @@ Dependencies point **downward only**. `pkg/*` must never import `internal/*`; `i
 never import `pkg/jira/cloud` directly — it takes the port interface; only `cmd/*` and
 `internal/config` construct a concrete adapter; `internal/app` must never import `internal/ui`,
 because a use case is driven by a view and never reaches back up into one; `pkg/adf` must never
-import `pkg/jira`, because the document library does not know about issues; and `internal/store` must
+import `pkg/jira`, because the document library does not know about issues; `internal/store` must
 never import `internal/ui`, because the cache is written to and read by the layers above it and never
-renders anything. All six are enforced in CI by an import-boundary test (see `docs/TESTING.md`).
+renders anything; and `internal/ui` must never import `internal/store`, because a view takes what it
+needs as an interface declared above the store and can then be driven by a fake. All seven are
+enforced in CI by an import-boundary test (see `docs/TESTING.md`).
 
 The "no IO libs" on `internal/app` is the one line above that no test can hold you to: the
 import-boundary test only sees imports within this module, so a `net/http` in a use case is invisible
-to it. Treat it as a rule a reviewer enforces.
+to it. Treat it as a rule a reviewer enforces. It means a use case does not open sockets or files
+itself, not that it may not reach the layer below: `internal/app` holds the cache policy and so imports
+`internal/store`, which is downward and deliberate. bbolt is named in exactly one package.
 
 ## Ports and adapters
 
@@ -168,8 +173,11 @@ reports of Jira returning a token that loops back to page one.
 
 ## Capabilities as a value object
 
-The probe runs once per site and project, is cached in the store, and is refreshable with `R`. Views
-read it; nobody re-probes ad hoc.
+The probe runs once per site and project, on the kernel's `Init`, and is refreshable with `R`. Views
+read it; nobody re-probes ad hoc. It is **not** kept between runs: what a token may do is exactly the
+kind of answer that changes without warning, and a first frame drawn from a stored one would hide or
+offer a view on last week's permissions. Persisting it needs the kernel to revalidate behind the
+frame, which is [#81](https://github.com/varijkapil13/saral/issues/81).
 
 ```go
 type Capabilities struct {
@@ -325,20 +333,50 @@ Conventions:
 
 ## Caching
 
-`internal/store` is bbolt with typed buckets and a stale-while-revalidate policy:
+`internal/store` is bbolt: the file, the buckets, and records that carry the moment they were
+written. It knows nothing about issues. The policy over it — what the kinds are, how long each lives,
+how a value is encoded, and what a bound is — is `internal/app/cache.go`, together with the `app.Cache`
+interface a view reaches it through. That interface is declared with the implementation that exercises
+it so that its shape answers to a caller rather than being guessed at, and it is declared in
+`internal/app` because `internal/ui` sits above `internal/store` and must not import it, which
+`internal/arch` enforces.
 
-1. A view asks for data and gets whatever is cached **synchronously** — first paint never waits.
-2. If the entry is older than its TTL, a background refresh is issued.
-3. When it lands, a `Msg` carries the delta and the view patches its rows in place, preserving the
-   cursor and scroll position.
+Stale-while-revalidate, as it actually runs:
 
-TTLs by kind: fields and createmeta 24h, board config 1h, versions 10m, issue detail 60s, search
-results 30s. All refreshable on demand. The cache is keyed by site + account so profiles cannot
-bleed into each other.
+1. A view reads the cache **in its constructor**, not in `Init`. `kernel.FirstPaint` builds a view and
+   renders one frame without ever calling `Init`, so a read there is a read that never happens on the
+   path docs/PERFORMANCE.md budgets. First paint never waits.
+2. Rows inside their TTL are drawn and nothing is asked of the site at all. Rows past it are drawn and
+   revalidated behind the frame.
+3. The revalidation arrives as the same cursor-preserving patch a manual refresh uses, so the row
+   under the cursor, the scroll offset and the filter all survive it.
+4. Anything still on screen that could not be confirmed — past its TTL, or a 403, 429 or transport
+   failure over the top of it — is badged with `Theme.StaleBadge` rather than cleared. Seeing
+   yesterday's rows beats seeing none.
 
-The interface a view reaches it through is declared with the implementation that exercises it, in
-`internal/app`, so that its shape is answerable to a caller rather than guessed at. `internal/ui`
-sits above `internal/store` and must not import it, which `internal/arch` now enforces.
+TTLs by kind, from `Kind.TTL()`: fields and createmeta 24h, board config 1h, versions 10m, issue 60s,
+search 30s. All refreshable on demand; `R` also drops the stored answer rather than only refetching.
+The cache is keyed by site + account through `store.Scope`, so profiles cannot bleed into each other.
+The account is the profile's email: the Jira account ID takes a round trip to learn, and the first
+frame is drawn before one could have answered.
+
+Issues are stored once each, keyed by issue key, and a search stores the keys it matched and their
+order. That is what makes two things work. A refresh merges into the copy already held rather than
+replacing it, so a narrow read cannot blank a field it never asked for — `app.MergeIssue` over
+`Issue.Requested`, which is what that mask exists for. And the issue bucket is one corpus rather than
+one per search, bounded to `app.DefaultIssueBound` (5,000) by dropping what was stored longest ago, so
+a long session cannot grow the file without limit.
+
+`Cache.Generation()` counts every write. Anything holding a derived copy of the cache — the local
+fuzzy index in P3.4 — compares one number to find out that its copy is behind, rather than walking the
+corpus to check. It over-reports rather than under-reports: a write a particular reader does not care
+about still moves it, which costs that reader a rebuild and never leaves it answering from a stale
+index. An in-memory counter is a complete answer because bbolt holds the file exclusively, so the
+process that has it open is the only writer there is.
+
+A session with nowhere to keep a cache carries a nil one and every caller draws without it: a first
+run has nothing on disk, another copy of Saral may be holding the file (`store.ErrLocked`, which must
+not stop the program starting), and a home directory is not always writable.
 
 ## Rendering and performance
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -240,21 +240,29 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
 - [ ] **P3.1 — Command palette** · [#12](https://github.com/varijkapil13/saral/issues/12) · **owns** `internal/ui/palette/**`
   `ctrl+k`, fuzzy over the command registry, frecency ranking, shows the keybinding for what you ran.
   Wires up `app.SavedQuery`, whose number-key binding PC.2 settles.
-- [ ] **P3.2 — Cache and offline** · [#13](https://github.com/varijkapil13/saral/issues/13) · **owns** `internal/store/**`, `internal/app/cache.go`, `go.mod`, `cmd/saral/main.go` and `internal/ui/kernel/view.go` (opening the cache and adding the one `Deps` field that carries it — nothing else)
-  Adds the bbolt dependency, in its own commit ahead of the code that needs it. bbolt buckets, TTLs,
-  stale-while-revalidate, cursor-preserving row patching, stale badge. Row patching is the other
-  consumer of PC.1's field-presence answer. **Adds the `internal/store` must-not-import-`internal/ui`
-  rule to `internal/arch` in the same PR** — PC.4 adds its sibling and cannot add this one, because
-  the package does not exist yet.
-  The dependency landed first and on its own, alongside the smallest `internal/store` that keeps it —
-  opening the file, closing it, naming buckets — and the import rule. CI runs `go mod tidy` before
-  anything else and that strips a `require` line nothing imports, so the package is what makes the
-  dependency real. The cache is what is left: `internal/app/cache.go` declaring the interface —
-  declared here because a view may not import the store — the bbolt implementation of it, the
-  `kernel.Deps` field that carries it, and `build()` opening it from `config.CacheDir()` and the
-  profile. **Interface and implementation land in the same PR**, and the interface answers to what
-  P3.4 needs to read as well as to what a view needs: knowing that the cache changed, not only what
-  is in it. A session with nowhere to cache carries a nil one and every caller copes.
+- [x] **P3.2 — Cache and offline** · [#13](https://github.com/varijkapil13/saral/issues/13) · **owns** `internal/store/**`, `internal/app/cache.go`, `cmd/saral/main.go`, `internal/ui/kernel/view.go` (the one `Deps` field that carries the cache — nothing else), `internal/ui/list/**` including its `testdata/**`, `internal/arch/imports_test.go`, `docs/{ARCHITECTURE,TESTING,ROADMAP}.md`
+  The bbolt dependency and the smallest `internal/store` that keeps it landed first and on their own,
+  in [#78](https://github.com/varijkapil13/saral/pull/78), with the `internal/store`
+  must-not-import-`internal/ui` rule; W0-b added the sibling rule the other way round, so
+  `internal/arch` needed nothing here beyond confirming both. CI runs `go mod tidy` before anything
+  else and that strips a `require` line nothing imports, so the package is what made the dependency
+  real, and `go.mod` is no longer this packet's to touch.
+  The cache is the rest: `internal/app/cache.go` declaring `app.Cache` — declared there because a view
+  may not import the store — with the bbolt-backed implementation beside it, the `kernel.Deps` field
+  that carries it, and `build()` opening it from `config.CacheDir()` and the profile.
+  **Row patching was already built:** `internal/ui/list`'s `patchedMsg`/`reload`/`patch` have preserved
+  the cursor across a refresh since P1.5, so this packet pointed them at the cache instead of writing a
+  second one. What it did add there is the read in `list.New` — a first paint happens in the
+  constructor, because `kernel.FirstPaint` never calls `Init` — the stale badge, the paging that
+  follows rows off disk which carry no cursor, and the optional per-view poller.
+  `app.MergeIssue` is the other consumer of PC.1's field-presence answer: issues are stored once each
+  and a narrow refresh merges into the copy already held, so a list row cannot unassign an issue a
+  wider read filled in. The interface also answers what P3.4 needs and not only what a view needs —
+  `EachIssue` for the corpus and `Generation()` for knowing the corpus moved. A session with nowhere to
+  cache carries a nil one and every caller copes.
+  The clause in `docs/ARCHITECTURE.md` saying the capability probe "is cached in the store" was false
+  and is gone; persisting it needs the kernel, which is
+  [#81](https://github.com/varijkapil13/saral/issues/81).
 - [ ] **P3.3 — Mouse** · [#14](https://github.com/varijkapil13/saral/issues/14) · **owns** `internal/ui/widget/zone*.go` + zone wiring in own files
   Click, double-click, wheel-under-pointer, drag-to-resize, clickable chips and footer.
 - [ ] **P3.4 — Local fuzzy index** · [#15](https://github.com/varijkapil13/saral/issues/15) · **owns** `internal/app/index.go` · **after P3.2**

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -83,7 +83,8 @@ Bubble Tea's `teatest` drives full programs where an interaction sequence matter
 - Table-driven tests, subtests named after the case in prose.
 - `t.Parallel()` wherever there is no shared state — which should be everywhere.
 - No `time.Sleep` in tests. Inject a clock; `jiratest.Delay` plus `teatest`'s wait helpers cover the
-  async cases.
+  async cases. `app.WithClock` is there for exactly this: every cache TTL is checked by winding a
+  clock forward, never by waiting for one.
 - No network in any test, and CI is what makes that true. The race suite runs inside a network
   namespace with only loopback up, so a test that reaches for a real host fails the build instead of
   passing for whoever wrote it. A step before it compiles every test binary while the network is
@@ -97,7 +98,7 @@ Bubble Tea's `teatest` drives full programs where an interaction sequence matter
 
 ## Import boundaries
 
-A test in `internal/arch` asserts the layering from `docs/ARCHITECTURE.md`. Six rules, one table
+A test in `internal/arch` asserts the layering from `docs/ARCHITECTURE.md`. Seven rules, one table
 entry each:
 
 - `pkg/**` must not import `internal/**`
@@ -106,6 +107,7 @@ entry each:
 - `internal/app` must not import `internal/ui`
 - `pkg/adf` must not import `pkg/jira`
 - `internal/store` must not import `internal/ui`
+- `internal/ui/**` must not import `internal/store`
 
 A second test reads the table itself, because a rule can be wrong in a way that only ever shows up as
 green: a duplicated name, a missing `why`, an exemption that no package the rule covers could match,

--- a/internal/app/cache.go
+++ b/internal/app/cache.go
@@ -1,0 +1,615 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/store"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// Kind is what a cached entry holds. It names the bucket the entry lives in and
+// the TTL it lives under.
+//
+// The set is closed and spelt here because the alternative is two packets
+// agreeing out of band on a string constant, which is a cache with two spellings
+// of one thing and no error anywhere.
+type Kind string
+
+// The kinds of thing worth keeping between runs.
+const (
+	KindIssue       Kind = "issue"
+	KindSearch      Kind = "search"
+	KindFields      Kind = "fields"
+	KindCreateMeta  Kind = "createmeta"
+	KindBoardConfig Kind = "boardconfig"
+	KindVersions    Kind = "versions"
+)
+
+// TTL is how long an entry of this kind counts as current. Past it the entry is
+// still served — seeing yesterday's rows beats seeing none — but it is badged
+// and revalidated behind the frame it was drawn into.
+//
+// The numbers are how fast the underlying thing actually changes: a field
+// catalogue is site configuration and moves about as often as an administrator
+// does, while a search is a question whose answer somebody else can change while
+// you are reading it.
+func (k Kind) TTL() time.Duration {
+	switch k {
+	case KindFields, KindCreateMeta:
+		return 24 * time.Hour
+	case KindBoardConfig:
+		return time.Hour
+	case KindVersions:
+		return 10 * time.Minute
+	case KindIssue:
+		return 60 * time.Second
+	case KindSearch:
+		return 30 * time.Second
+	default:
+		return 0
+	}
+}
+
+// Snapshot is what a search left on disk the last time it ran: its rows, when
+// they were written, whether that was long enough ago to badge, and whether the
+// search had more pages than the rows account for.
+type Snapshot struct {
+	Issues   []jira.Issue
+	StoredAt time.Time
+	Stale    bool
+	// More reports that the search had another page when it was stored. The rows
+	// carry no cursor across a restart, so a caller that reaches the end of them
+	// has to ask the search again rather than page on from here.
+	More bool
+}
+
+// Cache is the copy on disk of what a site has already answered, so that the
+// first frame is drawn from it instead of from a round trip (docs/UX.md
+// principle 1).
+//
+// A nil Cache is a session with nowhere to keep one — a first run, a read-only
+// home directory, another copy of Saral holding the file — and every caller has
+// to work without it rather than refuse to draw.
+//
+// It is keyed by site and account below this interface, so a caller names a
+// search and cannot reach another profile's rows even by accident.
+type Cache interface {
+	// Rows returns what a search last brought back, whatever its age. It takes
+	// the JQL rather than a key so that nothing outside this package has to know
+	// how a key is spelt.
+	//
+	// There is no error: this is the read a first paint is drawn from, so it runs
+	// on the event loop and has nowhere to put one. A cache that cannot be read
+	// is a cache with nothing in it, and the next fetch to land overwrites
+	// whatever could not be understood.
+	Rows(jql string) (Snapshot, bool)
+
+	// PutRows stores what a search brought back.
+	//
+	// Each issue is merged into the copy already held, so a narrow read cannot
+	// blank a field it never asked for: a list row asks for six fields, and
+	// storing one must not unassign an issue whose assignee a wider read put
+	// there.
+	PutRows(jql string, issues []jira.Issue, more bool) error
+
+	// Forget drops a search's rows, which is what a purging refresh asks for
+	// beyond a refetch. The issues themselves stay: they are shared with every
+	// other search that matched them, and the refetch overwrites what it asked
+	// for anyway.
+	Forget(jql string) error
+
+	// EachIssue visits every issue held, in key order, stopping early when fn
+	// returns false. It is how an index over what is already on disk is built
+	// without a round trip.
+	EachIssue(fn func(iss jira.Issue, storedAt time.Time) bool) error
+
+	// Generation counts the changes this cache has made to what is on disk. It
+	// only ever increases, and it moves for any write, so something holding a
+	// derived copy — an index built by walking EachIssue — can tell that its
+	// copy is behind by comparing one number.
+	//
+	// It over-reports rather than under-reports: a change that happens not to
+	// affect a particular reader still moves it, which costs that reader a
+	// rebuild and never leaves it holding a stale answer.
+	Generation() uint64
+}
+
+// DefaultIssueBound is how many issues the cache keeps before it starts dropping
+// the ones stored longest ago. A session that scrolls all day would otherwise
+// grow the file without limit.
+const DefaultIssueBound = 5000
+
+// DiskCache is the bbolt-backed Cache, scoped to one site and account.
+type DiskCache struct {
+	db    *store.DB
+	scope store.Scope
+	now   func() time.Time
+	bound int
+
+	gen atomic.Uint64
+}
+
+var _ Cache = (*DiskCache)(nil)
+
+// CacheOption adjusts a DiskCache at construction.
+type CacheOption func(*DiskCache)
+
+// WithClock replaces the clock the TTLs are measured against, which is what lets
+// an expiry be tested without waiting for one.
+func WithClock(now func() time.Time) CacheOption {
+	return func(c *DiskCache) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// WithIssueBound sets how many issues are kept. Zero or less leaves the default.
+func WithIssueBound(n int) CacheOption {
+	return func(c *DiskCache) {
+		if n > 0 {
+			c.bound = n
+		}
+	}
+}
+
+// NewCache builds the cache over an open database. The scope is whose cache it
+// is: two accounts on one site, and one account on two sites, never see each
+// other's rows.
+func NewCache(db *store.DB, scope store.Scope, opts ...CacheOption) *DiskCache {
+	c := &DiskCache{db: db, scope: scope, now: time.Now, bound: DefaultIssueBound}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	return c
+}
+
+// Rows implements Cache.
+func (c *DiskCache) Rows(jql string) (Snapshot, bool) {
+	key := rowsKey(jql)
+	if c == nil || c.db == nil || key == "" {
+		return Snapshot{}, false
+	}
+	rec, ok, err := c.db.Get(c.scope, string(KindSearch), key)
+	if err != nil || !ok {
+		return Snapshot{}, false
+	}
+	var entry wireSearch
+	if err := json.Unmarshal(rec.Value, &entry); err != nil || len(entry.Keys) == 0 {
+		return Snapshot{}, false
+	}
+	held, err := c.db.GetAll(c.scope, string(KindIssue), entry.Keys)
+	if err != nil {
+		return Snapshot{}, false
+	}
+	issues := make([]jira.Issue, 0, len(held))
+	for i := range held {
+		iss, err := decodeIssue(held[i].Value)
+		if err != nil {
+			continue
+		}
+		issues = append(issues, iss)
+	}
+	if len(issues) == 0 {
+		return Snapshot{}, false
+	}
+	return Snapshot{
+		Issues:   issues,
+		StoredAt: rec.StoredAt,
+		Stale:    c.now().Sub(rec.StoredAt) > KindSearch.TTL(),
+		More:     entry.More,
+	}, true
+}
+
+// PutRows implements Cache.
+func (c *DiskCache) PutRows(jql string, issues []jira.Issue, more bool) error {
+	key := rowsKey(jql)
+	if c == nil || c.db == nil || key == "" {
+		return nil
+	}
+	keys := make([]string, 0, len(issues))
+	for i := range issues {
+		if issues[i].Key != "" {
+			keys = append(keys, issues[i].Key)
+		}
+	}
+	if err := c.mergeIssues(issues, keys); err != nil {
+		return err
+	}
+	entry, err := json.Marshal(wireSearch{Keys: keys, More: more})
+	if err != nil {
+		return fmt.Errorf("encoding the rows of a search: %w", err)
+	}
+	if err := c.db.Put(c.scope, string(KindSearch), store.Record{
+		Key: key, Value: entry, StoredAt: c.now(),
+	}); err != nil {
+		return err
+	}
+	c.gen.Add(1)
+	return nil
+}
+
+// mergeIssues writes each issue over the copy already held, keeping every field
+// the fresh read did not ask about, and then brings the issue count back to the
+// bound.
+func (c *DiskCache) mergeIssues(issues []jira.Issue, keys []string) error {
+	if len(issues) == 0 {
+		return nil
+	}
+	held, err := c.db.GetAll(c.scope, string(KindIssue), keys)
+	if err != nil {
+		return err
+	}
+	base := make(map[string]jira.Issue, len(held))
+	for i := range held {
+		iss, err := decodeIssue(held[i].Value)
+		if err != nil {
+			continue
+		}
+		base[held[i].Key] = iss
+	}
+
+	now := c.now()
+	recs := make([]store.Record, 0, len(issues))
+	for i := range issues {
+		if issues[i].Key == "" {
+			continue
+		}
+		value, err := encodeIssue(MergeIssue(base[issues[i].Key], issues[i]))
+		if err != nil {
+			return err
+		}
+		recs = append(recs, store.Record{Key: issues[i].Key, Value: value, StoredAt: now})
+	}
+	if err := c.db.Put(c.scope, string(KindIssue), recs...); err != nil {
+		return err
+	}
+	if _, err := c.db.Trim(c.scope, string(KindIssue), c.bound); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Forget implements Cache.
+func (c *DiskCache) Forget(jql string) error {
+	key := rowsKey(jql)
+	if c == nil || c.db == nil || key == "" {
+		return nil
+	}
+	if err := c.db.Delete(c.scope, string(KindSearch), key); err != nil {
+		return err
+	}
+	c.gen.Add(1)
+	return nil
+}
+
+// EachIssue implements Cache.
+func (c *DiskCache) EachIssue(fn func(jira.Issue, time.Time) bool) error {
+	if c == nil || c.db == nil || fn == nil {
+		return nil
+	}
+	var bad error
+	err := c.db.Each(c.scope, string(KindIssue), func(rec store.Record) bool {
+		iss, err := decodeIssue(rec.Value)
+		if err != nil {
+			bad = fmt.Errorf("the cached copy of %s cannot be read: %w", rec.Key, err)
+			return false
+		}
+		return fn(iss, rec.StoredAt)
+	})
+	if err != nil {
+		return err
+	}
+	return bad
+}
+
+// Generation implements Cache.
+func (c *DiskCache) Generation() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.gen.Load()
+}
+
+// rowsKey is how a search is spelt on disk: the JQL itself, trimmed. It is the
+// question rather than the answer's shape, so two callers asking the same
+// question with different field sets share one entry — which is correct, because
+// what the entry holds is which issues matched and in what order, while the
+// fields live on the issues.
+func rowsKey(jql string) string { return strings.TrimSpace(jql) }
+
+// MergeIssue combines a fresh read with the copy already held.
+//
+// The fresh read wins for every field it asked for, and only for those: a field
+// outside its Requested mask is absent because nothing asked, which is a
+// different answer from Jira having nothing to send, and treating the two the
+// same is how a list refresh that never mentions the assignee unassigns the row.
+//
+// A read that asked for nothing changes nothing, which is the safe direction for
+// an issue that did not come from a read at all.
+func MergeIssue(base, fresh jira.Issue) jira.Issue {
+	switch {
+	case base.Key == "" && base.ID == "":
+		return fresh
+	case fresh.Requested.Wide():
+		return fresh
+	case fresh.Requested.Len() == 0:
+		return base
+	}
+
+	out := base
+	if fresh.ID != "" {
+		out.ID = fresh.ID
+	}
+	if fresh.Key != "" {
+		out.Key = fresh.Key
+	}
+	for _, col := range issueColumns {
+		if fresh.Requested.Has(col.id) {
+			col.take(&out, &fresh)
+		}
+	}
+	for _, id := range fresh.Requested.IDs() {
+		if isColumn(id) {
+			continue
+		}
+		ref := jira.FieldRef{ID: id}
+		if v, ok := fresh.Fields.ByID(id); ok {
+			out.Fields = out.Fields.With(ref, v)
+			continue
+		}
+		out.Fields = out.Fields.Without(ref)
+	}
+	// A base that was read wide stays wide: it already carries every field the
+	// site has, and a narrow refresh over it replaces some of them rather than
+	// narrowing what is known.
+	if base.Requested.Wide() {
+		out.Requested = jira.AllFields()
+		return out
+	}
+	out.Requested = jira.NewFieldMask(append(base.Requested.IDs(), fresh.Requested.IDs()...))
+	return out
+}
+
+// issueColumns maps the platform field IDs an issue's own struct fields come
+// from. These are the same on every site — the per-site IDs are the custom
+// fields, which travel in Fields and are matched by the loop above.
+var issueColumns = []struct {
+	id   string
+	take func(dst, src *jira.Issue)
+}{
+	{"summary", func(dst, src *jira.Issue) { dst.Summary = src.Summary }},
+	{"description", func(dst, src *jira.Issue) { dst.Description = src.Description }},
+	{"project", func(dst, src *jira.Issue) { dst.Project = src.Project }},
+	{"issuetype", func(dst, src *jira.Issue) { dst.Type = src.Type }},
+	{"status", func(dst, src *jira.Issue) { dst.Status = src.Status }},
+	{"priority", func(dst, src *jira.Issue) { dst.Priority = src.Priority }},
+	{"resolution", func(dst, src *jira.Issue) { dst.Resolution = src.Resolution }},
+	{"assignee", func(dst, src *jira.Issue) { dst.Assignee = src.Assignee }},
+	{"reporter", func(dst, src *jira.Issue) { dst.Reporter = src.Reporter }},
+	{"labels", func(dst, src *jira.Issue) { dst.Labels = src.Labels }},
+	{"components", func(dst, src *jira.Issue) { dst.Components = src.Components }},
+	{"fixVersions", func(dst, src *jira.Issue) { dst.FixVersions = src.FixVersions }},
+	{"parent", func(dst, src *jira.Issue) { dst.Parent = src.Parent }},
+	{"subtasks", func(dst, src *jira.Issue) { dst.Subtasks = src.Subtasks }},
+	{"issuelinks", func(dst, src *jira.Issue) { dst.Links = src.Links }},
+	{"duedate", func(dst, src *jira.Issue) { dst.Due = src.Due }},
+	{"created", func(dst, src *jira.Issue) { dst.Created = src.Created }},
+	{"updated", func(dst, src *jira.Issue) { dst.Updated = src.Updated }},
+	{"resolutiondate", func(dst, src *jira.Issue) { dst.Resolved = src.Resolved }},
+	{"timetracking", func(dst, src *jira.Issue) { dst.TimeTracking = src.TimeTracking }},
+}
+
+func isColumn(id string) bool {
+	for i := range issueColumns {
+		if issueColumns[i].id == id {
+			return true
+		}
+	}
+	return false
+}
+
+// wireSearch is a search's answer: which issues matched, in the order they came
+// back, and whether there were more pages behind them.
+type wireSearch struct {
+	Keys []string `json:"keys"`
+	More bool     `json:"more,omitempty"`
+}
+
+// wireIssue is how an issue is encoded. It exists because three of the things an
+// issue carries cannot round-trip through encoding/json on their own: FieldSet
+// and FieldMask hold their contents unexported on purpose, and a user's timezone
+// is a *time.Location, which encodes as an empty object and decodes as nothing.
+type wireIssue struct {
+	ID           string                    `json:"id,omitempty"`
+	Key          string                    `json:"key,omitempty"`
+	Project      jira.ProjectRef           `json:"project,omitzero"`
+	Summary      string                    `json:"summary,omitempty"`
+	Description  adf.Doc                   `json:"description,omitzero"`
+	Type         jira.IssueType            `json:"type,omitzero"`
+	Status       jira.Status               `json:"status,omitzero"`
+	Priority     *jira.Priority            `json:"priority,omitempty"`
+	Resolution   *jira.Resolution          `json:"resolution,omitempty"`
+	Assignee     *wireUser                 `json:"assignee,omitempty"`
+	Reporter     *wireUser                 `json:"reporter,omitempty"`
+	Labels       []string                  `json:"labels,omitempty"`
+	Components   []jira.Component          `json:"components,omitempty"`
+	FixVersions  []jira.Version            `json:"fixVersions,omitempty"`
+	Parent       *jira.IssueRef            `json:"parent,omitempty"`
+	Subtasks     []jira.IssueRef           `json:"subtasks,omitempty"`
+	Links        []jira.IssueLink          `json:"links,omitempty"`
+	Due          jira.Date                 `json:"due,omitzero"`
+	Created      time.Time                 `json:"created,omitzero"`
+	Updated      time.Time                 `json:"updated,omitzero"`
+	Resolved     *time.Time                `json:"resolved,omitempty"`
+	TimeTracking *jira.TimeTracking        `json:"timeTracking,omitempty"`
+	Fields       map[string]wireFieldValue `json:"fields,omitempty"`
+	Requested    []string                  `json:"requested,omitempty"`
+	Wide         bool                      `json:"wide,omitempty"`
+}
+
+type wireUser struct {
+	AccountID   string `json:"accountId,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Email       string `json:"email,omitempty"`
+	TimeZone    string `json:"timeZone,omitempty"`
+	Active      bool   `json:"active,omitempty"`
+	AvatarURL   string `json:"avatarUrl,omitempty"`
+}
+
+type wireFieldValue struct {
+	Kind    jira.FieldKind `json:"kind,omitempty"`
+	Text    string         `json:"text,omitempty"`
+	Number  float64        `json:"number,omitempty"`
+	Bool    bool           `json:"bool,omitempty"`
+	Date    jira.Date      `json:"date,omitzero"`
+	Time    time.Time      `json:"time,omitzero"`
+	Doc     adf.Doc        `json:"doc,omitzero"`
+	Options []jira.Option  `json:"options,omitempty"`
+	Users   []wireUser     `json:"users,omitempty"`
+}
+
+func encodeIssue(iss jira.Issue) ([]byte, error) {
+	out := wireIssue{
+		ID: iss.ID, Key: iss.Key, Project: iss.Project, Summary: iss.Summary,
+		Description: iss.Description, Type: iss.Type, Status: iss.Status,
+		Priority: iss.Priority, Resolution: iss.Resolution,
+		Assignee: encodeUser(iss.Assignee), Reporter: encodeUser(iss.Reporter),
+		Labels: iss.Labels, Components: iss.Components, FixVersions: iss.FixVersions,
+		Parent: iss.Parent, Subtasks: iss.Subtasks, Links: iss.Links,
+		Due: iss.Due, Created: iss.Created, Updated: iss.Updated, Resolved: iss.Resolved,
+		TimeTracking: iss.TimeTracking,
+		Requested:    iss.Requested.IDs(), Wide: iss.Requested.Wide(),
+	}
+	if ids := iss.Fields.IDs(); len(ids) > 0 {
+		out.Fields = make(map[string]wireFieldValue, len(ids))
+		for _, id := range ids {
+			v, ok := iss.Fields.ByID(id)
+			if !ok {
+				continue
+			}
+			out.Fields[id] = wireFieldValue{
+				Kind: v.Kind, Text: v.Text, Number: v.Number, Bool: v.Bool,
+				Date: v.Date, Time: v.Time, Doc: v.Doc,
+				Options: v.Options, Users: encodeUsers(v.Users),
+			}
+		}
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("encoding %s: %w", iss.Key, err)
+	}
+	return data, nil
+}
+
+func decodeIssue(data []byte) (jira.Issue, error) {
+	var in wireIssue
+	if err := json.Unmarshal(data, &in); err != nil {
+		return jira.Issue{}, fmt.Errorf("decoding a cached issue: %w", err)
+	}
+	out := jira.Issue{
+		ID: in.ID, Key: in.Key, Project: in.Project, Summary: in.Summary,
+		Description: in.Description, Type: in.Type, Status: in.Status,
+		Priority: in.Priority, Resolution: in.Resolution,
+		Assignee: decodeUser(in.Assignee), Reporter: decodeUser(in.Reporter),
+		Labels: in.Labels, Components: in.Components, FixVersions: in.FixVersions,
+		Parent: in.Parent, Subtasks: in.Subtasks, Links: in.Links,
+		Due: in.Due, Created: in.Created, Updated: in.Updated, Resolved: in.Resolved,
+		TimeTracking: in.TimeTracking,
+	}
+	if in.Wide {
+		out.Requested = jira.AllFields()
+	} else {
+		out.Requested = jira.NewFieldMask(in.Requested)
+	}
+	if len(in.Fields) > 0 {
+		values := make(map[string]jira.FieldValue, len(in.Fields))
+		for id := range in.Fields {
+			v := in.Fields[id]
+			values[id] = jira.FieldValue{
+				Kind: v.Kind, Text: v.Text, Number: v.Number, Bool: v.Bool,
+				Date: v.Date, Time: v.Time, Doc: v.Doc,
+				Options: v.Options, Users: decodeUsers(v.Users),
+			}
+		}
+		out.Fields = jira.NewFieldSet(values)
+	}
+	return out, nil
+}
+
+func encodeUser(u *jira.User) *wireUser {
+	if u == nil {
+		return nil
+	}
+	out := wireUser{
+		AccountID: u.AccountID, DisplayName: u.DisplayName, Email: u.Email,
+		Active: u.Active, AvatarURL: u.AvatarURL,
+	}
+	if u.TimeZone != nil {
+		out.TimeZone = u.TimeZone.String()
+	}
+	return &out
+}
+
+func decodeUser(u *wireUser) *jira.User {
+	if u == nil {
+		return nil
+	}
+	out := jira.User{
+		AccountID: u.AccountID, DisplayName: u.DisplayName, Email: u.Email,
+		Active: u.Active, AvatarURL: u.AvatarURL, TimeZone: location(u.TimeZone),
+	}
+	return &out
+}
+
+func encodeUsers(in []jira.User) []wireUser {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]wireUser, 0, len(in))
+	for i := range in {
+		out = append(out, *encodeUser(&in[i]))
+	}
+	return out
+}
+
+func decodeUsers(in []wireUser) []jira.User {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]jira.User, 0, len(in))
+	for i := range in {
+		out = append(out, *decodeUser(&in[i]))
+	}
+	return out
+}
+
+// zones memoizes the zoneinfo lookups a decode does. Every row of a list can
+// name the same timezone, and time.LoadLocation reads a file each time it is
+// asked; a name this machine has no entry for stays absent rather than failing
+// the decode of an issue that is otherwise fine.
+var zones sync.Map
+
+func location(name string) *time.Location {
+	if name == "" {
+		return nil
+	}
+	if held, ok := zones.Load(name); ok {
+		loc, _ := held.(*time.Location)
+		return loc
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		loc = nil
+	}
+	zones.Store(name, loc)
+	return loc
+}

--- a/internal/app/cache_budget_test.go
+++ b/internal/app/cache_budget_test.go
@@ -1,0 +1,18 @@
+//go:build !race
+
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+// The budget in docs/PERFORMANCE.md is about the binary that ships. The race
+// detector puts around twenty times the cost on a decode-heavy path, so
+// asserting the budget under -race would measure the instrumentation instead.
+func TestCacheRead_StaysUnderTheFirstPaintBudget(t *testing.T) {
+	res := testing.Benchmark(BenchmarkCacheReadFirstPaint)
+	if per := time.Duration(res.NsPerOp()); per > 5*time.Millisecond {
+		t.Errorf("reading a screen of rows off disk took %s, want under the 5ms in docs/PERFORMANCE.md", per)
+	}
+}

--- a/internal/app/cache_test.go
+++ b/internal/app/cache_test.go
@@ -1,0 +1,664 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/store"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+const cacheJQL = `project = "PROJ" ORDER BY key`
+
+var (
+	testScope = store.Scope{Site: "example.atlassian.net", Account: "you@example.com"}
+	testNow   = time.Date(2026, time.March, 2, 9, 0, 0, 0, time.UTC)
+)
+
+// clock is a hand-wound clock. docs/TESTING.md forbids a sleep, and every TTL in
+// this file is checked by moving this instead.
+type clock struct{ at time.Time }
+
+func (c *clock) now() time.Time { return c.at }
+
+func openDB(t testing.TB) *store.DB {
+	t.Helper()
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "cache.db"))
+	if err != nil {
+		t.Fatalf("opening the cache: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("closing the cache: %v", err)
+		}
+	})
+	return db
+}
+
+func newTestCache(t testing.TB, opts ...CacheOption) (*DiskCache, *clock) {
+	t.Helper()
+
+	c := &clock{at: testNow}
+	return NewCache(openDB(t), testScope, append([]CacheOption{WithClock(c.now)}, opts...)...), c
+}
+
+// listRows is what the list view stores: the six fields of ListProjection and a
+// mask saying so.
+func listRows(n int) []jira.Issue {
+	mask := jira.NewFieldMask(ListProjection().IDs)
+	out := jiratest.Gen(n)
+	for i := range out {
+		out[i].Requested = mask
+		out[i].Description = adf.Doc{}
+	}
+	return out
+}
+
+func keysOf(issues []jira.Issue) []string {
+	out := make([]string, 0, len(issues))
+	for i := range issues {
+		out = append(out, issues[i].Key)
+	}
+	return out
+}
+
+func TestKindTTL_IsTheTableTheProjectPublishes(t *testing.T) {
+	t.Parallel()
+
+	want := map[Kind]time.Duration{
+		KindFields:      24 * time.Hour,
+		KindCreateMeta:  24 * time.Hour,
+		KindBoardConfig: time.Hour,
+		KindVersions:    10 * time.Minute,
+		KindIssue:       60 * time.Second,
+		KindSearch:      30 * time.Second,
+	}
+	for kind, ttl := range want {
+		if got := kind.TTL(); got != ttl {
+			t.Errorf("%s lives for %s, want %s", kind, got, ttl)
+		}
+	}
+	if got := Kind("something else").TTL(); got != 0 {
+		t.Errorf("an unknown kind claims a TTL of %s; nothing should be kept under a name nobody defined", got)
+	}
+}
+
+func TestRows_ComeBackAsTheyWereStored(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	stored := listRows(3)
+	if err := cache.PutRows(cacheJQL, stored, true); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	got, ok := cache.Rows(cacheJQL)
+	if !ok {
+		t.Fatal("the rows just stored are not there")
+	}
+	if !slices.Equal(keysOf(got.Issues), keysOf(stored)) {
+		t.Errorf("the rows came back as %v, want %v in that order", keysOf(got.Issues), keysOf(stored))
+	}
+	if got.Issues[0].Summary != stored[0].Summary {
+		t.Errorf("the first row came back summarised as %q", got.Issues[0].Summary)
+	}
+	if !got.More {
+		t.Error("a search stored with another page behind it came back looking complete")
+	}
+	if got.Stale {
+		t.Error("rows stored this instant came back stale")
+	}
+	if !got.StoredAt.Equal(testNow) {
+		t.Errorf("the rows say they were stored at %s, want %s", got.StoredAt, testNow)
+	}
+}
+
+func TestRows_AreAMissWhenNothingWasStoredForThatSearch(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	if err := cache.PutRows(cacheJQL, listRows(2), false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+	for _, jql := range []string{"", "   ", `project = "OTHER"`, cacheJQL + " AND assignee IS EMPTY"} {
+		if _, ok := cache.Rows(jql); ok {
+			t.Errorf("%q found rows stored under another question", jql)
+		}
+	}
+	if _, ok := cache.Rows("  " + cacheJQL + "\n"); !ok {
+		t.Error("the same question with whitespace around it missed; a key is the trimmed JQL")
+	}
+}
+
+func TestRows_TurnStaleOnceTheSearchTTLHasPassed(t *testing.T) {
+	t.Parallel()
+
+	cache, clk := newTestCache(t)
+	if err := cache.PutRows(cacheJQL, listRows(2), false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	clk.at = testNow.Add(KindSearch.TTL())
+	if got, _ := cache.Rows(cacheJQL); got.Stale {
+		t.Error("rows exactly at their TTL are still current")
+	}
+	clk.at = testNow.Add(KindSearch.TTL() + time.Second)
+	got, ok := cache.Rows(cacheJQL)
+	if !ok {
+		t.Fatal("stale rows were dropped rather than badged; seeing yesterday's rows beats seeing none")
+	}
+	if !got.Stale {
+		t.Error("rows past their TTL did not come back stale")
+	}
+	if len(got.Issues) != 2 {
+		t.Errorf("stale rows came back %d long, want the 2 that were stored", len(got.Issues))
+	}
+}
+
+func TestRows_StayInsideTheProfileThatStoredThem(t *testing.T) {
+	t.Parallel()
+
+	db := openDB(t)
+	clk := &clock{at: testNow}
+	mine := NewCache(db, testScope, WithClock(clk.now))
+	theirs := NewCache(db, store.Scope{Site: testScope.Site, Account: "someone.else@example.com"}, WithClock(clk.now))
+
+	if err := mine.PutRows(cacheJQL, listRows(3), false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+	if _, ok := theirs.Rows(cacheJQL); ok {
+		t.Error("one account read another's rows off the same file")
+	}
+	seen := 0
+	if err := theirs.EachIssue(func(jira.Issue, time.Time) bool { seen++; return true }); err != nil {
+		t.Fatalf("EachIssue: %v", err)
+	}
+	if seen != 0 {
+		t.Errorf("another account's cache holds %d of this one's issues", seen)
+	}
+
+	otherSite := NewCache(db, store.Scope{Site: "other.atlassian.net", Account: testScope.Account}, WithClock(clk.now))
+	if _, ok := otherSite.Rows(cacheJQL); ok {
+		t.Error("one account on two sites shares one cache; the two sites are different Jiras")
+	}
+}
+
+func TestPutRows_DropsTheIssuesStoredLongestAgoOnceItIsOverTheBound(t *testing.T) {
+	t.Parallel()
+
+	cache, clk := newTestCache(t, WithIssueBound(4))
+	first := listRows(6)[:3]
+	if err := cache.PutRows(`project = "PROJ" AND key >= "PROJ-1"`, first, false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	clk.at = testNow.Add(time.Minute)
+	second := jiratest.GenFor("OTHER", 3)
+	mask := jira.NewFieldMask(ListProjection().IDs)
+	for i := range second {
+		second[i].Requested = mask
+	}
+	if err := cache.PutRows(`project = "OTHER"`, second, false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	var held []string
+	if err := cache.EachIssue(func(iss jira.Issue, _ time.Time) bool {
+		held = append(held, iss.Key)
+		return true
+	}); err != nil {
+		t.Fatalf("EachIssue: %v", err)
+	}
+	if len(held) != 4 {
+		t.Fatalf("the cache holds %d issues (%v), want the bound of 4", len(held), held)
+	}
+	for _, key := range keysOf(second) {
+		if !slices.Contains(held, key) {
+			t.Errorf("%s was evicted although it was stored last", key)
+		}
+	}
+	if slices.Contains(held, "PROJ-1") {
+		t.Error("PROJ-1 survived; the bound drops what was stored longest ago")
+	}
+}
+
+func TestForget_DropsASearchAndKeepsTheIssuesItMatched(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	stored := listRows(3)
+	if err := cache.PutRows(cacheJQL, stored, false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+	if err := cache.Forget(cacheJQL); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	if _, ok := cache.Rows(cacheJQL); ok {
+		t.Error("the search survived being forgotten")
+	}
+
+	held := 0
+	if err := cache.EachIssue(func(jira.Issue, time.Time) bool { held++; return true }); err != nil {
+		t.Fatalf("EachIssue: %v", err)
+	}
+	if held != len(stored) {
+		t.Errorf("forgetting one search left %d of %d issues; the issues are shared with every other search",
+			held, len(stored))
+	}
+}
+
+func TestEachIssue_VisitsEveryIssueInKeyOrderAndStopsWhenAsked(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	if err := cache.PutRows(cacheJQL, listRows(4), false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	var seen []string
+	if err := cache.EachIssue(func(iss jira.Issue, storedAt time.Time) bool {
+		if !storedAt.Equal(testNow) {
+			t.Errorf("%s says it was stored at %s", iss.Key, storedAt)
+		}
+		seen = append(seen, iss.Key)
+		return true
+	}); err != nil {
+		t.Fatalf("EachIssue: %v", err)
+	}
+	want := []string{"PROJ-1", "PROJ-2", "PROJ-3", "PROJ-4"}
+	if !slices.Equal(seen, want) {
+		t.Errorf("EachIssue visited %v, want %v", seen, want)
+	}
+
+	seen = nil
+	if err := cache.EachIssue(func(iss jira.Issue, _ time.Time) bool {
+		seen = append(seen, iss.Key)
+		return false
+	}); err != nil {
+		t.Fatalf("EachIssue: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Errorf("a walk told to stop visited %d issues", len(seen))
+	}
+}
+
+// TestGeneration_TellsAnIndexBuiltFromTheCacheThatItIsBehind is the shape P3.4
+// reads this cache with: walk it once, then notice a write without walking again.
+func TestGeneration_TellsAnIndexBuiltFromTheCacheThatItIsBehind(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	if err := cache.PutRows(cacheJQL, listRows(2), false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	indexed := cache.Generation()
+	var index []string
+	if err := cache.EachIssue(func(iss jira.Issue, _ time.Time) bool {
+		index = append(index, iss.Key)
+		return true
+	}); err != nil {
+		t.Fatalf("EachIssue: %v", err)
+	}
+	if cache.Generation() != indexed {
+		t.Error("reading the cache moved its generation; only a write may")
+	}
+
+	if err := cache.PutRows(`project = "OTHER"`, listRows(3), false); err != nil {
+		t.Fatalf("second PutRows: %v", err)
+	}
+	if cache.Generation() == indexed {
+		t.Fatal("a write left the generation where it was, so an index built before it has no way to know")
+	}
+	if cache.Generation() < indexed {
+		t.Error("the generation went backwards")
+	}
+	if err := cache.Forget(cacheJQL); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	if cache.Generation() == indexed+1 {
+		t.Error("dropping a search left the generation where the write before it put it")
+	}
+	_ = index
+}
+
+func TestNilCache_AnswersEveryCallWithoutPanicking(t *testing.T) {
+	t.Parallel()
+
+	var cache *DiskCache
+	if _, ok := cache.Rows(cacheJQL); ok {
+		t.Error("a cache that does not exist found rows")
+	}
+	if err := cache.PutRows(cacheJQL, listRows(1), false); err != nil {
+		t.Errorf("storing into a cache that does not exist failed: %v", err)
+	}
+	if err := cache.Forget(cacheJQL); err != nil {
+		t.Errorf("forgetting in a cache that does not exist failed: %v", err)
+	}
+	if err := cache.EachIssue(func(jira.Issue, time.Time) bool { return true }); err != nil {
+		t.Errorf("walking a cache that does not exist failed: %v", err)
+	}
+	if got := cache.Generation(); got != 0 {
+		t.Errorf("a cache that does not exist is at generation %d", got)
+	}
+}
+
+// TestPutRows_LeavesAloneTheFieldsANarrowRefreshNeverAskedAbout is the case PC.1
+// built Issue.Requested for: a list row asks for six fields, and storing one must
+// not throw away what a wider read put on the same issue.
+func TestPutRows_LeavesAloneTheFieldsANarrowRefreshNeverAskedAbout(t *testing.T) {
+	t.Parallel()
+
+	cache, clk := newTestCache(t)
+	wide := jiratest.Gen(1)[0]
+	wide.Requested = jira.AllFields()
+	if wide.Assignee == nil || wide.Description.IsZero() || len(wide.Labels) == 0 {
+		t.Fatalf("the fixture is not wide enough to prove anything: %+v", wide)
+	}
+	if err := cache.PutRows(`key = "PROJ-1"`, []jira.Issue{wide}, false); err != nil {
+		t.Fatalf("storing the wide read: %v", err)
+	}
+
+	narrow := jira.Issue{
+		ID:        wide.ID,
+		Key:       wide.Key,
+		Summary:   "a summary the refresh did bring",
+		Status:    wide.Status,
+		Requested: jira.NewFieldMask([]string{"summary", "status"}),
+	}
+	clk.at = testNow.Add(time.Minute)
+	if err := cache.PutRows(cacheJQL, []jira.Issue{narrow}, false); err != nil {
+		t.Fatalf("storing the narrow read: %v", err)
+	}
+
+	got, ok := cache.Rows(cacheJQL)
+	if !ok || len(got.Issues) != 1 {
+		t.Fatalf("the narrow read did not come back: found %t, %d rows", ok, len(got.Issues))
+	}
+	merged := got.Issues[0]
+	if merged.Summary != narrow.Summary {
+		t.Errorf("the refresh's own summary was lost: %q", merged.Summary)
+	}
+	if merged.Assignee == nil {
+		t.Error("a refresh that never mentioned the assignee unassigned the issue")
+	}
+	if merged.Description.IsZero() {
+		t.Error("a refresh that never mentioned the description emptied it")
+	}
+	if len(merged.Labels) == 0 {
+		t.Error("a refresh that never mentioned the labels dropped them")
+	}
+	if !merged.Requested.Wide() {
+		t.Errorf("the merged issue was read with %v, want the wide read it was merged into to stay wide",
+			merged.Requested.IDs())
+	}
+}
+
+func TestMergeIssue(t *testing.T) {
+	t.Parallel()
+
+	points := jira.FieldRef{ID: "customfield_20001"}
+	rank := jira.FieldRef{ID: "customfield_20002"}
+	ada := jira.User{AccountID: "acct-ada", DisplayName: "Ada Lovelace"}
+
+	base := jira.Issue{
+		ID: "20001", Key: "PROJ-1",
+		Summary:  "as it was",
+		Assignee: &ada,
+		Labels:   []string{"cache"},
+		Fields: jira.NewFieldSet(map[string]jira.FieldValue{
+			points.ID: {Kind: jira.KindNumber, Number: 5},
+			rank.ID:   {Kind: jira.KindText, Text: "0|i00001:"},
+		}),
+		Requested: jira.NewFieldMask([]string{"summary", "assignee", "labels", points.ID, rank.ID}),
+	}
+
+	tests := []struct {
+		name  string
+		fresh jira.Issue
+		check func(t *testing.T, got jira.Issue)
+	}{
+		{
+			name: "a narrow read keeps what it did not ask about",
+			fresh: jira.Issue{
+				Key: "PROJ-1", Summary: "as it is now",
+				Requested: jira.NewFieldMask([]string{"summary"}),
+			},
+			check: func(t *testing.T, got jira.Issue) {
+				if got.Summary != "as it is now" {
+					t.Errorf("summary is %q", got.Summary)
+				}
+				if got.Assignee == nil || len(got.Labels) != 1 {
+					t.Error("a field outside the mask was cleared")
+				}
+			},
+		},
+		{
+			name: "a read that asked for a field Jira had nothing for clears it",
+			fresh: jira.Issue{
+				Key: "PROJ-1", Requested: jira.NewFieldMask([]string{"assignee"}),
+			},
+			check: func(t *testing.T, got jira.Issue) {
+				if got.Assignee != nil {
+					t.Error("a read that asked about the assignee and came back with none left the old one in place")
+				}
+				if got.Summary != base.Summary {
+					t.Errorf("summary is %q, and nothing asked about it", got.Summary)
+				}
+			},
+		},
+		{
+			name: "a custom field outside the mask survives",
+			fresh: jira.Issue{
+				Key:       "PROJ-1",
+				Fields:    jira.NewFieldSet(map[string]jira.FieldValue{points.ID: {Kind: jira.KindNumber, Number: 8}}),
+				Requested: jira.NewFieldMask([]string{points.ID}),
+			},
+			check: func(t *testing.T, got jira.Issue) {
+				if n, ok := got.Fields.Number(points); !ok || n != 8 {
+					t.Errorf("the field the read asked for is %v (found %t)", n, ok)
+				}
+				if _, ok := got.Fields.Text(rank); !ok {
+					t.Error("a custom field the read never named was dropped")
+				}
+			},
+		},
+		{
+			name: "a custom field the read asked for and Jira had nothing for goes",
+			fresh: jira.Issue{
+				Key:       "PROJ-1",
+				Requested: jira.NewFieldMask([]string{rank.ID}),
+			},
+			check: func(t *testing.T, got jira.Issue) {
+				if _, ok := got.Fields.Text(rank); ok {
+					t.Error("a field that was asked for and came back empty kept its old value")
+				}
+				if _, ok := got.Fields.Number(points); !ok {
+					t.Error("a field nobody asked about went with it")
+				}
+			},
+		},
+		{
+			name: "a wide read replaces everything",
+			fresh: jira.Issue{
+				Key: "PROJ-1", Summary: "everything", Requested: jira.AllFields(),
+			},
+			check: func(t *testing.T, got jira.Issue) {
+				if got.Assignee != nil || len(got.Labels) != 0 {
+					t.Error("a read that asked for every field left something from the old copy behind")
+				}
+				if !got.Requested.Wide() {
+					t.Error("the result of a wide read is not itself wide")
+				}
+			},
+		},
+		{
+			name:  "a read that asked for nothing changes nothing",
+			fresh: jira.Issue{Key: "PROJ-1", Summary: ""},
+			check: func(t *testing.T, got jira.Issue) {
+				if got.Summary != base.Summary || got.Assignee == nil {
+					t.Error("an issue that did not come from a read overwrote one that did")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.check(t, MergeIssue(base, tc.fresh))
+		})
+	}
+}
+
+func TestMergeIssue_TakesTheFreshCopyWholeWhenThereIsNothingToMergeInto(t *testing.T) {
+	t.Parallel()
+
+	fresh := jira.Issue{Key: "PROJ-1", Summary: "new", Requested: jira.NewFieldMask([]string{"summary"})}
+	if got := MergeIssue(jira.Issue{}, fresh); got.Summary != "new" || got.Key != "PROJ-1" {
+		t.Errorf("merging into nothing gave %+v", got)
+	}
+}
+
+func TestStoredIssue_CarriesEverythingBackThatItTookIn(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("this machine has no zoneinfo entry for Europe/Berlin: %v", err)
+	}
+	doc, err := adf.Unmarshal([]byte(`{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a description"}]}]}`))
+	if err != nil {
+		t.Fatalf("parsing the description: %v", err)
+	}
+
+	want := jira.Issue{
+		ID: "20001", Key: "PROJ-1",
+		Project:     jira.ProjectRef{ID: "10000", Key: "PROJ", Name: "Project"},
+		Summary:     "everything an issue carries",
+		Description: doc,
+		Type:        jira.IssueType{ID: "10301", Name: "Story"},
+		Status:      jira.Status{ID: "10202", Name: "Building", Category: jira.CategoryInProgress},
+		Priority:    &jira.Priority{ID: "10402", Name: "Normal"},
+		Resolution:  &jira.Resolution{ID: "10501", Name: "Delivered"},
+		Assignee: &jira.User{
+			AccountID: "acct-ada", DisplayName: "Ada Lovelace",
+			Email: "ada@example.com", TimeZone: loc, Active: true,
+		},
+		Reporter:    &jira.User{AccountID: "acct-grace", DisplayName: "Grace Hopper"},
+		Labels:      []string{"cache", "offline"},
+		Components:  []jira.Component{{ID: "10600", Name: "Storage"}},
+		FixVersions: []jira.Version{{ID: "10700", Name: "1.2.0", ReleaseDate: jira.Date{Year: 2026, Month: time.April, Day: 1}}},
+		Parent:      &jira.IssueRef{ID: "20000", Key: "PROJ-0", Summary: "an epic"},
+		Subtasks:    []jira.IssueRef{{ID: "20002", Key: "PROJ-2"}},
+		Links: []jira.IssueLink{{
+			ID: "30001", Type: "Blocks", Label: "is blocked by",
+			Direction: jira.LinkInward, Other: jira.IssueRef{Key: "PROJ-3"},
+		}},
+		Due:          jira.Date{Year: 2026, Month: time.March, Day: 20},
+		Created:      testNow.Add(-72 * time.Hour),
+		Updated:      testNow.Add(-time.Hour),
+		Resolved:     ptr(testNow.Add(-30 * time.Minute)),
+		TimeTracking: &jira.TimeTracking{OriginalEstimate: 3600, RemainingEstimate: 1800, TimeSpent: 1800},
+		Fields: jira.NewFieldSet(map[string]jira.FieldValue{
+			"customfield_20001": {Kind: jira.KindNumber, Number: 8},
+			"customfield_20002": {Kind: jira.KindText, Text: "0|i00001:"},
+			"customfield_20003": {Kind: jira.KindDoc, Doc: doc},
+			"customfield_20004": {Kind: jira.KindOptions, Options: []jira.Option{{ID: "1", Label: "one"}}},
+			"customfield_20005": {Kind: jira.KindUsers, Users: []jira.User{{AccountID: "acct-alan", TimeZone: loc}}},
+			"customfield_20006": {Kind: jira.KindDate, Date: jira.Date{Year: 2026, Month: time.May, Day: 4}},
+			"customfield_20007": {Kind: jira.KindBool, Bool: true},
+		}),
+		Requested: jira.AllFields(),
+	}
+	if err := cache.PutRows(cacheJQL, []jira.Issue{want}, false); err != nil {
+		t.Fatalf("PutRows: %v", err)
+	}
+
+	got, ok := cache.Rows(cacheJQL)
+	if !ok || len(got.Issues) != 1 {
+		t.Fatalf("found %t with %d rows", ok, len(got.Issues))
+	}
+	back := got.Issues[0]
+
+	if !back.Requested.Wide() {
+		t.Error("a wide read came back narrow, so a later merge would refuse to overwrite anything")
+	}
+	if back.Assignee.TimeZone == nil || back.Assignee.TimeZone.String() != loc.String() {
+		t.Errorf("the assignee's timezone came back as %v", back.Assignee.TimeZone)
+	}
+	if back.Description.IsZero() || len(back.Description.Content) != 1 {
+		t.Errorf("the description came back as %+v", back.Description)
+	}
+	if !slices.Equal(back.Fields.IDs(), want.Fields.IDs()) {
+		t.Errorf("the custom fields came back as %v, want %v", back.Fields.IDs(), want.Fields.IDs())
+	}
+	if n, _ := back.Fields.Number(jira.FieldRef{ID: "customfield_20001"}); n != 8 {
+		t.Errorf("a numeric custom field came back as %v", n)
+	}
+	if users, _ := back.Fields.Users(jira.FieldRef{ID: "customfield_20005"}); len(users) != 1 || users[0].TimeZone == nil {
+		t.Errorf("a user-valued custom field came back as %+v", users)
+	}
+	for _, field := range []struct {
+		name       string
+		want, back any
+	}{
+		{"id", want.ID, back.ID},
+		{"key", want.Key, back.Key},
+		{"project", want.Project, back.Project},
+		{"summary", want.Summary, back.Summary},
+		{"type", want.Type, back.Type},
+		{"status", want.Status, back.Status},
+		{"priority", *want.Priority, *back.Priority},
+		{"resolution", *want.Resolution, *back.Resolution},
+		{"labels", fmt.Sprint(want.Labels), fmt.Sprint(back.Labels)},
+		{"components", fmt.Sprint(want.Components), fmt.Sprint(back.Components)},
+		{"fix versions", fmt.Sprint(want.FixVersions), fmt.Sprint(back.FixVersions)},
+		{"parent", *want.Parent, *back.Parent},
+		{"subtasks", fmt.Sprint(want.Subtasks), fmt.Sprint(back.Subtasks)},
+		{"links", fmt.Sprint(want.Links), fmt.Sprint(back.Links)},
+		{"due", want.Due, back.Due},
+		{"time tracking", *want.TimeTracking, *back.TimeTracking},
+	} {
+		if fmt.Sprint(field.want) != fmt.Sprint(field.back) {
+			t.Errorf("%s came back as %v, want %v", field.name, field.back, field.want)
+		}
+	}
+	for _, when := range []struct {
+		name       string
+		want, back time.Time
+	}{
+		{"created", want.Created, back.Created},
+		{"updated", want.Updated, back.Updated},
+		{"resolved", *want.Resolved, *back.Resolved},
+	} {
+		if !when.want.Equal(when.back) {
+			t.Errorf("%s came back as %s, want %s", when.name, when.back, when.want)
+		}
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// BenchmarkCacheReadFirstPaint measures the budget in docs/PERFORMANCE.md that
+// this packet owns: the cache read a view's first frame waits on.
+func BenchmarkCacheReadFirstPaint(b *testing.B) {
+	cache, _ := newTestCache(b)
+	if err := cache.PutRows(cacheJQL, listRows(50), true); err != nil {
+		b.Fatalf("PutRows: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, ok := cache.Rows(cacheJQL); !ok {
+			b.Fatal("the rows went away")
+		}
+	}
+}

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -326,6 +326,14 @@ func TestBrokenRules_MatchTheOffendingPackagesAndNothingElse(t *testing.T) {
 			want:    nil,
 		},
 		{
+			// The cache policy — kinds, TTLs, the codec — is a use case over the
+			// file, so this direction is deliberate rather than tolerated.
+			name:    "a use case reaching down into the store",
+			pkgDir:  "internal/app",
+			imports: "internal/store",
+			want:    nil,
+		},
+		{
 			name:    "a package whose name merely starts with an exempt one",
 			pkgDir:  "internal/configuration",
 			imports: "pkg/jira/cloud",

--- a/internal/store/record.go
+++ b/internal/store/record.go
@@ -1,0 +1,255 @@
+package store
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"go.etcd.io/bbolt"
+)
+
+// stampSize is the width of the write time each value is prefixed with.
+const stampSize = 8
+
+// Record is one value in a bucket together with the moment it was written.
+//
+// The time is stored beside the value rather than derived from the file, because
+// a TTL is per entry and bbolt knows nothing about either. Nothing here reads a
+// clock: the caller stamps what it writes, which is what lets a cache expiry be
+// tested with an injected clock rather than a sleep.
+type Record struct {
+	Key      string
+	Value    []byte
+	StoredAt time.Time
+}
+
+// Get reads one record. A key with nothing under it, and a kind never written
+// to, are both a false rather than an error.
+func (db *DB) Get(s Scope, kind, key string) (Record, bool, error) {
+	var out Record
+	found := false
+	err := db.bolt.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(s.Bucket(kind))
+		if bucket == nil {
+			return nil
+		}
+		rec, ok, err := read(bucket, key)
+		out, found = rec, ok
+		return err
+	})
+	if err != nil {
+		return Record{}, false, fmt.Errorf("reading %s/%s: %w", kind, key, err)
+	}
+	return out, found, nil
+}
+
+// GetAll reads several keys in one transaction, in the order they were asked
+// for. A key with nothing under it is left out, so the result is shorter than
+// the request rather than carrying a hole.
+//
+// It is one transaction because this is the read a first paint waits on: fifty
+// rows fetched one transaction apiece is fifty times the work for the same
+// bytes.
+func (db *DB) GetAll(s Scope, kind string, keys []string) ([]Record, error) {
+	out := make([]Record, 0, len(keys))
+	err := db.bolt.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(s.Bucket(kind))
+		if bucket == nil {
+			return nil
+		}
+		for _, key := range keys {
+			rec, ok, err := read(bucket, key)
+			if err != nil {
+				return err
+			}
+			if ok {
+				out = append(out, rec)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading %d key(s) of %s: %w", len(keys), kind, err)
+	}
+	return out, nil
+}
+
+// Put writes records, replacing whatever their keys already held and creating
+// the bucket on first use.
+func (db *DB) Put(s Scope, kind string, recs ...Record) error {
+	if len(recs) == 0 {
+		return nil
+	}
+	err := db.bolt.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(s.Bucket(kind))
+		if err != nil {
+			return err
+		}
+		for _, rec := range recs {
+			if rec.Key == "" {
+				return errors.New("a record with no key cannot be stored")
+			}
+			if err := bucket.Put([]byte(rec.Key), stamp(rec)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("writing %d record(s) of %s: %w", len(recs), kind, err)
+	}
+	return nil
+}
+
+// Delete removes keys. One that is not there is not an error: the caller wanted
+// it gone and it is.
+func (db *DB) Delete(s Scope, kind string, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	err := db.bolt.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(s.Bucket(kind))
+		if bucket == nil {
+			return nil
+		}
+		for _, key := range keys {
+			if err := bucket.Delete([]byte(key)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("deleting %d key(s) of %s: %w", len(keys), kind, err)
+	}
+	return nil
+}
+
+// Each visits every record of one kind in key order, stopping early when fn
+// returns false. The value handed to fn is the caller's own copy.
+func (db *DB) Each(s Scope, kind string, fn func(Record) bool) error {
+	err := db.bolt.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(s.Bucket(kind))
+		if bucket == nil {
+			return nil
+		}
+		cursor := bucket.Cursor()
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			rec, err := decode(string(k), v)
+			if err != nil {
+				return err
+			}
+			if !fn(rec) {
+				return nil
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking %s: %w", kind, err)
+	}
+	return nil
+}
+
+// Trim keeps the keep most recently written records of one kind and deletes the
+// rest, reporting how many went. A keep of zero or less empties the kind.
+//
+// It walks and deletes inside one write transaction, so a reader either sees the
+// bucket before the trim or after it, and the walk cannot be overtaken by a
+// write it is about to act on.
+func (db *DB) Trim(s Scope, kind string, keep int) (int, error) {
+	removed := 0
+	err := db.bolt.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(s.Bucket(kind))
+		if bucket == nil {
+			return nil
+		}
+		held := make([]Record, 0, bucket.Stats().KeyN)
+		cursor := bucket.Cursor()
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			stored, err := stampOf(v)
+			if err != nil {
+				return err
+			}
+			held = append(held, Record{Key: string(k), StoredAt: stored})
+		}
+		if len(held) <= max(keep, 0) {
+			return nil
+		}
+		// Oldest first, key order breaking a tie so that two records written in
+		// the same nanosecond do not evict in map order.
+		slices.SortFunc(held, func(a, b Record) int {
+			if !a.StoredAt.Equal(b.StoredAt) {
+				return a.StoredAt.Compare(b.StoredAt)
+			}
+			if a.Key < b.Key {
+				return -1
+			}
+			return 1
+		})
+		for _, rec := range held[:len(held)-max(keep, 0)] {
+			if err := bucket.Delete([]byte(rec.Key)); err != nil {
+				return err
+			}
+			removed++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("trimming %s to %d: %w", kind, keep, err)
+	}
+	return removed, nil
+}
+
+func read(bucket *bbolt.Bucket, key string) (Record, bool, error) {
+	raw := bucket.Get([]byte(key))
+	if raw == nil {
+		return Record{}, false, nil
+	}
+	rec, err := decode(key, raw)
+	if err != nil {
+		return Record{}, false, err
+	}
+	return rec, true, nil
+}
+
+func stamp(rec Record) []byte {
+	out := make([]byte, stampSize+len(rec.Value))
+	binary.BigEndian.PutUint64(out, bitsOf(rec.StoredAt))
+	copy(out[stampSize:], rec.Value)
+	return out
+}
+
+// bitsOf encodes a write time. A zero time is written as zero rather than as
+// UnixNano's answer for it, which is outside the range time.Unix can invert.
+func bitsOf(t time.Time) uint64 {
+	if t.IsZero() {
+		return 0
+	}
+	return uint64(t.UnixNano()) //nolint:gosec // inverted by stampOf below
+}
+
+// decode copies the value out of the transaction. bbolt hands back a window
+// into the mapped file, which is only valid until the transaction ends.
+func decode(key string, raw []byte) (Record, error) {
+	stored, err := stampOf(raw)
+	if err != nil {
+		return Record{}, fmt.Errorf("%s: %w", key, err)
+	}
+	value := make([]byte, len(raw)-stampSize)
+	copy(value, raw[stampSize:])
+	return Record{Key: key, Value: value, StoredAt: stored}, nil
+}
+
+func stampOf(raw []byte) (time.Time, error) {
+	if len(raw) < stampSize {
+		return time.Time{}, fmt.Errorf("a stored value is %d bytes, too short to carry the time it was written", len(raw))
+	}
+	bits := binary.BigEndian.Uint64(raw)
+	if bits == 0 {
+		return time.Time{}, nil
+	}
+	return time.Unix(0, int64(bits)), nil //nolint:gosec // the inverse of bitsOf
+}

--- a/internal/store/record_test.go
+++ b/internal/store/record_test.go
@@ -1,0 +1,279 @@
+package store
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const kind = "issue"
+
+var scope = Scope{Site: "example.atlassian.net", Account: "you@example.com"}
+
+func openTemp(t *testing.T) *DB {
+	t.Helper()
+
+	db, err := Open(filepath.Join(t.TempDir(), "cache.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+	return db
+}
+
+func TestGet_ReadsBackWhatPutWrote(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	written := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC)
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("rows"), StoredAt: written}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, ok, err := db.Get(scope, kind, "PROJ-1")
+	if err != nil || !ok {
+		t.Fatalf("Get: %v, found %t", err, ok)
+	}
+	if string(got.Value) != "rows" {
+		t.Errorf("the value came back as %q", got.Value)
+	}
+	if !got.StoredAt.Equal(written) {
+		t.Errorf("the write time came back as %s, want %s", got.StoredAt, written)
+	}
+}
+
+func TestGet_ReportsAMissRatherThanAnError(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	if _, ok, err := db.Get(scope, kind, "PROJ-1"); err != nil || ok {
+		t.Errorf("a kind never written to gave %v, found %t; want a plain miss", err, ok)
+	}
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("x"), StoredAt: time.Now()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, ok, err := db.Get(scope, kind, "PROJ-2"); err != nil || ok {
+		t.Errorf("a key never written gave %v, found %t; want a plain miss", err, ok)
+	}
+}
+
+func TestGetAll_KeepsTheOrderAskedForAndSkipsWhatIsNotThere(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	now := time.Now()
+	for _, key := range []string{"PROJ-1", "PROJ-2", "PROJ-3"} {
+		if err := db.Put(scope, kind, Record{Key: key, Value: []byte(key), StoredAt: now}); err != nil {
+			t.Fatalf("Put %s: %v", key, err)
+		}
+	}
+
+	got, err := db.GetAll(scope, kind, []string{"PROJ-3", "PROJ-9", "PROJ-1"})
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetAll returned %d records, want the two that exist", len(got))
+	}
+	if got[0].Key != "PROJ-3" || got[1].Key != "PROJ-1" {
+		t.Errorf("GetAll returned %s then %s; the order asked for is what a list draws",
+			got[0].Key, got[1].Key)
+	}
+}
+
+func TestPut_ReplacesWhatAKeyHeld(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	first := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC)
+	second := first.Add(time.Hour)
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("old"), StoredAt: first}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("new"), StoredAt: second}); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, _, err := db.Get(scope, kind, "PROJ-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got.Value) != "new" || !got.StoredAt.Equal(second) {
+		t.Errorf("the key still holds %q from %s", got.Value, got.StoredAt)
+	}
+}
+
+func TestPut_RefusesARecordWithNoKey(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	if err := db.Put(scope, kind, Record{Value: []byte("x"), StoredAt: time.Now()}); err == nil {
+		t.Error("a record with no key was stored under one")
+	}
+}
+
+func TestPut_KeepsAZeroWriteTimeZero(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("x")}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, _, err := db.Get(scope, kind, "PROJ-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.StoredAt.IsZero() {
+		t.Errorf("an unstamped record came back written at %s", got.StoredAt)
+	}
+}
+
+func TestDelete_RemovesAKeyAndForgivesOneThatIsNotThere(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("x"), StoredAt: time.Now()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := db.Delete(scope, kind, "PROJ-1", "PROJ-404"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok, _ := db.Get(scope, kind, "PROJ-1"); ok {
+		t.Error("the key survived being deleted")
+	}
+}
+
+func TestEach_WalksInKeyOrderAndStopsWhenAsked(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	now := time.Now()
+	for _, key := range []string{"PROJ-3", "PROJ-1", "PROJ-2"} {
+		if err := db.Put(scope, kind, Record{Key: key, Value: []byte(key), StoredAt: now}); err != nil {
+			t.Fatalf("Put %s: %v", key, err)
+		}
+	}
+
+	var seen []string
+	if err := db.Each(scope, kind, func(rec Record) bool {
+		seen = append(seen, rec.Key)
+		return true
+	}); err != nil {
+		t.Fatalf("Each: %v", err)
+	}
+	want := []string{"PROJ-1", "PROJ-2", "PROJ-3"}
+	if fmt.Sprint(seen) != fmt.Sprint(want) {
+		t.Errorf("Each walked %v, want %v", seen, want)
+	}
+
+	seen = nil
+	if err := db.Each(scope, kind, func(rec Record) bool {
+		seen = append(seen, rec.Key)
+		return false
+	}); err != nil {
+		t.Fatalf("Each: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Errorf("a walk told to stop visited %d records", len(seen))
+	}
+}
+
+func TestEach_OverAKindNeverWrittenToVisitsNothing(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	visited := 0
+	if err := db.Each(scope, "search", func(Record) bool {
+		visited++
+		return true
+	}); err != nil {
+		t.Fatalf("Each: %v", err)
+	}
+	if visited != 0 {
+		t.Errorf("a walk over nothing visited %d records", visited)
+	}
+}
+
+func TestTrim_KeepsTheMostRecentlyWrittenAndDropsTheRest(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	base := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC)
+	for i := range 10 {
+		key := fmt.Sprintf("PROJ-%d", i)
+		rec := Record{Key: key, Value: []byte(key), StoredAt: base.Add(time.Duration(i) * time.Minute)}
+		if err := db.Put(scope, kind, rec); err != nil {
+			t.Fatalf("Put %s: %v", key, err)
+		}
+	}
+
+	removed, err := db.Trim(scope, kind, 4)
+	if err != nil {
+		t.Fatalf("Trim: %v", err)
+	}
+	if removed != 6 {
+		t.Errorf("Trim removed %d records, want 6", removed)
+	}
+	for i := range 10 {
+		key := fmt.Sprintf("PROJ-%d", i)
+		_, ok, err := db.Get(scope, kind, key)
+		if err != nil {
+			t.Fatalf("Get %s: %v", key, err)
+		}
+		if want := i >= 6; ok != want {
+			t.Errorf("%s present = %t, want %t: the oldest writes are what a bound drops", key, ok, want)
+		}
+	}
+}
+
+func TestTrim_LeavesAKindThatIsAlreadyUnderTheBoundAlone(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("x"), StoredAt: time.Now()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	removed, err := db.Trim(scope, kind, 10)
+	if err != nil {
+		t.Fatalf("Trim: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("Trim removed %d records from a kind under the bound", removed)
+	}
+	if _, ok, _ := db.Get(scope, kind, "PROJ-1"); !ok {
+		t.Error("the only record was dropped by a trim that had nothing to do")
+	}
+}
+
+func TestRecords_StayInsideTheirOwnScope(t *testing.T) {
+	t.Parallel()
+
+	db := openTemp(t)
+	other := Scope{Site: scope.Site, Account: "someone.else@example.com"}
+	now := time.Now()
+	if err := db.Put(scope, kind, Record{Key: "PROJ-1", Value: []byte("mine"), StoredAt: now}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := db.Put(other, kind, Record{Key: "PROJ-1", Value: []byte("theirs"), StoredAt: now}); err != nil {
+		t.Fatalf("Put for the other account: %v", err)
+	}
+
+	got, _, err := db.Get(scope, kind, "PROJ-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got.Value) != "mine" {
+		t.Errorf("one account read %q out of another's bucket", got.Value)
+	}
+	if _, err := db.Trim(other, kind, 0); err != nil {
+		t.Fatalf("Trim the other account: %v", err)
+	}
+	if _, ok, _ := db.Get(scope, kind, "PROJ-1"); !ok {
+		t.Error("emptying one account's cache emptied another's")
+	}
+}

--- a/internal/ui/kernel/view.go
+++ b/internal/ui/kernel/view.go
@@ -91,6 +91,10 @@ type Deps struct {
 	// with mouse = false disables the manager, so Zones.Enabled() answers that
 	// question and Mark writes nothing into the frame.
 	Zones *zone.Manager
+	// Cache is what this session has already read from the site, or nil when it
+	// has nowhere to keep one. Every view has to draw without it: a first run has
+	// nothing on disk, and another copy of Saral may be holding the file.
+	Cache app.Cache
 	// Site is the host this session is talking to, for display only.
 	Site string
 	// Now is the clock. Tests inject a fixed one.

--- a/internal/ui/list/cache_test.go
+++ b/internal/ui/list/cache_test.go
@@ -1,0 +1,550 @@
+package list
+
+import (
+	"errors"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// fakeCache is an app.Cache in a map. The real one is bbolt-backed and lives
+// below internal/app, which a view may not import — which is the whole point of
+// the interface being where it is.
+type fakeCache struct {
+	mu      sync.Mutex
+	rows    map[string]app.Snapshot
+	issues  map[string]jira.Issue
+	gen     uint64
+	forgot  []string
+	putFail error
+}
+
+var _ app.Cache = (*fakeCache)(nil)
+
+func newFakeCache() *fakeCache {
+	return &fakeCache{rows: map[string]app.Snapshot{}, issues: map[string]jira.Issue{}}
+}
+
+// hold puts rows in as though a previous session had left them there.
+func (c *fakeCache) hold(jql string, issues []jira.Issue, stale, more bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rows[jql] = app.Snapshot{Issues: slices.Clone(issues), StoredAt: cacheStoredAt, Stale: stale, More: more}
+	for i := range issues {
+		c.issues[issues[i].Key] = issues[i]
+	}
+}
+
+func (c *fakeCache) Rows(jql string) (app.Snapshot, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	snap, ok := c.rows[strings.TrimSpace(jql)]
+	return snap, ok
+}
+
+func (c *fakeCache) PutRows(jql string, issues []jira.Issue, more bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.putFail != nil {
+		return c.putFail
+	}
+	c.gen++
+	c.rows[strings.TrimSpace(jql)] = app.Snapshot{Issues: slices.Clone(issues), StoredAt: cacheStoredAt, More: more}
+	for i := range issues {
+		c.issues[issues[i].Key] = app.MergeIssue(c.issues[issues[i].Key], issues[i])
+	}
+	return nil
+}
+
+func (c *fakeCache) Forget(jql string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gen++
+	c.forgot = append(c.forgot, jql)
+	delete(c.rows, strings.TrimSpace(jql))
+	return nil
+}
+
+func (c *fakeCache) EachIssue(fn func(jira.Issue, time.Time) bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, key := range slices.Sorted(maps.Keys(c.issues)) {
+		if !fn(c.issues[key], cacheStoredAt) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (c *fakeCache) Generation() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gen
+}
+
+var cacheStoredAt = time.Date(2025, time.March, 5, 8, 30, 0, 0, time.UTC)
+
+// storedRows are what a previous session would have written: the six fields of
+// the list projection, and a mask that says so.
+func storedRows(n int) []jira.Issue {
+	mask := jira.NewFieldMask(app.ListProjection().IDs)
+	out := jiratest.Gen(n)
+	for i := range out {
+		out[i].Requested = mask
+	}
+	return out
+}
+
+func withCache(d kernel.Deps, c app.Cache) kernel.Deps {
+	d.Cache = c
+	return d
+}
+
+// refusing is a site that answers nothing at all, which is what a first paint
+// has to work through.
+func refusing(t *testing.T, issues int) *jiratest.Fake {
+	t.Helper()
+	f := newFake(issues)
+	f.FailNextN(200, &jira.TransportError{Op: "search", Err: errors.New("dial tcp: no such host")})
+	return f
+}
+
+// TestNew_DrawsTheStoredRowsBeforeAnythingIsAskedOfTheSite is the gate on this
+// packet. It builds the view and renders one frame without ever calling Init,
+// which is exactly what kernel.FirstPaint does, so a cache read moved into Init
+// fails here.
+func TestNew_DrawsTheStoredRowsBeforeAnythingIsAskedOfTheSite(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := refusing(t, 0)
+	deps := withCache(testDeps(f), cache)
+	jql, _ := defaultQuery(deps.Project)
+	rows := storedRows(4)
+	cache.hold(jql, rows, false, false)
+
+	view, ok := New(deps).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	next, _ := view.Update(kernel.SizeMsg{Width: 120, Height: 20})
+	m, _ := next.(*Model)
+	frame := m.View()
+
+	for _, iss := range rows {
+		mustContain(t, frame, iss.Key, iss.Summary)
+	}
+	if calls := f.Calls(); len(calls) != 0 {
+		t.Errorf("the first frame made %v; nothing may be asked of the site before it is drawn", calls)
+	}
+}
+
+func TestFirstPaint_DrawsStoredRowsWithNothingReachable(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := refusing(t, 0)
+	deps := withCache(testDeps(f), cache)
+	jql, _ := defaultQuery(deps.Project)
+	rows := storedRows(6)
+	cache.hold(jql, rows, false, false)
+
+	took, frame, err := kernel.FirstPaint(deps, 120, 40)
+	if err != nil {
+		t.Fatalf("FirstPaint: %v", err)
+	}
+	for _, iss := range rows {
+		mustContain(t, frame, iss.Key)
+	}
+	if calls := f.Calls(); len(calls) != 0 {
+		t.Errorf("the first paint made %v", calls)
+	}
+	if took > 60*time.Millisecond {
+		t.Errorf("the first paint from the cache took %s, want under the 60ms in docs/PERFORMANCE.md", took)
+	}
+}
+
+func TestList_DoesNotAskTheSiteAgainWhileTheStoredRowsAreStillFresh(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := newFake(20)
+	deps := withCache(testDeps(f), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), false, false)
+
+	dr := newDriver(t, deps, 120, 20)
+
+	if got := countCalls(f, "Search"); got != 0 {
+		t.Errorf("a list opened on rows written seconds ago searched %d times; the cache exists to spare that", got)
+	}
+	if len(dr.m.issues) != 4 {
+		t.Errorf("the list holds %d rows, want the 4 that were stored", len(dr.m.issues))
+	}
+	mustNotContain(t, dr.view(), staleLabel)
+}
+
+func TestList_RevalidatesStoredRowsThatArePastTheirTTL(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := newFake(20)
+	deps := withCache(testDeps(f), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), true, false)
+
+	dr := newDriver(t, deps, 120, 20)
+
+	if got := countCalls(f, "Search"); got == 0 {
+		t.Error("rows past their TTL were drawn and never checked")
+	}
+	if dr.m.stale {
+		t.Error("the badge stayed up after the refresh landed")
+	}
+	mustNotContain(t, dr.view(), staleLabel)
+}
+
+// TestList_RevalidationArrivesAsAPatchRatherThanAFreshLoad pins that the rows
+// off disk are fed into the cursor-preserving patch this view already had, and
+// not into the load that starts again at row one.
+func TestList_RevalidationArrivesAsAPatchRatherThanAFreshLoad(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(newFake(20)), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), true, false)
+
+	stored, _ := New(deps).(*Model)
+	switch msg := firstMsg(t, stored.Init()).(type) {
+	case patchedMsg:
+	default:
+		t.Errorf("revalidating stored rows produced a %T, want the patchedMsg that keeps the cursor", msg)
+	}
+
+	cold, _ := New(withCache(testDeps(newFake(20)), newFakeCache())).(*Model)
+	switch msg := firstMsg(t, cold.Init()).(type) {
+	case loadedMsg:
+	default:
+		t.Errorf("a list with nothing stored produced a %T, want a loadedMsg", msg)
+	}
+}
+
+func TestList_ARefreshAfterAStoredPaintKeepsThePlace(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(newFake(60)), cache)
+	cache.hold(allJQL, storedRows(40), false, false)
+
+	dr := newDriver(t, deps, 120, 20)
+	dr.send(QueryMsg{JQL: allJQL, Title: "All issues"})
+	if len(dr.m.issues) != 40 {
+		t.Fatalf("the retargeted list holds %d rows, want the 40 that were stored", len(dr.m.issues))
+	}
+	for range 25 {
+		dr.key("j")
+	}
+	under, cursor, top := dr.m.selectedKey(), dr.m.cursor, dr.m.top
+	if top == 0 {
+		t.Fatal("the list never scrolled, so this proves nothing about the offset")
+	}
+
+	dr.send(kernel.RefreshMsg{})
+
+	if dr.m.selectedKey() != under || dr.m.cursor != cursor || dr.m.top != top {
+		t.Errorf("the refresh moved to %s at %d/%d, want %s at %d/%d",
+			dr.m.selectedKey(), dr.m.cursor, dr.m.top, under, cursor, top)
+	}
+}
+
+func TestList_KeepsTheStoredRowsOnScreenWhenTheSiteRefuses(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err  error
+		says string
+	}{
+		"a permission the token does not have": {
+			err:  &jira.CapabilityError{Capability: jira.CapBoards, Reason: "needs Browse Projects permission"},
+			says: "needs Browse Projects permission",
+		},
+		"the rate limiter": {
+			err:  &jira.RateLimitError{RetryAfter: 30 * time.Second},
+			says: "retry in 30s",
+		},
+		"a transport failure": {
+			err:  &jira.TransportError{Op: "search", Err: errors.New("dial tcp: no such host")},
+			says: "no such host",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cache := newFakeCache()
+			f := newFake(20)
+			deps := withCache(testDeps(f), cache)
+			jql, _ := defaultQuery(deps.Project)
+			rows := storedRows(4)
+			cache.hold(jql, rows, true, false)
+			f.FailNextN(20, tc.err)
+
+			dr := newDriver(t, deps, 120, 20)
+
+			if len(dr.m.issues) != len(rows) {
+				t.Fatalf("%d rows survived the refusal, want the %d off disk", len(dr.m.issues), len(rows))
+			}
+			view := dr.view()
+			mustContain(t, view, rows[0].Key, staleLabel)
+			if status := dr.lastStatus(); !strings.Contains(status.Text, tc.says) {
+				t.Errorf("the status line reads %q, want the error's own words %q", status.Text, tc.says)
+			}
+		})
+	}
+}
+
+func TestList_BadgesRowsItCouldNotRefreshEvenWhenTheyWereFreshOnDisk(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := newFake(20)
+	deps := withCache(testDeps(f), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), false, false)
+
+	dr := newDriver(t, deps, 120, 20)
+	mustNotContain(t, dr.view(), staleLabel)
+
+	f.FailNext(&jira.TransportError{Op: "search", Err: errors.New("dial tcp: no such host")})
+	dr.send(kernel.RefreshMsg{})
+
+	if !dr.m.stale {
+		t.Error("rows the site refused to confirm are not badged")
+	}
+	mustContain(t, dr.view(), staleLabel)
+}
+
+func TestList_StoresWhatItFetchedSoTheNextSessionDrawsItFirst(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(newFake(60, jiratest.WithPageSize(20))), cache)
+	dr := openAll(t, deps, 120, 20)
+
+	snap, ok := cache.Rows(allJQL)
+	if !ok {
+		t.Fatal("a search that worked stored nothing")
+	}
+	if len(snap.Issues) != len(dr.m.issues) {
+		t.Errorf("%d rows were stored against the %d on screen", len(snap.Issues), len(dr.m.issues))
+	}
+	if snap.Issues[0].Key != dr.m.issues[0].Key {
+		t.Errorf("the stored rows start at %s and the screen at %s", snap.Issues[0].Key, dr.m.issues[0].Key)
+	}
+	if !snap.More {
+		t.Error("a search with another page behind it was stored as complete")
+	}
+}
+
+func TestList_StoresEveryPageTheUserScrolledThroughAndNotJustTheLast(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(newFake(60, jiratest.WithPageSize(20))), cache)
+	dr := openAll(t, deps, 120, 30)
+	for range 32 {
+		dr.key("j")
+	}
+	if len(dr.m.issues) <= 20 {
+		t.Fatalf("the list only ever loaded %d rows, so nothing was paged", len(dr.m.issues))
+	}
+
+	snap, ok := cache.Rows(allJQL)
+	if !ok {
+		t.Fatal("nothing was stored")
+	}
+	if len(snap.Issues) != len(dr.m.issues) {
+		t.Errorf("%d rows were stored against the %d the user has scrolled through", len(snap.Issues), len(dr.m.issues))
+	}
+}
+
+func TestList_SaysSoWhenRowsCannotBeStored(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	cache.putFail = errors.New("the cache file is read-only")
+	deps := withCache(testDeps(newFake(10)), cache)
+
+	dr := openAll(t, deps, 120, 20)
+
+	if len(dr.m.issues) == 0 {
+		t.Fatal("a cache that could not be written dropped rows that had already arrived")
+	}
+	var said bool
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "read-only") {
+			said = true
+		}
+	}
+	if !said {
+		t.Errorf("nothing was said about a cache that refused the rows: %+v", dr.statuses)
+	}
+}
+
+func TestList_APurgingRefreshDropsTheStoredCopyToo(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(newFake(10)), cache)
+	dr := openAll(t, deps, 120, 20)
+
+	dr.send(kernel.RefreshMsg{Purge: true})
+
+	if !slices.Contains(cache.forgot, allJQL) {
+		t.Errorf("a purging refresh forgot %v, want it to drop %q", cache.forgot, allJQL)
+	}
+}
+
+func TestList_AsksTheSiteAgainToPageOnFromStoredRowsThatWerePartial(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := newFake(60, jiratest.WithPageSize(20))
+	deps := withCache(testDeps(f), cache)
+	cache.hold(allJQL, storedRows(4), false, true)
+
+	dr := newDriver(t, deps, 120, 20)
+	before := countCalls(f, "Search")
+	dr.send(QueryMsg{JQL: allJQL, Title: "All issues"})
+
+	if countCalls(f, "Search") == before {
+		t.Fatal("rows that were only part of an answer left the rest unreachable")
+	}
+	if len(dr.m.issues) <= 4 {
+		t.Errorf("the list still holds %d rows; stored rows carry no cursor, so the search is asked again",
+			len(dr.m.issues))
+	}
+}
+
+func TestList_ShowsAnOpenEndedCountForStoredRowsThatWerePartial(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(nil), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), false, true)
+
+	view, _ := New(deps).(*Model)
+	next, _ := view.Update(kernel.SizeMsg{Width: 120, Height: 20})
+	m, _ := next.(*Model)
+
+	mustContain(t, m.View(), "4+ issues")
+}
+
+func TestList_WithNoCacheDrawsExactlyWhatItDrewBefore(t *testing.T) {
+	t.Parallel()
+
+	withNone := start(t, testDeps(newFake(12)), 120, 30)
+	withEmpty := start(t, withCache(testDeps(newFake(12)), newFakeCache()), 120, 30)
+
+	if frame(withNone) != frame(withEmpty) {
+		t.Errorf("a session with nowhere to cache draws a different frame\n--- no cache ---\n%s\n--- empty cache ---\n%s",
+			frame(withNone), frame(withEmpty))
+	}
+}
+
+func TestList_WithNoCacheDrawsAFrameWhenTheSiteRefuses(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(refusing(t, 10))
+	if deps.Cache != nil {
+		t.Fatal("this test is about a session with no cache at all")
+	}
+	dr := newDriver(t, deps, 120, 20)
+
+	if len(dr.m.issues) != 0 {
+		t.Errorf("a session with nothing stored and nothing reachable found %d rows", len(dr.m.issues))
+	}
+	if status := dr.lastStatus(); !strings.Contains(status.Text, "no such host") {
+		t.Errorf("the status line reads %q, want the transport failure", status.Text)
+	}
+	mustNotContain(t, dr.view(), staleLabel)
+	if view := dr.view(); strings.TrimSpace(view) == "" {
+		t.Error("nothing was drawn at all")
+	}
+}
+
+func TestStaleBadge_Golden(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	f := newFake(20)
+	deps := withCache(testDeps(f), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(6), true, false)
+	f.FailNextN(20, &jira.TransportError{Op: "search", Err: errors.New("dial tcp: no such host")})
+
+	m := start(t, deps, 120, 30)
+	golden(t, "list_stale_120x30.golden", frame(m))
+}
+
+// firstMsg runs a command, unwrapping a batch, and returns the first message it
+// produced. It is how the outcome a command reports is asserted without letting
+// the model act on it.
+func firstMsg(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+
+	queue := []tea.Cmd{cmd}
+	for len(queue) > 0 {
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if cmds, ok := unwrapCmds(msg); ok {
+			queue = append(queue, cmds...)
+			continue
+		}
+		return msg
+	}
+	t.Fatal("the command produced no message")
+	return nil
+}
+
+func BenchmarkFirstPaintFromCache(b *testing.B) {
+	cache := newFakeCache()
+	deps := kernel.Deps{
+		Caps:    fullCaps(),
+		Project: "PROJ",
+		Theme:   kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs()),
+		Now:     func() time.Time { return time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC) },
+		Cache:   cache,
+	}
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(50), false, true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		view, _ := New(deps).(*Model)
+		next, _ := view.Update(kernel.SizeMsg{Width: 120, Height: 40})
+		m, _ := next.(*Model)
+		_ = m.View()
+	}
+}

--- a/internal/ui/list/cmds.go
+++ b/internal/ui/list/cmds.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -20,12 +21,14 @@ type loadedMsg struct {
 	gen     int
 	page    jira.Page[jira.Issue]
 	missing []string
+	stored  error
 }
 
 // pagedMsg carries the page after the one the list already has.
 type pagedMsg struct {
-	gen  int
-	page jira.Page[jira.Issue]
+	gen    int
+	page   jira.Page[jira.Issue]
+	stored error
 }
 
 // patchedMsg carries a re-read of the rows already on screen. It is a separate
@@ -35,6 +38,7 @@ type patchedMsg struct {
 	gen    int
 	issues []jira.Issue
 	page   jira.Page[jira.Issue]
+	stored error
 }
 
 // failedMsg is any search that did not produce rows. The error travels whole so
@@ -48,32 +52,61 @@ func request(jql string) app.Request {
 	return app.Request{JQL: jql, Projection: app.ListProjection(), MaxResults: pageSize}
 }
 
+// keep stores what a fetch brought back, so that the next session draws these
+// rows before it asks the site anything.
+//
+// The error travels back with the rows rather than replacing them: the fetch
+// worked, and a cache that could not be written is worth a line in the status
+// bar and nothing more.
+func keep(cache app.Cache, jql string, issues []jira.Issue, more bool) error {
+	if cache == nil {
+		return nil
+	}
+	return cache.PutRows(jql, issues, more)
+}
+
+// notStored says that rows the user can see were not written to disk. It is a
+// line in the status bar rather than an error, because the rows arrived.
+func notStored(err error) tea.Cmd {
+	if err == nil {
+		return nil
+	}
+	return kernel.Warn("these rows could not be stored for next time: " + err.Error())
+}
+
 // load fetches the first page of a query.
-func load(ctx context.Context, search *app.Search, jql string, gen int) tea.Cmd {
+func load(ctx context.Context, search *app.Search, cache app.Cache, jql string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		res, err := search.Run(ctx, request(jql))
 		if err != nil {
 			return failedMsg{gen: gen, err: err}
 		}
-		return loadedMsg{gen: gen, page: res.Page, missing: res.Missing}
+		return loadedMsg{
+			gen: gen, page: res.Page, missing: res.Missing,
+			stored: keep(cache, jql, res.Page.Items, res.Page.HasMore()),
+		}
 	}
 }
 
-// more fetches the page after the one in hand.
-func more(ctx context.Context, page jira.Page[jira.Issue], gen int) tea.Cmd {
+// more fetches the page after the one in hand. The rows already on screen come
+// with it so that what is stored is the whole of what the user has scrolled
+// through, not just its last page.
+func more(ctx context.Context, cache app.Cache, jql string, have []jira.Issue, page jira.Page[jira.Issue], gen int) tea.Cmd {
 	return func() tea.Msg {
 		next, err := page.Next(ctx)
 		if err != nil {
 			return failedMsg{gen: gen, err: err}
 		}
-		return pagedMsg{gen: gen, page: next}
+		whole := make([]jira.Issue, 0, len(have)+len(next.Items))
+		whole = append(append(whole, have...), next.Items...)
+		return pagedMsg{gen: gen, page: next, stored: keep(cache, jql, whole, next.HasMore())}
 	}
 }
 
 // reload re-reads the rows the list already has, walking as many pages as it
 // took to get them. It exists so that a refresh can patch rows in place rather
 // than throw the user's position away and start again at row one.
-func reload(ctx context.Context, search *app.Search, jql string, want, gen int) tea.Cmd {
+func reload(ctx context.Context, search *app.Search, cache app.Cache, jql string, want, gen int) tea.Cmd {
 	return func() tea.Msg {
 		res, err := search.Run(ctx, request(jql))
 		if err != nil {
@@ -88,6 +121,9 @@ func reload(ctx context.Context, search *app.Search, jql string, want, gen int) 
 			}
 			issues = append(issues, page.Items...)
 		}
-		return patchedMsg{gen: gen, issues: issues, page: page}
+		return patchedMsg{
+			gen: gen, issues: issues, page: page,
+			stored: keep(cache, jql, issues, page.HasMore()),
+		}
 	}
 }

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -4,6 +4,7 @@ package list
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strconv"
 	"strings"
@@ -44,6 +45,7 @@ var _ kernel.KeyCapturer = (*Model)(nil)
 type Model struct {
 	deps     kernel.Deps
 	search   *app.Search
+	cache    app.Cache
 	normal   map[string]action
 	inFilter map[string]action
 	styles   *styles
@@ -98,6 +100,21 @@ type Model struct {
 	gen     int
 	cancel  context.CancelFunc
 
+	// stale marks the rows on screen as older than they should be: they came off
+	// disk past their TTL, or the refresh that would have replaced them failed.
+	// It is what the badge in the summary line is drawn from.
+	stale bool
+	// cachedMore records that the stored rows were only part of the answer. Rows
+	// off disk carry no cursor, so paging on from them means asking the search
+	// again rather than following one.
+	cachedMore bool
+
+	focused bool
+
+	poll       time.Duration
+	pollArmed  bool
+	pollPaused bool
+
 	zonePrefix string
 }
 
@@ -124,10 +141,12 @@ func (m *Model) WantsRawKeys() bool { return m.filtering || m.bind != bindNone }
 func New(d kernel.Deps) kernel.View {
 	m := &Model{
 		deps:   d,
+		cache:  d.Cache,
 		styles: newStyles(d.Theme),
 		rows:   newRowCache(rowCacheLimit),
 		filter: newFilterInput(),
 		saved:  d.Saved,
+		poll:   PollInterval(),
 	}
 	if m.deps.Theme == nil {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
@@ -143,7 +162,31 @@ func New(d kernel.Deps) kernel.View {
 	m.jql, m.title = defaultQuery(d.Project)
 	m.defaulted = true
 	m.relayout()
+	m.fromCache()
 	return m
+}
+
+// fromCache puts the rows the last session left on disk on screen, before
+// anything at all is asked of the site (docs/UX.md principle 1).
+//
+// It runs here rather than in Init because this is where a first paint happens:
+// kernel.FirstPaint builds the view and renders one frame without ever calling
+// Init, which is the thing docs/PERFORMANCE.md budgets at 60ms.
+func (m *Model) fromCache() {
+	if m.cache == nil {
+		return
+	}
+	snap, ok := m.cache.Rows(m.jql)
+	if !ok || len(snap.Issues) == 0 {
+		return
+	}
+	m.issues, m.needles = snap.Issues, nil
+	m.page, m.missing = jira.Page[jira.Issue]{}, nil
+	m.cachedMore, m.stale = snap.More, snap.Stale
+	m.loaded, m.cursor, m.top = true, 0, 0
+	m.rows.reset()
+	m.relayout()
+	m.refilter()
 }
 
 func defaultQuery(project string) (jql, title string) {
@@ -178,8 +221,23 @@ type QueryMsg struct {
 // does, rather than a second implementation of it.
 type SaveQueryMsg struct{}
 
-// Init runs the opening search.
-func (m *Model) Init() tea.Cmd { return m.load() }
+// Init asks the site for what the first frame could not draw from disk.
+func (m *Model) Init() tea.Cmd {
+	if m.loaded {
+		return tea.Batch(m.revalidate(), m.pageAheadIfNeeded())
+	}
+	return m.load()
+}
+
+// revalidate re-reads rows that came off disk, and only once they are past their
+// TTL: rows written seconds ago are what the last frame of the last session
+// showed, and asking for them again is the round trip the cache exists to spare.
+func (m *Model) revalidate() tea.Cmd {
+	if !m.stale {
+		return nil
+	}
+	return m.refresh(false)
+}
 
 // Update handles one message.
 func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
@@ -189,7 +247,7 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 		cmd = m.resize(msg.Width, msg.Height)
 
 	case kernel.FocusMsg:
-		m.setFocus(msg.Focused)
+		cmd = m.setFocus(msg.Focused)
 
 	case kernel.ThemeMsg:
 		m.styles = newStyles(msg.Theme)
@@ -231,6 +289,9 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case failedMsg:
 		cmd = m.failed(msg)
 
+	case pollMsg:
+		cmd = m.polled(msg)
+
 	case tea.KeyPressMsg:
 		cmd = m.key(msg)
 
@@ -243,16 +304,21 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	return m, cmd
 }
 
-// setFocus keeps the filter's cursor out of a pane nobody is looking at.
-func (m *Model) setFocus(on bool) {
-	if !m.filtering {
-		return
+// setFocus keeps the filter's cursor out of a pane nobody is looking at, and the
+// poller scoped to the view somebody is.
+func (m *Model) setFocus(on bool) tea.Cmd {
+	m.focused = on
+	switch {
+	case !m.filtering:
+	case on:
+		_ = m.filter.Focus()
+	default:
+		m.filter.Blur()
 	}
 	if on {
-		_ = m.filter.Focus()
-		return
+		return m.pollTick()
 	}
-	m.filter.Blur()
+	return nil
 }
 
 func (m *Model) resize(w, h int) tea.Cmd {
@@ -329,21 +395,27 @@ func (m *Model) load() tea.Cmd {
 		return nil
 	}
 	ctx, gen := m.begin()
-	return withCancel(m.cancel, load(ctx, m.search, m.jql, gen))
+	return withCancel(m.cancel, load(ctx, m.search, m.cache, m.jql, gen))
 }
 
 func (m *Model) refresh(purge bool) tea.Cmd {
 	if m.search == nil {
 		return nil
 	}
+	var said tea.Cmd
 	if purge {
 		m.search.Invalidate()
+		if m.cache != nil {
+			if err := m.cache.Forget(m.jql); err != nil {
+				said = kernel.Warn("the stored copy of this search could not be dropped: " + err.Error())
+			}
+		}
 	}
 	if !m.loaded {
-		return m.load()
+		return tea.Batch(said, m.load())
 	}
 	ctx, gen := m.begin()
-	return withCancel(m.cancel, reload(ctx, m.search, m.jql, len(m.issues), gen))
+	return tea.Batch(said, withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues), gen)))
 }
 
 func (m *Model) retarget(msg QueryMsg) tea.Cmd {
@@ -376,8 +448,13 @@ func (m *Model) setQuery(jql, title string, byDefault bool) tea.Cmd {
 	}
 	m.issues, m.page, m.missing, m.view, m.needles = nil, jira.Page[jira.Issue]{}, nil, nil, nil
 	m.cursor, m.top, m.loaded = 0, 0, false
+	m.cachedMore, m.stale = false, false
 	m.rows.reset()
 	m.refilter()
+	m.fromCache()
+	if m.loaded {
+		return tea.Batch(m.revalidate(), m.pageAheadIfNeeded())
+	}
 	return m.load()
 }
 
@@ -397,11 +474,12 @@ func (m *Model) loadedPage(msg loadedMsg) tea.Cmd {
 	m.loading, m.loaded = false, true
 	m.issues, m.needles = slices.Clone(msg.page.Items), nil
 	m.page, m.missing = msg.page, msg.missing
+	m.cachedMore, m.stale = false, false
 	m.rows.reset()
 	m.relayout()
 	m.refilter()
 	m.cursor, m.top = 0, 0
-	return tea.Batch(m.missingFields(), m.pageAheadIfNeeded())
+	return tea.Batch(m.missingFields(), notStored(msg.stored), m.pageAheadIfNeeded(), m.pollTick())
 }
 
 func (m *Model) nextPage(msg pagedMsg) tea.Cmd {
@@ -411,9 +489,10 @@ func (m *Model) nextPage(msg pagedMsg) tea.Cmd {
 	m.loading = false
 	m.issues, m.needles = append(m.issues, msg.page.Items...), nil
 	m.page = msg.page
+	m.cachedMore, m.stale = false, false
 	m.relayout()
 	m.refilter()
-	return m.pageAheadIfNeeded()
+	return tea.Batch(notStored(msg.stored), m.pageAheadIfNeeded(), m.pollTick())
 }
 
 // patch replaces the rows with a re-read of themselves, leaving the cursor on
@@ -425,19 +504,30 @@ func (m *Model) patch(msg patchedMsg) tea.Cmd {
 	m.loading, m.loaded = false, true
 	under := m.selectedKey()
 	m.issues, m.page, m.needles = msg.issues, msg.page, nil
+	m.cachedMore, m.stale = false, false
 	m.rows.reset()
 	m.relayout()
 	m.refilter()
 	m.restore(under)
-	return m.pageAheadIfNeeded()
+	return tea.Batch(notStored(msg.stored), m.pageAheadIfNeeded(), m.pollTick())
 }
 
+// failed keeps whatever is on screen. Rows that are already drawn are the last
+// true answer this session had, so a refusal badges them rather than clearing
+// them (docs/UX.md — stale data is badged, not hidden).
 func (m *Model) failed(msg failedMsg) tea.Cmd {
 	if !m.current(msg.gen) {
 		return nil
 	}
 	m.loading = false
-	return kernel.Fail(msg.err)
+	if len(m.issues) > 0 {
+		m.stale = true
+	}
+	var limit *jira.RateLimitError
+	if errors.As(msg.err, &limit) {
+		m.pollPaused = true
+	}
+	return tea.Batch(kernel.Fail(msg.err), m.pollTick())
 }
 
 // missingFields reports the projection fields this site has no field for, which
@@ -453,7 +543,7 @@ func (m *Model) missingFields() tea.Cmd {
 // what is loaded, or when the local filter has left too few rows to fill the
 // screen. One request is in flight at a time, whatever the cursor does.
 func (m *Model) pageAheadIfNeeded() tea.Cmd {
-	if m.loading || !m.page.HasMore() {
+	if m.loading || m.search == nil || !m.hasMore() {
 		return nil
 	}
 	near := m.cursor >= len(m.view)-lookahead
@@ -462,8 +552,17 @@ func (m *Model) pageAheadIfNeeded() tea.Cmd {
 		return nil
 	}
 	ctx, gen := m.begin()
-	return withCancel(m.cancel, more(ctx, m.page, gen))
+	// Rows that came off disk carry no cursor to follow, so the page after them
+	// is reached by asking the search again and walking to where they end.
+	if !m.page.HasMore() {
+		return withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues)+pageSize, gen))
+	}
+	return withCancel(m.cancel, more(ctx, m.cache, m.jql, m.issues, m.page, gen))
 }
+
+// hasMore reports whether anything is left to fetch, from the live page or from
+// what the stored rows said about the answer they were part of.
+func (m *Model) hasMore() bool { return m.page.HasMore() || m.cachedMore }
 
 // --- selection and filtering ------------------------------------------------
 
@@ -829,13 +928,15 @@ type summaryKey struct {
 	more            bool
 	loading, loaded bool
 	filtered        bool
+	stale           bool
 }
 
 func (m *Model) summaryKey() summaryKey {
 	return summaryKey{
 		title: m.title, width: m.width, gen: m.styles.gen,
-		issues: len(m.issues), visible: len(m.view), more: m.page.HasMore(),
+		issues: len(m.issues), visible: len(m.view), more: m.hasMore(),
 		loading: m.loading, loaded: m.loaded, filtered: m.query != "",
+		stale: m.stale,
 	}
 }
 
@@ -849,12 +950,21 @@ func (m *Model) summaryLine() string {
 	}
 	ell := m.deps.Theme.Glyphs.Ellipsis
 	count := m.countLabel()
-	title := ansi.Truncate(m.title, max(m.width-ansi.StringWidth(count)-1, 1), ell)
-	pad := max(m.width-ansi.StringWidth(title)-ansi.StringWidth(count), 1)
-	m.summary = m.styles.title.Render(title) + strings.Repeat(" ", pad) + m.styles.count.Render(count)
+	badge := ""
+	if m.stale {
+		badge = m.deps.Theme.StaleBadge.Render(staleLabel)
+	}
+	right := ansi.StringWidth(badge) + ansi.StringWidth(count)
+	title := ansi.Truncate(m.title, max(m.width-right-1, 1), ell)
+	pad := max(m.width-ansi.StringWidth(title)-right, 1)
+	m.summary = m.styles.title.Render(title) + strings.Repeat(" ", pad) + badge + m.styles.count.Render(count)
 	m.sumKey = key
 	return m.summary
 }
+
+// staleLabel is a word and not a glyph: the glyph beside the count already means
+// a refresh is in flight, which is the opposite state.
+const staleLabel = "stale"
 
 func (m *Model) countLabel() string {
 	var b strings.Builder
@@ -878,7 +988,7 @@ func (m *Model) countLabel() string {
 
 func (m *Model) total() string {
 	n := strconv.Itoa(len(m.issues))
-	if m.page.HasMore() {
+	if m.hasMore() {
 		return n + "+"
 	}
 	return n

--- a/internal/ui/list/poll.go
+++ b/internal/ui/list/poll.go
@@ -1,0 +1,63 @@
+package list
+
+import (
+	"sync/atomic"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// pollEvery is how often a focused list re-reads itself, or zero for never,
+// which is where it starts.
+//
+// It is a package variable set by the composition root rather than a field on
+// kernel.Deps, for the same reason onboarding takes its connector that way: this
+// is a preference of the run, the kernel is closed to another field for it, and a
+// view may not read the config file itself.
+var pollEvery atomic.Int64
+
+// SetPollInterval turns the optional poller on for this process. Zero or less
+// turns it off, which is the default: a client that polls whether or not anybody
+// asked spends every user's rate limit on a screen nobody is looking at.
+func SetPollInterval(d time.Duration) { pollEvery.Store(int64(d)) }
+
+// PollInterval reports what SetPollInterval was last given, so that the
+// composition root can check its own flag arrived.
+func PollInterval() time.Duration { return time.Duration(pollEvery.Load()) }
+
+// pollMsg is a poll coming due. It carries the generation it was scheduled for,
+// so a tick left over from a search the user has already changed is not acted on
+// as though it were about the one on screen.
+type pollMsg struct{ gen int }
+
+// pollTick schedules the next poll, or nothing at all.
+//
+// One tick is outstanding at a time, it is only scheduled for the view that has
+// the keyboard, and it stops for good the first time Jira says it is being asked
+// too often (docs/UX.md — a rate limit pauses any poller).
+func (m *Model) pollTick() tea.Cmd {
+	if m.poll <= 0 || m.pollArmed || m.pollPaused || !m.focused || m.search == nil {
+		return nil
+	}
+	m.pollArmed = true
+	gen := m.gen
+	return tea.Tick(m.poll, func(time.Time) tea.Msg { return pollMsg{gen: gen} })
+}
+
+// polled acts on a tick: re-read what is on screen, which patches the rows and
+// leaves the cursor, the scroll and the filter alone.
+//
+// A poll while the user is typing into the filter or picking a number key is
+// dropped rather than run: the rows would move under a gesture that is half
+// finished. The next tick is lined up anyway, so the poller does not stop
+// because somebody paused over a keystroke.
+func (m *Model) polled(msg pollMsg) tea.Cmd {
+	m.pollArmed = false
+	switch {
+	case m.pollPaused || !m.focused:
+		return nil
+	case !m.current(msg.gen) || m.loading || m.filtering || m.bind != bindNone:
+		return m.pollTick()
+	}
+	return m.refresh(false)
+}

--- a/internal/ui/list/poll_test.go
+++ b/internal/ui/list/poll_test.go
@@ -1,0 +1,174 @@
+package list
+
+import (
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+func TestPoller_IsOffUnlessTheRunAsksForIt(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(10)), 120, 20)
+	if dr.m.poll != 0 {
+		t.Fatalf("a list built with nobody asking polls every %s", dr.m.poll)
+	}
+	if cmd := dr.m.pollTick(); cmd != nil {
+		t.Error("a poller nobody asked for scheduled itself")
+	}
+	if dr.m.pollArmed {
+		t.Error("a poller nobody asked for is armed")
+	}
+}
+
+// TestSetPollInterval_ReachesTheNextListBuilt is not parallel: it moves the
+// process-wide interval the composition root sets, and puts it back.
+func TestSetPollInterval_ReachesTheNextListBuilt(t *testing.T) {
+	SetPollInterval(45 * time.Second)
+	t.Cleanup(func() { SetPollInterval(0) })
+
+	m, ok := New(testDeps(newFake(1))).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	if m.poll != 45*time.Second {
+		t.Errorf("the list polls every %s, want the 45s the run asked for", m.poll)
+	}
+}
+
+func TestPoller_OnlyRunsForTheViewWithTheKeyboard(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(10)), 120, 20)
+	dr.m.poll = time.Minute
+
+	if cmd := dr.m.pollTick(); cmd == nil {
+		t.Fatal("a focused list with polling on scheduled nothing")
+	}
+	dr.m.pollArmed = false
+	dr.m.focused = false
+	if cmd := dr.m.pollTick(); cmd != nil {
+		t.Error("a list nobody is looking at scheduled a poll")
+	}
+}
+
+func TestPoller_SchedulesOneTickAtATime(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(10)), 120, 20)
+	dr.m.poll = time.Minute
+
+	if cmd := dr.m.pollTick(); cmd == nil {
+		t.Fatal("the first tick was not scheduled")
+	}
+	if cmd := dr.m.pollTick(); cmd != nil {
+		t.Error("a second tick was scheduled on top of the first, which doubles the poll rate every time")
+	}
+}
+
+func TestPoller_ReReadsTheRowsAndLeavesThePlaceAlone(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(60, jiratest.WithPageSize(20))
+	dr := openAll(t, testDeps(f), 120, 30)
+	for range 32 {
+		dr.key("j")
+	}
+	under, cursor, top := dr.m.selectedKey(), dr.m.cursor, dr.m.top
+	if top == 0 {
+		t.Fatal("the list never scrolled, so this proves nothing about the offset")
+	}
+
+	m := dr.m
+	m.poll, m.pollArmed = time.Minute, true
+	msg := firstMsg(t, m.polled(pollMsg{gen: m.gen}))
+	patched, ok := msg.(patchedMsg)
+	if !ok {
+		t.Fatalf("a poll produced a %T, want the patchedMsg that keeps the cursor", msg)
+	}
+
+	next, _ := m.Update(patched)
+	m, _ = next.(*Model)
+	if m.selectedKey() != under || m.cursor != cursor || m.top != top {
+		t.Errorf("a poll moved to %s at %d/%d, want %s at %d/%d",
+			m.selectedKey(), m.cursor, m.top, under, cursor, top)
+	}
+	if !m.pollArmed {
+		t.Error("the poll that just landed did not line up the next one")
+	}
+}
+
+func TestPoller_StopsForGoodOnceJiraSaysItIsBeingAskedTooOften(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(20)
+	dr := openAll(t, testDeps(f), 120, 20)
+	dr.m.poll = time.Minute
+	before := countCalls(f, "Search")
+
+	dr.send(failedMsg{gen: dr.m.gen, err: &jira.RateLimitError{RetryAfter: 30 * time.Second}})
+
+	if !dr.m.pollPaused {
+		t.Fatal("a rate limit left the poller running, which is what spends the rest of the budget")
+	}
+	if cmd := dr.m.pollTick(); cmd != nil {
+		t.Error("a paused poller scheduled another tick")
+	}
+	if cmd := dr.m.polled(pollMsg{gen: dr.m.gen}); cmd != nil {
+		t.Error("a tick outstanding when the limit arrived was acted on anyway")
+	}
+	if got := countCalls(f, "Search"); got != before {
+		t.Errorf("the site was asked %d more times after saying to stop", got-before)
+	}
+}
+
+func TestPoller_WaitsRatherThanMovingRowsUnderAHalfFinishedGesture(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(20)
+	dr := openAll(t, testDeps(f), 120, 20)
+	dr.m.poll = time.Minute
+
+	for _, tc := range []struct {
+		name  string
+		start func()
+	}{
+		{name: "a filter being typed into", start: func() { dr.key("/") }},
+		{name: "a number key being picked", start: func() { dr.key("s") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dr.m.pollArmed = false
+			tc.start()
+			before := countCalls(f, "Search")
+
+			if cmd := dr.m.polled(pollMsg{gen: dr.m.gen}); cmd == nil {
+				t.Error("the poller gave up rather than waiting for the gesture to finish")
+			}
+			if got := countCalls(f, "Search"); got != before {
+				t.Errorf("the rows were re-read under the gesture: %d more searches", got-before)
+			}
+			if !dr.m.pollArmed {
+				t.Error("the next tick was not lined up")
+			}
+			dr.key("esc")
+		})
+	}
+}
+
+func TestPoller_DropsATickLeftOverFromASearchTheUserHasChanged(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(20)
+	dr := openAll(t, testDeps(f), 120, 20)
+	dr.m.poll, dr.m.pollArmed = time.Minute, false
+	before := countCalls(f, "Search")
+
+	if cmd := dr.m.polled(pollMsg{gen: dr.m.gen - 1}); cmd == nil {
+		t.Error("a stale tick stopped the poller instead of being dropped")
+	}
+	if got := countCalls(f, "Search"); got != before {
+		t.Errorf("a tick for an older search was acted on: %d more searches", got-before)
+	}
+}

--- a/internal/ui/list/testdata/list_stale_120x30.golden
+++ b/internal/ui/list/testdata/list_stale_120x30.golden
@@ -1,0 +1,30 @@
+ saral | Issues                                                                            PROJ | example.atlassian.net 
+My issues in PROJ                                                                                         stale 6 issues
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-1  Add the nightly export                                 Epic       Building      Grace Hopper      02 Mar 12:00
+  PROJ-2  Rework webhook retries                                 Chore      Shipped       Alan Turing       02 Mar 14:00
+  PROJ-3  Investigate the onboarding wizard                      Story      Triage        Ada Lovelace      02 Mar 16:00
+  PROJ-4  Document CSV import                                    Defect     Building      unassigned        02 Mar 18:00
+  PROJ-5  Retire the audit trail                                 Chore      Shipped       Alan Turing       02 Mar 20:00
+  PROJ-6  Speed up session expiry                                Story      Triage        Ada Lovelace      02 Mar 22:00
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+search failed: dial tcp: no such host                                                                                   
+ g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit


### PR DESCRIPTION
## Packet

P3.2 — Cache and offline.

Closes #13

## What changed

Opening Saral no longer waits for a search. The issue list draws the rows the last session
left on disk, badges them when they are older than they should be, and checks them behind the
frame they were drawn into.

- **Rows inside their TTL are drawn and nothing is asked of the site at all.** Rows past it are
  drawn and revalidated. The revalidation arrives as `patchedMsg` — the cursor-preserving patch
  P1.5 already built — so the row under the cursor, the scroll offset and the filter all
  survive it.
- **A refusal keeps what is on screen.** 403, 429 or a dead network over the top of rows already
  drawn badges them and puts the site's own wording in the status line, rather than emptying the
  screen. `Theme.StaleBadge` has existed since P0.1 with no consumer; this is its first.
- **A narrow refresh cannot blank a field it never asked about.** Issues are stored once each,
  keyed by issue key, and a search stores which issues matched and in what order.
  `app.MergeIssue` merges over `Issue.Requested`, so a list row asking for six fields cannot
  unassign an issue that a wider read filled in. This is the second consumer of PC.1's
  field-presence answer.
- **Bounded and scoped.** Five thousand issues by default (`app.WithIssueBound`), evicting what
  was stored longest ago. Keyed by site + account through `store.Scope`, so two profiles never
  see each other's work.
- **A session with nowhere to cache runs anyway and says why**: a first run, another copy of
  Saral holding the file (`store.ErrLocked`), a home directory it cannot write to.
- **`R` drops the stored answer** as well as refetching, which is what purge should mean.
- **An optional poller**, off unless `--poll <duration>` is given, scoped to the view holding the
  keyboard, dropped rather than run under a half-typed filter, and stopped for good the first
  time Jira says it is being asked too often.

### The gate this packet had to hold

The named risk was shipping a cache nothing reads. So: **the read is in `list.New`, not in
`Init`.** `kernel.FirstPaint` builds a view and renders one frame without ever calling `Init`,
so a read there is a read that never happens on the path `docs/PERFORMANCE.md` budgets at 60 ms.
Three tests fail if it moves back:

| Test | Proves |
|---|---|
| `list.TestNew_DrawsTheStoredRowsBeforeAnythingIsAskedOfTheSite` | builds, sizes, renders one frame, asserts `fake.Calls()` is empty |
| `list.TestFirstPaint_DrawsStoredRowsWithNothingReachable` | the same through `kernel.FirstPaint`, with the fake refusing everything |
| `main.TestFirstPaint_DrawsRowsOutOfTheRealCacheFile` | the whole path: real bbolt file, two sessions, the second draws what the first stored |

That last one is the only test that crosses every layer, and it exists because
`internal/ui` may not import `internal/store` — so everything above the port is otherwise
tested against a map-backed `app.Cache`, and something had to check the real file.

`grep -rn 'app.Cache\|Deps.Cache'` returns the declaration, `DiskCache`, the wiring in
`build()`, and four call sites in `internal/ui/list`.

### Design notes worth a reviewer's attention

- **The interface takes JQL, not a kind and a key.** The version withdrawn from #79 had callers
  spelling their own keys, which is the out-of-band agreement the withdrawal was about. Handing
  it the question means there is no key format for two packets to disagree on. Full reasoning,
  and the shape verbatim, is on #13 and #15.
- **`Generation()` is the change signal P3.4 needs.** It counts every write and only increases.
  A message or a watch would need the kernel (closed) or a goroutine outliving a view (which
  `docs/PERFORMANCE.md` forbids); a counter is a pull, which MVU gives for free. It is a
  *complete* answer because bbolt holds the file exclusively — the process that has it open is
  the only writer. It over-reports rather than under-reports, which costs a rebuild and never
  leaves an index answering stale.
- **`internal/app` now imports `internal/store`.** `docs/ARCHITECTURE.md` already said the cache
  interface is declared "with the implementation that exercises it, in `internal/app`", so the
  policy — kinds, TTLs, the codec, the bound — lives there and bbolt is named in exactly one
  package. Downward and deliberate; a case in `internal/arch` now says so.
- **The issue bound is write-recency, not access-recency.** A read does not touch an entry:
  touching fifty rows on every first paint would rewrite them for nothing, and every refresh
  rewrites the displayed rows anyway, so the search on screen is always among the newest. The
  ceiling is configurable, as `docs/PERFORMANCE.md` asks; the ordering is in the doc comment.
- **`build()` grew a fifth result**, a function that releases the cache file. bbolt holds an
  exclusive lock for as long as it is open, so the run that took it has to give it back.

### Golden file

One new: `internal/ui/list/testdata/list_stale_120x30.golden`. It is a list showing six rows
that came off disk past their TTL with the network refusing to confirm them. Visually, one
change to the summary line — `stale` appears immediately left of the count, from
`Theme.StaleBadge` (faint with a space either side in no-colour; amber in colour). The status
line carries the transport error. No existing golden changed: the badge only renders when
something on screen could not be confirmed, and every other test paints from a live fake.

### Doc claims made true

- **`docs/ARCHITECTURE.md` said the capability probe "is cached in the store".** It never was —
  the kernel probes on `Init` and nothing persisted it. The clause is **deleted** and replaced
  with what actually happens. Persisting it needs the kernel to revalidate behind the frame, and
  the kernel is closed for this batch; doing it half way would offer a view on last week's
  permissions. Filed as #81, which the doc now points at.
- **The arch rules.** W0-b had already added `ui-must-not-import-the-store` beside
  `store-must-not-import-the-ui`, so nothing was duplicated. What was stale was the count: both
  docs said "six rules" over a table of seven. Fixed in both, plus a table case for the new
  `internal/app` → `internal/store` edge.
- The Caching section is rewritten to describe what landed rather than what was planned.

### Owned paths

Corrected in the roadmap row in this PR, and it matches the list the packet was assigned with:
`internal/store/**`, `internal/app/cache.go`, `cmd/saral/main.go`, the one `Deps` field in
`internal/ui/kernel/view.go`, `internal/ui/list/**` including its `testdata/**`,
`internal/arch/imports_test.go`, and `docs/{ARCHITECTURE,TESTING,ROADMAP}.md`. `go.mod` is
dropped from the row — #78 landed the dependency and `go mod tidy` is clean here. Two
extensions beyond the literal list, both forced by the definition of done: `cmd/saral/main_test.go`
(the file it owns had to be tested, and every test that isolates `SARAL_CONFIG_DIR` now isolates
`SARAL_CACHE_DIR` too, because `build()` opens a real file) and `internal/app/cache_test.go`
plus a `//go:build !race` companion for the one budget assertion.

## Numbers

Measured on an M2 Pro, `-benchmem`:

```
BenchmarkCacheReadFirstPaint-10        340342 ns/op    2068 allocs/op   # budget: < 5ms
BenchmarkFirstPaintFromCache-10        260015 ns/op     729 allocs/op   # 50 rows at 120x40
BenchmarkListSteadyScroll10k-10          1803 ns/op       1 allocs/op   # unchanged
BenchmarkListSteadyScroll20-10           1157 ns/op       1 allocs/op   # unchanged
BenchmarkFrame-10                      121235 ns/op     297 allocs/op   # unchanged
BenchmarkKeyToFrame-10                 123538 ns/op     310 allocs/op   # unchanged
```

The two budgeted frame paths are untouched at 297 and 310 allocs. A first paint out of the real
file is about 0.6 ms of the 60 ms budget. Stripped binary 11 MiB, under the 15 MiB ceiling.

The budget assertion for the cache read sits behind `//go:build !race`: the race detector puts
about twenty times the cost on a decode-heavy path, and asserting 5 ms under it would measure
the instrumentation. The benchmark itself runs everywhere.

## Definition of done

- [x] Works against `pkg/jira/jiratest` — no live Jira needed to run the tests
- [x] Failure paths tested: 403 (capability), 429 (rate limit), transport error — all three over
      the top of cached rows, asserting the rows stay, the badge appears and the site's own
      wording reaches the status line
- [x] Golden-file tests for any rendering; the one new golden is described above
- [x] Nothing instance-specific hardcoded. The platform field IDs in `issueColumns` are the
      same on every site and are the set `app.ListProjection` already names; every per-site ID
      travels in `Issue.Fields` and is matched through `Issue.Requested`
- [x] Keybindings and mouse zones registered, not hardcoded — no new keys or zones; the poller
      is a flag and the badge is not interactive
- [x] Benchmarks added/updated — two new, four checked for regression
- [x] Stayed inside the packet's owned paths (two test-file extensions named above)
- [x] `make check` green
- [x] `docs/ROADMAP.md` checkbox ticked in this PR

`python3 scripts/checkleak.py` clean, and no capture has been run in this tree.
