### PR TITLE
test(app): hold the coalescing check until every caller has joined the flight

### DIFF
--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -126,7 +126,7 @@ type Search struct {
 	client SearchClient
 	saved  SavedQueries
 
-	flight singleflight.Group
+	flight flights
 
 	mu        sync.Mutex
 	catalogue []jira.Field
@@ -319,6 +319,15 @@ const coalesceAttempts = 3
 // say on its own.
 var errLeaderLeft = errors.New("app: the caller that started this request left")
 
+// flights is the group identical calls collapse into.
+type flights struct {
+	group singleflight.Group
+	// joined fires on a caller's own goroutine the moment that caller is
+	// registered in the group, which is the first instant it is certain to share
+	// a call rather than start one. Nothing outside a test sets it.
+	joined func(key string)
+}
+
 // coalesce runs one call for however many callers ask for it at the same
 // moment.
 //
@@ -326,22 +335,25 @@ var errLeaderLeft = errors.New("app: the caller that started this request left")
 // the only caller really does cancel the work. When that caller leaves while
 // others are still waiting, one of them starts the call again rather than
 // inheriting a cancellation it did not ask for.
-func coalesce[T any](ctx context.Context, group *singleflight.Group, key string, fn func(context.Context) (T, error)) (T, error) {
+func coalesce[T any](ctx context.Context, in *flights, key string, fn func(context.Context) (T, error)) (T, error) {
 	var zero T
 	for range coalesceAttempts {
 		if err := ctx.Err(); err != nil {
 			return zero, err
 		}
-		shared := group.DoChan(key, func() (any, error) {
+		shared := in.group.DoChan(key, func() (any, error) {
 			out, err := fn(ctx)
 			if ctx.Err() != nil {
 				return nil, errLeaderLeft
 			}
 			return out, err
 		})
+		if in.joined != nil {
+			in.joined(key)
+		}
 		select {
 		case <-ctx.Done():
-			group.Forget(key)
+			in.group.Forget(key)
 			return zero, ctx.Err()
 		case res := <-shared:
 			if errors.Is(res.Err, errLeaderLeft) {

--- a/internal/app/search_test.go
+++ b/internal/app/search_test.go
@@ -325,19 +325,27 @@ func TestRun_CollapsesIdenticalSearchesThatAreInFlightAtOnce(t *testing.T) {
 	}
 	s := NewSearch(blocking)
 
-	var entered atomic.Int64
+	// Joining the flight is the barrier: a caller merely started would
+	// legitimately begin a second search once this one had finished.
+	wanted := searchKey(jira.Query{JQL: testJQL, Fields: ListProjection().IDs})
+	var joined atomic.Int64
+	s.flight.joined = func(key string) {
+		if key == wanted {
+			joined.Add(1)
+		}
+	}
+
 	results := make(chan error, callers)
 	for range callers {
 		go func() {
-			entered.Add(1)
 			_, err := s.Run(t.Context(), Request{JQL: testJQL, Projection: ListProjection()})
 			results <- err
 		}()
 	}
 
 	<-blocking.arrived
-	waitFor(t, "every caller to have reached the search", func() bool {
-		return entered.Load() == callers
+	waitFor(t, "every caller to have joined the search in flight", func() bool {
+		return joined.Load() == callers
 	})
 	close(blocking.release)
 	for range callers {


### PR DESCRIPTION
## Packet

Not a roadmap packet — the flaky coalescing test reported while landing PC.1.

Closes #58

## What changed

`TestRun_CollapsesIdenticalSearchesThatAreInFlightAtOnce` no longer counts
goroutines that have *started*. It waits until every caller is registered in the
flight group, which is the first moment a caller is certain to share the call in
progress rather than begin one of its own.

The old barrier was `entered.Add(1)` before `s.Run`, so a caller still inside
`Resolve` counted as being in flight. Under whole-suite load that gap widens:
the release fires, the leader's flight completes, and the straggler then
*correctly* starts a second search. The failure read

```
search_test.go:350: the adapter ran 2 searches, want 1: a cursor moving down a list must not fan out a fetch per keystroke
```

which is indistinguishable from a real coalescing regression, so every person
and agent who hit it had to rule out a bug in `internal/app/search.go` first.
That was the cost, and it is why retrying CI was not the fix.

The production code was right and is unchanged in behaviour. To make the barrier
exact, `Search.flight` became a `flights`: the `singleflight.Group` plus a
`joined` hook that fires on the caller's own goroutine once `DoChan` has
returned — that is, once the caller is in the group. Nothing but the test sets
it; production pays one nil check per coalesced call. A test-only seam is the
honest answer here because `singleflight` exposes no way to ask how many callers
have attached to a flight, and every other candidate barrier (an arrival counted
in the fake client, a delay, a goroutine count) either cannot see the waiters at
all or is the same race with a shorter window.

The assertion is untouched: four concurrent identical searches, exactly one
fetch.

### Reproduced before it was fixed

- The whole `internal/app` suite, `-count=30 -cpu 1,2`, with 16 busy loops
  competing for the CPU: **5 failures in 60 runs on `main`** ("ran 2", "ran 3",
  "ran 4").
- The same load, narrowed to the scenario so it can be run often —
  `-run Collapses -count=1000 -cpu 1,2` (2000 executions), 16 busy loops and a
  suite loop alongside for allocation pressure: **5 failures on `main`**, and
  **0 in 3200 executions with this change**, `-race` and not.
- A 2 ms delay inserted between `entered.Add(1)` and `s.Run` — the scheduling gap
  load opens, made explicit — fails the old test on most runs. Instrumented, the
  extra searches provably start *after* the release: "3 of the 4 searches started
  after the barrier released". With the new barrier, the same injected delay is
  green over 200 plain and 600 `-race` runs at GOMAXPROCS 1, 2 and 8.

### The assertion still bites

Two mutants of `search.go`, both reverted:

- every caller gets its own group (`(&singleflight.Group{}).DoChan`) →
  `the adapter ran 4 searches, want 1: a cursor moving down a list must not fan out a fetch per keystroke`
- `Run` calls `s.client.Search` directly, no coalescer →
  `timed out waiting for every caller to have joined the search in flight`

### One more of these, not in these owned paths

`pkg/jira/cloud/client_test.go` has the same shape twice, and I have left both
alone:

- `TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce` (line 536) waits for
  `runtime.NumGoroutine() > 0 && len(s.Requests()) == 1`. The first is always
  true and the second is already true when the barrier runs, because
  `jiratest.Server` records a request *before* calling the handler that signals
  `arrived`. So it waits for nothing, and its own assertion ("the site served %d
  requests, want 1") is the same false alarm waiting to happen.
- `TestCoalesce_...LeaderLeaves` (line 622) waits for `len(s.Requests()) == 1` to
  mean "the follower reached the call in flight" — again already true. Benign
  today, since both orderings end up serving 2, but the barrier means nothing.

Worth its own issue against whoever owns `pkg/jira/cloud`.

## Definition of done

- [x] Works against `pkg/jira/jiratest` — no live Jira needed to run the tests
- [x] Failure paths tested: 403 (capability), 429 (rate limit), transport error — unchanged and still covered by `TestRun_ReturnsTheAdaptersOwnTypedFailure`
- [x] Golden-file tests for any rendering; diffs reviewed, not blind-updated — n/a, nothing renders here
- [x] Nothing instance-specific hardcoded (field IDs, statuses, project keys, permissions)
- [x] Keybindings and mouse zones registered, not hardcoded — n/a
- [x] Benchmarks added/updated if a render or list path was touched — n/a, no render or list path touched
- [x] Stayed inside the packet's owned paths
- [x] `make check` green
- [x] `docs/ROADMAP.md` checkbox ticked in this PR — n/a, this is not a roadmap packet

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
