### PR TITLE
fix(list): say why a search came back empty, and keep saying it

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -388,6 +388,27 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
   counter, the call site and the frecency table that packet already owns, and W0-b landed
   `CommandRanMsg{ID, Keys}` as the signal. A second counter in the chrome would be a second answer.
 
+## First-run corrections · found by running against a site
+
+The first end-to-end run — the real Cloud adapter against a Jira on loopback, driving the real kernel
+and views — found the spine works and turned up defects that would dead-end a testing session. They
+are filed and fixed here rather than in a batch, because Batch 3 is closed and none of them is a
+feature. Each is one PR, small and tested, in the paths it names.
+
+- [x] **F1 — A failed search must not look like a hang** · [#94](https://github.com/varijkapil13/saral/issues/94) · **owns** `internal/ui/list/**` including its `testdata/**`, the transport sentence in `pkg/jira/cloud/client.go`, `docs/{UX,ROADMAP}.md`
+  `appendEmpty` drew "Searching…" whenever `!m.loaded` and `failed()` never touched `loaded`, so a
+  wrong project key, a bad JQL, a dead host and a rate limit were one screen that looked hung — and
+  the status line carrying the reason was wiped by the next keypress. An empty pane now names which
+  of five kinds of empty it is and keeps naming it; the failed one carries the reason in the error's
+  own words, the JQL it was asked about, and the key that runs it again. Both ways in are the same
+  line: a first load, and any retarget, which drops the rows before the new search is issued.
+  The transport sentence lost the URL it repeated after the method and path `TransportError.Op`
+  already carries, which is what truncated it before "connection refused". No error type and no
+  classification moved; the cause still satisfies `errors.Is`.
+  Adjacent, in the same path: a filter accepted with `enter` had the count reading `1 of 3` as its
+  only trace and no way off it, since `esc` in a root view belongs to the kernel. It is named under
+  the rows the way a clicked cell is, `ctrl+g` clears it, and the palette carries the same gesture.
+
 ## Batch 4 — Attachments · parallel ×3
 
 - [ ] **P4.1 — List and download** · [#17](https://github.com/varijkapil13/saral/issues/17) · **owns** `pkg/jira/cloud/attachment.go`

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -80,6 +80,7 @@ quit                   q / ctrl+c     only from a root view, and only when nothi
 palette                ctrl+k         everything, fuzzy; opens over what you were in, esc returns.
                                       the one global a view taking typing cannot swallow
 search in view         /              filter rows live
+clear that filter      ctrl+g         from the browsing state; esc does it while still typing
 save this search       s              bind the query on screen to a number key
 refresh                r / R          current view / purge and refetch
 ```
@@ -192,6 +193,13 @@ carries *show only rows with this row's status / type / assignee* and *show ever
 anyone without a pointer. It composes with `/`: both are things being left out, and a row has to
 survive both.
 
+**And `/`'s own filter is named the same way once it has been accepted.** `esc` closes the prompt and
+keeps the filter, and after that `esc` belongs to the kernel, so the count reading `1 of 3` was the
+only trace a filter was on at all and the only way off it was to open it again. So a kept filter gets
+the line under the rows too, `ctrl+g` clears it — the stroke `esc` already answers to while the
+prompt is open, which is why it is not a new key to learn — and the palette carries *clear the filter
+on these rows*. The footer offers `ctrl+g` only while there is a filter to clear.
+
 Two gestures this table used to promise are not built, and are not being built here:
 
 - **Drag a divider to resize panes** — [#75](https://github.com/varijkapil13/saral/issues/75). There
@@ -242,3 +250,16 @@ the mouse — click, wheel, drag or release — reaches the view while the help 
 - Stale data is badged rather than hidden. Seeing yesterday's board beats seeing nothing.
 - Errors state what failed and what to do. `403` becomes "You need the Bulk Change permission to move
   issues between projects", which is the capability `Reason` verbatim.
+- **The status line is transient, so nothing that has to persist may live only there.** It is one
+  line, it is overwritten by the next thing that happens, and a keypress clears it. Anything that is
+  still true after that keypress belongs in the pane as well: a stale badge, a refusal, a count.
+- **An empty pane says which kind of empty it is, in words, and keeps saying it.** There are five,
+  and a user cannot act on the difference unless the screen names it: no site in this session,
+  nothing asked of it yet, a search in flight, an answer with no rows in it — worth naming the JQL —
+  and a search that failed, which also carries the reason and the key that tries again. All of them
+  drew "Searching…" once, so a wrong project key, a bad JQL, a dead host and a rate limit were one
+  screen that looked like a hang.
+- **A message the user has to read must fit the terminal they have.** A sentence that leads with a
+  method, a path and then the same URL again is truncated before it says what went wrong, which is
+  worse than saying less: the endpoint is worth one mention, and the reason goes where it survives a
+  narrow window. Where the reason cannot be shortened, the pane wraps it rather than cutting it.

--- a/internal/ui/list/bench_test.go
+++ b/internal/ui/list/bench_test.go
@@ -80,6 +80,29 @@ func BenchmarkListSteadyScroll20(b *testing.B) { scroll(b, loaded(b, 20, 120, 40
 // it did before there were any.
 func BenchmarkListSteadyScrollMarked10k(b *testing.B) { scroll(b, markedList(b, 10000, 120, 40)) }
 
+// BenchmarkListSteadyScrollFiltered10k is the same scroll under a filter that
+// has been accepted, which draws a line naming it under the rows.
+func BenchmarkListSteadyScrollFiltered10k(b *testing.B) {
+	scroll(b, narrowed(b, 10000, 120, 40))
+}
+
+// narrowed is a list with a filter typed and accepted, which is what a user
+// browses in after pressing enter.
+func narrowed(tb testing.TB, n, w, h int) *Model {
+	tb.Helper()
+	m := loaded(tb, n, w, h)
+	for _, key := range []tea.Msg{keyPress("/"), tea.KeyPressMsg{Code: 'l', Text: "l"},
+		tea.KeyPressMsg{Code: 'o', Text: "o"}, tea.KeyPressMsg{Code: 'g', Text: "g"}, keyPress("enter")} {
+		next, _ := m.Update(key)
+		m, _ = next.(*Model)
+	}
+	if m.query == "" || len(m.view) == len(m.issues) {
+		tb.Fatalf("the filter left %d of %d rows, so this is not the narrowed state", len(m.view), len(m.issues))
+	}
+	_ = m.View()
+	return m
+}
+
 // BenchmarkListWalk10k walks a fresh row into view on every frame, which is the
 // worst case: every frame misses the memo by construction.
 func BenchmarkListWalk10k(b *testing.B) {
@@ -187,6 +210,17 @@ func TestScrolling_CostsTheSameWithTheMouseOn(t *testing.T) {
 	marked := testing.Benchmark(BenchmarkListSteadyScrollMarked10k)
 	if got := marked.AllocsPerOp(); got > 1 {
 		t.Errorf("a steady-state frame with the mouse on allocates %d times, want the memo to carry all but the frame itself", got)
+	}
+}
+
+// The line that names an accepted filter is on every frame it is on, so it is
+// memoized the way the summary is.
+func TestScrolling_CostsTheSameUnderAFilterThatHasBeenAccepted(t *testing.T) {
+	t.Parallel()
+
+	narrow := testing.Benchmark(BenchmarkListSteadyScrollFiltered10k)
+	if got := narrow.AllocsPerOp(); got > 1 {
+		t.Errorf("a steady-state frame under a kept filter allocates %d times, want the frame string and nothing else", got)
 	}
 }
 

--- a/internal/ui/list/empty_test.go
+++ b/internal/ui/list/empty_test.go
@@ -1,0 +1,334 @@
+package list
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// refusedConnection is the shape the Cloud adapter gives a site that is not
+// listening: the endpoint in Op, and the reason on its own.
+func refusedConnection() error {
+	return &jira.TransportError{
+		Op:  "POST /rest/api/3/search/jql",
+		Err: errors.New("dial tcp 127.0.0.1:62630: connect: connection refused"),
+	}
+}
+
+// sized builds the view and gives it a box, and stops there — which is the state
+// kernel.FirstPaint renders, since it never calls Init.
+func sized(t *testing.T, d kernel.Deps, w, h int) *Model {
+	t.Helper()
+	m, ok := New(d).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	next, _ := m.Update(kernel.SizeMsg{Width: w, Height: h})
+	sized, ok := next.(*Model)
+	if !ok {
+		t.Fatal("Update did not return a *Model")
+	}
+	return sized
+}
+
+// emptyPanes are the four answers a pane with no rows has to be able to give.
+// Each is built the way a session reaches it rather than by setting the fields.
+var emptyPanes = []struct {
+	name  string
+	file  string
+	build func(t *testing.T, w, h int) *Model
+	says  []string
+}{
+	{
+		name:  "nothing has been asked yet",
+		file:  "unasked",
+		build: func(t *testing.T, w, h int) *Model { return sized(t, testDeps(newFake(0)), w, h) },
+		says:  []string{"Nothing has been asked of Jira yet."},
+	},
+	{
+		name: "a search in flight",
+		file: "searching",
+		build: func(t *testing.T, w, h int) *Model {
+			m := sized(t, testDeps(newFake(0)), w, h)
+			// Init has run begin(); the command it returned has not, so this is
+			// the frame between the question and the answer.
+			_ = m.Init()
+			t.Cleanup(m.stop)
+			return m
+		},
+		says: []string{"Searching", "searching"},
+	},
+	{
+		name:  "an answer with no rows in it",
+		file:  "none",
+		build: func(t *testing.T, w, h int) *Model { return newDriver(t, testDeps(newFake(0)), w, h).m },
+		says:  []string{"Nothing matches this search.", "currentUser()", "0 issues"},
+	},
+	{
+		name: "a search that failed",
+		file: "failed",
+		build: func(t *testing.T, w, h int) *Model {
+			f := newFake(0)
+			f.FailNext(refusedConnection())
+			return newDriver(t, testDeps(f), w, h).m
+		},
+		says: []string{"The search failed.", "connection refused", "no answer", retryHint},
+	},
+}
+
+func TestEmptyPane_SaysWhichKindOfEmptyItIs(t *testing.T) {
+	t.Parallel()
+
+	for _, pane := range emptyPanes {
+		t.Run(pane.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := pane.build(t, 120, 30)
+			mustContain(t, ansi.Strip(m.View()), pane.says...)
+		})
+	}
+}
+
+// Four states that read the same are one state with four names.
+func TestEmptyPane_NoTwoOfThemReadTheSame(t *testing.T) {
+	seen := make(map[string]string, len(emptyPanes))
+	for _, pane := range emptyPanes {
+		body := ansi.Strip(pane.build(t, 120, 30).View())
+		if other, clash := seen[body]; clash {
+			t.Errorf("%q and %q draw the same pane:\n%s", pane.name, other, body)
+		}
+		seen[body] = pane.name
+	}
+}
+
+func TestEmptyPane_Golden(t *testing.T) {
+	t.Parallel()
+
+	for _, size := range []struct{ w, h int }{{120, 30}, {80, 20}} {
+		for _, pane := range emptyPanes {
+			t.Run(fmt.Sprintf("%s at %dx%d", pane.name, size.w, size.h), func(t *testing.T) {
+				t.Parallel()
+
+				m := pane.build(t, size.w, size.h)
+				name := fmt.Sprintf("list_empty_%s_%dx%d.golden", pane.file, size.w, size.h)
+				golden(t, name, ansi.Strip(m.View()))
+			})
+		}
+	}
+}
+
+// The status line is transient by design: the next thing that happens writes
+// over it, so the pane has to carry the reason itself.
+func TestFailedSearch_KeepsSayingWhyAfterAKeypress(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(0)
+	f.FailNext(refusedConnection())
+	dr := newDriver(t, testDeps(f), 120, 30)
+
+	mustContain(t, dr.view(), "The search failed.", "connection refused")
+	mustNotContain(t, dr.view(), "Searching")
+
+	dr.key("j", "k", "G", "g", "g")
+	mustContain(t, dr.view(), "The search failed.", "connection refused")
+}
+
+// A retarget drops the rows before the new search is issued, so a search that
+// then fails leaves the pane with nothing to badge.
+func TestFailedRetarget_SaysSoRatherThanLookingLikeASearchStillRunning(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	dr := openAll(t, testDeps(f), 120, 30)
+	if len(dr.m.issues) == 0 {
+		t.Fatal("no rows were on screen, so this proves nothing about dropping them")
+	}
+
+	refused := `the project "NOPE" does not exist`
+	f.FailNext(&jira.ValidationError{Fields: []jira.FieldError{{Field: "jql", Message: refused}}})
+	dr.send(QueryMsg{JQL: `project = "NOPE" ORDER BY key`, Title: "Nope"})
+
+	mustNotContain(t, dr.view(), "Searching")
+	mustContain(t, dr.view(), "The search failed.", refused)
+
+	dr.key("j")
+	mustContain(t, dr.view(), refused)
+}
+
+// r is the kernel's refresh, which the pane names, so after a failure it has to
+// run the search again.
+func TestFailedSearch_RefreshRunsItAgainAndTheRowsComeBack(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(6)
+	dr := openAll(t, testDeps(f), 120, 30)
+	want := len(dr.m.issues)
+
+	f.FailNext(refusedConnection())
+	dr.send(QueryMsg{JQL: allJQL, Title: "All issues"})
+	mustContain(t, dr.view(), "The search failed.")
+
+	before := countCalls(f, "Search")
+	dr.send(kernel.RefreshMsg{})
+
+	if got := countCalls(f, "Search") - before; got != 1 {
+		t.Errorf("the retry made %d searches, want exactly one", got)
+	}
+	if dr.m.failure != nil {
+		t.Errorf("the failure outlived a search that worked: %v", dr.m.failure)
+	}
+	if got := len(dr.m.issues); got != want {
+		t.Errorf("the retry brought back %d rows, want the %d the search holds", got, want)
+	}
+	mustNotContain(t, dr.view(), "The search failed.")
+}
+
+func TestFailedPane_ReportsWhatTheErrorItselfSays(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err  error
+		want string
+	}{
+		// docs/UX.md: a 403 reaches the user as the capability's Reason, whole.
+		"a permission the token does not have": {
+			err: &jira.CapabilityError{
+				Capability: jira.CapBoards,
+				Reason:     "You need the Browse Projects permission for this project",
+			},
+			want: "You need the Browse Projects permission for this project",
+		},
+		"the rate limiter": {
+			err:  &jira.RateLimitError{RetryAfter: 30 * time.Second},
+			want: "rate limited by Jira, retry in 30s",
+		},
+		"a query the site refused": {
+			err:  &jira.ValidationError{Fields: []jira.FieldError{{Field: "jql", Message: "unknown field 'projec'"}}},
+			want: "jql: unknown field 'projec'",
+		},
+		"a host that is not listening": {
+			err:  refusedConnection(),
+			want: "dial tcp 127.0.0.1:62630: connect: connection refused",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(0)
+			f.FailNext(tc.err)
+			dr := newDriver(t, testDeps(f), 120, 30)
+
+			mustContain(t, dr.view(), tc.want)
+			dr.key("j")
+			mustContain(t, dr.view(), tc.want)
+		})
+	}
+}
+
+// The sentence led with the method, the path and the whole URL, so on a terminal
+// somebody actually has, the part saying what went wrong was the part cut off.
+func TestFailedPane_SaysWhyInsideEightyColumns(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(0)
+	f.FailNext(refusedConnection())
+	dr := newDriver(t, testDeps(f), 80, 20)
+
+	mustContain(t, dr.view(), "connection refused")
+	for i, line := range strings.Split(dr.view(), "\n") {
+		if got := ansi.StringWidth(line); got > 80 {
+			t.Errorf("line %d is %d columns wide: %q", i, got, line)
+		}
+	}
+}
+
+func TestFilter_IsNamedUnderTheRowsAndClearedFromBrowsing(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(40)), 120, 30)
+	dr.key("/")
+	dr.typeText("login")
+	dr.key("enter")
+
+	if narrowed := len(dr.m.view); narrowed == 0 || narrowed == len(dr.m.issues) {
+		t.Fatalf("the filter leaves %d of %d rows, so this proves nothing", narrowed, len(dr.m.issues))
+	}
+	mustContain(t, dr.view(), `only rows matching "login"`, "ctrl+g")
+
+	set, gen := dr.m.LiveKeys()
+	if gen != int(keysNarrowed) {
+		t.Errorf("a kept filter reports key state %d, want %d", gen, keysNarrowed)
+	}
+	if !strings.Contains(shortOf(set), "clear filter") {
+		t.Errorf("the footer of a narrowed list does not offer the key that widens it: %s", shortOf(set))
+	}
+
+	dr.key("ctrl+g")
+
+	if got := len(dr.m.view); got != len(dr.m.issues) {
+		t.Errorf("%d of %d rows came back", got, len(dr.m.issues))
+	}
+	mustNotContain(t, dr.view(), "only rows matching")
+	if state, _ := dr.m.LiveKeys(); shortOf(state) != shortOf(liveSets[keysBrowsing]) {
+		t.Errorf("the footer still advertises a filter there is none of: %s", shortOf(state))
+	}
+}
+
+func TestFilter_KeptGolden(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(40)), 120, 30)
+	dr.key("/")
+	dr.typeText("login")
+	dr.key("enter")
+
+	golden(t, "list_kept_filter_120x30.golden", dr.view())
+}
+
+// The palette reaches the same gesture the key does, which is what makes the
+// filter clearable without one.
+func TestClearFilterCommand_IsRegisteredAndClearsWhatWasTyped(t *testing.T) {
+	t.Parallel()
+
+	var unfilter kernel.Command
+	for _, cmd := range kernel.Commands() {
+		if cmd.ID == "issues.clear-filter" {
+			unfilter = cmd
+		}
+	}
+	if unfilter.ID == "" {
+		t.Fatal("issues.clear-filter is not in the registry, so the palette cannot reach it")
+	}
+
+	var sent bool
+	for _, msg := range collect(unfilter.Run(kernel.Deps{})) {
+		if got, ok := msg.(kernel.BroadcastMsg); ok {
+			_, sent = got.Msg.(ClearFilterMsg)
+		}
+	}
+	if !sent {
+		t.Fatal("the command broadcasts no ClearFilterMsg")
+	}
+
+	dr := openAll(t, testDeps(newFake(40)), 120, 30)
+	dr.key("/")
+	dr.typeText("login")
+	dr.key("enter")
+	dr.send(ClearFilterMsg{})
+
+	if dr.m.query != "" {
+		t.Errorf("the filter still reads %q", dr.m.query)
+	}
+	if got := len(dr.m.view); got != len(dr.m.issues) {
+		t.Errorf("%d of %d rows came back", got, len(dr.m.issues))
+	}
+}

--- a/internal/ui/list/keys.go
+++ b/internal/ui/list/keys.go
@@ -19,6 +19,10 @@ type keyMap struct {
 	Save     kernel.Binding
 	Accept   kernel.Binding
 	Clear    kernel.Binding
+	// Unfilter takes an accepted filter off from the browsing state. esc is not
+	// one of its keys: the kernel keeps that for itself in a root view, so naming
+	// it here would advertise a stroke that never arrives.
+	Unfilter kernel.Binding
 	// Slot, Take and Drop answer the gesture that binds the search on screen to
 	// a number key. bindKey reads the digit and the y itself, because every other
 	// key ends the gesture and a table would have to enumerate the alphabet to
@@ -44,6 +48,7 @@ func defaultKeys() keyMap {
 		Save:     kernel.Bind([]string{"s"}, "s", "save this query to a key"),
 		Accept:   kernel.Bind([]string{"enter"}, "enter", "keep filter"),
 		Clear:    kernel.Bind([]string{"esc", "ctrl+g"}, "esc", "clear filter"),
+		Unfilter: kernel.Bind([]string{"ctrl+g"}, "ctrl+g", "clear filter"),
 		Slot:     kernel.Bind(digits, "1-9", "the key to bind it to"),
 		Take:     kernel.Bind([]string{"y"}, "y", "take the key"),
 		Drop:     kernel.Bind([]string{"esc"}, "esc", "leave it alone"),
@@ -55,13 +60,23 @@ var digits = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}
 // keySet is the resting state: a list nobody is typing into. Nothing here is a
 // second copy of the bindings above — both come from the same value, so a key
 // that moves cannot leave a stale hint behind.
-func (k keyMap) keySet() kernel.KeySet {
+func (k keyMap) keySet() kernel.KeySet { return k.browsing(false) }
+
+// browsing is the resting state, with or without a filter already narrowing the
+// rows. The narrowed one offers the key that clears it.
+func (k keyMap) browsing(narrowed bool) kernel.KeySet {
+	short := []kernel.Binding{k.Down, k.Up, k.Open, k.Filter}
+	actions := []kernel.Binding{k.Open, k.Filter, k.Save}
+	if narrowed {
+		short = []kernel.Binding{k.Down, k.Up, k.Open, k.Unfilter}
+		actions = []kernel.Binding{k.Open, k.Filter, k.Unfilter, k.Save}
+	}
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Open, k.Filter},
+		Short: short,
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
-			{k.Open, k.Filter, k.Save},
+			actions,
 		},
 	}
 }
@@ -73,6 +88,7 @@ type keyState int
 
 const (
 	keysBrowsing keyState = iota
+	keysNarrowed
 	keysFiltering
 	keysPickingSlot
 	keysConfirmingSlot
@@ -85,6 +101,7 @@ var liveSets = func() [keyStates]kernel.KeySet {
 	k := defaultKeys()
 	var sets [keyStates]kernel.KeySet
 	sets[keysBrowsing] = k.keySet()
+	sets[keysNarrowed] = k.browsing(true)
 	sets[keysFiltering] = kernel.KeySet{
 		Short: []kernel.Binding{k.Accept, k.Clear},
 		Full:  [][]kernel.Binding{{k.Accept, k.Clear}},
@@ -102,7 +119,8 @@ var liveSets = func() [keyStates]kernel.KeySet {
 
 // LiveKeys reports the keys that work in the state the list is actually in. An
 // open filter answers enter and esc and nothing else; the gesture that binds a
-// number key answers a digit, then a y.
+// number key answers a digit, then a y; a list already narrowed by a filter
+// offers the key that widens it again.
 func (m *Model) LiveKeys() (set kernel.KeySet, gen int) {
 	state := keysBrowsing
 	switch {
@@ -112,6 +130,8 @@ func (m *Model) LiveKeys() (set kernel.KeySet, gen int) {
 		state = keysPickingSlot
 	case m.bind == bindConfirm:
 		state = keysConfirmingSlot
+	case m.keptFilter():
+		state = keysNarrowed
 	}
 	return liveSets[state], int(state)
 }
@@ -147,7 +167,7 @@ func (k keyMap) tables() (normal, filtering map[string]action) {
 		binding{k.HalfDown, actHalfDown}, binding{k.HalfUp, actHalfUp},
 		binding{k.Go, actGo}, binding{k.Top, actTop}, binding{k.Bottom, actBottom},
 		binding{k.Open, actOpen}, binding{k.Filter, actFilter},
-		binding{k.Save, actSave},
+		binding{k.Unfilter, actClear}, binding{k.Save, actSave},
 	)
 	filtering = table(binding{k.Accept, actAccept}, binding{k.Clear, actClear})
 	return normal, filtering

--- a/internal/ui/list/keys_test.go
+++ b/internal/ui/list/keys_test.go
@@ -18,6 +18,7 @@ func TestLiveKeys_EveryStateGolden(t *testing.T) {
 		state keyState
 	}{
 		{"browsing", keysBrowsing},
+		{"a filter kept on the rows", keysNarrowed},
 		{"filter open", keysFiltering},
 		{"picking the number key", keysPickingSlot},
 		{"confirming a number key that is taken", keysConfirmingSlot},
@@ -42,7 +43,8 @@ func TestLiveKeys_FollowWhatTheListIsDoing(t *testing.T) {
 		enter func()
 		state keyState
 	}{
-		{"browsing", func() { m.filtering, m.bind = false, bindNone }, keysBrowsing},
+		{"browsing", func() { m.filtering, m.bind, m.query = false, bindNone, "" }, keysBrowsing},
+		{"a filter kept on the rows", func() { m.query = "login" }, keysNarrowed},
 		{"filter open", func() { m.filtering = true }, keysFiltering},
 		{"picking a key", func() { m.filtering, m.bind = false, bindPick }, keysPickingSlot},
 		{"confirming a key", func() { m.bind = bindConfirm }, keysConfirmingSlot},

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -77,6 +77,8 @@ type Model struct {
 	lines   []string
 	summary string
 	sumKey  summaryKey
+	chip    string
+	chipKey chipKey
 
 	filtering bool
 	filter    textinput.Model
@@ -104,6 +106,11 @@ type Model struct {
 	loaded  bool
 	gen     int
 	cancel  context.CancelFunc
+
+	// failure is why the search on screen brought back no rows. The status line
+	// kernel.Fail writes is replaced by the next keypress, so the pane keeps its
+	// own copy of the reason for as long as it is empty.
+	failure error
 
 	// stale marks the rows on screen as older than they should be: they came off
 	// disk past their TTL, or the refresh that would have replaced them failed.
@@ -226,6 +233,10 @@ type QueryMsg struct {
 // does, rather than a second implementation of it.
 type SaveQueryMsg struct{}
 
+// ClearFilterMsg drops the filter narrowing the rows. It is exported for the
+// same reason FacetMsg is: the palette has to reach the gesture the key does.
+type ClearFilterMsg struct{}
+
 // Init asks the site for what the first frame could not draw from disk.
 func (m *Model) Init() tea.Cmd {
 	if m.loaded {
@@ -284,6 +295,9 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 
 	case FacetMsg:
 		cmd = m.facetMsg(msg)
+
+	case ClearFilterMsg:
+		cmd = m.clearFilter()
 
 	case loadedMsg:
 		cmd = m.loadedPage(msg)
@@ -364,10 +378,13 @@ func (m *Model) widestKey() int {
 }
 
 // rowsHeight is how many issue rows fit: the box, less the summary line, the
-// column captions and the filter prompt when one is open.
+// column captions and whichever of the four lines below the rows are drawn.
 func (m *Model) rowsHeight() int {
 	h := m.height - 2
 	if m.facet.on() {
+		h--
+	}
+	if m.keptFilter() {
 		h--
 	}
 	if m.filtering || m.bind != bindNone {
@@ -387,7 +404,7 @@ func (m *Model) begin() (ctx context.Context, gen int) {
 	m.gen++
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-	m.loading = true
+	m.loading, m.failure = true, nil
 	return ctx, m.gen
 }
 
@@ -459,7 +476,7 @@ func (m *Model) setQuery(jql, title string, byDefault bool) tea.Cmd {
 	}
 	m.issues, m.page, m.missing, m.view, m.needles = nil, jira.Page[jira.Issue]{}, nil, nil, nil
 	m.cursor, m.top, m.loaded = 0, 0, false
-	m.cachedMore, m.stale = false, false
+	m.cachedMore, m.stale, m.failure = false, false, nil
 	m.facet = facet{}
 	m.rows.reset()
 	m.refilter()
@@ -527,6 +544,10 @@ func (m *Model) patch(msg patchedMsg) tea.Cmd {
 // failed keeps whatever is on screen. Rows that are already drawn are the last
 // true answer this session had, so a refusal badges them rather than clearing
 // them (docs/UX.md — stale data is badged, not hidden).
+//
+// With no rows to badge the refusal is all there is, so it is kept. A retarget
+// reaches that state as well as a first load: it drops the rows it had before
+// the search that replaces them is issued.
 func (m *Model) failed(msg failedMsg) tea.Cmd {
 	if !m.current(msg.gen) {
 		return nil
@@ -534,6 +555,8 @@ func (m *Model) failed(msg failedMsg) tea.Cmd {
 	m.loading = false
 	if len(m.issues) > 0 {
 		m.stale = true
+	} else {
+		m.failure = msg.err
 	}
 	var limit *jira.RateLimitError
 	if errors.As(msg.err, &limit) {
@@ -730,9 +753,11 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 		return m.open()
 	case actFilter:
 		return m.startFilter()
+	case actClear:
+		return m.clearFilter()
 	case actSave:
 		m.startBind()
-	case actNone, actAccept, actClear:
+	case actNone, actAccept:
 	}
 	return nil
 }
@@ -747,10 +772,7 @@ func (m *Model) filterKey(msg tea.KeyPressMsg, stroke string) tea.Cmd {
 	case actClear:
 		m.filtering = false
 		m.filter.Blur()
-		m.filter.Reset()
-		m.query, m.needles = "", nil
-		m.refilter()
-		m.scrollToCursor()
+		m.dropFilter()
 		return nil
 	default:
 	}
@@ -765,6 +787,25 @@ func (m *Model) filterKey(msg tea.KeyPressMsg, stroke string) tea.Cmd {
 		return m.pageAheadIfNeeded()
 	}
 	return nil
+}
+
+// clearFilter drops a filter that has already been accepted. The kernel takes
+// esc in a root view and never forwards it, so without this a filter put on with
+// / and enter comes off only by opening it again.
+func (m *Model) clearFilter() tea.Cmd {
+	if m.query == "" {
+		return nil
+	}
+	m.dropFilter()
+	return nil
+}
+
+// dropFilter forgets the query and the haystacks that were built to match it.
+func (m *Model) dropFilter() {
+	m.filter.Reset()
+	m.query, m.needles = "", nil
+	m.refilter()
+	m.scrollToCursor()
 }
 
 func (m *Model) startFilter() tea.Cmd {
@@ -911,6 +952,9 @@ func (m *Model) View() string {
 	if m.facet.on() {
 		lines = append(lines, m.facetPrompt())
 	}
+	if m.keptFilter() {
+		lines = append(lines, m.filterChip())
+	}
 	if m.filtering {
 		lines = append(lines, m.filter.View())
 	}
@@ -961,6 +1005,7 @@ type summaryKey struct {
 	loading, loaded bool
 	filtered        bool
 	stale           bool
+	failed          bool
 }
 
 func (m *Model) summaryKey() summaryKey {
@@ -968,7 +1013,7 @@ func (m *Model) summaryKey() summaryKey {
 		title: m.title, width: m.width, gen: m.styles.gen,
 		issues: len(m.issues), visible: len(m.view), more: m.hasMore(),
 		loading: m.loading, loaded: m.loaded, filtered: m.filtered(),
-		stale: m.stale,
+		stale: m.stale, failed: m.failure != nil,
 	}
 }
 
@@ -1003,6 +1048,9 @@ func (m *Model) countLabel() string {
 	switch {
 	case !m.loaded && m.loading:
 		b.WriteString("searching")
+	case m.failure != nil:
+		// "0 issues" here would be a count of an answer nobody got.
+		b.WriteString("no answer")
 	case m.filtered():
 		b.WriteString(strconv.Itoa(len(m.view)))
 		b.WriteString(" of ")
@@ -1026,13 +1074,20 @@ func (m *Model) total() string {
 	return n
 }
 
+// appendEmpty says which kind of empty this is. Five of them are told apart
+// here, and the one that failed is the only one that also has to say what to do
+// about it.
 func (m *Model) appendEmpty(lines []string, h int) []string {
 	at := len(lines)
 	switch {
 	case m.search == nil:
 		lines = append(lines, m.styles.muted.Render("  No Jira connection in this session yet."))
-	case !m.loaded:
+	case m.loading && !m.loaded:
 		lines = append(lines, m.styles.muted.Render("  Searching"+m.deps.Theme.Glyphs.Ellipsis))
+	case m.failure != nil:
+		lines = m.appendFailure(lines, h)
+	case !m.loaded:
+		lines = append(lines, m.styles.muted.Render("  Nothing has been asked of Jira yet."))
 	case m.filtered():
 		lines = append(lines, m.styles.muted.Render("  No loaded row matches "+m.filterWords()+"."))
 	default:
@@ -1044,3 +1099,56 @@ func (m *Model) appendEmpty(lines []string, h int) []string {
 	}
 	return lines[:at+h]
 }
+
+// appendFailure is what the pane says instead of rows: the reason in the error's
+// own words, the query it was asked about, and the key that runs it again. The
+// reason is wrapped rather than cut, since a transport failure names a host and a
+// port before it says what is wrong with them.
+func (m *Model) appendFailure(lines []string, h int) []string {
+	reason, _ := jira.Reason(m.failure)
+	lines = append(lines, m.styles.danger.Render("  The search failed."))
+	room := max(m.width-2, 8)
+	said := strings.Split(ansi.Wrap(reason, room, ""), "\n")
+	for _, line := range said[:min(len(said), max(h-3, 1))] {
+		lines = append(lines, m.styles.muted.Render("  "+line))
+	}
+	return append(lines,
+		m.styles.muted.Render("  "+ansi.Truncate(m.jql, room, m.deps.Theme.Glyphs.Ellipsis)),
+		"",
+		m.styles.muted.Render("  "+retryHint))
+}
+
+// keptFilter reports that a filter is narrowing the rows while nothing is being
+// typed into it, which is the state with no prompt of its own to show it.
+func (m *Model) keptFilter() bool { return m.query != "" && !m.filtering }
+
+// chipKey is everything the accepted-filter line is built from, so that
+// scrolling under one costs what scrolling without one costs.
+type chipKey struct {
+	query      string
+	width, gen int
+}
+
+// filterChip names the filter the rows are being narrowed by, and the key that
+// takes it off — the same answer facetPrompt gives for a clicked cell, and for
+// the same reason.
+func (m *Model) filterChip() string {
+	key := chipKey{query: m.query, width: m.width, gen: m.styles.gen}
+	if m.chip != "" && key == m.chipKey {
+		return m.chip
+	}
+	label := "only rows matching " + strconv.Quote(m.query)
+	room := max(m.width-ansi.StringWidth(clearHint), 8)
+	m.chip = m.styles.prompt.Render(ansi.Truncate(label, room, m.deps.Theme.Glyphs.Ellipsis)) +
+		m.styles.muted.Render(clearHint)
+	m.chipKey = key
+	return m.chip
+}
+
+// The two sentences that name a key, spelt from the binding rather than written
+// out. The retry names the kernel's own refresh, which this view registers
+// nothing for.
+var (
+	retryHint = kernel.DefaultGlobalKeys().Refresh.Help().Key + " tries the search again."
+	clearHint = "  " + defaultKeys().Unfilter.Help().Key + " clears it"
+)

--- a/internal/ui/list/register.go
+++ b/internal/ui/list/register.go
@@ -34,6 +34,16 @@ func init() {
 			return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(SaveQueryMsg{}))
 		},
 	})
+	// No Keys: kernel.KeysFor holds a view's resting keys, and the stroke that
+	// clears a filter is shown only by the state that has one to clear.
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "issues.clear-filter",
+		Title: "Clear the filter on these rows",
+		Group: "Search",
+		Run: func(kernel.Deps) tea.Cmd {
+			return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(ClearFilterMsg{}))
+		},
+	})
 	// The cells a click narrows the rows by, reachable without a pointer. There
 	// is no key for them: every letter left is one somebody types into a filter.
 	for _, f := range []struct {

--- a/internal/ui/list/render.go
+++ b/internal/ui/list/render.go
@@ -100,6 +100,7 @@ type styles struct {
 	title      lipgloss.Style
 	count      lipgloss.Style
 	prompt     lipgloss.Style
+	danger     lipgloss.Style
 	categories [4]lipgloss.Style
 }
 
@@ -112,6 +113,7 @@ func newStyles(t *kernel.Theme) *styles {
 		title:    t.Title,
 		count:    t.Muted,
 		prompt:   t.Accent,
+		danger:   t.Danger,
 	}
 	s.categories = [4]lipgloss.Style{
 		jira.CategoryUnknown:    t.Muted,

--- a/internal/ui/list/testdata/keys.golden
+++ b/internal/ui/list/testdata/keys.golden
@@ -3,6 +3,11 @@ browsing
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
   full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
   full   [enter open, / filter, s save this query to a key]
+a filter kept on the rows
+  short  ↓/j down · ↑/k up · enter open · ctrl+g clear filter
+  full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
+  full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
+  full   [enter open, / filter, ctrl+g clear filter, s save this query to a key]
 filter open
   short  enter keep filter · esc clear filter
   full   [enter keep filter, esc clear filter]

--- a/internal/ui/list/testdata/list_empty_failed_120x30.golden
+++ b/internal/ui/list/testdata/list_empty_failed_120x30.golden
@@ -1,0 +1,29 @@
+My issues in PROJ                                                                                              no answer
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+  The search failed.
+  POST /rest/api/3/search/jql failed: dial tcp 127.0.0.1:62630: connect: connection refused
+  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC
+
+  r tries the search again.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_failed_80x20.golden
+++ b/internal/ui/list/testdata/list_empty_failed_80x20.golden
@@ -1,0 +1,19 @@
+My issues in PROJ                                                      no answer
+  KEY     SUMMARY                                        TYPE       STATUS      
+  The search failed.
+  POST /rest/api/3/search/jql failed: dial tcp 127.0.0.1:62630: connect:
+  connection refused
+  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC
+
+  r tries the search again.
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_none_120x30.golden
+++ b/internal/ui/list/testdata/list_empty_none_120x30.golden
@@ -1,0 +1,29 @@
+My issues in PROJ                                                                                               0 issues
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+  Nothing matches this search.
+  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_none_80x20.golden
+++ b/internal/ui/list/testdata/list_empty_none_80x20.golden
@@ -1,0 +1,19 @@
+My issues in PROJ                                                       0 issues
+  KEY     SUMMARY                                        TYPE       STATUS      
+  Nothing matches this search.
+  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_searching_120x30.golden
+++ b/internal/ui/list/testdata/list_empty_searching_120x30.golden
@@ -1,0 +1,29 @@
+My issues in PROJ                                                                                              searching
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+  Searching...
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_searching_80x20.golden
+++ b/internal/ui/list/testdata/list_empty_searching_80x20.golden
@@ -1,0 +1,19 @@
+My issues in PROJ                                                      searching
+  KEY     SUMMARY                                        TYPE       STATUS      
+  Searching...
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_unasked_120x30.golden
+++ b/internal/ui/list/testdata/list_empty_unasked_120x30.golden
@@ -1,0 +1,29 @@
+My issues in PROJ                                                                                               0 issues
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+  Nothing has been asked of Jira yet.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_empty_unasked_80x20.golden
+++ b/internal/ui/list/testdata/list_empty_unasked_80x20.golden
@@ -1,0 +1,19 @@
+My issues in PROJ                                                       0 issues
+  KEY     SUMMARY                                        TYPE       STATUS      
+  Nothing has been asked of Jira yet.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/list/testdata/list_kept_filter_120x30.golden
+++ b/internal/ui/list/testdata/list_kept_filter_120x30.golden
@@ -1,0 +1,30 @@
+All issues                                                                                                       3 of 40
+  KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
+  PROJ-22  Add the login flow                                    Defect     Building      Grace Hopper      03 Mar 13:00
+  PROJ-33  Retire the login flow                                 Story      Triage        Ada Lovelace      04 Mar 11:00
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+only rows matching "login"  ctrl+g clears it

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -1,6 +1,6 @@
  saral | Commands                                                                          PROJ | example.atlassian.net 
 > what do you want to do?                                                                                               
------------------------------------------------------------------------------------------------------------- 15 commands
+------------------------------------------------------------------------------------------------------------ 16 commands
 > Follow the terminal's own colours             Appearance                                                              
   Turn colour off                               Appearance                                                              
   Use the dark theme                            Appearance                                                              
@@ -8,6 +8,7 @@
   Issues                                        Go to                                                                 g1
   Change this issue's status                    Issue                                                                  t
   Edit this issue                               Issue                                                                  e
+  Clear the filter on these rows                Search                                                                  
   Issues I reported                             Search                                                                  
   My issues                                     Search                                                                  
   Save this query to a number key               Search                                                                 s
@@ -16,7 +17,6 @@
   Show only rows with this row's status         Search                                                                  
   Show only rows with this row's type           Search                                                                  
   Unassigned issues                             Search                                                                  
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/pkg/jira/cloud/client.go
+++ b/pkg/jira/cloud/client.go
@@ -431,9 +431,20 @@ func (c *Client) endpoint(r request) string {
 // failure turns whatever went wrong into the taxonomy in pkg/jira.
 func (c *Client) failure(r request, resp *response, err error) error {
 	if err != nil {
-		return &jira.TransportError{Op: r.op(), Err: err}
+		return &jira.TransportError{Op: r.op(), Err: cause(err)}
 	}
 	return c.apiError(r, resp)
+}
+
+// cause drops the wrapper net/http puts around a failed request. It repeats the
+// method and the whole URL, which Op already carries, and what a status line then
+// runs out of room for is the reason.
+func cause(err error) error {
+	var sent *url.Error
+	if errors.As(err, &sent) && sent.Err != nil {
+		return sent.Err
+	}
+	return err
 }
 
 // apiError maps a response Jira refused. The status is the authority: a body

--- a/pkg/jira/cloud/client_test.go
+++ b/pkg/jira/cloud/client_test.go
@@ -723,6 +723,41 @@ func TestWithHTTPClient_SendsThroughTheCallersClientAndMapsItsTimeout(t *testing
 	}
 }
 
+// A status line is one line wide, and the sentence a site that is not listening
+// produces has to have said why by the end of it.
+func TestFailure_NamesTheReasonWithoutRepeatingTheURLTheOpAlreadyCarries(t *testing.T) {
+	t.Parallel()
+
+	const why = "dial tcp 127.0.0.1:62630: connect: connection refused"
+	doer := &stubDoer{err: &url.Error{
+		Op:  "Post",
+		URL: "http://127.0.0.1:62630/rest/api/3/search/jql?fields=summary%2Cstatus",
+		Err: errors.New(why),
+	}}
+	c, _ := testClient(t, "127.0.0.1:62630", WithHTTPClient(doer), WithRetry(RetryPolicy{Attempts: 1}))
+
+	_, err := c.do(t.Context(), request{method: http.MethodPost, path: "/rest/api/3/search/jql", repeatable: true})
+	if err == nil {
+		t.Fatal("a site that is not listening produced no error")
+	}
+	said := err.Error()
+
+	if !strings.Contains(said, why) {
+		t.Errorf("the sentence does not say why: %q", said)
+	}
+	if !strings.Contains(said, "POST /rest/api/3/search/jql") {
+		t.Errorf("the sentence no longer names the endpoint, which a bug report needs: %q", said)
+	}
+	if strings.Contains(said, "http://127.0.0.1:62630/rest") {
+		t.Errorf("the sentence repeats the URL the endpoint already names: %q", said)
+	}
+	// 100 columns is a narrow terminal, not a small one, and the reason has to
+	// have arrived by then.
+	if cut := 100; len(said) > cut || !strings.Contains(said[:min(len(said), cut)], "connection refused") {
+		t.Errorf("the reason is %d characters in, past where a status line ends: %q", strings.Index(said, why), said)
+	}
+}
+
 func TestDecode_LeavesTheTargetAloneWhenTheAnswerHasNoBody(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #94.

An empty issue list drew `Searching…` whenever it held no rows, whatever had happened.
`appendEmpty` keyed off `!m.loaded` and `Model.failed()` set `loading = false` without ever touching
`loaded`, so a wrong project key, a bad JQL, an unreachable host and a rate limit were one screen
that looked like a hang — and the reason was on the status line, which the next keypress replaced.

Before, against a closed port:

```
My issues in PROJ                                                              0 issues
  Searching…
```

After:

```
My issues in PROJ                                                             no answer
  The search failed.
  POST /rest/api/3/search/jql failed: dial tcp 127.0.0.1:62630: connect: connection refused
  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC

  r tries the search again.
```

## What changed

**An empty pane names which kind of empty it is, and keeps naming it.** Five now, from three: no
site in this session, nothing asked of it yet, a search in flight, an answer with no rows in it, and
a search that failed. `Model.failure` holds the error for as long as the pane is empty, because
`kernel.Fail` writes a status line that the next keypress replaces — the pane needs a copy of its own
or the explanation is gone by the time the user reacts to it. The failed pane carries the reason in
the error's own words (a 403 is the `CapabilityError` `Reason`, whole), the JQL it was asked about,
and the key that runs it again, which is read off `kernel.DefaultGlobalKeys().Refresh` rather than
written out as `r`.

**Both ways in are the same line.** `failed()` keeps the error when there are no rows to badge;
`begin()` and `setQuery` clear it. A retarget drops its rows before the new search is issued, so a
search that then fails lands in exactly the state a failing first load does — and now says so
instead of showing a permanent `Searching…` where three rows had been a moment earlier.

**The count says `no answer`, not `0 issues`.** The old count was a count of an answer nobody got.

**The reason is wrapped, not truncated.** At 80 columns the transport sentence takes two lines and
`connection refused` survives; every line in the pane still measures within the width.

## The transport sentence

`pkg/jira/cloud`'s `failure()` drops the `*url.Error` that `net/http` wraps a failed request in. Its
method and URL are exactly what `TransportError.Op` already carries as the method and path, and
repeating them is what pushed the reason past the end of a status line:

```
- POST /rest/api/3/search/jql failed: Post "http://127.0.0.1:62630/rest/api/3/search/jql?fields=…": dial tcp 127.0.0.1:62630: connect: connection refused
+ POST /rest/api/3/search/jql failed: dial tcp 127.0.0.1:62630: connect: connection refused
```

`failure()` is the only site in the adapter that can receive that wrapper — everything `attempt()`
returns (the round trip, the body read, `NewRequestWithContext`, the concurrency gate) funnels
through it, and the other three `TransportError`s in the package are built from sentences of their
own. **No error type moved and nothing is classified differently:** the address and the syscall stay,
because `dial tcp <addr>: connect: connection refused` is the sentence a user can search for, and the
cause still satisfies `errors.Is` — the existing `os.ErrDeadlineExceeded` test proves it.

`pkg/jira/cloud/client_test.go` is outside the paths on the issue and has one test added to it. The
message cannot be asserted from anywhere else, and a fix to it with no test there is a fix that
regresses silently; it uses the `stubDoer` + `url.Error` pattern already in the file. Flag it if you
would rather it lived elsewhere.

## Adjacent, in the same path

A filter accepted with `enter` had the count reading `1 of 3` as its only trace, `esc` belongs to the
kernel in a root view, and the only way off it was `/` then `esc`. `keyMap.tables()` put `Clear` only
in the `filtering` table and `Model.key()` ignored `actClear`.

Now: the filter is named under the rows the way a clicked cell is (`only rows matching "login"`),
`ctrl+g` clears it from the browsing state, and the palette carries *Clear the filter on these rows*.

`ctrl+g` rather than `esc` — `esc` in a root view never reaches the view, so advertising it would
name a stroke that does nothing, which is the failure `docs/UX.md` principle 2 describes. `ctrl+g` is
already one of the strokes `esc` answers to while the prompt is open, so it is not a new key to
learn. It is a binding of its own rather than a second label on `Clear`, and a fifth `LiveKeys` state
advertises it **only while there is a filter to clear**.

The command registers **no** `Keys`. `kernel.KeysFor` holds a view's resting keys and this stroke is
shown only by the state that has something to clear, so teaching it there would name a key the
footer does not show — the same reason the facet commands carry none. The chip carries no mouse zone,
matching `facetPrompt`; the pointer route is the palette entry.

## Goldens — all of these are UI changes

- **Nine new** in `internal/ui/list/testdata`: the four empty panes at 120x30 and 80x20, and a list
  under a kept filter. The 80x20 failed pane is the one worth reading: the reason wraps and
  `connection refused` is on the second line rather than off the end of the first.
- **`keys.golden`** gains a fifth state between browsing and filtering. Its footer reads
  `↓/j down · ↑/k up · enter open · ctrl+g clear filter` where the resting one reads `/ filter`, and
  its help column gains `ctrl+g clear filter` beside `/ filter`.
- **`internal/ui/palette/testdata/session_120x30.golden`** gains one row and its count goes 15 → 16.
  That file is P3.1's, and it is a fixture of the whole command registry: any packet that registers a
  command has to update it. The diff is the new row and the number, nothing else.

## Consumers

- `internal/ui/list` is the only consumer of `Model.failure`, `ClearFilterMsg`, `keptFilter`,
  `filterChip` and `keyMap.Unfilter`; `grep` shows the definition, the call, the registration and the
  test for each.
- The transport sentence has three readers, and none of them classifies on the message:
  `internal/ui/onboarding`'s `connectFailed` and `pkg/jira/cloud/caps.go` both branch on
  `errors.As(&*jira.TransportError)`, and `kernel.Fail` renders whatever `jira.Reason` returns. All
  three now show a shorter sentence with the same meaning.
- `internal/ui/keys_test.go`'s registry sweep and `internal/ui/livekeys_test.go`'s reporter sweep
  both pass untouched.

## Budgets

`BenchmarkFrame` and `BenchmarkKeyToFrame` measure identically before and after this branch (298 and
311 allocs/op on this machine, on both). The line naming a kept filter is memoized the way the
summary line is — `chipKey` over the query, the width and the theme generation — and
`BenchmarkListSteadyScrollFiltered10k` plus `TestScrolling_CostsTheSameUnderAFilterThatHasBeenAccepted`
hold scrolling under one at the same single allocation a frame as scrolling without one. Rebuilding
the line per frame would have put three allocations under a keystroke that had one.

## Verification

```
go mod tidy && git diff --exit-code go.mod go.sum   clean
go vet ./... && golangci-lint run                   0 issues
go test -race -count=1 ./...                        all packages ok
go build -trimpath -ldflags "-s -w" ./cmd/saral     ok
python3 scripts/checkleak.py                        clean (no capture in this tree)
```

No fixture was touched and no capture has been run here.

## One thing left on the table

`retryHint` names `kernel.DefaultGlobalKeys().Refresh`, not the keymap the running kernel holds.
Nothing passes `kernel.WithGlobalKeys` today, so the two are the same string, but a session that
rebound refresh would be told to press `r`. `kernel.Deps` carries no keymap and the kernel is closed
this wave, so it stays as it is; worth an issue if `WithGlobalKeys` ever gets a caller.

## Note for whoever merges second

The other fix in this wave also registers commands, so it also has to update
`internal/ui/palette/testdata/session_120x30.golden`. Both changes are one row and a count in the
same fixture, so they will conflict textually. Whichever lands second wants
`go test ./internal/ui/palette -update` rather than a hand merge.
