### PR TITLE
feat(index): rank every issue already on disk against what you type

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -15,6 +15,8 @@ These are budgets, not aspirations: CI enforces the ones it can, and benchmarks 
 | RSS with 10k issues cached | **< 60 MB** | measured in the bench harness |
 | Stripped binary | **< 15 MiB** | enforced in CI (`ci.yml`) |
 | Cache read for a view's first paint | < 5 ms | bbolt read benchmark |
+| Rank 10k cached issues against a keystroke | **< 16 ms**, 1 allocation | `BenchmarkIndexSearch10k`, asserted in `internal/app/index_budget_test.go` |
+| Rebuild the local index over 10k cached issues | < 16 ms | `BenchmarkIndexRebuild10k`, asserted beside it |
 
 ## Where the time actually goes
 
@@ -60,6 +62,26 @@ func BenchmarkRowRender(b *testing.B)    { ... }
 
 `make bench` runs them all. P9.2 wires `benchstat` into CI to fail a PR that regresses a budgeted
 path by more than 10%.
+
+### What the local index costs today
+
+Measured on an M2 Pro at ten thousand cached issues — twice the 5,000 the cache itself is bounded to,
+so the real worst case is half of each of these:
+
+| Benchmark | ns/op | allocs/op |
+|---|---|---|
+| `BenchmarkIndexSearch10k` — three runes typed, a screenful asked for | 795,000 | 1 |
+| `BenchmarkIndexSearchOneRune10k` — one rune, which nearly everything matches | 1,016,000 | 1 |
+| `BenchmarkIndexSearchUnbounded10k` — every hit rather than a screenful | 926,000 | 1 |
+| `BenchmarkIndexRebuild10k` — the walk a moved generation costs | 245,000 | 1 |
+| `BenchmarkPatternScore` — one candidate scored | 65 | 0 |
+
+The one allocation is the answer handed back, which the caller keeps. Everything behind it — the
+rows, the prepared pattern, the ranking buffer — outlives the call or never leaves the stack, and
+`app.Pattern` folds case without copying either side, so scoring is allocation-free however many
+candidates it is run over. That is the property that made writing the scorer cheaper than taking
+`github.com/sahilm/fuzzy`, whose API materialises a `[]string` of every target and a `[]int` of
+matched offsets per hit.
 
 ## Measuring for real
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -265,11 +265,34 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
   [#81](https://github.com/varijkapil13/saral/issues/81).
 - [ ] **P3.3 — Mouse** · [#14](https://github.com/varijkapil13/saral/issues/14) · **owns** `internal/ui/widget/zone*.go` + zone wiring in own files
   Click, double-click, wheel-under-pointer, drag-to-resize, clickable chips and footer.
-- [ ] **P3.4 — Local fuzzy index** · [#15](https://github.com/varijkapil13/saral/issues/15) · **owns** `internal/app/index.go` · **after P3.2**
-  Instant search over cached issues with no round trip; the thing that makes it feel faster than the web.
-  It reads through the cache P3.2 defines, so it follows P3.2 rather than running beside it: two
-  packets agreeing out of band on the kinds, the key format and the value codec is how the shape
-  comes out wrong.
+- [x] **P3.4 — Local fuzzy index** · [#15](https://github.com/varijkapil13/saral/issues/15) · **owns** `internal/app/{index,match}.go`, their tests and benchmarks, `docs/{PERFORMANCE,ROADMAP}.md` · **after P3.2**
+  **This row used to promise "instant search over cached issues with no round trip".** Half of that
+  already shipped in P1.5: `internal/ui/list` filters as you type with no round trip and no
+  allocation — `refilter` reuses its slice over needles built once per page, and
+  `BenchmarkFilterKeystroke10k` guards it. What was missing is **ranking**, and **reach past the rows
+  on screen** — the second being the cache, which is why this followed P3.2 rather than running
+  beside it.
+  So this packet is two things. `internal/app/match.go` is the scorer: `app.Pattern`, a subsequence
+  match over **any string**, ranked whole candidate → prefix → word start → the initials of several
+  words → inside a word → scattered, ties going to the earlier match and then the shorter candidate.
+  It folds case without copying either side and allocates nothing, which is what let Batch 3 keep its
+  decision not to add `github.com/sahilm/fuzzy`: that API materialises a `[]string` of every target
+  and a `[]int` per hit, against a 16 ms keystroke budget.
+  `internal/app/index.go` is the corpus: `app.Index` over `IssueCorpus`, the two-method narrow
+  interface `app.Cache` already satisfies, rebuilt when `Generation()` moves and not otherwise. A
+  walk is a whole rebuild, because a counter says that something changed and not what — 795 µs and
+  one allocation at ten thousand issues, so the honest answer was to rebuild rather than invent a
+  delta the cache cannot express. `Hit` carries `HasSummary`, because PC.1's mask means a narrow read
+  stores an issue whose title nothing asked for, and `StoredAt`, so a caller badges age against
+  `Deps.Now` and the index needs no clock.
+  **The list's filter was deliberately left alone.** It is the budgeted keystroke path at 1 alloc/op
+  and another packet in this wave is in that directory; ranking it is
+  [#84](https://github.com/varijkapil13/saral/issues/84).
+  **Its consumer is P3.1** ([#12](https://github.com/varijkapil13/saral/issues/12)): the palette
+  ranks commands with `app.Pattern`, and the signature was published on #12 and #15 before this
+  packet was finished so it could be coded against. `app.Index` itself has no view yet —
+  [#85](https://github.com/varijkapil13/saral/issues/85) reaches it from the palette and
+  [#62](https://github.com/varijkapil13/saral/issues/62) from a key jump.
 - [x] **P3.5a — The contextual footer, the `?` overlay and the theme switch** · [#16](https://github.com/varijkapil13/saral/issues/16) · **owns** `internal/ui/kernel/{theme,chrome_test,theme_test}.go`, the chrome functions in `internal/ui/kernel/kernel.go`, the `KeyReporter` lines in `internal/ui/kernel/{view,registry}.go`, `internal/ui/kernel/testdata/**`, the `keys*.go` and `testdata/keys.golden` of `internal/ui/{list,issue,form,comment,onboarding}`, `internal/ui/livekeys_test.go`, `docs/{UX,ARCHITECTURE,ROADMAP}.md`
   Contextual footer showing only valid keys, `?` overlay from the key registry, light/dark/no-color
   themes switchable while the program runs.

--- a/internal/app/index.go
+++ b/internal/app/index.go
@@ -1,0 +1,207 @@
+package app
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// summaryFieldID is the platform's own ID for an issue's title, which is the
+// same on every site — the IDs that differ per site are the custom fields.
+const summaryFieldID = "summary"
+
+// IssueCorpus is the part of a Cache an index is built from: the issues it
+// holds, and a number that moves when they change.
+//
+// It is narrower than Cache because an index never reads a search's rows and
+// never writes anything, so a test for one needs a dozen lines rather than a
+// whole cache, and a later corpus that is not the disk cache can be indexed
+// without widening anything.
+type IssueCorpus interface {
+	// EachIssue visits every issue held, in key order, stopping early when fn
+	// returns false.
+	EachIssue(fn func(iss jira.Issue, storedAt time.Time) bool) error
+	// Generation counts the changes made to what is held. It only ever
+	// increases, and it moves for any write.
+	Generation() uint64
+}
+
+// A Cache is a corpus: the index a session searches is built from the cache
+// that session already holds, and nothing else has to be passed around for it.
+var _ IssueCorpus = Cache(nil)
+
+// Hit is one issue a pattern matched, and how well.
+type Hit struct {
+	// Key is the issue key, which is what a caller opens the issue with.
+	Key string
+	// Summary is the issue's title. HasSummary is whether that is an answer: a
+	// narrow read stores an issue whose title nothing asked for, and an empty
+	// string there is different from an issue with an empty title.
+	Summary    string
+	HasSummary bool
+	// StoredAt is when the copy this answer came from was written. Every answer
+	// an index gives is from disk, so a caller that badges stale data compares
+	// this against its own clock rather than against time.Now.
+	StoredAt time.Time
+	// Score is what the pattern scored against this issue, for a caller that
+	// wants to blend it with a ranking of its own. Hits already arrive ordered.
+	Score int
+}
+
+// Index answers what somebody typed from the issues a cache already holds, with
+// no round trip. It keeps a key and a title per issue rather than the issues
+// themselves, so a corpus at the cache's bound costs a few hundred kilobytes
+// and no decoded JSON is held.
+//
+// The zero Index and one built over a nil corpus are both a search that finds
+// nothing, which is what a first run, a locked cache file and an unwritable
+// home all look like.
+//
+// An Index belongs to whatever holds it and is not safe for concurrent use: it
+// is read and rebuilt on the event loop, like every other read a first paint
+// depends on.
+type Index struct {
+	corpus IssueCorpus
+	rows   []indexRow
+	hits   []Hit
+	built  uint64
+	walked bool
+}
+
+type indexRow struct {
+	key        string
+	summary    string
+	hasSummary bool
+	storedAt   time.Time
+}
+
+// NewIndex returns an index over a corpus, without reading it. A nil corpus is
+// a session with nowhere to cache, and searching it finds nothing.
+func NewIndex(corpus IssueCorpus) *Index { return &Index{corpus: corpus} }
+
+// Len reports how many issues the index holds as of its last walk.
+func (ix *Index) Len() int {
+	if ix == nil {
+		return 0
+	}
+	return len(ix.rows)
+}
+
+// Refresh walks the corpus when it has moved since the last walk and does
+// nothing when it has not, reporting whether it walked. Comparing one number is
+// what keeps a keystroke from re-reading ten thousand issues; the corpus counts
+// every write, so this rebuilds more often than it strictly must and can never
+// answer from a copy that is behind.
+//
+// A walk is a rebuild rather than a delta because a generation says that
+// something changed, not what: the cache evicts and merges under its own bound,
+// and no per-issue difference is recoverable from a counter.
+//
+// A walk that fails part way keeps the rows it did read and is not walked again
+// until the corpus moves, so one issue that cannot be decoded costs one report
+// rather than one per keystroke.
+func (ix *Index) Refresh() (bool, error) {
+	if ix == nil || ix.corpus == nil {
+		return false, nil
+	}
+	gen := ix.corpus.Generation()
+	if ix.walked && gen == ix.built {
+		return false, nil
+	}
+	ix.rows = ix.rows[:0]
+	err := ix.corpus.EachIssue(func(iss jira.Issue, storedAt time.Time) bool {
+		if iss.Key == "" {
+			return true
+		}
+		row := indexRow{key: iss.Key, storedAt: storedAt}
+		if iss.Summary != "" || iss.Requested.Has(summaryFieldID) {
+			row.summary, row.hasSummary = iss.Summary, true
+		}
+		ix.rows = append(ix.rows, row)
+		return true
+	})
+	ix.built, ix.walked = gen, true
+	return true, err
+}
+
+// Search ranks the issues held against what somebody typed, best first, and
+// returns at most limit of them. A limit of zero or less is every issue that
+// matched, which costs a sort over the whole corpus; a caller drawing a screen
+// asks for the screenful it can show.
+//
+// An issue is ranked by whichever of its key and its title matches better. An
+// issue whose title nothing asked for is matched on its key alone.
+//
+// It refreshes first, so a caller cannot answer from a corpus that has moved
+// underneath it. The error is that refresh's: an issue that could not be read,
+// reported rather than swallowed, alongside the hits from the rest of them.
+//
+// The slice returned is the caller's own, so a view may keep it in its model
+// across frames.
+func (ix *Index) Search(text string, limit int) ([]Hit, error) {
+	if ix == nil {
+		return nil, nil
+	}
+	_, err := ix.Refresh()
+
+	pattern := NewPattern(text)
+	ix.hits = ix.hits[:0]
+	for i := range ix.rows {
+		row := &ix.rows[i]
+		score, ok := pattern.Score(row.key)
+		if row.hasSummary {
+			if other, matched := pattern.Score(row.summary); matched && (!ok || other > score) {
+				score, ok = other, true
+			}
+		}
+		if !ok {
+			continue
+		}
+		ix.keep(Hit{
+			Key: row.key, Summary: row.summary, HasSummary: row.hasSummary,
+			StoredAt: row.storedAt, Score: score,
+		}, limit)
+	}
+	if limit <= 0 {
+		slices.SortFunc(ix.hits, byRank)
+	}
+	if len(ix.hits) == 0 {
+		return nil, err
+	}
+	return slices.Clone(ix.hits), err
+}
+
+// keep inserts a hit into the ranked run built so far. Bounded, that is a
+// compare against the worst hit held for all but the few that beat it, which is
+// what a screenful out of ten thousand costs instead of a whole sort.
+func (ix *Index) keep(h Hit, limit int) {
+	if limit <= 0 {
+		ix.hits = append(ix.hits, h)
+		return
+	}
+	if len(ix.hits) == limit {
+		if byRank(h, ix.hits[limit-1]) >= 0 {
+			return
+		}
+		ix.hits = ix.hits[:limit-1]
+	}
+	at := len(ix.hits)
+	for at > 0 && byRank(h, ix.hits[at-1]) < 0 {
+		at--
+	}
+	ix.hits = append(ix.hits, Hit{})
+	copy(ix.hits[at+1:], ix.hits[at:])
+	ix.hits[at] = h
+}
+
+// byRank orders hits best first: by score, and by key where two issues scored
+// the same, so that one corpus and one pattern always come back in one order.
+func byRank(a, b Hit) int {
+	if a.Score != b.Score {
+		return cmp.Compare(b.Score, a.Score)
+	}
+	return strings.Compare(a.Key, b.Key)
+}

--- a/internal/app/index_budget_test.go
+++ b/internal/app/index_budget_test.go
@@ -1,0 +1,54 @@
+//go:build !race
+
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+// The budgets in docs/PERFORMANCE.md are about the binary that ships. The race
+// detector puts around twenty times the cost on a scan of this shape, so
+// asserting them under -race would measure the instrumentation instead.
+
+func TestIndexSearch_StaysUnderTheKeystrokeBudgetAtTenThousandIssues(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		of   func(*testing.B)
+	}{
+		{name: "a pattern of three runes", of: BenchmarkIndexSearch10k},
+		{name: "the first rune typed, which nearly everything matches", of: BenchmarkIndexSearchOneRune10k},
+		{name: "every hit rather than a screenful", of: BenchmarkIndexSearchUnbounded10k},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := testing.Benchmark(tc.of)
+			if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
+				t.Errorf("ranking ten thousand cached issues took %s, want under the 16ms in docs/PERFORMANCE.md", per)
+			}
+		})
+	}
+}
+
+// A keystroke is allowed the answer it hands back and nothing else: the rows,
+// the pattern and the ranking buffer all outlive the call.
+func TestIndexSearch_AllocatesOnlyTheAnswerItHandsBack(t *testing.T) {
+	t.Parallel()
+
+	res := testing.Benchmark(BenchmarkIndexSearch10k)
+	if got := res.AllocsPerOp(); got > 1 {
+		t.Errorf("a search allocates %d times, want only the slice it returns", got)
+	}
+}
+
+// Rebuilding is the cost the generation counter exists to keep off the
+// keystroke path, and it still has to fit inside one when it is paid.
+func TestIndexRebuild_StaysUnderTheKeystrokeBudgetAtTenThousandIssues(t *testing.T) {
+	t.Parallel()
+
+	res := testing.Benchmark(BenchmarkIndexRebuild10k)
+	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
+		t.Errorf("rebuilding over ten thousand cached issues took %s, want under the 16ms in docs/PERFORMANCE.md", per)
+	}
+}

--- a/internal/app/index_test.go
+++ b/internal/app/index_test.go
@@ -1,0 +1,490 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+var indexStored = time.Date(2026, time.March, 1, 8, 30, 0, 0, time.UTC)
+
+// stubCorpus is an IssueCorpus over a slice. It counts its walks, so a test can
+// assert that a rebuild did not happen.
+type stubCorpus struct {
+	issues []jira.Issue
+	stored time.Time
+	gen    uint64
+	walks  int
+	fail   error
+}
+
+func (c *stubCorpus) EachIssue(fn func(jira.Issue, time.Time) bool) error {
+	c.walks++
+	for i := range c.issues {
+		if !fn(c.issues[i], c.stored) {
+			break
+		}
+	}
+	return c.fail
+}
+
+func (c *stubCorpus) Generation() uint64 { return c.gen }
+
+func newStubCorpus(issues ...jira.Issue) *stubCorpus {
+	return &stubCorpus{issues: issues, stored: indexStored, gen: 1}
+}
+
+// titledIssue is an issue stored by a read that asked for its title.
+func titledIssue(key, summary string) jira.Issue {
+	return jira.Issue{
+		Key: key, Summary: summary,
+		Requested: jira.NewFieldMask(ListProjection().IDs),
+	}
+}
+
+// untitledIssue is an issue stored by a read so narrow it never asked for the
+// title, which is not the same as an issue with no title.
+func untitledIssue(key string) jira.Issue {
+	return jira.Issue{Key: key, Requested: jira.NewFieldMask([]string{"status"})}
+}
+
+func hitKeys(hits []Hit) []string {
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.Key
+	}
+	return out
+}
+
+func searched(t *testing.T, ix *Index, text string, limit int) []Hit {
+	t.Helper()
+
+	hits, err := ix.Search(text, limit)
+	if err != nil {
+		t.Fatalf("searching for %q: %v", text, err)
+	}
+	return hits
+}
+
+func TestIndex_FindsAnIssueByItsKeyAndByWordsOfItsTitle(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		titledIssue("PROJ-1", "Fix the login flow"),
+		titledIssue("PROJ-2", "Speed up the nightly export"),
+		titledIssue("OPS-14", "Rework webhook retries"),
+	))
+
+	cases := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{name: "a whole key", text: "PROJ-2", want: []string{"PROJ-2"}},
+		{name: "a key typed in lower case", text: "ops-14", want: []string{"OPS-14"}},
+		{name: "the digits of a key", text: "14", want: []string{"OPS-14"}},
+		{name: "a word of a title", text: "login", want: []string{"PROJ-1"}},
+		{name: "two words of a title", text: "nightly export", want: []string{"PROJ-2"}},
+		{name: "letters scattered through a title", text: "wbhk", want: []string{"OPS-14"}},
+		{name: "a word two titles share", text: "the", want: []string{"PROJ-1", "PROJ-2"}},
+		{name: "nothing any issue has", text: "kubernetes", want: nil},
+		{name: "a pattern longer than every key and title", text: "a pattern nothing here is remotely as long as", want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hitKeys(searched(t, ix, tc.text, 10)); !slices.Equal(got, tc.want) {
+				t.Errorf("searching for %q found %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIndex_RanksAKeyPrefixAboveATitleWordAboveAScatteredMatch(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		titledIssue("PROJ-14", "Investigate session expiry"),
+		titledIssue("PROJ-142", "Add the release checklist"),
+		titledIssue("OPS-7", "Rework the PROJ-14 handover"),
+		titledIssue("OPS-8", "Prepare the report on old jobs"),
+		titledIssue("OPS-9", "Retire the audit trail"),
+	))
+
+	want := []string{
+		"PROJ-14",  // the key, from its first rune
+		"PROJ-142", // the same, on a longer key
+		"OPS-7",    // a word of the title
+		"OPS-8",    // scattered through the title
+	}
+	if got := hitKeys(searched(t, ix, "proj", 10)); !slices.Equal(got, want) {
+		t.Errorf("searching for %q ranked %v, want %v", "proj", got, want)
+	}
+}
+
+func TestIndex_RanksAnIssueByWhicheverOfItsKeyAndTitleMatchesBetter(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		titledIssue("PROJ-9", "export"),
+		titledIssue("EXPORT-1", "Fix the nightly job"),
+	))
+
+	hits := searched(t, ix, "export", 10)
+	if got := hitKeys(hits); !slices.Equal(got, []string{"PROJ-9", "EXPORT-1"}) {
+		t.Errorf("searching for %q ranked %v; the title that is the whole pattern beats a key that only starts with it",
+			"export", got)
+	}
+}
+
+func TestIndex_MatchesOnTheKeyAloneWhenNothingAskedForTheTitle(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		untitledIssue("PROJ-1"),
+		titledIssue("PROJ-2", "Retire the audit trail"),
+	))
+
+	hits := searched(t, ix, "proj", 10)
+	if got := hitKeys(hits); !slices.Equal(got, []string{"PROJ-1", "PROJ-2"}) {
+		t.Errorf("searching for %q found %v, want both keys", "proj", got)
+	}
+	if hits[0].HasSummary || hits[0].Summary != "" {
+		t.Errorf("%s reports a title of %q; nothing asked the site for one", hits[0].Key, hits[0].Summary)
+	}
+	if !hits[1].HasSummary {
+		t.Errorf("%s reports no title, but the read that stored it asked for one", hits[1].Key)
+	}
+	if got := hitKeys(searched(t, ix, "audit", 10)); !slices.Equal(got, []string{"PROJ-2"}) {
+		t.Errorf("searching for %q found %v; an issue with no title cannot match a word of one", "audit", got)
+	}
+}
+
+func TestIndex_KeepsATitleItWasGivenEvenWhenNoReadClaimsIt(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(jira.Issue{Key: "PROJ-3", Summary: "Document the release checklist"}))
+
+	hits := searched(t, ix, "release", 10)
+	if len(hits) != 1 || !hits[0].HasSummary {
+		t.Fatalf("an issue carrying a title was indexed as %+v; a title that is there is an answer", hits)
+	}
+}
+
+func TestIndex_FindsATranslatedTitle(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		titledIssue("PROJ-1", "会議のサポート体制を見直す"),
+		titledIssue("PROJ-2", "Überprüfung der Rechnungsrundung"),
+		titledIssue("PROJ-3", "Corriger le café du matin"),
+	))
+
+	cases := []struct {
+		text string
+		want []string
+	}{
+		{text: "サポート", want: []string{"PROJ-1"}},
+		{text: "überprüfung", want: []string{"PROJ-2"}},
+		{text: "RECHNUNG", want: []string{"PROJ-2"}},
+		{text: "café", want: []string{"PROJ-3"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.text, func(t *testing.T) {
+			if got := hitKeys(searched(t, ix, tc.text, 10)); !slices.Equal(got, tc.want) {
+				t.Errorf("searching for %q found %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIndex_DoesNotWalkTheCorpusAgainWhileItsGenerationStandsStill(t *testing.T) {
+	t.Parallel()
+
+	corpus := newStubCorpus(titledIssue("PROJ-1", "Fix the login flow"))
+	ix := NewIndex(corpus)
+
+	for _, text := range []string{"l", "lo", "log", "logi", "login"} {
+		searched(t, ix, text, 10)
+	}
+	if corpus.walks != 1 {
+		t.Errorf("five keystrokes walked the corpus %d times, want the generation to have saved all but the first", corpus.walks)
+	}
+	if walked, err := ix.Refresh(); walked || err != nil {
+		t.Errorf("Refresh reported walked=%v err=%v with nothing changed, want false and no error", walked, err)
+	}
+}
+
+func TestIndex_WalksAgainOnceTheCorpusHasMoved(t *testing.T) {
+	t.Parallel()
+
+	corpus := newStubCorpus(titledIssue("PROJ-1", "Fix the login flow"))
+	ix := NewIndex(corpus)
+	searched(t, ix, "login", 10)
+
+	corpus.issues = append(corpus.issues, titledIssue("PROJ-2", "Retire the login banner"))
+	corpus.gen++
+
+	hits := searched(t, ix, "login", 10)
+	if corpus.walks != 2 {
+		t.Errorf("the corpus was walked %d times across a change to it, want twice", corpus.walks)
+	}
+	if got := hitKeys(hits); !slices.Equal(got, []string{"PROJ-1", "PROJ-2"}) {
+		t.Errorf("after the corpus grew, searching found %v, want both issues", got)
+	}
+	if ix.Len() != 2 {
+		t.Errorf("the index holds %d issues, want 2", ix.Len())
+	}
+}
+
+func TestIndex_ReportsAnIssueItCouldNotReadWithoutRetryingItEveryKeystroke(t *testing.T) {
+	t.Parallel()
+
+	corpus := newStubCorpus(titledIssue("PROJ-1", "Fix the login flow"))
+	corpus.fail = errors.New("the cached copy of PROJ-2 cannot be read")
+	ix := NewIndex(corpus)
+
+	hits, err := ix.Search("login", 10)
+	if err == nil {
+		t.Fatal("a corpus that could not be read entirely reported no error")
+	}
+	if got := hitKeys(hits); !slices.Equal(got, []string{"PROJ-1"}) {
+		t.Errorf("a failed walk answered with %v, want the issues it did read", got)
+	}
+
+	if _, err := ix.Search("login", 10); err != nil {
+		t.Errorf("the second keystroke reported %v; a failed walk is not retried until the corpus moves", err)
+	}
+	if corpus.walks != 1 {
+		t.Errorf("a corpus that failed was walked %d times over two keystrokes, want once", corpus.walks)
+	}
+}
+
+func TestIndex_FindsNothingAndSaysNothingWithNowhereToCache(t *testing.T) {
+	t.Parallel()
+
+	var absent Cache
+	for _, tc := range []struct {
+		name string
+		ix   *Index
+	}{
+		{name: "a session with no cache at all", ix: NewIndex(nil)},
+		{name: "a session holding a nil cache", ix: NewIndex(absent)},
+		{name: "a nil index", ix: nil},
+		{name: "an index nobody built", ix: new(Index)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hits, err := tc.ix.Search("login", 10)
+			if err != nil || len(hits) != 0 {
+				t.Errorf("searching found %v, %v; want nothing and no error", hits, err)
+			}
+			if walked, err := tc.ix.Refresh(); walked || err != nil {
+				t.Errorf("Refresh reported walked=%v err=%v, want false and no error", walked, err)
+			}
+			if tc.ix.Len() != 0 {
+				t.Errorf("the index holds %d issues, want none", tc.ix.Len())
+			}
+		})
+	}
+}
+
+func TestIndex_BoundsWhatItHandsBackToWhatWasAskedFor(t *testing.T) {
+	t.Parallel()
+
+	issues := make([]jira.Issue, 0, 40)
+	for i := 1; i <= 40; i++ {
+		issues = append(issues, titledIssue(fmt.Sprintf("PROJ-%d", i), "Fix the login flow"))
+	}
+	ix := NewIndex(newStubCorpus(issues...))
+
+	if got := len(searched(t, ix, "login", 5)); got != 5 {
+		t.Errorf("a search bounded at 5 returned %d hits", got)
+	}
+	if got := len(searched(t, ix, "login", 500)); got != 40 {
+		t.Errorf("a search bounded above the corpus returned %d hits, want all 40", got)
+	}
+	if got := len(searched(t, ix, "login", 0)); got != 40 {
+		t.Errorf("an unbounded search returned %d hits, want all 40", got)
+	}
+}
+
+func TestIndex_RanksTheSameWayBoundedAsUnbounded(t *testing.T) {
+	t.Parallel()
+
+	issues := make([]jira.Issue, 0, 60)
+	for i := 1; i <= 60; i++ {
+		issues = append(issues, titledIssue(fmt.Sprintf("PROJ-%d", i), fmt.Sprintf("Fix the login flow of stage %d", i)))
+	}
+	ix := NewIndex(newStubCorpus(issues...))
+
+	all := hitKeys(searched(t, ix, "log", 0))
+	few := hitKeys(searched(t, ix, "log", 8))
+	if !slices.Equal(all[:len(few)], few) {
+		t.Errorf("the first %d of an unbounded search are %v, and a bounded one returned %v", len(few), all[:len(few)], few)
+	}
+}
+
+func TestIndex_AnEmptyPatternIsEveryIssueInKeyOrder(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		titledIssue("PROJ-1", "Fix the login flow"),
+		titledIssue("PROJ-2", "Retire the audit trail"),
+		untitledIssue("PROJ-3"),
+	))
+
+	want := []string{"PROJ-1", "PROJ-2", "PROJ-3"}
+	if got := hitKeys(searched(t, ix, "", 10)); !slices.Equal(got, want) {
+		t.Errorf("an empty pattern found %v, want %v", got, want)
+	}
+}
+
+func TestIndex_SkipsAnIssueWithNoKeyToOpenItBy(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		jira.Issue{Summary: "Fix the login flow"},
+		titledIssue("PROJ-2", "Fix the login banner"),
+	))
+
+	if got := hitKeys(searched(t, ix, "login", 10)); !slices.Equal(got, []string{"PROJ-2"}) {
+		t.Errorf("searching found %v; an issue with no key is one nothing can open", got)
+	}
+}
+
+func TestIndex_SaysWhenTheCopyItAnsweredFromWasStored(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(titledIssue("PROJ-1", "Fix the login flow")))
+
+	hits := searched(t, ix, "login", 10)
+	if len(hits) != 1 {
+		t.Fatalf("searching found %d hits, want 1", len(hits))
+	}
+	if !hits[0].StoredAt.Equal(indexStored) {
+		t.Errorf("the hit was stored at %s, want %s; a caller badges staleness against its own clock",
+			hits[0].StoredAt, indexStored)
+	}
+}
+
+func TestIndex_HandsBackASliceTheCallerKeeps(t *testing.T) {
+	t.Parallel()
+
+	ix := NewIndex(newStubCorpus(
+		titledIssue("PROJ-1", "Fix the login flow"),
+		titledIssue("PROJ-2", "Retire the login banner"),
+	))
+
+	held := searched(t, ix, "login", 10)
+	searched(t, ix, "retire", 10)
+
+	if got := hitKeys(held); !slices.Equal(got, []string{"PROJ-1", "PROJ-2"}) {
+		t.Errorf("hits held across a second search became %v; the answer is the caller's own", got)
+	}
+}
+
+// The stub above is a slice. This one is the cache a session actually holds:
+// bbolt keys the issues, DiskCache decodes them, and the generation moves
+// because rows were written.
+func TestIndex_SearchesTheIssuesTheDiskCacheHolds(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t)
+	rows := listRows(30)
+	if err := cache.PutRows(cacheJQL, rows, false); err != nil {
+		t.Fatalf("storing rows: %v", err)
+	}
+
+	ix := NewIndex(cache)
+	if got := hitKeys(searched(t, ix, "PROJ-7", 5)); len(got) == 0 || got[0] != "PROJ-7" {
+		t.Errorf("searching the disk cache for %q ranked %v", "PROJ-7", got)
+	}
+	if ix.Len() != len(rows) {
+		t.Errorf("the index holds %d of the %d issues stored", ix.Len(), len(rows))
+	}
+
+	hits := searched(t, ix, rows[3].Summary, 5)
+	if len(hits) == 0 || hits[0].Summary != rows[3].Summary {
+		t.Errorf("searching for a stored title ranked %v", hitKeys(hits))
+	}
+
+	before := ix.Len()
+	if err := cache.PutRows(`project = "OPS" ORDER BY key`, listRows(4), false); err != nil {
+		t.Fatalf("storing a second search: %v", err)
+	}
+	searched(t, ix, "", 1)
+	if ix.Len() != before {
+		t.Errorf("the index holds %d issues after a second search stored the same keys, want %d", ix.Len(), before)
+	}
+}
+
+// indexOf10k is the corpus the budgets in docs/PERFORMANCE.md are written
+// against: the cache's own bound is 5,000 issues, so ten thousand is twice the
+// worst case a session can reach.
+func indexOf10k(tb testing.TB) *Index {
+	tb.Helper()
+
+	ix := NewIndex(newStubCorpus(listRows(10000)...))
+	if _, err := ix.Refresh(); err != nil {
+		tb.Fatalf("building the index: %v", err)
+	}
+	return ix
+}
+
+// BenchmarkIndexSearch10k is the keystroke: a pattern typed into a screenful of
+// results over ten thousand cached issues.
+func BenchmarkIndexSearch10k(b *testing.B) {
+	ix := indexOf10k(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := ix.Search("log", 20); err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+	}
+}
+
+// BenchmarkIndexSearchOneRune10k is the worst keystroke there is: the first
+// letter typed, which nearly every issue matches, so the ranking cannot skip
+// anything.
+func BenchmarkIndexSearchOneRune10k(b *testing.B) {
+	ix := indexOf10k(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := ix.Search("e", 20); err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+	}
+}
+
+// BenchmarkIndexSearchUnbounded10k is what asking for every hit costs, which is
+// a sort over the corpus rather than a compare against the worst hit held.
+func BenchmarkIndexSearchUnbounded10k(b *testing.B) {
+	ix := indexOf10k(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := ix.Search("log", 0); err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+	}
+}
+
+// BenchmarkIndexRebuild10k is the cost the generation counter is there to avoid
+// paying on every keystroke.
+func BenchmarkIndexRebuild10k(b *testing.B) {
+	corpus := newStubCorpus(listRows(10000)...)
+	ix := NewIndex(corpus)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		corpus.gen = uint64(i + 1)
+		if _, err := ix.Refresh(); err != nil {
+			b.Fatalf("Refresh: %v", err)
+		}
+	}
+}

--- a/internal/app/match.go
+++ b/internal/app/match.go
@@ -1,0 +1,223 @@
+package app
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Every bonus and penalty below is a whole multiple of scoreUnit, and the only
+// term smaller than one unit is the tail: how far into the candidate the match
+// starts, and how long the candidate is. So the tiers decide the order and the
+// tail only ever breaks a tie inside one.
+const (
+	scoreUnit = 256
+
+	// scorePrefix is for the pattern spelt out from the candidate's first rune,
+	// and scoreWhole for one that is the entire candidate. Together they are
+	// what puts a prefix above a word start.
+	scorePrefix = 8 * scoreUnit
+	scoreWhole  = 8 * scoreUnit
+	// scoreWordStart is for a matched rune that begins a word, which is what
+	// puts a word start above a match landing in the middle of one.
+	scoreWordStart = 4 * scoreUnit
+	// scoreAdjacent is for a matched rune that follows the one before it, and
+	// scoreGap against a run of runes skipped between two of them: contiguous
+	// beats scattered. A gap costs more than a word start pays, so that a
+	// pattern spelt out of the initials of three words stays below the same
+	// pattern found whole inside one of them.
+	scoreAdjacent = 3 * scoreUnit
+	scoreGap      = 2 * scoreUnit
+)
+
+// The tail is the part of a score under one unit, so it can only order two
+// candidates the tiers above have already tied. An earlier match wins first,
+// and a shorter candidate breaks what is left: five bits of rune count against
+// three of how far in the match began.
+const (
+	tailLeadStep = 32
+	tailMaxLead  = 7
+	tailMaxRunes = 31
+)
+
+// A pattern's first rune can begin many words in one candidate, and each one is
+// a separate attempt at the best match. Eight is where a ranking difference
+// stops being one anybody can see, and the alternative is a scan that grows
+// with the square of the title.
+const maxStarts = 8
+
+// Pattern is what somebody typed, prepared once for a pass over many
+// candidates. Preparing one holds no slice and copies no string, so a keystroke
+// folds the pattern once rather than once per row.
+//
+// It matches a subsequence: every rune of the pattern has to appear in the
+// candidate in that order, though not next to each other. Case is ignored on
+// both sides, and neither side is copied to do it.
+//
+// The candidate is any string. An issue key, an issue title and a command's
+// name in the palette are all scored by the same code, which is why there is no
+// fuzzy-matching dependency in this module.
+type Pattern struct {
+	text  string
+	first rune
+	runes int
+	ascii bool
+}
+
+// NewPattern prepares what somebody typed. It allocates nothing, so a caller
+// ranking ten thousand rows against one keystroke prepares it outside the loop
+// and pays for it once.
+//
+// The text is taken as typed. Trailing space is part of the pattern, because a
+// space is a rune a title can be matched on like any other.
+func NewPattern(text string) Pattern {
+	p := Pattern{text: text, ascii: true}
+	for _, r := range text {
+		if p.runes == 0 {
+			p.first = fold(r)
+		}
+		if r >= utf8.RuneSelf {
+			p.ascii = false
+		}
+		p.runes++
+	}
+	return p
+}
+
+// Empty reports whether the pattern is the one that matches everything.
+func (p Pattern) Empty() bool { return p.runes == 0 }
+
+// Score reports how well the pattern matches a candidate. A higher score is a
+// better match; the bool is the only answer about whether it matched at all,
+// since a poor match can score below zero.
+//
+// The empty pattern matches every candidate with a score of nothing, so a
+// caller filtering on it keeps whatever order it already had.
+//
+// Equal scores are for the caller to break. Comparing the two candidates is
+// enough to make it a total order, which is what Index does.
+func (p Pattern) Score(candidate string) (int, bool) {
+	if p.runes == 0 {
+		return 0, true
+	}
+	// A pattern of n ASCII runes is n bytes, and it needs n runes of candidate,
+	// which is at least n bytes of it. Folding a non-ASCII rune can shorten it,
+	// so this is only safe to skip on the ASCII side.
+	if candidate == "" || (p.ascii && len(p.text) > len(candidate)) {
+		return 0, false
+	}
+
+	best, found, starts := 0, false, 0
+	prev, at := rune(-1), 0
+	for off, r := range candidate {
+		if fold(r) == p.first && (starts == 0 || wordStart(prev, r)) {
+			score, gaps, ok := p.scoreFrom(candidate, off, at, prev)
+			if ok && (!found || score > best) {
+				best, found = score, true
+			}
+			// A contiguous match on the first rune cannot be beaten: no later
+			// start can hold the prefix bonus, and none can skip fewer runes.
+			if ok && off == 0 && gaps == 0 {
+				break
+			}
+			starts++
+			if starts >= maxStarts {
+				break
+			}
+		}
+		prev, at = r, at+1
+	}
+	if !found {
+		return 0, false
+	}
+	return best - lengthTail(candidate), true
+}
+
+// scoreFrom matches the whole pattern from one starting rune of the candidate,
+// taking the first place each later rune of the pattern appears. It reports the
+// score, how many runs of runes it had to skip, and whether the pattern fitted
+// at all.
+func (p Pattern) scoreFrom(candidate string, start, startRune int, before rune) (score, gaps int, ok bool) {
+	want, wantWidth := utf8.DecodeRuneInString(p.text)
+	folded := fold(want)
+
+	matched, taken := 0, wantWidth
+	prev, end := before, -1
+	for i := start; i < len(candidate); {
+		r, w := utf8.DecodeRuneInString(candidate[i:])
+		if fold(r) == folded {
+			if wordStart(prev, r) {
+				score += scoreWordStart
+			}
+			switch {
+			case matched == 0:
+			case i == end:
+				score += scoreAdjacent
+			default:
+				score -= scoreGap
+				gaps++
+			}
+			matched, end = matched+1, i+w
+			if taken == len(p.text) {
+				break
+			}
+			want, wantWidth = utf8.DecodeRuneInString(p.text[taken:])
+			folded, taken = fold(want), taken+wantWidth
+		}
+		prev, i = r, i+w
+	}
+	if matched < p.runes {
+		return 0, 0, false
+	}
+	// A prefix is the pattern spelt out from the candidate's first rune. Landing
+	// on the first rune and then skipping through the rest of it is a scattered
+	// match that happens to start early, and pays the tail for it instead.
+	if start == 0 && gaps == 0 {
+		score += scorePrefix
+		if end == len(candidate) {
+			score += scoreWhole
+		}
+	}
+	return score - min(startRune, tailMaxLead)*tailLeadStep, gaps, true
+}
+
+// lengthTail is the part of the tail that prefers a shorter candidate. It is
+// the same for every start in one candidate, so it is applied once rather than
+// per attempt.
+func lengthTail(candidate string) int {
+	return min(utf8.RuneCountInString(candidate), tailMaxRunes)
+}
+
+// fold is the one-rune case mapping the whole scorer uses, so that neither the
+// pattern nor the candidate is ever lowercased into a new string.
+func fold(r rune) rune {
+	if r < utf8.RuneSelf {
+		if 'A' <= r && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return r
+	}
+	return unicode.ToLower(r)
+}
+
+// wordStart reports whether cur begins a word, given the rune before it. A
+// negative prev is the start of the candidate, which counts: "the log" and
+// "log" both start a word at the l.
+func wordStart(prev, cur rune) bool {
+	switch {
+	case prev < 0, !wordRune(prev):
+		return true
+	case unicode.IsLower(prev) && unicode.IsUpper(cur):
+		return true
+	case unicode.IsLetter(prev) && unicode.IsDigit(cur):
+		return true
+	default:
+		return false
+	}
+}
+
+func wordRune(r rune) bool {
+	if r < utf8.RuneSelf {
+		return ('0' <= r && r <= '9') || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z')
+	}
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/internal/app/match_test.go
+++ b/internal/app/match_test.go
@@ -1,0 +1,250 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPattern_MatchesASubsequenceIgnoringCase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		pattern   string
+		candidate string
+		want      bool
+	}{
+		{name: "the whole candidate", pattern: "log", candidate: "log", want: true},
+		{name: "a prefix of it", pattern: "log", candidate: "login flow", want: true},
+		{name: "a word inside it", pattern: "flow", candidate: "Fix the login flow", want: true},
+		{name: "runes in order but apart", pattern: "lgn", candidate: "login flow", want: true},
+		{name: "runes out of order do not match", pattern: "nigol", candidate: "login flow", want: false},
+		{name: "a rune the candidate does not have", pattern: "logz", candidate: "login flow", want: false},
+		{name: "a pattern typed in capitals", pattern: "LOGIN", candidate: "the login flow", want: true},
+		{name: "a candidate written in capitals", pattern: "login", candidate: "LOGIN FLOW", want: true},
+		{name: "a pattern longer than the candidate", pattern: "login flow", candidate: "login", want: false},
+		{name: "an empty candidate", pattern: "log", candidate: "", want: false},
+		{name: "an empty pattern matches anything", pattern: "", candidate: "login flow", want: true},
+		{name: "an empty pattern matches an empty candidate", pattern: "", candidate: "", want: true},
+		{name: "a space in the pattern spans two words", pattern: "login flow", candidate: "Fix the login flow", want: true},
+		{name: "an issue key typed whole", pattern: "PROJ-142", candidate: "PROJ-142", want: true},
+		{name: "the digits of an issue key", pattern: "142", candidate: "PROJ-142", want: true},
+		{name: "the digits of another issue", pattern: "142", candidate: "PROJ-1420", want: true},
+		{name: "a pattern of only spaces needs a space", pattern: " ", candidate: "login", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, got := NewPattern(tc.pattern).Score(tc.candidate); got != tc.want {
+				t.Errorf("%q against %q matched %v, want %v", tc.pattern, tc.candidate, got, tc.want)
+			}
+		})
+	}
+}
+
+// Each slice is written best first, and every neighbouring pair is asserted
+// rather than only the ends.
+func TestPattern_RanksAPrefixOverAWordStartOverAScatteredMatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		pattern string
+		ordered []string
+	}{
+		{
+			name:    "a title matched on a word",
+			pattern: "log",
+			ordered: []string{
+				"log",                  // the whole candidate
+				"login",                // a prefix of it
+				"the log file",         // a word start further in, whole
+				"a lonely green apple", // the initials of three words
+				"catalogue",            // whole, but inside a word
+				"blowing granite",      // scattered, and inside a word
+			},
+		},
+		{
+			name:    "an issue key",
+			pattern: "proj-14",
+			ordered: []string{
+				"PROJ-14",
+				"PROJ-142",
+				"PROJ-1420",
+			},
+		},
+		{
+			name:    "the digits of a key against a title that also has them",
+			pattern: "142",
+			ordered: []string{
+				"142",
+				"PROJ-142",
+				"Rework the 1.4.2 upgrade notes",
+			},
+		},
+		{
+			name:    "a shorter title wins where the match is otherwise the same",
+			pattern: "the",
+			ordered: []string{
+				"the export",
+				"the nightly export",
+				"the nightly export of everything the site holds",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pattern := NewPattern(tc.pattern)
+			scores := make([]int, len(tc.ordered))
+			for i, candidate := range tc.ordered {
+				score, ok := pattern.Score(candidate)
+				if !ok {
+					t.Fatalf("%q did not match %q at all", tc.pattern, candidate)
+				}
+				scores[i] = score
+			}
+			for i := 1; i < len(scores); i++ {
+				if scores[i-1] <= scores[i] {
+					t.Errorf("%q scores %d on %q and %d on %q; the first is the better match",
+						tc.pattern, scores[i-1], tc.ordered[i-1], scores[i], tc.ordered[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPattern_RanksTranslatedTitlesTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		pattern string
+		ordered []string
+	}{
+		{
+			name:    "an accent in both the pattern and the title",
+			pattern: "café",
+			ordered: []string{"café", "caféine", "un caféier", "le café du matin"},
+		},
+		{
+			name:    "an accented pattern typed in capitals",
+			pattern: "CAFÉ",
+			ordered: []string{"café", "le café du matin"},
+		},
+		{
+			name:    "runes wider than a byte carry no byte offsets into the ranking",
+			pattern: "ポー",
+			ordered: []string{"ポート", "サポート", "会議のサポート体制"},
+		},
+		{
+			name:    "a Cyrillic word start beats one inside a word",
+			pattern: "вход",
+			ordered: []string{"вход", "исправить вход в систему", "невходной"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pattern := NewPattern(tc.pattern)
+			prev := 0
+			for i, candidate := range tc.ordered {
+				score, ok := pattern.Score(candidate)
+				if !ok {
+					t.Fatalf("%q did not match %q at all", tc.pattern, candidate)
+				}
+				if i > 0 && prev <= score {
+					t.Errorf("%q scores %d on %q and %d on %q; the first is the better match",
+						tc.pattern, prev, tc.ordered[i-1], score, candidate)
+				}
+				prev = score
+			}
+		})
+	}
+}
+
+func TestPattern_TreatsACamelCaseHumpAsAWordStart(t *testing.T) {
+	t.Parallel()
+
+	pattern := NewPattern("flow")
+	camel, _ := pattern.Score("loginFlow")
+	joined, _ := pattern.Score("loginflow")
+	spaced, _ := pattern.Score("login flow")
+	if camel <= joined {
+		t.Errorf("%q scores %d on %q and %d on %q; the hump starts a word and the run of letters does not",
+			"flow", camel, "loginFlow", joined, "loginflow")
+	}
+	if camel-spaced >= scoreUnit {
+		t.Errorf("%q scores %d in camel case against %d spaced; the two should differ only by the tail",
+			"flow", camel, spaced)
+	}
+}
+
+func TestPattern_KnowsWhenItIsTheOneThatMatchesEverything(t *testing.T) {
+	t.Parallel()
+
+	if !NewPattern("").Empty() {
+		t.Error("the empty pattern does not say it is empty")
+	}
+	if NewPattern(" ").Empty() {
+		t.Error("a pattern of one space says it is empty; a space is a rune like any other")
+	}
+	if score, ok := NewPattern("").Score("anything"); !ok || score != 0 {
+		t.Errorf("the empty pattern scored %d, %v on a candidate, want 0, true", score, ok)
+	}
+}
+
+func TestPattern_CostsNothingToPrepareOrToScore(t *testing.T) {
+	candidates := []string{
+		"PROJ-142", "Fix the login flow", "Speed up the nightly export",
+		"会議のサポート体制", "Rework webhook retries",
+	}
+	if got := testing.AllocsPerRun(500, func() {
+		pattern := NewPattern("log")
+		for _, candidate := range candidates {
+			_, _ = pattern.Score(candidate)
+		}
+	}); got != 0 {
+		t.Errorf("preparing a pattern and scoring five candidates allocates %.1f times, want none", got)
+	}
+}
+
+// A title that starts more words with the pattern's first rune than maxStarts
+// allows attempts from.
+func TestPattern_StillMatchesATitleThatStartsManyWordsWithTheSameRune(t *testing.T) {
+	t.Parallel()
+
+	candidate := strings.Repeat("log ", 40) + "final logout"
+	if _, ok := NewPattern("logout").Score(candidate); !ok {
+		t.Error("a match past the eighth word start was not found at all")
+	}
+	if _, ok := NewPattern("logz").Score(candidate); ok {
+		t.Error("a pattern the title cannot satisfy was reported as a match")
+	}
+}
+
+func BenchmarkPatternScore(b *testing.B) {
+	pattern := NewPattern("log")
+	candidates := []string{
+		"PROJ-142", "Fix the login flow", "Speed up the nightly export",
+		"Investigate webhook retries", "Document the release checklist",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		_, _ = pattern.Score(candidates[i%len(candidates)])
+	}
+}
+
+func BenchmarkPatternScoreTranslated(b *testing.B) {
+	pattern := NewPattern("ポー")
+	candidates := []string{"ポート", "サポート", "会議のサポート体制", "オンボーディング"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		_, _ = pattern.Score(candidates[i%len(candidates)])
+	}
+}


### PR DESCRIPTION
Closes #15. Two files in `internal/app`, no dependency, no `go.mod` change, nothing outside the
packet.

## The roadmap row overstated what was missing, and I corrected it

It read *"instant search over cached issues with no round trip; the thing that makes it feel faster
than the web."* Half of that shipped in P1.5. `internal/ui/list` already filters as you type with no
round trip and no allocation — `refilter()` reuses its slice over needles built once per page, and
`BenchmarkFilterKeystroke10k` guards it at 1 alloc/op.

What was genuinely absent is **ranking**, and **reach past the rows on screen** — the second being
the cache, which is why this waited on P3.2. The row now says that, and it also names the two
follow-ups below. **`owns` is corrected to `internal/app/{index,match}.go`, their tests and
benchmarks, and `docs/{PERFORMANCE,ROADMAP}.md`**, which is the approved list for this packet.

**I deliberately did not touch the list's filter.** It is the budgeted keystroke path and another
packet in this wave is in that directory. Ranking it is #84, filed with the two decisions it has to
take rather than inherit (does the cursor follow the ranking, and does the concatenated needle stay).

## `internal/app/match.go` — the scorer

`app.Pattern` is a subsequence match over **any string**, which is the whole point: the candidate is
an issue key here and a command title in the palette.

```go
func NewPattern(text string) Pattern            // allocates nothing
func (p Pattern) Empty() bool
func (p Pattern) Score(candidate string) (int, bool)
```

Ranked: the whole candidate, then a prefix, then a word start further in, then the initials of
several words, then whole-but-inside-a-word, then scattered inside a word. Ties go to the earlier
match and then to the shorter candidate. Every bonus is a whole multiple of one unit and the only
sub-unit term is that tail, so the tiers decide the order and the tail can only break a tie inside
one — that is the property that makes the table test in `match_test.go` a pinned order rather than a
snapshot of whatever the arithmetic happened to produce.

Case is folded per rune on both sides, so nothing is lowercased into a new string, and there is no
`[]string` of targets and no `[]int` of matched offsets per hit. That is the reason this is written
here instead of importing `github.com/sahilm/fuzzy`: its API allocates one of those per candidate,
and a one-rune query over 10k issues is 10k slice allocations against a 16 ms keystroke budget.

Two judgement calls worth reviewing rather than reading past:

- **A gap costs more than a word start pays** (2 units against 4, with adjacency at 3). Without that,
  `log` ranked *"a lonely green apple"* above *"the log file"*, because three word-start bonuses
  cancelled two gaps. Acronym matching still works and still beats a mid-word match; it no longer
  beats the real word.
- **A prefix bonus needs contiguity.** Landing on the candidate's first rune and then skipping
  through the rest of it is a scattered match that happens to start early. Before this, `proj` ranked
  *"Prepare the report on old jobs"* above *"Rework the PROJ-14 handover"*.

## `internal/app/index.go` — the index over the cache

`app.Index` reads through `IssueCorpus`, the two-method interface `app.Cache` already satisfies
(`var _ IssueCorpus = Cache(nil)` says so at compile time). Narrow because an index never reads a
search's rows and never writes — the `Counter` / `SearchClient` pattern this package already uses, and
what PC.6 is a whole packet about.

```go
func NewIndex(corpus IssueCorpus) *Index
func (ix *Index) Refresh() (bool, error)
func (ix *Index) Search(text string, limit int) ([]Hit, error)
func (ix *Index) Len() int
```

- **Rebuilt when `Generation()` moves, and not otherwise.** `Search` refreshes itself, so there is
  nothing to wire to a message and no goroutine to own. Five keystrokes over an unchanged corpus walk
  it once, asserted.
- **A walk is a whole rebuild**, and the roadmap row says why rather than pretending otherwise: a
  counter reports that something changed, not what, and the cache merges and evicts under its own
  bound. At 10k issues a rebuild is 245 µs, so the honest answer was to rebuild rather than invent a
  delta the interface cannot express.
- **A walk that fails part way keeps what it read and is not retried until the corpus moves**, so one
  undecodable issue costs one report rather than one per keystroke. The error comes back alongside the
  hits.
- **`Hit.HasSummary`** is the field-mask trap: a narrow read stores an issue whose title nothing asked
  for, which is not an issue with an empty title. Such an issue is matched on its key alone, reports
  no title, and a word of a title cannot match it. An issue that carries a title with no mask naming
  it is still indexed — a title that is there is an answer.
- **`Hit.StoredAt`** is when that copy was written, so a caller badges age against `Deps.Now`. The
  index holds no clock, which is what keeps that testable without a sleep.
- **A nil cache is normal.** `NewIndex(nil)`, `NewIndex` over a nil `app.Cache`, a nil `*Index` and
  the zero `Index` all search nothing, report nothing and refresh nothing.
- **The returned slice is the caller's**, cloned out of the ranking buffer, so a view can keep hits in
  its model across frames. One allocation per keystroke, none per candidate.

## Performance

`docs/PERFORMANCE.md` gains two budget rows and the measured table. On an M2 Pro at **ten thousand**
cached issues, twice the 5,000 the cache is bounded to:

| Benchmark | ns/op | allocs/op |
|---|---|---|
| `BenchmarkIndexSearch10k` — three runes, a screenful asked for | 794,814 | 1 |
| `BenchmarkIndexSearchOneRune10k` — one rune, nearly everything matches | 1,015,512 | 1 |
| `BenchmarkIndexSearchUnbounded10k` — every hit rather than a screenful | 926,286 | 1 |
| `BenchmarkIndexRebuild10k` | 245,379 | 1 |
| `BenchmarkPatternScore` | 65 | 0 |

So the worst keystroke is **6 % of the 16 ms budget**, and `index_budget_test.go` asserts all four
against it plus `allocs/op <= 1`, behind `//go:build !race` for the reason `cache_budget_test.go`
already documents. Worth knowing rather than discovering: `ci.yml` only ever runs `go test -race`, so
these assertions — like P3.2's cache-read budget beside them — run locally and in `make test` but
never in CI. That is the hole P9.2 fills with `benchstat`; I have not widened this packet into the
workflow to fix it. Bounded searches keep a screenful by comparing against the worst hit held rather
than sorting the corpus; unbounded sorts, and is measured so the cost of asking for it is written
down. **No budgeted path elsewhere is touched** — `BenchmarkFrame`, `BenchmarkKeyToFrame` and the
list's steady scroll are untouched code.

## Consumers, by name

This is the part the packet lives or dies on, so here it is plainly.

- **`app.Pattern` → P3.1's palette (#12).** The signature went up on #12 and #15 **before this packet
  was finished**, with the call site written out, so it could be coded against in parallel. In this
  branch its caller is `app.Index` (`internal/app/index.go:150`), so the scorer is not dead code
  whatever P3.1 does; when the palette lands, `grep -rn NewPattern internal/` gains a hit in
  `internal/ui/palette`.
- **`app.Index` has no view yet, and I filed that against myself: #85.** `grep -rn "app.NewIndex"
  internal/ui` is empty. Its two candidate consumers are the palette (#12, as a second section) and
  the key jump (#62); I commented on #62 with the call site. I am not widening this packet into
  `internal/ui` to manufacture one — that directory belongs to two other packets in this wave — but I
  am not calling the packet finished without saying so either.
- **`app.Cache` → `IssueCorpus`** is adopted by the real implementation, not just the interface:
  `TestIndex_SearchesTheIssuesTheDiskCacheHolds` builds a bbolt-backed `DiskCache`, stores rows
  through it and searches the result, so the decode, the key order and the generation move are all
  exercised through the type a session actually carries.

## Tests

`go test ./internal/app/` — 30 new tests and 6 benchmarks. Table-driven, `t.Parallel()`, no sleep, no
network, no fixture added.

Covered because the packet asked for each by name: a query with no match; an empty query (every issue
in key order); a query longer than every candidate; an issue with no summary; a nil cache in four
shapes; unicode in both query and title (Japanese, German, French, Cyrillic — ranked, not just
matched, since `len()` is not a width and a byte offset is not a rune index, #77); and that the
rebuild does not re-walk while the generation stands still.

**On the failure paths in the definition of done:** there is no HTTP in this packet — no adapter, no
`context`, no client — so 403, 429 and a transport failure have no call site here. The failure paths
that do exist are a corpus read that fails mid-walk and a cache that is absent, and both are tested.

`make check` green; `go build -trimpath -ldflags "-s -w"` is 11 MiB; `scripts/checkleak.py` clean and
no fixture or capture is involved. Every issue key and title in the tests is invented.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
