### PR TITLE
feat(mouse): click a status, type or assignee to see only those rows

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Three constraints drive every decision below:
 │  internal/ui          Bubble Tea models — one per view      │
 │    kernel/            root model, view stack, registries    │
 │    board/ issue/ ...  self-contained views                  │
-│    widget/            shared table, form, pager, zones      │
+│    widget/            zones, click timing, drag, scrolling  │
 ├─────────────────────────────────────────────────────────────┤
 │  internal/app         use cases — orchestration, no IO libs │
 │                       cache policy: kinds, TTLs, the codec  │
@@ -445,9 +445,30 @@ func (m Model) View() tea.View {
 
 Hit-testing uses [bubblezone](https://github.com/lrstanley/bubblezone): each interactive element
 wraps its rendered string in a zone ID, and a click is resolved by lookup rather than by arithmetic
-on coordinates. Required interactions: click to focus a pane, click to select a row, double-click to
-open, wheel to scroll the pane under the pointer, drag the pane divider to resize, click a status
-chip or label to filter by it, click the footer entries to switch views.
+on coordinates. There is no "what is at this point" in bubblezone and there is not meant to be — the
+view that minted the ids is the only thing that knows what they mean, so the hit test lives there.
+`docs/UX.md` has the gestures the program answers.
+
+`internal/ui/widget` holds the parts every view would otherwise write again:
+
+- **`widget.Zoner`** — one view instance's prefix plus `Mark`, `MarkLines` and `Hit`. The zero value
+  and a disabled manager behave identically: nothing is written into the frame and every hit misses,
+  so `mouse = false` needs no branch in any view. `Enabled()` is how a view asks whether to tell
+  anybody to click something.
+- **`widget.Clicks`** — the double-click, timed against `Deps.Now`. `tea.MouseClickMsg` carries no
+  click count and no timestamp, so a view cannot recognise one without a clock.
+- **`widget.Window`** — the slice of rendered lines a scrolled pane draws, with the one line that has
+  to stay visible. It slices rather than copies, so a scrolled pane costs no allocation per frame.
+- **`widget.Drag`** — press, move, release, bound to nothing yet
+  ([#75](https://github.com/varijkapil13/saral/issues/75)).
+
+**Zone ids are never freed.** `Mark` fills a permanent id map in the manager, and nothing evicts from
+it. Every id in this tree is minted from a per-instance prefix and a stable name, so redrawing an
+element reuses its id and the map grows only when something new is drawn: a bounded number of entries
+for the panes keyed by row index, and one per clickable cell per issue for the list, which grows with
+the rows a user actually scrolls past rather than with the size of the project. A pushed view mints a
+fresh prefix every time it is pushed, so opening the same issue twice leaves two sets behind. Nothing
+here needs the memory back yet; a view that draws a marked element per frame under a fresh id would.
 
 ## Errors
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -263,8 +263,29 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
   The clause in `docs/ARCHITECTURE.md` saying the capability probe "is cached in the store" was false
   and is gone; persisting it needs the kernel, which is
   [#81](https://github.com/varijkapil13/saral/issues/81).
-- [ ] **P3.3 — Mouse** · [#14](https://github.com/varijkapil13/saral/issues/14) · **owns** `internal/ui/widget/zone*.go` + zone wiring in own files
-  Click, double-click, wheel-under-pointer, drag-to-resize, clickable chips and footer.
+- [x] **P3.3 — Mouse** · [#14](https://github.com/varijkapil13/saral/issues/14) · **owns** `internal/ui/widget/**`, the zone and click wiring plus tests and `testdata/**` in `internal/ui/{list,issue,form,comment,onboarding}`, `docs/{UX,ARCHITECTURE,ROADMAP}.md`
+  **The `owns` line above is a correction.** It used to read `internal/ui/widget/zone*.go` + zone
+  wiring in own files, and `internal/ui/widget/` did not exist — so on day one this packet owned
+  nothing that renders, while every shipped view already marked zones and handled clicks.
+  **Most of this row was already built, and the audit is on the issue.** Click-to-select, the wheel
+  and the footer click were shipped by P1.5, P2.x and W0-b. What was actually missing: the
+  double-click, the chips, and the wheel over two panes that could not scroll at all.
+  `internal/ui/widget` is the copy-paste in all five view packages made one thing: `Zoner` (the prefix
+  plus `Mark`/`MarkLines`/`Hit`, where a nil or disabled manager needs no branch of its own),
+  `Clicks` (the double-click, timed against `Deps.Now` — `tea.MouseClickMsg` has neither a click count
+  nor a timestamp, and the "second click on the already-selected row" rule every view had reached for
+  fires on two deliberate clicks a minute apart), `Window` (the scrolled window) and `Drag`.
+  Clickable status, type and assignee cells narrow the list to that value and clear it on a second
+  click, composing with `/`, named in a line under the rows and reachable from the palette because
+  `esc` in a root view never reaches the view. **Labels are clickable nowhere:** no view that can
+  filter draws them, so `docs/UX.md` says that rather than promising it.
+  `internal/ui/issue`'s edit pane and move pane now scroll: both drew every line and let the frame
+  clip, so the last field was unreachable by wheel *or* cursor on a short terminal.
+  **Two gestures were cut and filed:** drag-to-resize is [#75](https://github.com/varijkapil13/saral/issues/75)
+  — there is no divider to drag until a view has two panes, so `widget.Drag` ships tested and bound to
+  nothing for P6.3 — and the right-click context menu is
+  [#76](https://github.com/varijkapil13/saral/issues/76), which needs `kernel.Command` to know what a
+  command applies to.
 - [x] **P3.4 — Local fuzzy index** · [#15](https://github.com/varijkapil13/saral/issues/15) · **owns** `internal/app/{index,match}.go`, their tests and benchmarks, `docs/{PERFORMANCE,ROADMAP}.md` · **after P3.2**
   **This row used to promise "instant search over cached issues with no round trip".** Half of that
   already shipped in P1.5: `internal/ui/list` filters as you type with no round trip and no

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -118,23 +118,52 @@ issue by key — typing `PROJ-142`, or pasting a Jira URL — is not built; it i
 ## Mouse
 
 Bubble Tea v2 declares mouse mode in the view; hit-testing is by zone lookup, not coordinate
-arithmetic (see `docs/ARCHITECTURE.md`).
+arithmetic (see `docs/ARCHITECTURE.md`). This table is what the program does.
 
 | Gesture | Result |
 |---|---|
-| click | focus that pane, select that row |
-| double-click | open (same as `enter`) |
+| click a row | select it |
+| double-click a row | open it, same as `enter` — and only when both clicks are one gesture |
+| click a status, type or assignee cell | show only the rows with that value; click it again to show them all |
 | wheel | scroll the pane under the pointer, not the focused one |
-| drag divider | resize panes; the ratio persists per view |
-| click a status chip / label / assignee | filter by it; click again to clear |
-| click footer entry | switch view |
-| right-click a row | context menu of the actions valid for it |
+| click a footer entry | switch view |
+| click anything else a view draws | do what it says — write, send, delete, confirm, put aside, pick a value, go back to an onboarding step |
+
+**A double-click is timed, because nothing else can time it.** `tea.MouseClickMsg` carries a
+position, a button and a modifier: no click count and no instant. Every view here first reached for
+"a second click on the row that is already selected", which cannot tell a double-click from two
+deliberate clicks a minute apart, so pointing at an issue and then pointing at it again opened it.
+`widget.Clicks` times the pair against `Deps.Now` — the clock a test injects — over a 400 ms window,
+and a slower second click only re-selects.
+
+**Narrowing by a cell is the one filter with no key**, and that is deliberate: every letter left is
+one somebody types into `/`, and `esc` in a root view never reaches the view at all. So the rows the
+narrowing leaves out are named in a line under the list, the same cell clears it, and the palette
+carries *show only rows with this row's status / type / assignee* and *show every row again* for
+anyone without a pointer. It composes with `/`: both are things being left out, and a row has to
+survive both.
+
+Two gestures this table used to promise are not built, and are not being built here:
+
+- **Drag a divider to resize panes** — [#75](https://github.com/varijkapil13/saral/issues/75). There
+  is no divider: no view has two panes, which is also why there is no `tab`. `widget.Drag` is the
+  press-move-release machine, tested and bound to nothing; P6.3 binds it to the first pane divider,
+  along with persisting the ratio.
+- **Right-click for a context menu of the actions valid for a row** —
+  [#76](https://github.com/varijkapil13/saral/issues/76). `kernel.Command` has no notion of what a
+  command applies to, so "the actions valid for this row" has no data source, and the menu itself
+  would be a second copy of the palette overlay.
+
+**Labels are clickable nowhere**, because no view that can filter draws them: the issue list's
+columns are key, summary, type, status, assignee and updated, and the detail pane that does list
+labels has nothing of its own to narrow. When a view draws a label it can narrow by, it marks the
+label the way the list marks its cells.
 
 Mouse mode must be disableable (`mouse = false` in config) for people who rely on terminal text
 selection. Off means off all the way down: the zone manager is disabled with it, so a view's markers
 are never written into the frame in the first place and there is nothing left for a selection to
-pick up. Nothing from the mouse — click, wheel, drag or release — reaches the view while the help
-overlay is covering it.
+pick up — and a view asks `Zones.Enabled()` before telling anybody to click something. Nothing from
+the mouse — click, wheel, drag or release — reaches the view while the help overlay is covering it.
 
 ## Rendering rules for modern terminals
 

--- a/internal/ui/comment/comment.go
+++ b/internal/ui/comment/comment.go
@@ -14,6 +14,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/adf"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
@@ -133,7 +134,9 @@ type Model struct {
 	width, height int
 	gen           int
 	cancel        context.CancelFunc
-	zonePrefix    string
+
+	zones  widget.Zoner
+	clicks *widget.Clicks
 }
 
 // New builds the thread with no issue yet. It is the registry's constructor:
@@ -164,9 +167,8 @@ func build(d kernel.Deps, key string) *Model {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
 	}
 	m.styles = newStyles(m.deps.Theme)
-	if d.Zones != nil {
-		m.zonePrefix = d.Zones.NewPrefix()
-	}
+	m.zones = widget.NewZoner(d.Zones)
+	m.clicks = widget.NewClicks(d.Now)
 	m.browse, m.confirm = m.keys.tables()
 	return m
 }
@@ -625,13 +627,7 @@ func (m *Model) blockLines(at int) []string {
 		return lines
 	}
 	lines := renderBlock(c, m.width, at == m.cursor, m.styles, m.deps.Theme, m.location())
-	if m.deps.Zones != nil && len(lines) > 0 {
-		// Marking the joined block and splitting it again puts the zone's start
-		// on the first line and its end on the last, so the rectangle the
-		// manager records is the whole comment rather than one line of it.
-		marked := m.deps.Zones.Mark(m.zonePrefix+zoneComment+c.ID, strings.Join(lines, "\n"))
-		lines = strings.Split(marked, "\n")
-	}
+	lines = m.zones.MarkLines(zoneComment+c.ID, lines)
 	lines = append(lines, "")
 	m.blocks.put(k, lines)
 	return lines
@@ -846,10 +842,10 @@ func (m *Model) confirmKey(stroke string) tea.Cmd {
 }
 
 func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
-	if msg.Button != tea.MouseLeft || m.deps.Zones == nil {
+	if msg.Button != tea.MouseLeft {
 		return nil
 	}
-	hit := func(name string) bool { return m.deps.Zones.Get(m.zonePrefix + name).InBounds(msg) }
+	hit := func(name string) bool { return m.zones.Hit(name, msg) }
 	switch m.mode {
 	case confirming:
 		switch {
@@ -878,10 +874,12 @@ func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
 		return m.askToDelete()
 	}
 	for i := m.top; i < len(m.comments); i++ {
-		if !hit(zoneComment + m.comments[i].ID) {
+		id := zoneComment + m.comments[i].ID
+		if !hit(id) {
 			continue
 		}
-		if i == m.cursor {
+		if m.clicks.Double(id) {
+			m.cursor = i
 			return m.editSelected()
 		}
 		return m.moveTo(i)
@@ -905,12 +903,7 @@ func (m *Model) wheel(msg tea.MouseWheelMsg) tea.Cmd {
 
 // --- rendering --------------------------------------------------------------
 
-func (m *Model) mark(name, s string) string {
-	if m.deps.Zones == nil {
-		return s
-	}
-	return m.deps.Zones.Mark(m.zonePrefix+name, s)
-}
+func (m *Model) mark(name, s string) string { return m.zones.Mark(name, s) }
 
 // View draws the window and nothing else: a thread of a thousand comments and a
 // thread of ten do the same work here.

--- a/internal/ui/comment/mouse_test.go
+++ b/internal/ui/comment/mouse_test.go
@@ -17,7 +17,7 @@ func clickOn(t *testing.T, d kernel.Deps, dr *driver, name string) {
 	t.Helper()
 
 	_ = d.Zones.Scan(dr.m.View())
-	id := dr.m.zonePrefix + name
+	id := dr.m.zones.ID(name)
 	eventually(t, "the zone "+id+" to be recorded", func() bool {
 		return !d.Zones.Get(id).IsZero()
 	})
@@ -126,5 +126,38 @@ func TestThread_ClickingTheEditorsOwnActionsSendsAndPutsAside(t *testing.T) {
 	dr.key("a")
 	if got := dr.m.editor.Value(); got != "Put aside with the mouse." {
 		t.Errorf("the draft did not survive the click: %q", got)
+	}
+}
+
+// threadClock is the clock the double-click is timed against, wound forward
+// rather than slept on.
+type threadClock struct{ at time.Time }
+
+func (c *threadClock) now() time.Time        { return c.at }
+func (c *threadClock) after(d time.Duration) { c.at = c.at.Add(d) }
+
+// Two clicks a second apart are two decisions rather than one gesture. Bubble
+// Tea reports no click count, so the clock is the only thing that tells them
+// apart.
+func TestThread_TwoDeliberateClicksOnACommentDoNotOpenTheEditor(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	first := comment(t, f, "PROJ-1", "The older one.")
+	comment(t, f, "PROJ-1", "The newer one.")
+	clock := &threadClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+	d := testDeps(t, f)
+	d.Now = clock.now
+	dr := newDriver(t, d, "PROJ-1", 100, 24)
+
+	clickOn(t, d, dr, zoneComment+first.ID)
+	if dr.m.cursor != 0 {
+		t.Fatalf("the click left the cursor on %d, want the comment that was clicked", dr.m.cursor)
+	}
+	clock.after(time.Second)
+	clickOn(t, d, dr, zoneComment+first.ID)
+
+	if dr.m.mode == writing {
+		t.Error("two clicks a second apart opened the editor, so a second look reads as a double-click")
 	}
 }

--- a/internal/ui/form/form.go
+++ b/internal/ui/form/form.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -75,8 +76,10 @@ type Model struct {
 	inChoose map[string]action
 	rows     *rowCache
 
-	project    string
-	zonePrefix string
+	project string
+
+	zones  widget.Zoner
+	clicks *widget.Clicks
 
 	stage stage
 
@@ -160,9 +163,8 @@ func newWith(d kernel.Deps, cache *schemaCache, store *draftStore) *Model {
 	if d.Jira != nil {
 		m.search = app.NewSearch(d.Jira)
 	}
-	if d.Zones != nil {
-		m.zonePrefix = d.Zones.NewPrefix()
-	}
+	m.zones = widget.NewZoner(d.Zones)
+	m.clicks = widget.NewClicks(d.Now)
 	m.relayout()
 	return m
 }
@@ -1087,7 +1089,7 @@ func (m *Model) createFailed(msg createFailedMsg) tea.Cmd {
 // --- mouse ------------------------------------------------------------------
 
 func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
-	if msg.Button != tea.MouseLeft || m.deps.Zones == nil {
+	if msg.Button != tea.MouseLeft {
 		return nil
 	}
 	if m.stage == stageTypes {
@@ -1100,10 +1102,12 @@ func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
 		return nil
 	}
 	for i := m.top; i < min(m.top+m.rowsHeight(), len(m.index)); i++ {
-		if !m.deps.Zones.Get(m.rowZone(i)).InBounds(msg) {
+		zone := m.rowZone(i)
+		if !m.zones.Hit(zone, msg) {
 			continue
 		}
-		if i == m.cursor {
+		if m.clicks.Double(zone) {
+			m.moveTo(i)
 			return m.activate()
 		}
 		m.moveTo(i)
@@ -1114,10 +1118,12 @@ func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
 
 func (m *Model) clickType(msg tea.MouseClickMsg) tea.Cmd {
 	for i := m.typeTop; i < min(m.typeTop+max(m.height-2, 1), len(m.types)); i++ {
-		if !m.deps.Zones.Get(m.typeZone(i)).InBounds(msg) {
+		zone := m.typeZone(i)
+		if !m.zones.Hit(zone, msg) {
 			continue
 		}
-		if i == m.typeCursor {
+		if m.clicks.Double(zone) {
+			m.typeCursor = i
 			return m.openType(m.types[i])
 		}
 		m.typeCursor = i
@@ -1130,10 +1136,12 @@ func (m *Model) clickType(msg tea.MouseClickMsg) tea.Cmd {
 func (m *Model) clickChoice(msg tea.MouseClickMsg) tea.Cmd {
 	visible := m.visibleChoices()
 	for i := m.pickTop; i < min(m.pickTop+m.chooserHeight(), len(visible)); i++ {
-		if !m.deps.Zones.Get(m.choiceZone(i)).InBounds(msg) {
+		zone := m.choiceZone(i)
+		if !m.zones.Hit(zone, msg) {
 			continue
 		}
-		if i == m.pick {
+		if m.clicks.Double(zone) {
+			m.pick = i
 			return m.chooseKey(tea.KeyPressMsg{Code: tea.KeyEnter}, "enter")
 		}
 		m.pick = i

--- a/internal/ui/form/form_test.go
+++ b/internal/ui/form/form_test.go
@@ -632,13 +632,13 @@ func TestForm_SelectsARowOnAClickAndOpensItOnTheNext(t *testing.T) {
 	dr.m.moveTo(0)
 
 	at := 2
-	click := clickIn(t, d, dr.m.View(), dr.m.rowZone(at))
+	click := clickIn(t, d, dr.m, dr.m.View(), dr.m.rowZone(at))
 	dr.send(click)
 	if dr.m.cursor != at {
 		t.Fatalf("the cursor is on row %d, want the row that was clicked", dr.m.cursor)
 	}
 
-	dr.send(clickIn(t, d, dr.m.View(), dr.m.rowZone(at)))
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.rowZone(at)))
 	if dr.m.edit == editNone {
 		t.Error("a second click on the selected row did not open its editor")
 	}
@@ -652,11 +652,11 @@ func TestForm_ClickingAValueInAPickerTakesIt(t *testing.T) {
 	dr.focus("priority")
 	dr.key("enter")
 
-	dr.send(clickIn(t, d, dr.m.View(), dr.m.choiceZone(1)))
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.choiceZone(1)))
 	if dr.m.pick != 1 {
 		t.Fatalf("the picker is on value %d, want the one that was clicked", dr.m.pick)
 	}
-	dr.send(clickIn(t, d, dr.m.View(), dr.m.choiceZone(1)))
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.choiceZone(1)))
 
 	priority := dr.field("priority")
 	if len(priority.picked) != 1 || priority.picked[0].ID != priority.meta.AllowedValues[1].ID {
@@ -700,11 +700,13 @@ func TestForm_SurvivesATerminalTooNarrowToDrawIn(t *testing.T) {
 	}
 }
 
-// clickIn scans a frame for one zone and builds a click inside it. The manager
-// records a zone on its own goroutine, so it is looked for until it appears.
-func clickIn(t *testing.T, d kernel.Deps, frame, id string) tea.MouseClickMsg {
+// clickIn scans a frame for one of the view's own zones and builds a click
+// inside it. The manager records a zone on its own goroutine, so it is looked
+// for until it appears.
+func clickIn(t *testing.T, d kernel.Deps, m *Model, frame, name string) tea.MouseClickMsg {
 	t.Helper()
 
+	id := m.zones.ID(name)
 	_ = d.Zones.Scan(frame)
 	deadline := time.Now().Add(5 * time.Second)
 	for d.Zones.Get(id).IsZero() {

--- a/internal/ui/form/mouse_test.go
+++ b/internal/ui/form/mouse_test.go
@@ -1,0 +1,66 @@
+package form
+
+import (
+	"testing"
+	"time"
+)
+
+// formClock is the clock the double-click is timed against, wound forward
+// rather than slept on.
+type formClock struct{ at time.Time }
+
+func (c *formClock) now() time.Time        { return c.at }
+func (c *formClock) after(d time.Duration) { c.at = c.at.Add(d) }
+
+func newFormClock() *formClock {
+	return &formClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+}
+
+// Two clicks a second apart are two decisions. Bubble Tea reports no click
+// count, and the rule this replaces — a second click on the row already
+// selected — could not tell the difference.
+func TestForm_TwoDeliberateClicksOnARowDoNotOpenItsEditor(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(20))
+	clock := newFormClock()
+	d.Now = clock.now
+	dr := openOn(t, d, 100, 24, fakeStory)
+	dr.m.moveTo(0)
+
+	at := 2
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.rowZone(at)))
+	if dr.m.cursor != at {
+		t.Fatalf("the cursor is on row %d, want the row that was clicked", dr.m.cursor)
+	}
+
+	clock.after(time.Second)
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.rowZone(at)))
+
+	if dr.m.edit != editNone {
+		t.Error("two clicks a second apart opened the field's editor")
+	}
+}
+
+func TestForm_TwoDeliberateClicksOnAValueDoNotTakeIt(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(20))
+	clock := newFormClock()
+	d.Now = clock.now
+	dr := openOn(t, d, 100, 24, fakeStory)
+	dr.focus("priority")
+	dr.key("enter")
+
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.choiceZone(1)))
+	if dr.m.pick != 1 {
+		t.Fatalf("the picker is on value %d, want the one that was clicked", dr.m.pick)
+	}
+
+	clock.after(2 * time.Second)
+	dr.send(clickIn(t, d, dr.m, dr.m.View(), dr.m.choiceZone(1)))
+
+	if got := dr.field("priority").picked; len(got) != 0 {
+		t.Errorf("two clicks two seconds apart took %+v", got)
+	}
+}

--- a/internal/ui/form/render.go
+++ b/internal/ui/form/render.go
@@ -481,16 +481,13 @@ func (m *Model) fit(s string) string {
 
 // --- zones ------------------------------------------------------------------
 
-func (m *Model) mark(id, line string) string {
-	if m.deps.Zones == nil {
-		return line
-	}
-	return m.deps.Zones.Mark(id, line)
-}
+func (m *Model) mark(id, line string) string { return m.zones.Mark(id, line) }
 
-func (m *Model) rowZone(i int) string    { return m.zonePrefix + "row:" + strconv.Itoa(i) }
-func (m *Model) typeZone(i int) string   { return m.zonePrefix + "type:" + strconv.Itoa(i) }
-func (m *Model) choiceZone(i int) string { return m.zonePrefix + "choice:" + strconv.Itoa(i) }
+// The zones are named after the row on screen rather than the field in it, so
+// the ids a session mints are bounded by the height of the terminal.
+func (m *Model) rowZone(i int) string    { return "row:" + strconv.Itoa(i) }
+func (m *Model) typeZone(i int) string   { return "type:" + strconv.Itoa(i) }
+func (m *Model) choiceZone(i int) string { return "choice:" + strconv.Itoa(i) }
 
 // padTruncate makes a string exactly width columns wide, counting grapheme
 // clusters rather than bytes so that an emoji or a CJK field name does not

--- a/internal/ui/issue/edit.go
+++ b/internal/ui/issue/edit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/adf"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
@@ -59,7 +60,19 @@ type editModel struct {
 	drafts draftStore
 
 	width, height int
-	zonePrefix    string
+	// top is the first field row on screen: the pane has more fields than a
+	// short terminal has room for. follow is set when the cursor has moved and
+	// the window has to come with it, and cleared once it has — otherwise the
+	// cursor would pull every frame back and the wheel could scroll nothing.
+	top    int
+	follow bool
+	// reach is how far the last frame could scroll. The wheel clamps against it
+	// rather than against nothing: an offset allowed to run past the end has to
+	// be wound all the way back before the next notch moves anything.
+	reach int
+
+	zones  widget.Zoner
+	clicks *widget.Clicks
 
 	gen    int
 	cancel context.CancelFunc
@@ -99,9 +112,8 @@ func NewEdit(d kernel.Deps, iss jira.Issue, opts ...editOption) kernel.View {
 	if d.Jira != nil {
 		m.search = app.NewSearch(d.Jira)
 	}
-	if d.Zones != nil {
-		m.zonePrefix = d.Zones.NewPrefix()
-	}
+	m.zones = widget.NewZoner(d.Zones)
+	m.clicks = widget.NewClicks(d.Now)
 	if store, err := newDraftStore(); err == nil {
 		m.drafts = store
 	}
@@ -184,6 +196,9 @@ func (m *editModel) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 
 	case tea.MouseClickMsg:
 		cmd = m.click(msg)
+
+	case tea.MouseWheelMsg:
+		m.wheel(msg)
 	}
 	return m, cmd
 }
@@ -347,6 +362,7 @@ func (m *editModel) moveTo(at int) {
 		return
 	}
 	m.cursor = min(max(at, 0), len(m.rows)-1)
+	m.follow = true
 	m.note, m.fail = "", ""
 }
 
@@ -477,23 +493,40 @@ func (m *editModel) reread() tea.Cmd {
 	return loadForEdit(ctx, m.search, m.issue.Key, gen)
 }
 
-// click puts the cursor on the row under the pointer, and acts on it when it
-// was already the row under the cursor.
+// click puts the cursor on the row under the pointer, and opens it on a
+// double-click. A single click never opens a field: the pane hands a description
+// to $EDITOR, which is not what somebody pointing at a row asked for.
 func (m *editModel) click(msg tea.MouseClickMsg) tea.Cmd {
-	if msg.Button != tea.MouseLeft || m.deps.Zones == nil || m.stage != stageBrowse {
+	if msg.Button != tea.MouseLeft || m.stage != stageBrowse {
 		return nil
 	}
 	for i := range m.rows {
-		if !m.deps.Zones.Get(m.zonePrefix + "row:" + m.rows[i].id).InBounds(msg) {
+		zone := editRowZone(m.rows[i].id)
+		if !m.zones.Hit(zone, msg) {
 			continue
 		}
-		if i == m.cursor {
+		if m.clicks.Double(zone) {
+			m.moveTo(i)
 			return m.act()
 		}
 		m.moveTo(i)
 		return nil
 	}
 	return nil
+}
+
+// wheel scrolls the field rows under the pointer. The offset is clamped where
+// the frame is drawn, because how many lines a row occupies depends on what the
+// site refused and how wide the terminal is.
+func (m *editModel) wheel(msg tea.MouseWheelMsg) {
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		m.top -= widget.WheelStep
+	case tea.MouseWheelDown:
+		m.top += widget.WheelStep
+	default:
+	}
+	m.top = min(max(m.top, 0), m.reach)
 }
 
 // --- the editor handoff -----------------------------------------------------

--- a/internal/ui/issue/edit_harness_test.go
+++ b/internal/ui/issue/edit_harness_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -141,25 +140,39 @@ func (p *panel) typed(text string) {
 func (p *panel) frame() string { return ansi.Strip(p.view.View()) }
 
 // zoneAt draws the pane, hands the frame to the zone manager the way the kernel
-// does, and returns where the named element ended up. The prefix is handed out
-// per component so it is discovered rather than assumed, and the manager
-// records on a goroutine of its own so it is looked for until it appears.
+// does, and returns where the named element ended up. The id comes from the pane
+// itself rather than being guessed at from the prefixes handed out so far — the
+// counter is global to the test binary and runs past any number a loop here
+// would try. The manager records on a goroutine of its own, so the zone is
+// looked for until it appears.
 func (p *panel) zoneAt(d kernel.Deps, suffix string) *zone.ZoneInfo {
 	p.t.Helper()
 
+	id := p.zoneID(suffix)
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		d.Zones.Scan(p.view.View())
-		for i := 1; i < 64; i++ {
-			at := d.Zones.Get("zone_" + strconv.Itoa(i) + "__" + suffix)
-			if !at.IsZero() {
-				return at
-			}
+		if at := d.Zones.Get(id); !at.IsZero() {
+			return at
 		}
 		if time.Now().After(deadline) {
-			p.t.Fatalf("nothing on screen is marked %q", suffix)
+			p.t.Fatalf("nothing on screen is marked %q", id)
 		}
 		runtime.Gosched()
+	}
+}
+
+func (p *panel) zoneID(suffix string) string {
+	p.t.Helper()
+
+	switch v := p.view.(type) {
+	case *editModel:
+		return v.zones.ID(suffix)
+	case *moveModel:
+		return v.zones.ID(suffix)
+	default:
+		p.t.Fatalf("a %T marks no zones", p.view)
+		return ""
 	}
 }
 

--- a/internal/ui/issue/edit_render.go
+++ b/internal/ui/issue/edit_render.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 )
 
 // editLabelWidth is the field-name column. Wide enough for the longest label
@@ -41,19 +42,51 @@ func newEditStyles(t *kernel.Theme) *editStyles {
 }
 
 // View draws the fields, then whatever the pane is waiting for an answer about.
+//
+// The title stays put and the footer keeps its lines; what scrolls is the field
+// rows between them, so a pane with more fields than the terminal has rows can
+// still reach the last one.
 func (m *editModel) View() string {
 	if m.width <= 0 || m.height <= 0 {
 		return ""
 	}
+	tail := flatten(append([]string{""}, m.footerLines()...))
+	body, under := m.fieldLinesAndCursor()
+	height := max(m.height-1-len(tail), 1)
+	rows, top := widget.Window(body, m.top, height, m.keep(under))
+	m.top, m.follow, m.reach = top, false, max(len(body)-height, 0)
+
 	lines := make([]string, 0, m.height)
 	lines = append(lines, m.editTitle())
-	for i := range m.rows {
-		lines = append(lines, m.rowLines(i)...)
-	}
-	lines = append(lines, "")
-	lines = append(lines, m.footerLines()...)
+	lines = append(lines, rows...)
+	lines = append(lines, tail...)
 	return strings.Join(fit(lines, m.height), "\n")
 }
+
+// fieldLinesAndCursor draws every field row and says which line the row under
+// the cursor starts on, which is what keeps it on screen as the cursor moves.
+func (m *editModel) fieldLinesAndCursor() (lines []string, under int) {
+	lines = make([]string, 0, len(m.rows)+4)
+	under = -1
+	for i := range m.rows {
+		if i == m.cursor {
+			under = len(lines)
+		}
+		lines = append(lines, flatten(m.rowLines(i))...)
+	}
+	return lines, under
+}
+
+// keep is the line the window may not scroll away from: the row under the
+// cursor, and only just after the cursor has moved.
+func (m *editModel) keep(under int) int {
+	if m.follow {
+		return under
+	}
+	return -1
+}
+
+func editRowZone(id string) string { return "row:" + id }
 
 func (m *editModel) editTitle() string {
 	ell := m.deps.Theme.Glyphs.Ellipsis
@@ -89,9 +122,7 @@ func (m *editModel) rowLines(at int) []string {
 	}
 
 	line := prefix + label + value
-	if m.deps.Zones != nil && m.zonePrefix != "" {
-		line = m.deps.Zones.Mark(m.zonePrefix+"row:"+row.id, line)
-	}
+	line = m.zones.Mark(editRowZone(row.id), line)
 	out := []string{line}
 	if reason, blocked := row.blocked(); blocked {
 		out = append(out, m.styles.warn.Render(indentWrap(reason, m.width)))
@@ -266,15 +297,22 @@ func wrapTo(s string, width int) []string {
 // draws fewer lines than it was allotted leaves the previous frame's rows on
 // screen, and one that draws more pushes the footer off it.
 func fit(lines []string, height int) []string {
-	flat := make([]string, 0, height)
-	for _, line := range lines {
-		flat = append(flat, strings.Split(line, "\n")...)
-	}
+	flat := flatten(lines)
 	if len(flat) > height {
 		return flat[:height]
 	}
 	for len(flat) < height {
 		flat = append(flat, "")
+	}
+	return flat
+}
+
+// flatten splits out every embedded newline, so that a wrapped sentence counts
+// as the rows it will actually take up rather than as one.
+func flatten(lines []string) []string {
+	flat := make([]string, 0, len(lines)+4)
+	for _, line := range lines {
+		flat = append(flat, strings.Split(line, "\n")...)
 	}
 	return flat
 }

--- a/internal/ui/issue/edit_transition.go
+++ b/internal/ui/issue/edit_transition.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -50,7 +51,17 @@ type moveModel struct {
 	fail string
 
 	width, height int
-	zonePrefix    string
+	// top is the first move on screen: an issue with more transitions than the
+	// terminal has rows is what the wheel is for. follow is set while the window
+	// still has to catch up with a cursor that moved.
+	top    int
+	follow bool
+	// reach is how far the last frame could scroll, which is what the wheel
+	// clamps against so that a notch back always moves.
+	reach int
+
+	zones  widget.Zoner
+	clicks *widget.Clicks
 
 	gen    int
 	cancel context.CancelFunc
@@ -88,9 +99,8 @@ func NewMove(d kernel.Deps, iss jira.Issue) kernel.View {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
 	}
 	m.styles = newEditStyles(m.deps.Theme)
-	if d.Zones != nil {
-		m.zonePrefix = d.Zones.NewPrefix()
-	}
+	m.zones = widget.NewZoner(d.Zones)
+	m.clicks = widget.NewClicks(d.Now)
 	return m
 }
 
@@ -126,6 +136,7 @@ func (m *moveModel) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case movesLoadedMsg:
 		if m.current(msg.gen) {
 			m.moves, m.loaded, m.cursor = msg.moves, true, 0
+			m.top, m.follow = 0, true
 		}
 
 	case moveDoneMsg:
@@ -145,6 +156,9 @@ func (m *moveModel) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 
 	case tea.MouseClickMsg:
 		cmd = m.click(msg)
+
+	case tea.MouseWheelMsg:
+		m.wheel(msg)
 	}
 	return m, cmd
 }
@@ -195,6 +209,7 @@ func (m *moveModel) moveTo(at int) {
 		return
 	}
 	m.cursor = min(max(at, 0), len(m.moves)-1)
+	m.follow = true
 	m.fail = ""
 }
 
@@ -327,14 +342,16 @@ func (m *moveModel) done() tea.Cmd {
 }
 
 func (m *moveModel) click(msg tea.MouseClickMsg) tea.Cmd {
-	if msg.Button != tea.MouseLeft || m.deps.Zones == nil || m.stage != moveList {
+	if msg.Button != tea.MouseLeft || m.stage != moveList {
 		return nil
 	}
 	for i := range m.moves {
-		if !m.deps.Zones.Get(m.zonePrefix + "move:" + m.moves[i].ID).InBounds(msg) {
+		zone := moveZone(m.moves[i].ID)
+		if !m.zones.Hit(zone, msg) {
 			continue
 		}
-		if i == m.cursor {
+		if m.clicks.Double(zone) {
+			m.moveTo(i)
 			return m.choose()
 		}
 		m.moveTo(i)
@@ -342,6 +359,24 @@ func (m *moveModel) click(msg tea.MouseClickMsg) tea.Cmd {
 	}
 	return nil
 }
+
+// wheel scrolls the list of moves. There is nothing to scroll on a transition
+// screen: it holds the fields that move needs and they all fit.
+func (m *moveModel) wheel(msg tea.MouseWheelMsg) {
+	if m.stage != moveList {
+		return
+	}
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		m.top -= widget.WheelStep
+	case tea.MouseWheelDown:
+		m.top += widget.WheelStep
+	default:
+	}
+	m.top = min(max(m.top, 0), m.reach)
+}
+
+func moveZone(id string) string { return "move:" + id }
 
 // View draws the moves, or the screen one of them needs.
 func (m *moveModel) View() string {
@@ -354,23 +389,44 @@ func (m *moveModel) View() string {
 	case moveScreen, moveConfirm, moveDoing:
 		lines = append(lines, m.screenLines()...)
 	case moveList:
-		lines = append(lines, m.listLines()...)
+		tail := flatten(m.listTail())
+		moves, under := m.moveLinesAndCursor()
+		if !m.follow {
+			under = -1
+		}
+		height := max(m.height-1-len(tail), 1)
+		window, top := widget.Window(moves, m.top, height, under)
+		m.top, m.follow, m.reach = top, false, max(len(moves)-height, 0)
+		lines = append(lines, window...)
+		lines = append(lines, tail...)
 	}
 	return strings.Join(fit(lines, m.height), "\n")
 }
 
-func (m *moveModel) listLines() []string {
+// moveLinesAndCursor draws the moves and says which line the one under the
+// cursor is on, so that a cursor moved by a key comes back into view.
+func (m *moveModel) moveLinesAndCursor() (lines []string, under int) {
 	t := m.deps.Theme
-	out := make([]string, 0, len(m.moves)+3)
+	lines = make([]string, 0, len(m.moves)+1)
 	switch {
 	case !m.loaded:
-		out = append(out, m.styles.muted.Render(indentWrap("reading what this issue can do"+t.Glyphs.Ellipsis, m.width)))
+		lines = append(lines, m.styles.muted.Render(indentWrap("reading what this issue can do"+t.Glyphs.Ellipsis, m.width)))
 	case len(m.moves) == 0:
-		out = append(out, m.styles.muted.Render(indentWrap("this issue has no move available to you right now", m.width)))
+		lines = append(lines, m.styles.muted.Render(indentWrap("this issue has no move available to you right now", m.width)))
 	}
+	under = -1
 	for i := range m.moves {
-		out = append(out, m.moveLine(i))
+		if i == m.cursor {
+			under = len(lines)
+		}
+		lines = append(lines, m.moveLine(i))
 	}
+	return lines, under
+}
+
+// listTail is what stays below the moves however far they are scrolled.
+func (m *moveModel) listTail() []string {
+	out := make([]string, 0, 3)
 	out = append(out, "")
 	if m.fail != "" {
 		out = append(out, m.styles.fail.Render(wrapped(m.fail, m.width)))
@@ -392,10 +448,7 @@ func (m *moveModel) moveLine(at int) string {
 	room := max(m.width-editMarker, 8)
 	body := ansi.Truncate(padTo(move.Name, editLabelWidth+8)+move.To.Name+trailing, room, t.Glyphs.Ellipsis)
 	line := prefix + m.styles.value.Render(body)
-	if m.deps.Zones != nil && m.zonePrefix != "" {
-		line = m.deps.Zones.Mark(m.zonePrefix+"move:"+move.ID, line)
-	}
-	return line
+	return m.zones.Mark(moveZone(move.ID), line)
 }
 
 func (m *moveModel) screenLines() []string {

--- a/internal/ui/issue/mouse_test.go
+++ b/internal/ui/issue/mouse_test.go
@@ -1,0 +1,228 @@
+package issue
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// paneClock is what a double-click is timed against here. It is wound forward
+// rather than slept on, so a deliberate second click costs no wall time.
+type paneClock struct{ at time.Time }
+
+func (c *paneClock) now() time.Time        { return c.at }
+func (c *paneClock) after(d time.Duration) { c.at = c.at.Add(d) }
+
+func newPaneClock() *paneClock {
+	return &paneClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+}
+
+func (p *panel) wheel(button tea.MouseButton, times int) {
+	p.t.Helper()
+
+	for range times {
+		p.send(tea.MouseWheelMsg{Button: button, X: 4, Y: 4})
+	}
+}
+
+// A field editor opened by a click nobody meant is a description handed to
+// $EDITOR, so the second click has to be part of the same gesture.
+func TestEdit_TwoDeliberateClicksOnARowDoNotOpenIt(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	clock := newPaneClock()
+	d.Now = clock.now
+	p := newPanel(t, NewEdit(d, fullIssue(t, f, "PROJ-6"), withDrafts(tempDrafts(t))), 100, 28)
+
+	at := p.zoneAt(d, "row:labels")
+	p.clickAt(at)
+	if got := p.editor().row().id; got != "labels" {
+		t.Fatalf("the click put the cursor on %s, want labels", got)
+	}
+
+	clock.after(time.Second)
+	p.clickAt(at)
+
+	if p.editor().stage != stageBrowse {
+		t.Error("two clicks a second apart opened the field, so a second look reads as a double-click")
+	}
+}
+
+func TestMove_TwoDeliberateClicksOnAMoveDoNotChooseIt(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	clock := newPaneClock()
+	d.Now = clock.now
+	p := newPanel(t, NewMove(d, fullIssue(t, f, "PROJ-6")), 100, 28)
+
+	want := p.mover().moves[1]
+	at := p.zoneAt(d, "move:"+want.ID)
+	p.clickAt(at)
+	if got := p.mover().moves[p.mover().cursor].ID; got != want.ID {
+		t.Fatalf("the click put the cursor on %s, want %s", got, want.ID)
+	}
+
+	clock.after(2 * time.Second)
+	p.clickAt(at)
+
+	if p.mover().stage != moveList {
+		t.Error("two clicks two seconds apart chose the move under the pointer")
+	}
+}
+
+// The field rows are taller than a short terminal, and until now the pane drew
+// them all and let the frame clip: the last field could be neither seen nor
+// pointed at.
+func TestEdit_TheWheelReachesTheFieldsAShortTerminalClipsOff(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	p := newPanel(t, NewEdit(d, fullIssue(t, f, "PROJ-6"), withDrafts(tempDrafts(t))), 100, 6)
+
+	first := p.frame()
+	if !strings.Contains(first, "Summary") {
+		t.Fatalf("the first field is not on screen at all:\n%s", first)
+	}
+	if strings.Contains(first, "Due") {
+		t.Fatalf("every field fits, so this frame proves nothing:\n%s", first)
+	}
+
+	p.wheel(tea.MouseWheelDown, 3)
+	scrolled := p.frame()
+
+	if !strings.Contains(scrolled, "Due") {
+		t.Errorf("the wheel did not reach the last field:\n%s", scrolled)
+	}
+	if strings.Contains(scrolled, "Summary") {
+		t.Errorf("the wheel scrolled nothing away:\n%s", scrolled)
+	}
+
+	p.wheel(tea.MouseWheelUp, 6)
+	back := p.frame()
+	if !strings.Contains(back, "Summary") {
+		t.Errorf("the wheel could not get back to the first field:\n%s", back)
+	}
+	if got := p.editor().top; got != 0 {
+		t.Errorf("the pane is scrolled to %d after going down and back up, want 0", got)
+	}
+}
+
+// The keyboard and the wheel have to agree about where the pane is: a cursor
+// walked past the bottom of a short terminal used to leave the screen.
+func TestEdit_WalkingTheCursorDownBringsItsRowBackOnScreen(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	p := newPanel(t, NewEdit(d, fullIssue(t, f, "PROJ-6"), withDrafts(tempDrafts(t))), 100, 6)
+
+	p.keys("j", "j", "j", "j")
+
+	if got := p.editor().row().id; got != "duedate" {
+		t.Fatalf("the cursor is on %s, want the last field", got)
+	}
+	if frame := p.frame(); !strings.Contains(frame, "Due") {
+		t.Errorf("the row under the cursor is off screen:\n%s", frame)
+	}
+}
+
+// manyMoves is a workflow with more transitions than a short terminal can draw.
+// A site really can offer this many, and the pane used to draw them all and let
+// the frame clip the rest.
+func manyMoves(n int) []jira.Transition {
+	out := make([]jira.Transition, 0, n)
+	for i := 1; i <= n; i++ {
+		at := strconv.Itoa(i)
+		out = append(out, jira.Transition{
+			ID:   "tr-" + at,
+			Name: "Step " + at,
+			To:   jira.Status{ID: "st-" + at, Name: "Stage " + at},
+		})
+	}
+	return out
+}
+
+func TestMove_TheWheelScrollsTheMovesAShortTerminalClipsOff(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	p := newPanel(t, NewMove(d, fullIssue(t, f, "PROJ-6")), 100, 8)
+	p.send(movesLoadedMsg{gen: p.mover().gen, moves: manyMoves(12)})
+
+	last := "Stage 12"
+	if got := p.frame(); strings.Contains(got, last) {
+		t.Fatalf("twelve moves fit in eight rows, so this frame proves nothing:\n%s", got)
+	}
+
+	p.wheel(tea.MouseWheelDown, 4)
+
+	if got := p.frame(); !strings.Contains(got, last) {
+		t.Errorf("the wheel did not reach the last move:\n%s", got)
+	}
+	if got := p.mover().top; got == 0 {
+		t.Error("the wheel moved the frame without moving the pane's own offset")
+	}
+
+	p.wheel(tea.MouseWheelUp, 8)
+	if got := p.mover().top; got != 0 {
+		t.Errorf("the pane is scrolled to %d after going down and back up, want the first move", got)
+	}
+}
+
+// The cursor and the wheel share one offset here too: a move chosen with j has
+// to be visible before enter is pressed on it.
+func TestMove_WalkingTheCursorDownBringsTheMoveBackOnScreen(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	p := newPanel(t, NewMove(d, fullIssue(t, f, "PROJ-6")), 100, 8)
+	p.send(movesLoadedMsg{gen: p.mover().gen, moves: manyMoves(12)})
+
+	for range 11 {
+		p.keys("j")
+	}
+
+	if got := p.mover().cursor; got != 11 {
+		t.Fatalf("the cursor is on move %d, want the last one", got)
+	}
+	if got := p.frame(); !strings.Contains(got, "Stage 12") {
+		t.Errorf("the move under the cursor is off screen:\n%s", got)
+	}
+}
+
+// A wheel on a transition screen has nothing to scroll, and must not move the
+// list underneath it either.
+func TestMove_TheWheelLeavesATransitionScreenAlone(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(8)
+	d := testDeps(f)
+	p := newPanel(t, NewMove(d, fullIssue(t, f, "PROJ-6")), 100, 24)
+
+	p.keys("j", "enter")
+	if p.mover().stage == moveList {
+		t.Fatalf("the move with a screen did not open one:\n%s", p.frame())
+	}
+	before := p.frame()
+
+	p.wheel(tea.MouseWheelDown, 4)
+
+	if got := p.frame(); got != before {
+		t.Errorf("the wheel changed a transition screen:\n%s", got)
+	}
+	if got := p.mover().top; got != 0 {
+		t.Errorf("the wheel scrolled the list behind the screen to %d", got)
+	}
+}

--- a/internal/ui/list/bench_test.go
+++ b/internal/ui/list/bench_test.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	zone "github.com/lrstanley/bubblezone/v2"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 	"github.com/varijkapil13/saral/pkg/jira/jiratest"
 )
@@ -14,12 +16,30 @@ import (
 // loaded builds a list holding n issues at a given size without touching the
 // network: the page arrives as the message a search would have produced.
 func loaded(tb testing.TB, n, w, h int) *Model {
-	tb.Helper()
-	d := kernel.Deps{
+	return listOf(tb, kernel.Deps{
 		Caps:  jira.Capabilities{TimeZone: time.UTC},
 		Theme: kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs()),
 		Now:   func() time.Time { return time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC) },
-	}
+	}, n, w, h)
+}
+
+// markedList is the same list a running program has: one with a zone manager, so
+// every row and every clickable cell in it carries a marker. It is the shape the
+// steady-state budget has to hold in, since a real session always has one.
+func markedList(tb testing.TB, n, w, h int) *Model {
+	tb.Helper()
+	mgr := zone.New()
+	tb.Cleanup(mgr.Close)
+	return listOf(tb, kernel.Deps{
+		Caps:  jira.Capabilities{TimeZone: time.UTC},
+		Theme: kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs()),
+		Now:   func() time.Time { return time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC) },
+		Zones: mgr,
+	}, n, w, h)
+}
+
+func listOf(tb testing.TB, d kernel.Deps, n, w, h int) *Model {
+	tb.Helper()
 	view, ok := New(d).(*Model)
 	if !ok {
 		tb.Fatal("New did not return a *Model")
@@ -54,6 +74,11 @@ func scroll(b *testing.B, m *Model) {
 func BenchmarkListSteadyScroll10k(b *testing.B) { scroll(b, loaded(b, 10000, 120, 40)) }
 
 func BenchmarkListSteadyScroll20(b *testing.B) { scroll(b, loaded(b, 20, 120, 40)) }
+
+// BenchmarkListSteadyScrollMarked10k is the same scroll with the mouse on. The
+// markers live inside the memoized row, so a frame that hits the memo costs what
+// it did before there were any.
+func BenchmarkListSteadyScrollMarked10k(b *testing.B) { scroll(b, markedList(b, 10000, 120, 40)) }
 
 // BenchmarkListWalk10k walks a fresh row into view on every frame, which is the
 // worst case: every frame misses the memo by construction.
@@ -96,7 +121,23 @@ func BenchmarkRowRender(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := range b.N {
-		_ = renderRow(&issues[i%len(issues)], lay, i%7 == 0, st, theme, time.UTC, now)
+		_ = renderRow(&issues[i%len(issues)], lay, i%7 == 0, st, theme, time.UTC, now, widget.Zoner{})
+	}
+}
+
+func BenchmarkRowRenderMarked(b *testing.B) {
+	issues := jiratest.Gen(64)
+	theme := kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs())
+	st := newStyles(theme)
+	lay := planLayout(120, 8)
+	now := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC)
+	mgr := zone.New()
+	b.Cleanup(mgr.Close)
+	z := widget.NewZoner(mgr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		_ = renderRow(&issues[i%len(issues)], lay, i%7 == 0, st, theme, time.UTC, now, z)
 	}
 }
 
@@ -134,6 +175,18 @@ func TestScrolling_CostsTheSameOnTenThousandRowsAsOnTwenty(t *testing.T) {
 	// return; everything behind it is memoized.
 	if bigAllocs > 1 {
 		t.Errorf("a steady-state frame allocates %d times, want the memo to carry all but the frame itself", bigAllocs)
+	}
+}
+
+// The clickable cells are the reason to check this twice: a marked row is a
+// longer string built out of more pieces, and if the marks were applied outside
+// the memo the whole window would be rebuilt on every frame.
+func TestScrolling_CostsTheSameWithTheMouseOn(t *testing.T) {
+	t.Parallel()
+
+	marked := testing.Benchmark(BenchmarkListSteadyScrollMarked10k)
+	if got := marked.AllocsPerOp(); got > 1 {
+		t.Errorf("a steady-state frame with the mouse on allocates %d times, want the memo to carry all but the frame itself", got)
 	}
 }
 

--- a/internal/ui/list/facet.go
+++ b/internal/ui/list/facet.go
@@ -1,0 +1,183 @@
+package list
+
+import (
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// Facet is a cell of a row the rows can be narrowed to: the status, the type or
+// the assignee a row draws. docs/UX.md asks that clicking one filters by it and
+// clicking it again clears the filter.
+type Facet uint8
+
+// The facets a row draws. Nothing here is a Jira field id or an English status
+// name: a facet holds whatever the row it was clicked on was showing.
+const (
+	FacetNone Facet = iota
+	FacetStatus
+	FacetType
+	FacetAssignee
+)
+
+// FacetMsg narrows the rows to one cell of one row, or clears the narrowing. It
+// is exported so the palette reaches the gesture the mouse does rather than a
+// second implementation of it: an empty Value means the row under the cursor,
+// which is the only row a command with no pointer can mean.
+type FacetMsg struct {
+	Kind  Facet
+	Value string
+}
+
+// unassigned is what an issue nobody owns draws in the assignee column. It is
+// this program's word rather than the site's, so the same word has to be what
+// the facet matches on.
+const unassigned = "unassigned"
+
+// facet is what the rows are narrowed to right now.
+type facet struct {
+	kind  Facet
+	value string
+}
+
+func (f facet) on() bool { return f.kind != FacetNone }
+
+// matches reports whether a row survives the narrowing. It compares the value
+// the row draws, so a row that reads "unassigned" is found by clicking another
+// row that reads the same.
+func (f facet) matches(iss *jira.Issue) bool {
+	if !f.on() {
+		return true
+	}
+	return facetValue(iss, f.kind) == f.value
+}
+
+func facetValue(iss *jira.Issue, kind Facet) string {
+	switch kind {
+	case FacetStatus:
+		return iss.Status.Name
+	case FacetType:
+		return iss.Type.Name
+	case FacetAssignee:
+		return assigneeName(iss, unassigned)
+	case FacetNone:
+		return ""
+	}
+	return ""
+}
+
+// label is the word for the facet in the line that says what is being shown.
+func (f Facet) label() string {
+	switch f {
+	case FacetStatus:
+		return "status"
+	case FacetType:
+		return "type"
+	case FacetAssignee:
+		return "assignee"
+	case FacetNone:
+		return ""
+	}
+	return ""
+}
+
+// The zones a row carries, one per clickable cell per issue. They are stable
+// for the life of the view — the prefix is minted once and the rest is the
+// issue's own key — which is as close to bounded as the manager allows: it
+// frees no id it has ever been handed.
+func rowZone(key string) string    { return "row:" + key }
+func statusZone(key string) string { return "status:" + key }
+func typeZone(key string) string   { return "type:" + key }
+func whoZone(key string) string    { return "who:" + key }
+
+// facetPrompt is the line under the rows while the list is narrowed to a cell.
+// It says what is being left out and how to stop leaving it out, because esc in
+// a root view never reaches this view and no key holds the narrowing.
+func (m *Model) facetPrompt() string {
+	label := "only " + m.facet.kind.label() + " " + strconv.Quote(m.facet.value)
+	hint := "  clear it from the palette"
+	if m.zones.Enabled() {
+		hint = "  click it again to clear"
+	}
+	room := max(m.width-ansi.StringWidth(hint), 8)
+	return m.styles.prompt.Render(ansi.Truncate(label, room, m.deps.Theme.Glyphs.Ellipsis)) +
+		m.styles.muted.Render(hint)
+}
+
+// filtered reports whether anything is being left out, by the local filter or
+// by a facet. Both empty the screen the same way, and both make the count a
+// fraction rather than a total.
+func (m *Model) filtered() bool { return m.query != "" || m.facet.on() }
+
+// filterWords names everything being left out, for the line that says nothing
+// matched.
+func (m *Model) filterWords() string {
+	parts := make([]string, 0, 2)
+	if m.facet.on() {
+		parts = append(parts, m.facet.kind.label()+" "+strconv.Quote(m.facet.value))
+	}
+	if m.query != "" {
+		parts = append(parts, strconv.Quote(m.query))
+	}
+	return strings.Join(parts, " and ")
+}
+
+// facetMsg answers the palette. It sets the narrowing rather than toggling it:
+// a command named after what it shows must not clear it every second time.
+func (m *Model) facetMsg(msg FacetMsg) tea.Cmd {
+	if msg.Kind == FacetNone {
+		return m.applyFacet(facet{})
+	}
+	value := msg.Value
+	if value == "" {
+		iss := m.selectedIssue()
+		if iss == nil {
+			return kernel.Warn("there is no row here to narrow these rows to")
+		}
+		value = facetValue(iss, msg.Kind)
+	}
+	return m.applyFacet(facet{kind: msg.Kind, value: value})
+}
+
+// toggleFacet is the click: the same cell twice means the user is done with it.
+func (m *Model) toggleFacet(kind Facet, value string) tea.Cmd {
+	next := facet{kind: kind, value: value}
+	if m.facet == next {
+		next = facet{}
+	}
+	return m.applyFacet(next)
+}
+
+func (m *Model) applyFacet(f facet) tea.Cmd {
+	if f == m.facet {
+		return nil
+	}
+	m.facet = f
+	m.refilter()
+	m.scrollToCursor()
+	return m.pageAheadIfNeeded()
+}
+
+// clickFacet narrows to the cell under the pointer. The cell zones are drawn
+// inside the row's own, so they are asked about first: a click on the status of
+// a row is in bounds for both.
+func (m *Model) clickFacet(msg tea.MouseClickMsg, iss *jira.Issue) (tea.Cmd, bool) {
+	for _, cell := range [...]struct {
+		zone string
+		kind Facet
+	}{
+		{statusZone(iss.Key), FacetStatus},
+		{typeZone(iss.Key), FacetType},
+		{whoZone(iss.Key), FacetAssignee},
+	} {
+		if m.zones.Hit(cell.zone, msg) {
+			return m.toggleFacet(cell.kind, facetValue(iss, cell.kind)), true
+		}
+	}
+	return nil, false
+}

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/ui/issue"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -81,6 +82,10 @@ type Model struct {
 	filter    textinput.Model
 	query     string
 
+	// facet is the cell somebody clicked, and what the rows stay narrowed to
+	// until they click it again.
+	facet facet
+
 	// defaulted records that the search on screen is still the one New derived
 	// from the session's project. A project switch retargets that search and
 	// leaves alone one the user asked for.
@@ -115,7 +120,8 @@ type Model struct {
 	pollArmed  bool
 	pollPaused bool
 
-	zonePrefix string
+	zones  widget.Zoner
+	clicks *widget.Clicks
 }
 
 // bindStep is how far the gesture that binds this query to a number key has
@@ -155,9 +161,8 @@ func New(d kernel.Deps) kernel.View {
 	if d.Jira != nil {
 		m.search = app.NewSearch(d.Jira)
 	}
-	if d.Zones != nil {
-		m.zonePrefix = d.Zones.NewPrefix()
-	}
+	m.zones = widget.NewZoner(d.Zones)
+	m.clicks = widget.NewClicks(d.Now)
 	m.normal, m.inFilter = defaultKeys().tables()
 	m.jql, m.title = defaultQuery(d.Project)
 	m.defaulted = true
@@ -277,6 +282,9 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case SaveQueryMsg:
 		m.startBind()
 
+	case FacetMsg:
+		cmd = m.facetMsg(msg)
+
 	case loadedMsg:
 		cmd = m.loadedPage(msg)
 
@@ -359,6 +367,9 @@ func (m *Model) widestKey() int {
 // column captions and the filter prompt when one is open.
 func (m *Model) rowsHeight() int {
 	h := m.height - 2
+	if m.facet.on() {
+		h--
+	}
 	if m.filtering || m.bind != bindNone {
 		h--
 	}
@@ -449,6 +460,7 @@ func (m *Model) setQuery(jql, title string, byDefault bool) tea.Cmd {
 	m.issues, m.page, m.missing, m.view, m.needles = nil, jira.Page[jira.Issue]{}, nil, nil, nil
 	m.cursor, m.top, m.loaded = 0, 0, false
 	m.cachedMore, m.stale = false, false
+	m.facet = facet{}
 	m.rows.reset()
 	m.refilter()
 	m.fromCache()
@@ -547,7 +559,7 @@ func (m *Model) pageAheadIfNeeded() tea.Cmd {
 		return nil
 	}
 	near := m.cursor >= len(m.view)-lookahead
-	starved := m.query != "" && len(m.view) < m.rowsHeight() && len(m.issues) < autoFillCap
+	starved := m.filtered() && len(m.view) < m.rowsHeight() && len(m.issues) < autoFillCap
 	if !near && !starved {
 		return nil
 	}
@@ -576,6 +588,17 @@ func (m *Model) selectedKey() string {
 	return ""
 }
 
+func (m *Model) selectedIssue() *jira.Issue {
+	if m.cursor < 0 || m.cursor >= len(m.view) {
+		return nil
+	}
+	at := m.view[m.cursor]
+	if at < 0 || at >= len(m.issues) {
+		return nil
+	}
+	return &m.issues[at]
+}
+
 // restore puts the cursor back on an issue by key, keeping the scroll offset so
 // that the row does not jump even when its index moved.
 func (m *Model) restore(key string) {
@@ -600,14 +623,16 @@ func (m *Model) refilter() {
 	needle := strings.ToLower(m.query)
 	if needle == "" {
 		for i := range m.issues {
-			m.view = append(m.view, i)
+			if m.facet.matches(&m.issues[i]) {
+				m.view = append(m.view, i)
+			}
 		}
 		m.restore(under)
 		return
 	}
 	m.buildNeedles()
 	for i := range m.issues {
-		if strings.Contains(m.needles[i], needle) {
+		if strings.Contains(m.needles[i], needle) && m.facet.matches(&m.issues[i]) {
 			m.view = append(m.view, i)
 		}
 	}
@@ -817,19 +842,25 @@ func (m *Model) open() tea.Cmd {
 	return kernel.Push(issue.ViewID, iss.Key, issue.New(m.deps, iss))
 }
 
-// click selects the row under the pointer, and opens it when it was already the
-// selected one. There is no double-click message in Bubble Tea v2, and a second
-// click on the row you just picked is the gesture that means "this one".
+// click narrows the rows to the cell under the pointer, or selects the row that
+// cell is on and opens it on a double-click. Bubble Tea v2 reports neither a
+// click count nor an instant, so the second click is timed against this
+// session's clock rather than inferred from the row already being selected.
 func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
-	if msg.Button != tea.MouseLeft || m.deps.Zones == nil {
+	if msg.Button != tea.MouseLeft {
 		return nil
 	}
 	for i := m.top; i < min(m.top+m.rowsHeight(), len(m.view)); i++ {
 		iss := &m.issues[m.view[i]]
-		if !m.deps.Zones.Get(m.zonePrefix + "row:" + iss.Key).InBounds(msg) {
+		if cmd, narrowed := m.clickFacet(msg, iss); narrowed {
+			m.clicks.Forget()
+			return cmd
+		}
+		if !m.zones.Hit(rowZone(iss.Key), msg) {
 			continue
 		}
-		if i == m.cursor {
+		if m.clicks.Double(rowZone(iss.Key)) {
+			m.cursor = i
 			return m.open()
 		}
 		return m.moveTo(i)
@@ -877,6 +908,9 @@ func (m *Model) View() string {
 		}
 		m.warm(end)
 	}
+	if m.facet.on() {
+		lines = append(lines, m.facetPrompt())
+	}
 	if m.filtering {
 		lines = append(lines, m.filter.View())
 	}
@@ -904,10 +938,8 @@ func (m *Model) row(at int, selected bool) string {
 	if s, ok := m.rows.get(k); ok {
 		return s
 	}
-	s := renderRow(iss, m.lay, selected, m.styles, m.deps.Theme, m.deps.Caps.Location(), m.now())
-	if m.deps.Zones != nil {
-		s = m.deps.Zones.Mark(m.zonePrefix+"row:"+iss.Key, s)
-	}
+	s := renderRow(iss, m.lay, selected, m.styles, m.deps.Theme, m.deps.Caps.Location(), m.now(), m.zones)
+	s = m.zones.Mark(rowZone(iss.Key), s)
 	m.rows.put(k, s)
 	return s
 }
@@ -935,7 +967,7 @@ func (m *Model) summaryKey() summaryKey {
 	return summaryKey{
 		title: m.title, width: m.width, gen: m.styles.gen,
 		issues: len(m.issues), visible: len(m.view), more: m.hasMore(),
-		loading: m.loading, loaded: m.loaded, filtered: m.query != "",
+		loading: m.loading, loaded: m.loaded, filtered: m.filtered(),
 		stale: m.stale,
 	}
 }
@@ -971,7 +1003,7 @@ func (m *Model) countLabel() string {
 	switch {
 	case !m.loaded && m.loading:
 		b.WriteString("searching")
-	case m.query != "":
+	case m.filtered():
 		b.WriteString(strconv.Itoa(len(m.view)))
 		b.WriteString(" of ")
 		b.WriteString(m.total())
@@ -1001,8 +1033,8 @@ func (m *Model) appendEmpty(lines []string, h int) []string {
 		lines = append(lines, m.styles.muted.Render("  No Jira connection in this session yet."))
 	case !m.loaded:
 		lines = append(lines, m.styles.muted.Render("  Searching"+m.deps.Theme.Glyphs.Ellipsis))
-	case m.query != "":
-		lines = append(lines, m.styles.muted.Render("  No loaded row matches "+strconv.Quote(m.query)+"."))
+	case m.filtered():
+		lines = append(lines, m.styles.muted.Render("  No loaded row matches "+m.filterWords()+"."))
 	default:
 		lines = append(lines, m.styles.muted.Render("  Nothing matches this search."),
 			m.styles.muted.Render("  "+m.jql))

--- a/internal/ui/list/mouse_test.go
+++ b/internal/ui/list/mouse_test.go
@@ -1,0 +1,325 @@
+package list
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	zone "github.com/lrstanley/bubblezone/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// markingZoner is a zoner over a live manager, for a test that wants marked
+// output without a whole view around it.
+func markingZoner(tb testing.TB) widget.Zoner {
+	tb.Helper()
+	mgr := zone.New()
+	tb.Cleanup(mgr.Close)
+	return widget.NewZoner(mgr)
+}
+
+// pointerClock is the clock a double-click is timed against. Winding it forward
+// is how a slow click is written; docs/TESTING.md forbids sleeping for one.
+type pointerClock struct{ at time.Time }
+
+func (c *pointerClock) now() time.Time        { return c.at }
+func (c *pointerClock) after(d time.Duration) { c.at = c.at.Add(d) }
+func newPointerClock() *pointerClock {
+	return &pointerClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+}
+
+// pressOn scans the frame the view would draw and presses the left button in
+// the first cell of one of its zones. The manager records a zone on its own
+// goroutine, so the zone is waited for rather than assumed.
+func pressOn(t *testing.T, d kernel.Deps, dr *driver, name string) {
+	t.Helper()
+
+	_ = d.Zones.Scan(dr.m.View())
+	id := dr.m.zones.ID(name)
+	eventually(t, func() bool { return !d.Zones.Get(id).IsZero() })
+	at := d.Zones.Get(id)
+	dr.send(tea.MouseClickMsg{X: at.StartX, Y: at.StartY, Button: tea.MouseLeft})
+}
+
+func TestList_ClickingACellNarrowsTheRowsToItAndClickingItAgainClears(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		zone  func(string) string
+		key   string
+		kind  Facet
+		value string
+	}{
+		"a status chip": {zone: statusZone, key: "PROJ-2", kind: FacetStatus, value: "Shipped"},
+		"a type chip":   {zone: typeZone, key: "PROJ-2", kind: FacetType, value: "Chore"},
+		"an assignee":   {zone: whoZone, key: "PROJ-2", kind: FacetAssignee, value: "Alan Turing"},
+		"nobody at all": {zone: whoZone, key: "PROJ-4", kind: FacetAssignee, value: unassigned},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := testDeps(newFake(20))
+			dr := openAll(t, d, 120, 30)
+			all := len(dr.m.view)
+
+			pressOn(t, d, dr, tc.zone(tc.key))
+
+			if got := (facet{kind: tc.kind, value: tc.value}); dr.m.facet != got {
+				t.Fatalf("the rows are narrowed to %+v, want %+v", dr.m.facet, got)
+			}
+			if len(dr.m.view) == 0 || len(dr.m.view) >= all {
+				t.Fatalf("%d of %d rows survived the narrowing, want some but not all", len(dr.m.view), all)
+			}
+			for _, at := range dr.m.view {
+				iss := &dr.m.issues[at]
+				if got := facetValue(iss, tc.kind); got != tc.value {
+					t.Errorf("%s is still shown with %s %q, want only %q", iss.Key, tc.kind.label(), got, tc.value)
+				}
+			}
+			mustContain(t, dr.view(), "only "+tc.kind.label()+" \""+tc.value+"\"")
+
+			pressOn(t, d, dr, tc.zone(tc.key))
+
+			if dr.m.facet.on() {
+				t.Fatalf("a second click left the rows narrowed to %+v", dr.m.facet)
+			}
+			if len(dr.m.view) != all {
+				t.Errorf("%d rows came back, want all %d", len(dr.m.view), all)
+			}
+			mustNotContain(t, dr.view(), "only "+tc.kind.label())
+		})
+	}
+}
+
+// The selected row is drawn by styling the whole line at once, around cells
+// that already carry their own markers. A style that measured or rewrote those
+// markers would put the zone in the wrong place, and the chip on the row the
+// user is actually on is the one they are most likely to click.
+func TestList_TheChipsOnTheSelectedRowAreStillWhereTheyLook(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(20))
+	dr := openAll(t, d, 120, 30)
+	dr.key("j")
+	if got := dr.m.selectedKey(); got != "PROJ-2" {
+		t.Fatalf("the cursor is on %q, want PROJ-2", got)
+	}
+
+	pressOn(t, d, dr, statusZone("PROJ-2"))
+
+	if got := (facet{kind: FacetStatus, value: "Shipped"}); dr.m.facet != got {
+		t.Errorf("clicking the selected row's status narrowed to %+v, want %+v", dr.m.facet, got)
+	}
+}
+
+// The narrowing and the local filter are two different things being left out at
+// once, and the row that survives has to satisfy both.
+func TestList_NarrowingAndTheFilterApplyTogether(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(30))
+	dr := openAll(t, d, 120, 30)
+
+	pressOn(t, d, dr, statusZone("PROJ-2"))
+	dr.key("/")
+	dr.typeText("PROJ-2")
+
+	if len(dr.m.view) == 0 {
+		t.Fatal("nothing survived a narrowing and a filter that both match PROJ-2")
+	}
+	for _, at := range dr.m.view {
+		iss := &dr.m.issues[at]
+		if iss.Status.Name != "Shipped" || !strings.Contains(iss.Key, "PROJ-2") {
+			t.Errorf("%s (%s) survived both a status narrowing and a key filter", iss.Key, iss.Status.Name)
+		}
+	}
+}
+
+func TestList_ADoubleClickOpensARowAndTwoDeliberateClicksDoNot(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		gap  time.Duration
+		want int
+	}{
+		"two clicks in one gesture":       {gap: 90 * time.Millisecond, want: 1},
+		"two clicks a second apart":       {gap: time.Second, want: 0},
+		"two clicks a whole minute apart": {gap: time.Minute, want: 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			clock := newPointerClock()
+			d := testDeps(newFake(20))
+			d.Now = clock.now
+			dr := openAll(t, d, 120, 30)
+
+			pressOn(t, d, dr, rowZone("PROJ-3"))
+			if dr.m.selectedKey() != "PROJ-3" {
+				t.Fatalf("the first click left the cursor on %q", dr.m.selectedKey())
+			}
+			clock.after(tc.gap)
+			pressOn(t, d, dr, rowZone("PROJ-3"))
+
+			if got := len(dr.pushes); got != tc.want {
+				t.Fatalf("%s opened %d panes, want %d", name, got, tc.want)
+			}
+			if tc.want == 1 && dr.pushes[0].Title != "PROJ-3" {
+				t.Errorf("the pane opened is %q, want PROJ-3", dr.pushes[0].Title)
+			}
+		})
+	}
+}
+
+// A click on a cell is a narrowing and never half of a double-click: without
+// this the second click on a chip opens the row under it.
+func TestList_ClickingACellIsNotHalfOfADoubleClick(t *testing.T) {
+	t.Parallel()
+
+	clock := newPointerClock()
+	d := testDeps(newFake(20))
+	d.Now = clock.now
+	dr := openAll(t, d, 120, 30)
+
+	pressOn(t, d, dr, statusZone("PROJ-3"))
+	clock.after(50 * time.Millisecond)
+	pressOn(t, d, dr, rowZone("PROJ-3"))
+
+	if len(dr.pushes) != 0 {
+		t.Errorf("a chip click followed by a row click opened %d panes, want none", len(dr.pushes))
+	}
+}
+
+// Nothing here strips ANSI, and nothing may: a marker left in a frame with the
+// mouse off is what terminal text selection picks up, and stripping is exactly
+// what hid it for four batches.
+func TestList_WithTheMouseOffTheFrameCarriesNoMarkerAndNoCellNarrows(t *testing.T) {
+	t.Parallel()
+
+	off := zone.New()
+	t.Cleanup(off.Close)
+	off.SetEnabled(false)
+
+	d := plainDeps(newFake(20))
+	d.Zones = off
+	dr := openAll(t, d, 120, 30)
+
+	frame := dr.m.View()
+	if strings.ContainsRune(frame, '\x1b') {
+		t.Errorf("an escape survived a frame drawn with the mouse off:\n%q", frame)
+	}
+	if !strings.Contains(frame, "PROJ-2") {
+		t.Fatalf("the rows did not draw at all:\n%q", frame)
+	}
+
+	// The terminal reports nothing with the mouse off, but a synthesised click
+	// must still miss: the manager is disabled, so it recorded no zone to hit.
+	_ = off.Scan(frame)
+	dr.send(tea.MouseClickMsg{X: 60, Y: 3, Button: tea.MouseLeft})
+	if dr.m.facet.on() {
+		t.Errorf("a click narrowed the rows to %+v with the mouse off", dr.m.facet)
+	}
+	if len(dr.pushes) != 0 {
+		t.Errorf("a click opened %d panes with the mouse off", len(dr.pushes))
+	}
+}
+
+// plainDeps draws with a theme that writes no escape sequence of its own, so
+// that an escape left in a frame can only be a zone marker.
+func plainDeps(client jira.Client) kernel.Deps {
+	d := testDeps(client)
+	t := kernel.NewTheme(kernel.ThemeNoColor, true, kernel.ASCIIGlyphs())
+	plain := lipgloss.NewStyle()
+	for _, style := range []*lipgloss.Style{
+		&t.Base, &t.Muted, &t.Accent, &t.Danger, &t.Warning, &t.Success, &t.Title,
+		&t.Selected, &t.Badge, &t.StaleBadge,
+	} {
+		*style = plain
+	}
+	d.Theme = t
+	return d
+}
+
+func TestList_ThePaletteNarrowsToTheRowUnderTheCursor(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(20))
+	dr := openAll(t, d, 120, 30)
+	dr.key("j", "j")
+	under := dr.m.selectedKey()
+
+	dr.send(FacetMsg{Kind: FacetStatus})
+
+	if !dr.m.facet.on() {
+		t.Fatal("the palette narrowed nothing")
+	}
+	if got, want := dr.m.facet.value, facetValue(dr.m.selectedIssue(), FacetStatus); got != want {
+		t.Errorf("the rows are narrowed to %q, want the status of %s, %q", got, under, want)
+	}
+
+	// The command is named after what it shows, so running it twice must not
+	// undo it the way a second click does.
+	dr.send(FacetMsg{Kind: FacetStatus})
+	if !dr.m.facet.on() {
+		t.Error("running the command twice cleared the narrowing")
+	}
+
+	dr.send(FacetMsg{})
+	if dr.m.facet.on() {
+		t.Errorf("the rows are still narrowed to %+v after being told to show everything", dr.m.facet)
+	}
+}
+
+func TestList_ThePaletteSaysSoWhenThereIsNoRowToNarrowBy(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(0))
+	dr := openAll(t, d, 120, 30)
+
+	dr.send(FacetMsg{Kind: FacetStatus})
+
+	if dr.m.facet.on() {
+		t.Fatal("an empty list narrowed itself to a row that does not exist")
+	}
+	if got := dr.lastStatus().Text; !strings.Contains(got, "no row") {
+		t.Errorf("the status line says %q, want it to say there is no row here", got)
+	}
+}
+
+func TestList_GoldenWhileNarrowedToACell(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(12))
+	dr := openAll(t, d, 120, 30)
+	pressOn(t, d, dr, statusZone("PROJ-2"))
+
+	golden(t, "list_facet_120x30.golden", dr.view())
+}
+
+// The wheel scrolls the rows and leaves the selection alone, which is what a
+// wheel does everywhere else.
+func TestList_TheWheelScrollsWithoutMovingTheCursorOffTheRowItIsOn(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(newFake(80))
+	dr := openAll(t, d, 120, 20)
+	under := dr.m.selectedKey()
+
+	dr.send(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	if dr.m.top == 0 {
+		t.Error("the wheel scrolled nothing")
+	}
+	if got := dr.m.selectedKey(); got != under {
+		t.Errorf("the wheel moved the selection to %q, want it left on %q", got, under)
+	}
+
+	dr.send(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if dr.m.top != 0 {
+		t.Errorf("the wheel is at %d after going down and back up, want 0", dr.m.top)
+	}
+}

--- a/internal/ui/list/register.go
+++ b/internal/ui/list/register.go
@@ -34,6 +34,27 @@ func init() {
 			return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(SaveQueryMsg{}))
 		},
 	})
+	// The cells a click narrows the rows by, reachable without a pointer. There
+	// is no key for them: every letter left is one somebody types into a filter.
+	for _, f := range []struct {
+		id, title string
+		kind      Facet
+	}{
+		{"issues.only-status", "Show only rows with this row's status", FacetStatus},
+		{"issues.only-type", "Show only rows with this row's type", FacetType},
+		{"issues.only-assignee", "Show only rows with this row's assignee", FacetAssignee},
+		{"issues.show-all", "Show every row again", FacetNone},
+	} {
+		kind := f.kind
+		kernel.RegisterCommand(kernel.Command{
+			ID:    f.id,
+			Title: f.title,
+			Group: "Search",
+			Run: func(kernel.Deps) tea.Cmd {
+				return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(FacetMsg{Kind: kind}))
+			},
+		})
+	}
 	for _, q := range []struct{ id, title, jql string }{
 		{"issues.mine", "My issues", "assignee = currentUser() ORDER BY updated DESC"},
 		{"issues.reported", "Issues I reported", "reporter = currentUser() ORDER BY created DESC"},

--- a/internal/ui/list/render.go
+++ b/internal/ui/list/render.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -161,7 +162,12 @@ func (c *rowCache) put(k rowKey, s string) {
 func (c *rowCache) reset() { clear(c.rows) }
 
 // renderRow draws one row to exactly lay.width columns.
-func renderRow(iss *jira.Issue, lay layout, sel bool, st *styles, t *kernel.Theme, loc *time.Location, now time.Time) string {
+//
+// The three cells that name a facet carry a zone of their own, inside the row's,
+// so that a click can mean "narrow to this status" rather than only "this row".
+// They are marked here, inside what the memo holds, so that a marked cell costs
+// its id once per issue and nothing per frame.
+func renderRow(iss *jira.Issue, lay layout, sel bool, st *styles, t *kernel.Theme, loc *time.Location, now time.Time, z widget.Zoner) string {
 	ell := t.Glyphs.Ellipsis
 	var b strings.Builder
 	b.Grow(lay.width + 32)
@@ -177,20 +183,19 @@ func renderRow(iss *jira.Issue, lay layout, sel bool, st *styles, t *kernel.Them
 	writeCell(&b, iss.Summary, lay.summary, ell)
 	if lay.typ > 0 {
 		writeGap(&b)
-		writeCell(&b, iss.Type.Name, lay.typ, ell)
+		b.WriteString(z.Mark(typeZone(iss.Key), padTruncate(iss.Type.Name, lay.typ, ell)))
 	}
 	if lay.status > 0 {
 		writeGap(&b)
 		cell := padTruncate(iss.Status.Name, lay.status, ell)
-		if sel {
-			b.WriteString(cell)
-		} else {
-			b.WriteString(st.categories[categoryIndex(iss.Status.Category)].Render(cell))
+		if !sel {
+			cell = st.categories[categoryIndex(iss.Status.Category)].Render(cell)
 		}
+		b.WriteString(z.Mark(statusZone(iss.Key), cell))
 	}
 	if lay.assignee > 0 {
 		writeGap(&b)
-		writeCell(&b, assigneeName(iss, "unassigned"), lay.assignee, ell)
+		b.WriteString(z.Mark(whoZone(iss.Key), padTruncate(assigneeName(iss, unassigned), lay.assignee, ell)))
 	}
 	if lay.updated > 0 {
 		writeGap(&b)
@@ -210,9 +215,9 @@ func categoryIndex(c jira.StatusCategory) int {
 	return int(c)
 }
 
-func assigneeName(iss *jira.Issue, unassigned string) string {
+func assigneeName(iss *jira.Issue, fallback string) string {
 	if iss.Assignee == nil || strings.TrimSpace(iss.Assignee.DisplayName) == "" {
-		return unassigned
+		return fallback
 	}
 	return iss.Assignee.DisplayName
 }

--- a/internal/ui/list/render_test.go
+++ b/internal/ui/list/render_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -72,10 +73,15 @@ func TestRenderRow_IsExactlyAsWideAsTheLayoutWhateverTheContent(t *testing.T) {
 				t.Parallel()
 
 				lay := planLayout(width, 8)
-				for _, sel := range []bool{false, true} {
-					got := ansi.StringWidth(renderRow(&iss, lay, sel, st, theme, time.UTC, now))
-					if got != lay.width {
-						t.Errorf("row is %d columns at width %d (selected=%t), want %d", got, width, sel, lay.width)
+				// Marked and unmarked, because the clickable cells put private
+				// escape sequences inside the row and a marker that measured as
+				// a column would shift everything to its right.
+				for zname, z := range map[string]widget.Zoner{"unmarked": {}, "marked": markingZoner(t)} {
+					for _, sel := range []bool{false, true} {
+						got := ansi.StringWidth(renderRow(&iss, lay, sel, st, theme, time.UTC, now, z))
+						if got != lay.width {
+							t.Errorf("a %s row is %d columns at width %d (selected=%t), want %d", zname, got, width, sel, lay.width)
+						}
 					}
 				}
 			})

--- a/internal/ui/list/testdata/list_facet_120x30.golden
+++ b/internal/ui/list/testdata/list_facet_120x30.golden
@@ -1,0 +1,30 @@
+All issues                                                                                                       4 of 12
+  KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
+  PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00
+  PROJ-8   Add invoice rounding                                  Chore      Shipped       unassigned        03 Mar 02:00
+  PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+only status "Shipped"  click it again to clear

--- a/internal/ui/onboarding/kernel_test.go
+++ b/internal/ui/onboarding/kernel_test.go
@@ -155,7 +155,7 @@ func TestKernel_ClickingASuggestionAndACompletedStepWorks(t *testing.T) {
 	d.press("enter")
 	d.atStep(stepProject)
 
-	prefix := d.model().zone
+	prefix := d.model().zones.ID("")
 	scan(t, zones, d.view.View())
 	eventually(t, func() bool { return !zones.Get(prefix + "project:PROJ").IsZero() })
 
@@ -183,7 +183,7 @@ func TestKernel_ClickingATokenStoreChoosesIt(t *testing.T) {
 	d.credentials()
 	d.atStep(stepStorage)
 
-	prefix := d.model().zone
+	prefix := d.model().zones.ID("")
 	scan(t, zones, d.view.View())
 	eventually(t, func() bool { return !zones.Get(prefix + "store:command").IsZero() })
 

--- a/internal/ui/onboarding/onboarding.go
+++ b/internal/ui/onboarding/onboarding.go
@@ -25,6 +25,7 @@ import (
 	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/config"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -77,9 +78,7 @@ func NewWith(d kernel.Deps, connect Connector) kernel.View {
 		cfg:     config.Config{Mouse: true},
 		cache:   &renderCache{},
 	}
-	if d.Zones != nil {
-		m.zone = d.Zones.NewPrefix()
-	}
+	m.zones = widget.NewZoner(d.Zones)
 	m.restyle()
 	m.spin = spinner.New(spinner.WithSpinner(spinner.Spinner{
 		Frames: d.Theme.Glyphs.Spinner,
@@ -105,7 +104,7 @@ var _ kernel.KeyCapturer = Model{}
 type Model struct {
 	deps    kernel.Deps
 	connect Connector
-	zone    string
+	zones   widget.Zoner
 
 	width, height int
 
@@ -388,20 +387,20 @@ func (m *Model) cycleSuggestion(down bool) tea.Cmd {
 }
 
 func (m Model) click(msg tea.MouseClickMsg) (kernel.View, tea.Cmd) {
-	if m.zone == "" || m.deps.Zones == nil || msg.Button != tea.MouseLeft {
+	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}
 	switch m.step {
 	case stepStorage:
 		for kind := storeKind(0); kind < storeCount; kind++ {
-			if m.deps.Zones.Get(m.zone + "store:" + kind.String()).InBounds(msg) {
+			if m.zones.Hit("store:"+kind.String(), msg) {
 				cmd := m.setStore(kind)
 				return m, cmd
 			}
 		}
 	case stepProject:
 		for _, key := range m.suggested {
-			if m.deps.Zones.Get(m.zone + "project:" + key).InBounds(msg) {
+			if m.zones.Hit("project:"+key, msg) {
 				m.setValue(fieldProject, key)
 				return m, nil
 			}
@@ -409,7 +408,7 @@ func (m Model) click(msg tea.MouseClickMsg) (kernel.View, tea.Cmd) {
 	case stepSite, stepEmail, stepToken, stepReview, stepDone:
 	}
 	for s := stepSite; s < m.step; s++ {
-		if m.deps.Zones.Get(m.zone + "step:" + s.String()).InBounds(msg) {
+		if m.zones.Hit("step:"+s.String(), msg) {
 			cmd := m.goTo(s)
 			return m, cmd
 		}

--- a/internal/ui/onboarding/render.go
+++ b/internal/ui/onboarding/render.go
@@ -479,12 +479,7 @@ func (m Model) explain() []string {
 	return out
 }
 
-func (m Model) mark(id, row string) string {
-	if m.zone == "" || m.deps.Zones == nil {
-		return row
-	}
-	return m.deps.Zones.Mark(m.zone+id, row)
-}
+func (m Model) mark(id, row string) string { return m.zones.Mark(id, row) }
 
 func indent(s string) string { return strings.Repeat(" ", inputIndent) + s }
 

--- a/internal/ui/widget/click.go
+++ b/internal/ui/widget/click.go
@@ -1,0 +1,54 @@
+package widget
+
+import "time"
+
+// DoubleClick is how long after a click a second one on the same element is
+// still the same gesture. Long enough for a deliberate double-click on a
+// trackpad, short enough that two decisions a second apart stay two clicks.
+const DoubleClick = 400 * time.Millisecond
+
+// Clicks turns a stream of clicks into single and double ones.
+//
+// Bubble Tea v2 reports a click as position, button and modifier and nothing
+// else — no click count, and no instant to compare with the last one — so a view
+// that wants a double-click has to time it. The alternative every view here
+// reached for first was "a second click on the row that is already selected",
+// which cannot tell a double-click from two deliberate clicks minutes apart, and
+// so opens an issue under a user who was only looking at it.
+type Clicks struct {
+	window time.Duration
+	now    func() time.Time
+
+	id string
+	at time.Time
+}
+
+// NewClicks times double-clicks against the session's clock, which a test
+// injects and winds forward rather than sleeping on.
+func NewClicks(now func() time.Time) *Clicks {
+	if now == nil {
+		now = time.Now
+	}
+	return &Clicks{window: DoubleClick, now: now}
+}
+
+// Double records a click on id and reports whether it completes a double-click
+// on the same id. A double-click consumes both, so three clicks are a single, a
+// double and a single rather than two overlapping doubles.
+func (c *Clicks) Double(id string) bool {
+	at := c.now()
+	if id != "" && id == c.id {
+		if since := at.Sub(c.at); since >= 0 && since < c.window {
+			c.id, c.at = "", time.Time{}
+			return true
+		}
+	}
+	c.id, c.at = id, at
+	return false
+}
+
+// Forget drops what was clicked last, so that the next click on the same
+// element is a single one. A view calls it when the click it just took changed
+// what is on screen, and the element under the pointer is no longer the one that
+// was clicked.
+func (c *Clicks) Forget() { c.id, c.at = "", time.Time{} }

--- a/internal/ui/widget/click_test.go
+++ b/internal/ui/widget/click_test.go
@@ -1,0 +1,130 @@
+package widget
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeClock is the injected clock docs/TESTING.md asks for: a double-click is
+// timed by winding it forward, never by sleeping.
+type fakeClock struct{ at time.Time }
+
+func (c *fakeClock) now() time.Time       { return c.at }
+func (c *fakeClock) tick(d time.Duration) { c.at = c.at.Add(d) }
+
+func TestClicks_TellsADoubleClickFromTwoDeliberateOnes(t *testing.T) {
+	t.Parallel()
+
+	type click struct {
+		id    string
+		after time.Duration
+		want  bool
+	}
+	for name, sequence := range map[string][]click{
+		"two clicks inside the window are a double": {
+			{id: "row:1"},
+			{id: "row:1", after: 120 * time.Millisecond, want: true},
+		},
+		"two clicks a second apart are two clicks": {
+			{id: "row:1"},
+			{id: "row:1", after: time.Second},
+		},
+		"a click on the edge of the window is still a double": {
+			{id: "row:1"},
+			{id: "row:1", after: DoubleClick - time.Millisecond, want: true},
+		},
+		"a click on the window's far edge is not": {
+			{id: "row:1"},
+			{id: "row:1", after: DoubleClick},
+		},
+		"the second click has to be on the same element": {
+			{id: "row:1"},
+			{id: "row:2", after: 50 * time.Millisecond},
+		},
+		"a double click is consumed, so the third click is a single": {
+			{id: "row:1"},
+			{id: "row:1", after: 50 * time.Millisecond, want: true},
+			{id: "row:1", after: 50 * time.Millisecond},
+			{id: "row:1", after: 50 * time.Millisecond, want: true},
+		},
+		"a click elsewhere in between breaks the pair": {
+			{id: "row:1"},
+			{id: "row:2", after: 50 * time.Millisecond},
+			{id: "row:1", after: 50 * time.Millisecond},
+		},
+		"an unnamed element never doubles": {
+			{id: ""},
+			{id: "", after: 10 * time.Millisecond},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			clock := &fakeClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+			clicks := NewClicks(clock.now)
+			for i, c := range sequence {
+				clock.tick(c.after)
+				if got := clicks.Double(c.id); got != c.want {
+					t.Errorf("click %d on %q after %s: double=%v, want %v", i+1, c.id, c.after, got, c.want)
+				}
+			}
+		})
+	}
+}
+
+// A frozen clock is what a golden test hands a view, and two clicks at the same
+// instant are as close together as two clicks can be.
+func TestClicks_AFrozenClockStillReportsADouble(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)
+	clicks := NewClicks(func() time.Time { return at })
+
+	if clicks.Double("row:1") {
+		t.Error("the first click on an element reported a double")
+	}
+	if !clicks.Double("row:1") {
+		t.Error("a second click at the same instant did not report a double")
+	}
+}
+
+func TestClicks_ForgettingTheLastClickBreaksThePair(t *testing.T) {
+	t.Parallel()
+
+	clock := &fakeClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+	clicks := NewClicks(clock.now)
+
+	clicks.Double("row:1")
+	clicks.Forget()
+	clock.tick(10 * time.Millisecond)
+	if clicks.Double("row:1") {
+		t.Error("a click after Forget completed a pair the view had already spent")
+	}
+}
+
+// A clock going backwards — a machine's time being corrected under a running
+// program — must not read as two clicks in the same instant.
+func TestClicks_AClockThatGoesBackwardsIsNotADouble(t *testing.T) {
+	t.Parallel()
+
+	clock := &fakeClock{at: time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC)}
+	clicks := NewClicks(clock.now)
+
+	clicks.Double("row:1")
+	clock.tick(-time.Hour)
+	if clicks.Double("row:1") {
+		t.Error("a click before the previous one reported a double")
+	}
+}
+
+func TestClicks_WithoutAClockItStillTimesSomething(t *testing.T) {
+	t.Parallel()
+
+	clicks := NewClicks(nil)
+	if clicks.Double("row:1") {
+		t.Error("the first click reported a double")
+	}
+	if !clicks.Double("row:1") {
+		t.Error("two clicks in the same microsecond did not report a double")
+	}
+}

--- a/internal/ui/widget/drag.go
+++ b/internal/ui/widget/drag.go
@@ -1,0 +1,76 @@
+package widget
+
+import tea "charm.land/bubbletea/v2"
+
+// Drag is the press, move, release gesture: what was grabbed, and how far the
+// pointer has come from where it grabbed it.
+//
+// Nothing binds it yet. No view in this build has two panes, so there is no
+// divider to drag and no ratio to persist; the view that grows a second pane
+// binds this rather than writing the state machine again. It is here because the
+// machine is the part that is easy to get wrong — a release that lands outside
+// the element still ends the drag it started, and a move that arrives without a
+// press is not one.
+type Drag struct {
+	id     string
+	fromX  int
+	fromY  int
+	atX    int
+	atY    int
+	active bool
+}
+
+// Start grabs the element name at the press position. An empty name is a press
+// on nothing draggable and starts nothing, which is what a view passes when its
+// hit test missed.
+func (d *Drag) Start(name string, msg tea.MouseMsg) bool {
+	if name == "" {
+		return false
+	}
+	at := msg.Mouse()
+	d.id, d.active = name, true
+	d.fromX, d.fromY = at.X, at.Y
+	d.atX, d.atY = at.X, at.Y
+	return true
+}
+
+// Move follows the pointer and reports how far it has come from the press. It
+// reports false while nothing is being dragged, which is most motion messages:
+// cell-motion reporting sends them with no button held too.
+func (d *Drag) Move(msg tea.MouseMsg) (dx, dy int, ok bool) {
+	if !d.active {
+		return 0, 0, false
+	}
+	at := msg.Mouse()
+	d.atX, d.atY = at.X, at.Y
+	return d.atX - d.fromX, d.atY - d.fromY, true
+}
+
+// Release ends the drag wherever the pointer is, inside the element it grabbed
+// or far outside it. A divider dragged past the edge of its own zone is still
+// the divider being dragged, so the bounds are not checked again here: the
+// press decided what is being dragged and nothing since can change it.
+func (d *Drag) Release(msg tea.MouseMsg) (dx, dy int, ok bool) {
+	if !d.active {
+		return 0, 0, false
+	}
+	dx, dy, _ = d.Move(msg)
+	d.Cancel()
+	return dx, dy, true
+}
+
+// Cancel drops the gesture without applying it, which is what a view does when
+// something else takes over — a resize, a view switch, a key.
+func (d *Drag) Cancel() {
+	d.id, d.active = "", false
+	d.fromX, d.fromY, d.atX, d.atY = 0, 0, 0, 0
+}
+
+// Active reports whether a drag is under way.
+func (d *Drag) Active() bool { return d.active }
+
+// ID is the element the press grabbed, empty when nothing is being dragged.
+func (d *Drag) ID() string { return d.id }
+
+// At is where the pointer is now, and is meaningful only while Active.
+func (d *Drag) At() (x, y int) { return d.atX, d.atY }

--- a/internal/ui/widget/drag_test.go
+++ b/internal/ui/widget/drag_test.go
@@ -1,0 +1,133 @@
+package widget
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func motion(x, y int) tea.MouseMotionMsg {
+	return tea.MouseMotionMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
+
+func release(x, y int) tea.MouseReleaseMsg {
+	return tea.MouseReleaseMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
+
+func TestDrag_ReportsHowFarThePointerHasComeFromThePress(t *testing.T) {
+	t.Parallel()
+
+	var d Drag
+	if !d.Start("divider", clickAt(40, 10)) {
+		t.Fatal("a press on the divider started no drag")
+	}
+	if !d.Active() || d.ID() != "divider" {
+		t.Fatalf("the drag is active=%v on %q", d.Active(), d.ID())
+	}
+
+	dx, dy, ok := d.Move(motion(46, 12))
+	if !ok || dx != 6 || dy != 2 {
+		t.Errorf("moving to (46,12) reported (%d,%d,%v), want (6,2,true)", dx, dy, ok)
+	}
+	if x, y := d.At(); x != 46 || y != 12 {
+		t.Errorf("the pointer is at (%d,%d), want (46,12)", x, y)
+	}
+
+	dx, dy, ok = d.Move(motion(30, 10))
+	if !ok || dx != -10 || dy != 0 {
+		t.Errorf("moving back to (30,10) reported (%d,%d,%v), want (-10,0,true)", dx, dy, ok)
+	}
+
+	dx, dy, ok = d.Release(release(31, 10))
+	if !ok || dx != -9 || dy != 0 {
+		t.Errorf("releasing at (31,10) reported (%d,%d,%v), want (-9,0,true)", dx, dy, ok)
+	}
+	if d.Active() || d.ID() != "" {
+		t.Errorf("the drag is still active=%v on %q after a release", d.Active(), d.ID())
+	}
+}
+
+// A pointer that leaves the divider it grabbed is still dragging it: a release
+// far outside the original bounds completes the gesture rather than dropping it.
+func TestDrag_ReleasingOutsideTheElementStillEndsTheDrag(t *testing.T) {
+	t.Parallel()
+
+	var d Drag
+	d.Start("divider", clickAt(40, 10))
+
+	dx, dy, ok := d.Release(release(200, -4))
+	if !ok {
+		t.Fatal("a release well outside the divider ended nothing")
+	}
+	if dx != 160 || dy != -14 {
+		t.Errorf("the release reported (%d,%d), want (160,-14)", dx, dy)
+	}
+	if d.Active() {
+		t.Error("the drag is still active after a release outside the element")
+	}
+}
+
+func TestDrag_IgnoresWhatWasNeverPressed(t *testing.T) {
+	t.Parallel()
+
+	for name, act := range map[string]func(d *Drag) (int, int, bool){
+		"a motion with nothing held":     func(d *Drag) (int, int, bool) { return d.Move(motion(10, 10)) },
+		"a release with nothing pressed": func(d *Drag) (int, int, bool) { return d.Release(release(10, 10)) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var d Drag
+			if dx, dy, ok := act(&d); ok || dx != 0 || dy != 0 {
+				t.Errorf("%s reported (%d,%d,%v), want no drag", name, dx, dy, ok)
+			}
+			if d.Active() {
+				t.Errorf("%s left a drag under way", name)
+			}
+		})
+	}
+}
+
+func TestDrag_APressOnNothingDraggableStartsNothing(t *testing.T) {
+	t.Parallel()
+
+	var d Drag
+	if d.Start("", clickAt(5, 5)) {
+		t.Error("a press that hit no element started a drag")
+	}
+	if d.Active() {
+		t.Error("a press that hit no element left a drag under way")
+	}
+}
+
+func TestDrag_ASecondPressGrabsTheNewElement(t *testing.T) {
+	t.Parallel()
+
+	var d Drag
+	d.Start("divider", clickAt(40, 10))
+	d.Move(motion(48, 10))
+	d.Start("other", clickAt(12, 4))
+
+	if d.ID() != "other" {
+		t.Fatalf("the drag is on %q, want the element pressed last", d.ID())
+	}
+	dx, dy, _ := d.Move(motion(14, 4))
+	if dx != 2 || dy != 0 {
+		t.Errorf("the delta is measured from (%d,%d), want it measured from the second press", dx, dy)
+	}
+}
+
+func TestDrag_CancelDropsTheGesture(t *testing.T) {
+	t.Parallel()
+
+	var d Drag
+	d.Start("divider", clickAt(40, 10))
+	d.Cancel()
+
+	if d.Active() || d.ID() != "" {
+		t.Fatalf("cancel left the drag active=%v on %q", d.Active(), d.ID())
+	}
+	if _, _, ok := d.Release(release(50, 10)); ok {
+		t.Error("a release after cancel applied a drag nobody was making")
+	}
+}

--- a/internal/ui/widget/scroll.go
+++ b/internal/ui/widget/scroll.go
@@ -1,0 +1,32 @@
+package widget
+
+// Window is the part of a rendered pane that fits: height lines starting at
+// top, moved as little as it takes to keep the line at keep on screen. It
+// returns the offset it settled on so the caller can store it back, which is
+// what makes a wheel and a cursor agree about where the pane is.
+//
+// It slices rather than copies, so drawing a windowed pane costs nothing per
+// frame. A keep of -1 means no line has to stay visible.
+func Window(lines []string, top, height, keep int) (visible []string, at int) {
+	if height <= 0 {
+		return nil, 0
+	}
+	if len(lines) <= height {
+		return lines, 0
+	}
+	top = min(max(top, 0), len(lines)-height)
+	if keep >= 0 && keep < len(lines) {
+		switch {
+		case keep < top:
+			top = keep
+		case keep >= top+height:
+			top = keep - height + 1
+		}
+	}
+	return lines[top : top+height], top
+}
+
+// WheelStep is how many lines one notch of the wheel moves. Three is what a
+// terminal emulator sends a pager, and what every other pane in this program
+// already scrolls by.
+const WheelStep = 3

--- a/internal/ui/widget/scroll_test.go
+++ b/internal/ui/widget/scroll_test.go
@@ -1,0 +1,96 @@
+package widget
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+func numbered(n int) []string {
+	out := make([]string, 0, n)
+	for i := range n {
+		out = append(out, "line "+strconv.Itoa(i))
+	}
+	return out
+}
+
+func TestWindow_ShowsTheLinesThatFitAndKeepsTheOneThatMatters(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		lines       int
+		top, height int
+		keep        int
+		wantFirst   string
+		wantTop     int
+		wantLines   int
+	}{
+		"everything fits, so there is nothing to scroll": {
+			lines: 4, height: 10, keep: 3, wantFirst: "line 0", wantTop: 0, wantLines: 4,
+		},
+		"an offset inside the range is kept": {
+			lines: 40, top: 12, height: 6, keep: -1, wantFirst: "line 12", wantTop: 12, wantLines: 6,
+		},
+		"an offset past the end is pulled back to the last screen": {
+			lines: 40, top: 400, height: 6, keep: -1, wantFirst: "line 34", wantTop: 34, wantLines: 6,
+		},
+		"a negative offset is pulled back to the top": {
+			lines: 40, top: -8, height: 6, keep: -1, wantFirst: "line 0", wantTop: 0, wantLines: 6,
+		},
+		"a line above the window pulls the window up to it": {
+			lines: 40, top: 20, height: 6, keep: 3, wantFirst: "line 3", wantTop: 3, wantLines: 6,
+		},
+		"a line below the window pulls the window down to it": {
+			lines: 40, top: 0, height: 6, keep: 9, wantFirst: "line 4", wantTop: 4, wantLines: 6,
+		},
+		"a line already on screen moves nothing": {
+			lines: 40, top: 10, height: 6, keep: 12, wantFirst: "line 10", wantTop: 10, wantLines: 6,
+		},
+		"a line that does not exist is ignored": {
+			lines: 40, top: 10, height: 6, keep: 400, wantFirst: "line 10", wantTop: 10, wantLines: 6,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, at := Window(numbered(tc.lines), tc.top, tc.height, tc.keep)
+			if at != tc.wantTop {
+				t.Errorf("the window settled at %d, want %d", at, tc.wantTop)
+			}
+			if len(got) != tc.wantLines {
+				t.Fatalf("the window is %d lines, want %d", len(got), tc.wantLines)
+			}
+			if got[0] != tc.wantFirst {
+				t.Errorf("the window opens on %q, want %q", got[0], tc.wantFirst)
+			}
+		})
+	}
+}
+
+func TestWindow_ANoHeightPaneDrawsNothing(t *testing.T) {
+	t.Parallel()
+
+	got, at := Window(numbered(10), 4, 0, 2)
+	if len(got) != 0 || at != 0 {
+		t.Errorf("a pane with no height drew %d lines at %d, want none", len(got), at)
+	}
+}
+
+// The window is a slice of what it was handed, not a copy of it: a pane redrawn
+// on every frame must not allocate one.
+func TestWindow_SlicesRatherThanCopies(t *testing.T) {
+	t.Parallel()
+
+	lines := numbered(40)
+	got, _ := Window(lines, 10, 6, -1)
+	if len(got) == 0 {
+		t.Fatal("the window is empty")
+	}
+	if unsafe.SliceData(got) != unsafe.SliceData(lines[10:]) {
+		t.Error("the window copied the lines it was handed")
+	}
+	if strings.Join(got, "\n") == "" {
+		t.Error("the window holds nothing")
+	}
+}

--- a/internal/ui/widget/zone.go
+++ b/internal/ui/widget/zone.go
@@ -1,0 +1,83 @@
+// Package widget holds the interaction pieces more than one view needs: the
+// zone marking every clickable element does, the double-click Bubble Tea does
+// not report, the drag a two-pane view will need, and the window a scrolled
+// pane draws through.
+//
+// Nothing here renders anything on its own. A widget is a helper a view holds,
+// not a model it embeds, so a view keeps its own Update and its own frame.
+package widget
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	zone "github.com/lrstanley/bubblezone/v2"
+)
+
+// Zoner is one view instance's slice of the zone manager: the prefix that keeps
+// its ids apart from every other view's, and the two calls it makes with them.
+//
+// The manager is absent in a session with nowhere to put a mouse — a benchmark,
+// a test that never clicks — and disabled in one started with mouse = false.
+// Both answer the same way: Mark writes nothing into the frame and Hit misses,
+// so a view needs no branch of its own for either.
+//
+// The zero Zoner is usable and marks nothing, which is what a view built with
+// no manager gets.
+type Zoner struct {
+	mgr    *zone.Manager
+	prefix string
+}
+
+// NewZoner mints one view instance's prefix. Call it once, where the view is
+// built: a prefix per frame would put a fresh id in the manager's permanent id
+// map on every draw.
+func NewZoner(mgr *zone.Manager) Zoner {
+	if mgr == nil {
+		return Zoner{}
+	}
+	return Zoner{mgr: mgr, prefix: mgr.NewPrefix()}
+}
+
+// Enabled reports whether the mouse is on at all. A view asks when it would
+// otherwise draw something only a pointer can reach.
+func (z Zoner) Enabled() bool { return z.mgr != nil && z.mgr.Enabled() }
+
+// ID is the manager-wide id a name resolves to, which is what a test looks a
+// zone up by.
+func (z Zoner) ID(name string) string { return z.prefix + name }
+
+// Mark wraps s so that a click inside it resolves back to name. The markers are
+// private escape sequences of zero display width, so a marked string still
+// measures and truncates as what it draws.
+func (z Zoner) Mark(name, s string) string {
+	if z.mgr == nil {
+		return s
+	}
+	return z.mgr.Mark(z.prefix+name, s)
+}
+
+// MarkLines marks a block as one zone: the id opens on the first line and
+// closes on the last, so the rectangle recorded covers the whole block rather
+// than the shape of its last line.
+func (z Zoner) MarkLines(name string, lines []string) []string {
+	if z.mgr == nil || len(lines) == 0 {
+		return lines
+	}
+	marked := z.Mark(name, strings.Join(lines, "\n"))
+	if marked == "" {
+		return lines
+	}
+	return strings.Split(marked, "\n")
+}
+
+// Hit reports whether a mouse message landed inside the element marked name.
+// This is the only way a view resolves a click: bubblezone records where a
+// marked string was actually drawn, and arithmetic on coordinates does not
+// survive a resize, a scroll or a truncated cell.
+func (z Zoner) Hit(name string, msg tea.MouseMsg) bool {
+	if z.mgr == nil {
+		return false
+	}
+	return z.mgr.Get(z.prefix + name).InBounds(msg)
+}

--- a/internal/ui/widget/zone_test.go
+++ b/internal/ui/widget/zone_test.go
@@ -1,0 +1,153 @@
+package widget
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	zone "github.com/lrstanley/bubblezone/v2"
+)
+
+// scanned draws a frame the way the kernel does and waits for the manager to
+// record what it found. Zones land on the manager's own goroutine, so a test
+// that asks straight after scanning asks too early.
+func scanned(t *testing.T, mgr *zone.Manager, z Zoner, frame string, names ...string) string {
+	t.Helper()
+
+	out := mgr.Scan(frame)
+	deadline := time.Now().Add(5 * time.Second)
+	for _, name := range names {
+		for mgr.Get(z.ID(name)).IsZero() {
+			if time.Now().After(deadline) {
+				t.Fatalf("the zone %q was never recorded from the frame %q", name, frame)
+			}
+			runtime.Gosched()
+		}
+	}
+	return out
+}
+
+func clickAt(x, y int) tea.MouseClickMsg {
+	return tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
+
+// Nothing in this file strips ANSI, and nothing may: a marker left in a frame
+// with the mouse off is exactly what stripping hides.
+func TestZoner_MarksNothingWhenThereIsNoMouse(t *testing.T) {
+	t.Parallel()
+
+	off := zone.New()
+	t.Cleanup(off.Close)
+	off.SetEnabled(false)
+
+	for name, z := range map[string]Zoner{
+		"the zero value, built with no manager": {},
+		"a manager disabled by mouse = false":   NewZoner(off),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			const row = "PROJ-1  Fix the thing"
+			if got := z.Mark("row:PROJ-1", row); got != row {
+				t.Errorf("Mark returned %q, want the row unchanged", got)
+			}
+			lines := []string{"one", "two"}
+			marked := z.MarkLines("block", lines)
+			if strings.ContainsRune(strings.Join(marked, "\n"), '\x1b') {
+				t.Errorf("MarkLines wrote an escape into %q, which terminal text selection picks up", marked)
+			}
+			if z.Hit("row:PROJ-1", clickAt(0, 0)) {
+				t.Error("a click hit a zone that was never marked")
+			}
+			if z.Enabled() {
+				t.Error("Enabled is true with the mouse off")
+			}
+		})
+	}
+}
+
+func TestZoner_ResolvesAClickToTheElementItLandedIn(t *testing.T) {
+	t.Parallel()
+
+	mgr := zone.New()
+	t.Cleanup(mgr.Close)
+	z := NewZoner(mgr)
+
+	frame := z.Mark("row:PROJ-1", "PROJ-1  first") + "\n" + z.Mark("row:PROJ-2", "PROJ-2  second")
+	if !z.Enabled() {
+		t.Fatal("a live manager reports the mouse off")
+	}
+	scanned(t, mgr, z, frame, "row:PROJ-1", "row:PROJ-2")
+
+	for _, tc := range []struct {
+		name  string
+		click tea.MouseClickMsg
+		want  string
+	}{
+		{name: "the first row", click: clickAt(3, 0), want: "row:PROJ-1"},
+		{name: "the second row", click: clickAt(3, 1), want: "row:PROJ-2"},
+		{name: "below every row", click: clickAt(3, 9), want: ""},
+		{name: "past the end of a row", click: clickAt(60, 0), want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ""
+			for _, name := range []string{"row:PROJ-1", "row:PROJ-2"} {
+				if z.Hit(name, tc.click) {
+					got = name
+					break
+				}
+			}
+			if got != tc.want {
+				t.Errorf("a click at (%d,%d) hit %q, want %q", tc.click.X, tc.click.Y, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestZoner_MarkedLinesCoverTheWholeBlockAndNotItsLastLine(t *testing.T) {
+	t.Parallel()
+
+	mgr := zone.New()
+	t.Cleanup(mgr.Close)
+	z := NewZoner(mgr)
+
+	lines := z.MarkLines("comment:1", []string{"Ada wrote        ", "the body of it   ", "and signed it off"})
+	scanned(t, mgr, z, strings.Join(lines, "\n"), "comment:1")
+
+	for _, y := range []int{0, 1, 2} {
+		if !z.Hit("comment:1", clickAt(2, y)) {
+			t.Errorf("a click on line %d missed the block it was drawn in", y)
+		}
+	}
+	if z.Hit("comment:1", clickAt(2, 3)) {
+		t.Error("a click below the block hit it")
+	}
+}
+
+// Two views drawing the same element name must not answer for each other's
+// clicks, which is the whole reason a prefix is minted per instance.
+func TestZoner_TwoViewsMarkTheSameNameApart(t *testing.T) {
+	t.Parallel()
+
+	mgr := zone.New()
+	t.Cleanup(mgr.Close)
+	first, second := NewZoner(mgr), NewZoner(mgr)
+
+	if first.ID("row:1") == second.ID("row:1") {
+		t.Fatalf("both views mark row:1 as %q, so one view's click resolves in the other", first.ID("row:1"))
+	}
+
+	frame := first.Mark("row:1", "the first view's row") + "\n\n" + second.Mark("row:1", "the second view's row")
+	scanned(t, mgr, first, frame, "row:1")
+	scanned(t, mgr, second, frame, "row:1")
+
+	click := clickAt(2, 0)
+	if !first.Hit("row:1", click) {
+		t.Error("the click missed the row of the view that drew it there")
+	}
+	if second.Hit("row:1", click) {
+		t.Error("the click hit the other view's row of the same name")
+	}
+}


### PR DESCRIPTION
P3.3 — Mouse. Closes #14.

## The scope changed, and the audit is why

The roadmap row said **owns `internal/ui/widget/zone*.go` + zone wiring in own files**.
`internal/ui/widget/` did not exist, so "own files" was the empty set: on day one this packet owned
nothing that renders, while every shipped view already marked zones and handled clicks — about 280
mouse and zone references across six packages. So the first job was finding out what was left. The
full audit is [on the issue](https://github.com/varijkapil13/saral/issues/14#issuecomment-5407133503);
the summary:

| docs/UX.md's gesture | What was actually in the tree |
|---|---|
| click a row | built, in all six views |
| double-click to open | built as a heuristic — *and the heuristic was wrong*, see below |
| wheel | built in `list`, `form`, `comment`, `issue` detail, `onboarding`; missing in `issue`'s edit and move panes, **which could not scroll at all** |
| drag divider | nothing to drag → cut, #75 |
| click a status chip / label / assignee | **not built anywhere** — the one missing user-facing gesture |
| click footer entry | built in W0-b |
| right-click a row | cut, #76 |

The `owns` line in the row is corrected to the paths this PR touches, and the row now says what was
already built versus what this packet added.

## What this changes

**Clickable cells, with a real filter behind them.** Clicking a row's status, type or assignee cell
narrows the list to that value; clicking the same cell again shows everything. It is a facet match on
the value the row draws, not a substring search, so narrowing to a status called *Shipped* does not
also keep an issue whose summary mentions shipping. It composes with `/` — a row has to survive both —
and the paging that fills a screen a filter emptied treats it the same way.

Because `esc` in a root view never reaches the view (the kernel spends it) and there is no letter left
to bind, the narrowing has to be discoverable without a key: it names itself in a line under the rows
(`only status "Shipped"    click it again to clear`), and the palette carries *show only rows with this
row's status / type / assignee* and *show every row again*. Those four commands register no `Keys`, so
`internal/ui/keys_test.go`'s sweep stays honest.

**Labels are clickable nowhere, and docs/UX.md now says so** instead of promising it: the list's
columns are key, summary, type, status, assignee and updated, and the detail pane that does list
labels has nothing of its own to filter. When a view draws a label it can narrow by, it marks it the
way the list marks a cell.

**A double-click is timed.** `tea.MouseClickMsg` is `Mouse{X, Y, Button, Mod}` — no click count, no
instant — so every view had reached for "a second click on the row that is already selected". That
cannot tell a double-click from two deliberate clicks a minute apart, so pointing at an issue and then
pointing at it again opened it, handed a description to `$EDITOR`, or took a value in a picker.
`widget.Clicks` times the pair against `Deps.Now` over a 400 ms window; every call site that used the
heuristic now uses it (list rows, form rows, form type list, form picker, comment blocks, edit fields,
transition list). A test per package proves the slow pair does nothing.

**The two missing wheels, and the scrolling they needed.** `internal/ui/issue`'s edit pane and move
pane did not ignore only `MouseWheelMsg` — they did not scroll at all: both built every line and let
`fit()` clip at the height, so on a short terminal the last field was unreachable by wheel *and* by
cursor. Both now draw through `widget.Window`, with the title pinned and the footer keeping its lines.
The offset is shared by the wheel and the cursor: a cursor that moves pulls the window with it once,
and after that the wheel is free — which is how `internal/ui/list` has always behaved.

**`internal/ui/widget`** is the idiom that was in all five view packages, made one thing:

- `Zoner` — a per-instance prefix plus `Mark`, `MarkLines`, `Hit`, `Enabled`, `ID`. The zero value and
  a manager disabled by `mouse = false` behave identically: nothing is written into the frame and every
  hit misses, so no view needs `if deps.Zones != nil` any more (onboarding had a third check for the
  same condition). All five packages adopted it — `grep -rn 'widget\.' internal/ui` returns a hit per
  view package plus the definition and its tests.
- `Clicks` — the timed double-click above.
- `Window` — the scrolled window, slicing rather than copying so a scrolled pane costs no allocation.
- `Drag` — press, move, release, **bound to nothing**, with its state machine tested including a
  release far outside the element it grabbed. #75 is why: there is no divider until a view has two
  panes, and P6.3 binds this when it builds one.

## The golden that changed

One golden is new — `list_facet_120x30.golden`, the list narrowed to a status by a click: the count
reads `4 of 12`, only the four *Shipped* rows are drawn, the cursor has stayed on the row whose chip
was clicked, and the last line names the narrowing. No existing golden moved: the zone markers are
zero-width private escapes that `ansi.Strip` removes, and the new line is drawn only while a facet is
on.

## Things checked because they are easy to get wrong

- **`mouse = false` stays genuinely off.** `internal/ui/list`'s new test asserts a frame drawn with a
  disabled manager and a flattened theme contains no `\x1b` at all — no `ansi.Strip` anywhere near it,
  since stripping is what hid this leak for four batches — and that a synthesised click narrows
  nothing. `widget`'s own table covers the zero value and the disabled manager together.
- **Zone id growth.** `Mark` fills a permanent id map and bubblezone frees nothing. Every id here is a
  per-instance prefix plus a stable name, so redrawing reuses an id: the two `issue` panes and the form
  are bounded by the terminal's height (they key on row index), and the list mints four per issue —
  which grows with the rows a user actually scrolls past, not with the project. `docs/ARCHITECTURE.md`
  now says this plainly, including the one case that is not bounded: a pushed view mints a fresh prefix
  on every push.
- **Hit-testing is zone lookup only.** No coordinate arithmetic was added. The cells are nested zones
  inside the row's own zone, marked *inside* what the row memo holds, and the click asks the cells
  before the row because a click on a status is in bounds for both.
- **A marked row still measures as what it draws.** `render_test.go` now runs its exact-width table
  over a marked zoner as well as an unmarked one, at four widths, with emoji, ZWJ and CJK summaries,
  selected and not. The selected row is styled as one line *around* cells that already carry markers,
  so there is a test that the chip on the selected row is still where it looks.

## Budgets

Unmoved: `BenchmarkFrame` 297 allocs/op, `BenchmarkKeyToFrame` 310, list steady scroll 1 alloc/op.
The markers live inside the memoized row, so a steady-state frame with the mouse on is still one
allocation — there is a new `BenchmarkListSteadyScrollMarked10k` and a test asserting it, because if
the marks had been applied outside the memo the whole window would be rebuilt every frame. A memo
*miss* costs 15 → 22 allocs and 3.1 → 3.4 µs per row for the three extra marks; keystroke-to-frame at
10k rows stays far inside 16 ms.

## Verification

`go mod tidy` (no change), `go vet ./...`, `golangci-lint run` (0 issues), `go test -race -count=1
./...`, a trimmed build, `scripts/checkleak.py`. No `go.mod` change, nothing outside the owned paths,
and no `internal/ui/kernel/**`, `internal/ui/palette/**` or `internal/app/**` in the diff.

`internal/app`'s `TestRun_CollapsesIdenticalSearchesThatAreInFlightAtOnce` failed once under
whole-suite load and passes on its own — #58, and this packet does not touch that package.

## Exact library symbols used

Read from the module cache rather than assumed. bubbletea v2.0.9 `mouse.go`: `tea.MouseMsg` (the
interface, with `Mouse() Mouse`), `tea.Mouse{X, Y, Button, Mod}`, `tea.MouseClickMsg`,
`tea.MouseReleaseMsg`, `tea.MouseWheelMsg`, `tea.MouseMotionMsg`, `tea.MouseButton`, `tea.MouseLeft`,
`tea.MouseWheelUp`, `tea.MouseWheelDown` — and confirmed there is no click count and no timestamp on
any of them. bubblezone v2.0.0: `zone.New`, `(*Manager).NewPrefix`, `.Mark`, `.Get`, `.Scan`,
`.SetEnabled`, `.Enabled`, `.Close`, and `(*ZoneInfo).InBounds`, `.IsZero`, `.StartX/StartY/EndX/EndY`.
`Pos` exists and is deliberately unused — resolving a cell from a position inside the row's zone would
be the coordinate arithmetic `docs/ARCHITECTURE.md` forbids.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
