### PR TITLE
fix(comments): open the comment thread from the issue you are reading

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -214,8 +214,10 @@ a thing Batch 2 would otherwise get quietly wrong.
   through `adf.ParseMarkdownInto`, which is the only way a mention keeps its account id. `EditComment`
   reads the comment before writing it so that a restriction the port cannot carry is echoed back
   rather than dropped. Unsent text is kept on disk per issue and per comment being edited.
-  The thread is reached by being pushed with an issue; the detail pane cannot push it yet
-  ([#67](https://github.com/varijkapil13/saral/issues/67)).
+  The thread is reached by being pushed with an issue. The detail pane does that on `c`
+  ([#67](https://github.com/varijkapil13/saral/issues/67)), which is what makes the whole packet
+  reachable: until then nothing in the program handed the view an issue, so writing, editing and
+  deleting a comment were all dead code.
 
 ## Batch 3 — Make it a daily driver · parallel ×5
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -160,6 +160,14 @@ wizard. `kernel.RegisterView` refuses a second claim on a slot at startup, so th
 enforced rather than merely written down — but it is written down so that six later packets do not
 each pick a number.
 
+A view that cannot be built without knowing what it is about is reached from the view that knows.
+The comment thread is the case: `c` on the issue detail pane pushes the thread for the issue on
+screen, so `esc` lands back on that issue, and the palette's *comment on this issue* is the same
+gesture reached without the key — it is a broadcast, because the palette knows which command was run
+and never which issue is on screen. Nothing offers to open the thread with no issue behind it. A
+pane that has to say "open an issue and come back" is a dead end when nothing can come back to it,
+and `kernel.Open` on such a view is how one gets built.
+
 Two things this table does not promise. There is no `tab`: no view has two panes yet, and the gesture
 that moves focus between them belongs to the first one that grows a second pane. And jumping to an
 issue by key — typing `PROJ-142`, or pasting a Jira URL — is not built; it is

--- a/internal/ui/comment/comment_test.go
+++ b/internal/ui/comment/comment_test.go
@@ -669,12 +669,15 @@ func TestRegistration_PutsTheViewItsKeysAndItsCommandsInTheRegistry(t *testing.T
 		t.Error("the comment view registered no keys, so the footer can say nothing about it")
 	}
 	want := map[string]bool{
-		"comments.open": false, "comments.write": false,
-		"comments.edit": false, "comments.delete": false,
+		"comments.write": false, "comments.edit": false, "comments.delete": false,
 	}
 	for _, cmd := range kernel.Commands() {
 		if _, ours := want[cmd.ID]; ours {
 			want[cmd.ID] = true
+		}
+		if cmd.ID == "comments.open" {
+			t.Error("something registers comments.open again; it switched to this view with no issue " +
+				"behind it, which is a pane nothing can then satisfy")
 		}
 	}
 	for id, found := range want {

--- a/internal/ui/comment/register.go
+++ b/internal/ui/comment/register.go
@@ -8,7 +8,11 @@ import (
 
 // The thread claims no footer slot: docs/UX.md keeps the digits for the views a
 // session lives in, and this one is about whichever issue is being read. It is
-// reached by being pushed with an issue, by name, and from the palette.
+// reached by being pushed with an issue, and by name.
+//
+// Nothing here opens it without one: a thread with no issue behind it is a pane
+// nothing can then satisfy. The view that holds an issue carries the key and the
+// palette entry that open this.
 func init() {
 	kernel.RegisterView(kernel.ViewSpec{
 		ID:    ViewID,
@@ -16,12 +20,6 @@ func init() {
 		New:   New,
 	})
 	kernel.RegisterKeys(ViewID, defaultKeys().keySet())
-	kernel.RegisterCommand(kernel.Command{
-		ID:    "comments.open",
-		Title: "Comments",
-		Group: "Go to",
-		Run:   func(kernel.Deps) tea.Cmd { return kernel.Open(ViewID) },
-	})
 	keys := defaultKeys()
 	for _, c := range []struct {
 		id, title string

--- a/internal/ui/issue/comments.go
+++ b/internal/ui/issue/comments.go
@@ -1,0 +1,44 @@
+package issue
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/comment"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// CommentsMsg asks whichever detail pane is open to put up the comment thread
+// for the issue it is showing. It is how the command palette reaches the same
+// gesture the key does rather than a second implementation of it: the palette
+// knows which command was run and never which issue is on screen.
+type CommentsMsg struct{}
+
+// commentsBinding is the key the detail pane hangs the thread off. It lives here
+// with the rest of reaching the thread, and is named in the pane's keymap so the
+// footer and the help overlay advertise it.
+//
+// "comment" and not "comments": one column longer drops the whole hint line in
+// an 80-column terminal, the smallest size docs/UX.md supports.
+func commentsBinding() kernel.Binding {
+	return kernel.Bind([]string{"c"}, "c", "comment")
+}
+
+func init() {
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "issue.comments",
+		Title: "Comment on this issue",
+		Group: "Issue",
+		Keys:  []string{commentsBinding().Help().Key},
+		Run:   func(kernel.Deps) tea.Cmd { return kernel.Broadcast(CommentsMsg{}) },
+	})
+}
+
+// openComments pushes the thread for the issue this pane is showing, so that esc
+// comes back to it. The read-only thread drawn inside the pane is a different
+// thing: that one is the first paint, this one can be written in.
+func (m *Model) openComments() tea.Cmd {
+	if m.issue.Key == "" {
+		return nil
+	}
+	return comment.Push(m.deps, m.issue.Key)
+}

--- a/internal/ui/issue/comments_kernel_test.go
+++ b/internal/ui/issue/comments_kernel_test.go
@@ -1,0 +1,226 @@
+package issue
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// rowsViewID is a root view standing in for the issue list. The list is what
+// pushes the detail pane in the program, and this package may not import it, so
+// the kernel is given a root to push over and to pop back to. It takes the slot
+// docs/UX.md gives the issue list, so the footer these tests read is the one the
+// program draws rather than one with nothing on its left.
+const rowsViewID = "issue.rows"
+
+type rowsView struct{}
+
+func (rowsView) Init() tea.Cmd                         { return nil }
+func (rowsView) Update(tea.Msg) (kernel.View, tea.Cmd) { return rowsView{}, nil }
+func (rowsView) View() string                          { return "the rows this issue was opened from" }
+
+func init() {
+	kernel.RegisterView(kernel.ViewSpec{
+		ID:    rowsViewID,
+		Title: "Issues",
+		Slot:  1,
+		New:   func(kernel.Deps) kernel.View { return rowsView{} },
+	})
+}
+
+// session drives the whole program: the kernel, the global keys, the detail pane
+// pushed the way a list pushes it, and whatever that pane pushes in turn.
+type session struct {
+	t *testing.T
+	m kernel.Model
+}
+
+func boot(t *testing.T, d kernel.Deps, seed jira.Issue, w, h int) *session {
+	t.Helper()
+
+	m, err := kernel.New(d, kernel.WithSize(w, h), kernel.WithInitialView(rowsViewID), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	s := &session{t: t, m: m}
+	s.send(tea.WindowSizeMsg{Width: w, Height: h})
+	s.run(s.m.Init())
+	s.send(kernel.PushMsg{ID: ViewID, Title: seed.Key, View: New(d, seed)})
+	return s
+}
+
+func (s *session) send(msg tea.Msg) {
+	s.t.Helper()
+
+	next, cmd := s.m.Update(msg)
+	model, ok := next.(kernel.Model)
+	if !ok {
+		s.t.Fatal("the kernel stopped returning its own model")
+	}
+	s.m = model
+	s.run(cmd)
+}
+
+func (s *session) run(cmd tea.Cmd) {
+	s.t.Helper()
+
+	queue := []tea.Cmd{cmd}
+	for steps := 0; len(queue) > 0; steps++ {
+		if steps > 4000 {
+			s.t.Fatal("commands never settled")
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if cmds, ok := unwrapCmds(msg); ok {
+			queue = append(queue, cmds...)
+			continue
+		}
+		updated, follow := s.m.Update(msg)
+		model, ok := updated.(kernel.Model)
+		if !ok {
+			s.t.Fatal("the kernel stopped returning its own model")
+		}
+		s.m = model
+		queue = append(queue, follow)
+	}
+}
+
+func (s *session) press(keys ...string) {
+	s.t.Helper()
+
+	for _, k := range keys {
+		s.send(stroke(k))
+	}
+}
+
+func (s *session) frame() string { return ansi.Strip(s.m.Frame()) }
+
+func (s *session) footer() string {
+	lines := strings.Split(strings.TrimRight(s.frame(), "\n"), "\n")
+	return lines[len(lines)-1]
+}
+
+func (s *session) title() string { return strings.SplitN(s.frame(), "\n", 2)[0] }
+
+// The gesture through the whole program: the thread opens over the issue, and
+// esc lands back on the issue rather than walking past it.
+func TestSession_TheThreadOpensOverTheIssueAndEscComesBack(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-2", "The conversation you came for.")
+	s := boot(t, testDeps(f), seedOf(t, f, "PROJ-2"), 120, 30)
+	mustContain(t, s.title(), "PROJ-2")
+
+	s.press("c")
+	mustContain(t, s.frame(), "The conversation you came for.")
+	mustContain(t, s.title(), "PROJ-2")
+	mustContain(t, s.footer(), "a write a comment")
+
+	s.press("esc")
+	mustContain(t, s.frame(), "PROJ-2", "Comments (1)")
+	mustContain(t, s.footer(), "c comment")
+	mustNotContain(t, s.footer(), "a write a comment")
+
+	s.press("esc")
+	mustContain(t, s.frame(), "the rows this issue was opened from")
+}
+
+// docs/UX.md principle 2: the footer names c where it opens the thread, and does
+// not name it in the thread, where c is the thread's own key for writing one.
+func TestSession_TheFooterNamesTheKeyOnlyWhereItOpensTheThread(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-3", "Something to read.")
+	s := boot(t, testDeps(f), seedOf(t, f, "PROJ-3"), 120, 30)
+	mustContain(t, s.footer(), "c comment")
+
+	s.press("c")
+	mustContain(t, s.footer(), "a write a comment")
+	mustNotContain(t, s.footer(), "c comment")
+
+	s.press("esc")
+	mustContain(t, s.footer(), "c comment")
+}
+
+// The help overlay is the other half of the footer, and answers for the view it
+// is covering.
+func TestSession_TheHelpOverlayListsTheKeyForTheViewItIsCovering(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	s := boot(t, testDeps(f), seedOf(t, f, "PROJ-4"), 120, 30)
+
+	s.press("?")
+	mustContain(t, s.frame(), "c comment")
+
+	s.press("?", "c", "?")
+	mustContain(t, s.frame(), "a write a comment")
+	mustNotContain(t, s.frame(), "c comment")
+}
+
+// A comment written from the issue reaches the read-only thread the detail pane
+// draws, because coming back refetches what the pane is showing.
+func TestSession_WhatIsWrittenInTheThreadIsThereWhenYouComeBack(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	s := boot(t, testDeps(f), seedOf(t, f, "PROJ-5"), 120, 30)
+	mustContain(t, s.frame(), "Nobody has commented.")
+
+	s.press("c")
+	s.press("a")
+	for _, r := range "Written without leaving the issue." {
+		s.send(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	s.press("ctrl+s")
+	s.press("esc")
+	s.press("r")
+
+	mustContain(t, s.frame(), "Comments (1)", "Written without leaving the issue.")
+}
+
+// The hint line is one row that the help component overflows rather than
+// truncates once it runs out of room, and the kernel then draws none of it. A
+// fifth key on this pane is exactly the kind of thing that tips it, so the
+// smallest terminal docs/UX.md supports is held to still teaching the keys.
+func TestSession_TheSmallestTerminalStillTeachesThePanesKeys(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	s := boot(t, testDeps(f), seedOf(t, f, "PROJ-7"), kernel.MinWidth, kernel.MinHeight)
+
+	mustContain(t, s.footer(), "down", "up", "edit fields")
+}
+
+func TestSession_Frames(t *testing.T) {
+	t.Parallel()
+
+	for _, size := range []struct{ w, h int }{{120, 38}, {100, 28}, {80, 20}} {
+		t.Run(fmt.Sprintf("%dx%d", size.w, size.h), func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(12)
+			addComment(t, f, "PROJ-6", "A comment worth a line or two, and a second sentence to wrap.")
+			s := boot(t, testDeps(f), seedOf(t, f, "PROJ-6"), size.w, size.h)
+			golden(t, fmt.Sprintf("session_issue_%dx%d.golden", size.w, size.h), s.frame())
+
+			s.press("c")
+			golden(t, fmt.Sprintf("session_thread_%dx%d.golden", size.w, size.h), s.frame())
+		})
+	}
+}

--- a/internal/ui/issue/comments_test.go
+++ b/internal/ui/issue/comments_test.go
@@ -1,0 +1,293 @@
+package issue
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/ui/comment"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// threadOf is the view the detail pane asked the kernel to push, checked against
+// the issue it was opened from. The push is the assertion: a thread pushed under
+// another issue's key is a thread about the wrong conversation.
+func threadOf(t *testing.T, p *panel, key string) kernel.View {
+	t.Helper()
+
+	if len(p.pushes) != 1 {
+		t.Fatalf("the pane asked for %d views to be pushed, want one", len(p.pushes))
+	}
+	got := p.pushes[0]
+	if got.ID != comment.ViewID {
+		t.Errorf("the pushed view is %q, want %q", got.ID, comment.ViewID)
+	}
+	if got.Title != key {
+		t.Errorf("the thread was pushed titled %q, want the issue it is about, %q", got.Title, key)
+	}
+	if got.View == nil {
+		t.Fatal("the push carried no view")
+	}
+	return got.View
+}
+
+func threadPanel(t *testing.T, p *panel, key string, w, h int) *panel {
+	t.Helper()
+	return newPanel(t, threadOf(t, p, key), w, h)
+}
+
+func TestComments_TheKeyOpensTheThreadForTheIssueOnScreen(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-4", "What we agreed in the end.")
+	addComment(t, f, "PROJ-5", "Said on an issue nobody opened.")
+	p := newPanel(t, New(testDeps(f), seedOf(t, f, "PROJ-4")), 100, 24)
+
+	p.keys("c")
+
+	thread := threadPanel(t, p, "PROJ-4", 100, 24)
+	mustContain(t, thread.frame(), "PROJ-4", "What we agreed in the end.")
+	mustNotContain(t, thread.frame(), "Said on an issue nobody opened.")
+}
+
+// The palette knows which command ran and never which issue is on screen, so the
+// command has to arrive as a broadcast and be answered by the pane that holds
+// one.
+func TestComments_ThePaletteOpensTheSameThreadTheKeyDoes(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-6", "Reached without touching the keyboard shortcut.")
+	p := newPanel(t, New(testDeps(f), seedOf(t, f, "PROJ-6")), 100, 24)
+
+	p.send(CommentsMsg{})
+
+	thread := threadPanel(t, p, "PROJ-6", 100, 24)
+	mustContain(t, thread.frame(), "PROJ-6", "Reached without touching the keyboard shortcut.")
+}
+
+// Nothing retargets a thread that is already on the stack, because the kernel
+// never reuses a pushed view: two panes open two threads, each about its own
+// issue.
+func TestComments_EachPaneOpensTheThreadOfItsOwnIssue(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-1", "The first conversation.")
+	addComment(t, f, "PROJ-2", "The second conversation.")
+	d := testDeps(f)
+
+	first := newPanel(t, New(d, seedOf(t, f, "PROJ-1")), 100, 24)
+	first.keys("c")
+	second := newPanel(t, New(d, seedOf(t, f, "PROJ-2")), 100, 24)
+	second.keys("c")
+
+	one := threadPanel(t, first, "PROJ-1", 100, 24)
+	two := threadPanel(t, second, "PROJ-2", 100, 24)
+	mustContain(t, one.frame(), "The first conversation.")
+	mustNotContain(t, one.frame(), "The second conversation.")
+	mustContain(t, two.frame(), "The second conversation.")
+	mustNotContain(t, two.frame(), "The first conversation.")
+}
+
+// The whole point of the packet: a comment written, changed and removed without
+// leaving the issue, and the fake agreeing at every step.
+func TestComments_WriteEditAndDeleteReachTheSiteFromTheDetailPane(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	p := newPanel(t, New(testDeps(f), seedOf(t, f, "PROJ-7")), 100, 24)
+	p.keys("c")
+	thread := threadPanel(t, p, "PROJ-7", 100, 24)
+
+	thread.keys("a")
+	thread.typed("Written from the issue.")
+	thread.keys("ctrl+s")
+	mustContain(t, thread.statusText(), "the comment has been added")
+	if got := bodiesOn(t, f, "PROJ-7"); !slices.Contains(got, "Written from the issue.") {
+		t.Fatalf("the site holds %v, not the comment that was written", got)
+	}
+
+	thread.keys("e")
+	thread.typed(" Changed my mind.")
+	thread.keys("ctrl+s")
+	mustContain(t, thread.statusText(), "the comment has been changed")
+	if got := bodiesOn(t, f, "PROJ-7"); !slices.Contains(got, "Written from the issue. Changed my mind.") {
+		t.Fatalf("the site holds %v, not the edit", got)
+	}
+
+	thread.keys("d", "y")
+	mustContain(t, thread.statusText(), "the comment is gone")
+	if got := bodiesOn(t, f, "PROJ-7"); len(got) != 0 {
+		t.Errorf("the site still holds %v after the deletion", got)
+	}
+}
+
+// The confirmation is unskippable from here too: d alone leaves the comment
+// where it is.
+func TestComments_DeletingStillWaitsForTheAnswerItAsksFor(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-8", "Not going anywhere.")
+	p := newPanel(t, New(testDeps(f), seedOf(t, f, "PROJ-8")), 100, 24)
+	p.keys("c")
+	thread := threadPanel(t, p, "PROJ-8", 100, 24)
+
+	thread.keys("d")
+	mustContain(t, thread.frame(), "Not going anywhere.")
+	if got := bodiesOn(t, f, "PROJ-8"); len(got) != 1 {
+		t.Fatalf("the site holds %v; d on its own deleted a comment", got)
+	}
+
+	thread.keys("esc")
+	if got := bodiesOn(t, f, "PROJ-8"); len(got) != 1 {
+		t.Errorf("the site holds %v after the confirmation was refused", got)
+	}
+}
+
+func TestComments_ReadingTheThreadThatFailsSaysWhyRatherThanShowingAnEmptyOne(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "a refusal",
+			err:  &jira.CapabilityError{Reason: "you need the Browse Projects permission to read this issue"},
+			want: "Browse Projects permission",
+		},
+		{
+			name: "a rate limit",
+			err:  &jira.RateLimitError{RetryAfter: 45 * time.Second},
+			want: "retry in 45s",
+		},
+		{
+			name: "a transport failure",
+			err:  &jira.TransportError{Op: "GET /comment", Err: errors.New("connection refused")},
+			want: "connection refused",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(12)
+			addComment(t, f, "PROJ-3", "Never read.")
+			p := newPanel(t, New(testDeps(f), seedOf(t, f, "PROJ-3")), 100, 24)
+			p.keys("c")
+
+			view := threadOf(t, p, "PROJ-3")
+			f.FailNext(tc.err)
+			thread := newPanel(t, view, 100, 24)
+
+			if got := thread.statusText(); !strings.Contains(got, tc.want) {
+				t.Errorf("the status line says %q, want it to carry %q", got, tc.want)
+			}
+			mustNotContain(t, thread.frame(), "Nobody has commented")
+		})
+	}
+}
+
+// A pane built with no issue has nothing to comment on, and answers by doing
+// nothing rather than by pushing a thread that says so.
+func TestComments_APaneWithNoIssueOpensNothing(t *testing.T) {
+	t.Parallel()
+
+	p := newPanel(t, New(testDeps(newFake(2)), jira.Issue{}), 100, 24)
+
+	p.keys("c")
+	p.send(CommentsMsg{})
+
+	if len(p.pushes) != 0 {
+		t.Errorf("a pane with no issue pushed %d views", len(p.pushes))
+	}
+}
+
+// c had to be free, and taking it must not have cost the pane a gesture it
+// already spends: g g and g e still walk the document.
+func TestComments_TakingCLeftTheOtherGesturesAlone(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(12)
+	addComment(t, f, "PROJ-9", strings.Repeat("A long conversation. ", 60))
+	p := newPanel(t, New(testDeps(f), seedOf(t, f, "PROJ-9")), 100, 12)
+
+	p.keys("g", "e")
+	if len(p.pushes) != 0 {
+		t.Fatalf("g then e pushed %d views; it is the gesture that goes to the end of the issue", len(p.pushes))
+	}
+	pane, ok := p.view.(*Model)
+	if !ok {
+		t.Fatal("the pane is no longer a *Model")
+	}
+	if pane.pager.YOffset() == 0 {
+		t.Error("g then e did not reach the end of the issue")
+	}
+
+	p.keys("g", "g")
+	if pane.pager.YOffset() != 0 {
+		t.Error("g then g did not come back to the top of the issue")
+	}
+}
+
+func TestComments_RegisterTheKeyTheFooterShowsAndThePaletteEntryThatReachesIt(t *testing.T) {
+	t.Parallel()
+
+	if errs := kernel.RegistrationErrors(); len(errs) > 0 {
+		t.Fatalf("registration went wrong: %v", errs)
+	}
+
+	var advertised []string
+	set := kernel.KeysFor(ViewID)
+	for _, row := range append([][]kernel.Binding{set.Short}, set.Full...) {
+		for _, binding := range row {
+			advertised = append(advertised, binding.Help().Key)
+		}
+	}
+	if !slices.Contains(advertised, "c") {
+		t.Errorf("the detail pane does not advertise %q; the footer only shows keys that work: %v", "c", advertised)
+	}
+
+	cmd, ok := kernel.LookupCommand("issue.comments")
+	if !ok {
+		t.Fatal("the palette has no issue.comments; every action is reachable a key and a command")
+	}
+	if cmd.Group != "Issue" {
+		t.Errorf("issue.comments is grouped under %q, want it beside the other things done to an issue", cmd.Group)
+	}
+	if !slices.Equal(cmd.Keys, []string{"c"}) {
+		t.Errorf("issue.comments teaches %v, want the key the detail pane shows", cmd.Keys)
+	}
+
+	if _, gone := kernel.LookupCommand("comments.open"); gone {
+		t.Error("comments.open is still registered; it switched to a thread with no issue, which nothing can then satisfy")
+	}
+}
+
+// bodiesOn is what the site holds for an issue, as plain text, so a test can say
+// what was written rather than what the view thinks it wrote.
+func bodiesOn(t *testing.T, f *jiratest.Fake, key string) []string {
+	t.Helper()
+
+	page, err := f.Comments(t.Context(), key)
+	if err != nil {
+		t.Fatalf("Comments: %v", err)
+	}
+	all, err := jira.Collect(t.Context(), page, commentCap)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	out := make([]string, 0, len(all))
+	for i := range all {
+		out = append(out, strings.TrimSpace(adf.Markdown(all[i].Body)))
+	}
+	return out
+}

--- a/internal/ui/issue/harness_test.go
+++ b/internal/ui/issue/harness_test.go
@@ -2,6 +2,7 @@ package issue
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -21,6 +22,24 @@ import (
 )
 
 var update = flag.Bool("update", false, "rewrite the golden files")
+
+// TestMain points the cache directory at one of this run's own. The comment
+// thread the detail pane opens finds its drafts directory when it is built, and
+// nothing here may reach the cache directory of whoever is running the suite.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "saral-issue-cache")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("SARAL_CACHE_DIR", dir); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 func fullCaps() jira.Capabilities {
 	ok := jira.Capability{OK: true}
@@ -49,9 +68,9 @@ func newFake(issues int, opts ...jiratest.Option) *jiratest.Fake {
 	}, opts...)...)
 }
 
-// comment writes a comment onto an issue the way a person would, so the thread
+// addComment writes a comment onto an issue the way a person would, so the thread
 // under test is one the fake actually holds.
-func comment(t *testing.T, f *jiratest.Fake, key string, paragraphs ...string) {
+func addComment(t *testing.T, f *jiratest.Fake, key string, paragraphs ...string) {
 	t.Helper()
 	nodes := make([]adf.Node, 0, len(paragraphs))
 	for _, p := range paragraphs {

--- a/internal/ui/issue/issue.go
+++ b/internal/ui/issue/issue.go
@@ -132,6 +132,9 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 			cmd = kernel.Fail(msg.err)
 		}
 
+	case CommentsMsg:
+		cmd = m.openComments()
+
 	case tea.KeyPressMsg:
 		cmd = m.key(msg)
 
@@ -200,6 +203,8 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 		return cmd
 	}
 	switch {
+	case kernel.Matches(msg, m.keys.Comments):
+		return m.openComments()
 	case kernel.Matches(msg, m.keys.Go):
 		m.pendingGo = true
 		return nil

--- a/internal/ui/issue/issue_test.go
+++ b/internal/ui/issue/issue_test.go
@@ -26,8 +26,8 @@ func TestIssue_Golden(t *testing.T) {
 			t.Parallel()
 
 			f := newFake(20)
-			comment(t, f, "PROJ-12", "Reproduced on staging, twice.", "The fix is in the shared client.")
-			comment(t, f, "PROJ-12", "Agreed. I will pick this up on Monday.")
+			addComment(t, f, "PROJ-12", "Reproduced on staging, twice.", "The fix is in the shared client.")
+			addComment(t, f, "PROJ-12", "Agreed. I will pick this up on Monday.")
 			dr := newDriver(t, testDeps(f), seedOf(t, f, "PROJ-12"), size.w, size.h)
 
 			golden(t, "issue_"+name+".golden", dr.view())
@@ -56,8 +56,8 @@ func TestIssue_ShowsTheCommentThreadOldestFirst(t *testing.T) {
 	t.Parallel()
 
 	f := newFake(20)
-	comment(t, f, "PROJ-3", "First thing said.")
-	comment(t, f, "PROJ-3", "Second thing said.")
+	addComment(t, f, "PROJ-3", "First thing said.")
+	addComment(t, f, "PROJ-3", "Second thing said.")
 	dr := newDriver(t, testDeps(f), seedOf(t, f, "PROJ-3"), 120, 40)
 
 	got := dr.view()
@@ -222,7 +222,7 @@ func TestIssue_RendersDatesInTheAccountsTimezoneAndNotTheMachines(t *testing.T) 
 	}
 
 	f := newFake(20)
-	comment(t, f, "PROJ-9", "Said something.")
+	addComment(t, f, "PROJ-9", "Said something.")
 	seed := seedOf(t, f, "PROJ-9")
 
 	utc := newDriver(t, testDeps(f), seed, 120, 40)
@@ -238,7 +238,7 @@ func TestIssue_StillRendersWhenTheCapabilityProbeFoundNothing(t *testing.T) {
 	t.Parallel()
 
 	f := newFake(20)
-	comment(t, f, "PROJ-10", "Still readable.")
+	addComment(t, f, "PROJ-10", "Still readable.")
 	d := testDeps(f)
 	d.Caps = jira.Capabilities{}
 	dr := newDriver(t, d, seedOf(t, f, "PROJ-10"), 120, 30)
@@ -251,7 +251,7 @@ func TestIssue_ScrollsTheBodyAndKeepsTheIdentityLinesPut(t *testing.T) {
 
 	f := newFake(20)
 	for i := range 30 {
-		comment(t, f, "PROJ-11", "Comment number "+strings.Repeat("x", i%5+1))
+		addComment(t, f, "PROJ-11", "Comment number "+strings.Repeat("x", i%5+1))
 	}
 	dr := newDriver(t, testDeps(f), seedOf(t, f, "PROJ-11"), 100, 14)
 
@@ -278,7 +278,7 @@ func TestIssue_AResizeReflowsWithoutLosingThePlace(t *testing.T) {
 
 	f := newFake(20)
 	for range 20 {
-		comment(t, f, "PROJ-13", "Something worth several lines when the pane is narrow.")
+		addComment(t, f, "PROJ-13", "Something worth several lines when the pane is narrow.")
 	}
 	dr := newDriver(t, testDeps(f), seedOf(t, f, "PROJ-13"), 120, 16)
 	dr.key("ctrl+d", "ctrl+d")
@@ -298,7 +298,7 @@ func TestIssue_ARefreshRereadsTheIssueAndTheThread(t *testing.T) {
 
 	f := newFake(20)
 	dr := newDriver(t, testDeps(f), seedOf(t, f, "PROJ-14"), 120, 40)
-	comment(t, f, "PROJ-14", "Added while you were reading.")
+	addComment(t, f, "PROJ-14", "Added while you were reading.")
 
 	dr.send(kernel.RefreshMsg{})
 

--- a/internal/ui/issue/keys.go
+++ b/internal/ui/issue/keys.go
@@ -14,6 +14,7 @@ type keyMap struct {
 	Bottom   kernel.Binding
 	Edit     kernel.Binding
 	Move     kernel.Binding
+	Comments kernel.Binding
 }
 
 func defaultKeys() keyMap {
@@ -29,16 +30,17 @@ func defaultKeys() keyMap {
 		Bottom:   kernel.Bind([]string{"G", "end"}, "G", "bottom"),
 		Edit:     editBinding(),
 		Move:     moveBinding(),
+		Comments: commentsBinding(),
 	}
 }
 
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Edit, k.Move},
+		Short: []kernel.Binding{k.Down, k.Up, k.Edit, k.Move, k.Comments},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
-			{k.Edit, k.Move},
+			{k.Edit, k.Move, k.Comments},
 		},
 	}
 }

--- a/internal/ui/issue/testdata/session_issue_100x28.golden
+++ b/internal/ui/issue/testdata/session_issue_100x28.golden
@@ -1,0 +1,28 @@
+ saral | PROJ-6                                                        PROJ | example.atlassian.net 
+PROJ-6  Speed up session expiry                                                                     
+Story | Triage | Urgent | Ada Lovelace | updated 02 Mar 2025 22:00                                  
+----------------------------------------------------------------------------------------------------
+Speed up session expiry.                                                                            
+                                                                                                    
+- Filed against PROJ-6.                                                                             
+- Only happens for accounts created before the migration.                                           
+                                                                                                    
+Details                                                                                             
+  Reporter     Grace Hopper                                                                         
+  Project      PROJ PROJ Project                                                                    
+  Fix versions 1.0                                                                                  
+  Due          2025-03-16                                                                           
+  Created      02 Mar 2025 15:00                                                                    
+                                                                                                    
+Comments (1)                                                                                        
+  Sam Tester | 02 Mar 2026 09:00                                                                    
+    A comment worth a line or two, and a second sentence to wrap.                                   
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+ g1 Issues       ↓/j down | ↑/k up | e edit fields | t change status | c comment | ? help | esc back

--- a/internal/ui/issue/testdata/session_issue_120x38.golden
+++ b/internal/ui/issue/testdata/session_issue_120x38.golden
@@ -1,0 +1,38 @@
+ saral | PROJ-6                                                                            PROJ | example.atlassian.net 
+PROJ-6  Speed up session expiry                                                                                         
+Story | Triage | Urgent | Ada Lovelace | updated 02 Mar 2025 22:00                                                      
+------------------------------------------------------------------------------------------------------------------------
+Speed up session expiry.                                                                                                
+                                                                                                                        
+- Filed against PROJ-6.                                                                                                 
+- Only happens for accounts created before the migration.                                                               
+                                                                                                                        
+Details                                                                                                                 
+  Reporter     Grace Hopper                                                                                             
+  Project      PROJ PROJ Project                                                                                        
+  Fix versions 1.0                                                                                                      
+  Due          2025-03-16                                                                                               
+  Created      02 Mar 2025 15:00                                                                                        
+                                                                                                                        
+Comments (1)                                                                                                            
+  Sam Tester | 02 Mar 2026 09:00                                                                                        
+    A comment worth a line or two, and a second sentence to wrap.                                                       
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ g1 Issues                           ↓/j down | ↑/k up | e edit fields | t change status | c comment | ? help | esc back

--- a/internal/ui/issue/testdata/session_issue_80x20.golden
+++ b/internal/ui/issue/testdata/session_issue_80x20.golden
@@ -1,0 +1,20 @@
+ saral | PROJ-6                                    PROJ | example.atlassian.net 
+PROJ-6  Speed up session expiry                                                 
+Story | Triage | Urgent | Ada Lovelace | updated 02 Mar 2025 22:00              
+--------------------------------------------------------------------------------
+Speed up session expiry.                                                        
+                                                                                
+- Filed against PROJ-6.                                                         
+- Only happens for accounts created before the migration.                       
+                                                                                
+Details                                                                         
+  Reporter     Grace Hopper                                                     
+  Project      PROJ PROJ Project                                                
+  Fix versions 1.0                                                              
+  Due          2025-03-16                                                       
+  Created      02 Mar 2025 15:00                                                
+                                                                                
+Comments (1)                                                                    
+  Sam Tester | 02 Mar 2026 09:00                                                
+    A comment worth a line or two, and a second sentence to wrap.               
+ g1 Issues   ↓/j down | ↑/k up | e edit fields | t change status | c comment ...

--- a/internal/ui/issue/testdata/session_thread_100x28.golden
+++ b/internal/ui/issue/testdata/session_thread_100x28.golden
@@ -1,0 +1,28 @@
+ saral | PROJ-6                                                        PROJ | example.atlassian.net 
+PROJ-6 | 1 comment                                                               write  edit  delete
+----------------------------------------------------------------------------------------------------
+> Sam Tester | 02 Mar 2026 09:00                                                                    
+    A comment worth a line or two, and a second sentence to wrap.                                   
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+ g1 Issues  

--- a/internal/ui/issue/testdata/session_thread_120x38.golden
+++ b/internal/ui/issue/testdata/session_thread_120x38.golden
@@ -1,0 +1,38 @@
+ saral | PROJ-6                                                                            PROJ | example.atlassian.net 
+PROJ-6 | 1 comment                                                                                   write  edit  delete
+------------------------------------------------------------------------------------------------------------------------
+> Sam Tester | 02 Mar 2026 09:00                                                                                        
+    A comment worth a line or two, and a second sentence to wrap.                                                       
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+ g1 Issues               ↓/j down | ↑/k up | a write a comment | e edit this one | d delete this one | ? help | esc back

--- a/internal/ui/issue/testdata/session_thread_80x20.golden
+++ b/internal/ui/issue/testdata/session_thread_80x20.golden
@@ -1,0 +1,20 @@
+ saral | PROJ-6                                    PROJ | example.atlassian.net 
+PROJ-6 | 1 comment                                           write  edit  delete
+--------------------------------------------------------------------------------
+> Sam Tester | 02 Mar 2026 09:00                                                
+    A comment worth a line or two, and a second sentence to wrap.               
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+ g1 Issues           ↓/j down | ↑/k up | a write a comment | e edit this one ...

--- a/internal/ui/keys_test.go
+++ b/internal/ui/keys_test.go
@@ -20,6 +20,7 @@ var keyOwners = map[string]string{
 	"comments.write":    comment.ViewID,
 	"comments.edit":     comment.ViewID,
 	"comments.delete":   comment.ViewID,
+	"issue.comments":    issue.ViewID,
 	"issue.edit":        issue.ViewID,
 	"issue.transition":  issue.ViewID,
 	"issues.save-query": list.ViewID,

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -1,6 +1,6 @@
  saral | Commands                                                                          PROJ | example.atlassian.net 
 > what do you want to do?                                                                                               
------------------------------------------------------------------------------------------------------------- 19 commands
+------------------------------------------------------------------------------------------------------------ 20 commands
 > Follow the terminal's own colours             Appearance                                                              
   Turn colour off                               Appearance                                                              
   Use the dark theme                            Appearance                                                              
@@ -12,6 +12,7 @@
   Change this issue's status                    Issue                                                                  t
   Comment on this issue                         Issue                                                                  c
   Edit this issue                               Issue                                                                  e
+  Clear the filter on these rows                Search                                                                  
   Issues I reported                             Search                                                                  
   My issues                                     Search                                                                  
   Save this query to a number key               Search                                                                 s
@@ -20,7 +21,6 @@
   Show only rows with this row's status         Search                                                                  
   Show only rows with this row's type           Search                                                                  
   Unassigned issues                             Search                                                                  
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -1,14 +1,17 @@
  saral | Commands                                                                          PROJ | example.atlassian.net 
 > what do you want to do?                                                                                               
------------------------------------------------------------------------------------------------------------- 16 commands
+------------------------------------------------------------------------------------------------------------ 19 commands
 > Follow the terminal's own colours             Appearance                                                              
   Turn colour off                               Appearance                                                              
   Use the dark theme                            Appearance                                                              
   Use the light theme                           Appearance                                                              
+  Delete the comment you are on                 Comments                                                               d
+  Edit the comment you are on                   Comments                                                               e
+  Write a comment                               Comments                                                               a
   Issues                                        Go to                                                                 g1
   Change this issue's status                    Issue                                                                  t
+  Comment on this issue                         Issue                                                                  c
   Edit this issue                               Issue                                                                  e
-  Clear the filter on these rows                Search                                                                  
   Issues I reported                             Search                                                                  
   My issues                                     Search                                                                  
   Save this query to a number key               Search                                                                 s
@@ -17,9 +20,6 @@
   Show only rows with this row's status         Search                                                                  
   Show only rows with this row's type           Search                                                                  
   Unassigned issues                             Search                                                                  
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         


### PR DESCRIPTION
Closes #67.

## The defect

`internal/ui/comment` — a virtualized thread, an editor, an unskippable delete confirmation, drafts on disk — was unreachable. The view takes an issue key and **nothing in the program ever gave it one**. Before this branch:

```
$ grep -rn 'comment\.Push\|comment\.Thread\|comment\.ThreadMsg' internal/ cmd/ | grep -v '^internal/ui/comment/'
(no output)
```

After:

```
$ grep -rn 'comment\.Push\|comment\.Thread\|comment\.ThreadMsg' internal/ cmd/ | grep -v '^internal/ui/comment/'
internal/ui/issue/comments.go:43:	return comment.Push(m.deps, m.issue.Key)
```

The only entry point was the palette's *Comments*, which did `kernel.Open(comment.ViewID)` and landed on a pane that said "this view comments on one issue, and has not been told which. Open an issue and come back" — with nothing to come back to. Pressing `a` there answered "open an issue first: a comment needs something to be about".

## The decisions, with the reasoning each needs

**The gesture is `c`, on the detail pane.** It was the only free letter that means the thing: `e` edits fields, `t` changes status, `g` is the buffered prefix and `g e`/`g g` walk the document, `G`/`home`/`end`/`j`/`k` and the page keys are taken, and the kernel holds `q`, `r`, `R`, `?`, the digits, `esc`, `ctrl+c` and `ctrl+k`. `#67` suggested `c` for the same reason and `TestComments_TakingCLeftTheOtherGesturesAlone` holds `g e` and `g g` to still being the document's.

**It is a push, not a retarget.** `comment.Push(deps, key)` — the seam P2.4 left — is `kernel.Push(comment.ViewID, key, comment.Thread(deps, key))`, the same route `internal/ui/list` uses for the detail pane itself, so `esc` lands back on the issue the conversation is about. **No `ThreadMsg` broadcast:** the kernel's `push` never reuses a pushed instance (only `open` consults `m.live`), so every open builds the thread for the issue it was opened from and there is nothing on the stack to retarget. `TestComments_EachPaneOpensTheThreadOfItsOwnIssue` is that assertion.

**`comments.open` is gone; `issue.comments` replaces it.** The old command opened a pane nothing could satisfy, so it is removed rather than kept as a synonym, and `internal/ui/comment`'s registration test now holds it to staying gone. The new one is *"Comment on this issue"* in group **Issue**, beside *Edit this issue* and *Change this issue's status*, and it broadcasts the way both of those do — the palette knows which command was run and never which issue is on screen, so a broadcast answered by the pane holding one is the only shape that works. It is registered from `internal/ui/issue` because that is where the key and the gesture live, and a command whose `Keys` came from another package's binding could drift from what that package's footer shows. Like `issue.edit` and `issue.transition` (nothing else answers either), it is silent from a root view; the title is what says it needs an issue.

**The footer.** The detail pane still implements no `kernel.KeyReporter` and stays in `staticKeys` in `internal/ui/livekeys_test.go`, unchanged: the exemption's reason — "it scrolls a document and every one of its keys works whatever it is showing" — is still true, because the pane always has an issue (`New` is only ever called with a row, and `openComments` guards an empty key anyway). So the registry's set *is* the live set, and `c comment` appears on the detail pane and nowhere else. `TestSession_TheFooterNamesTheKeyOnlyWhereItOpensTheThread` and `TestSession_TheHelpOverlayListsTheKeyForTheViewItIsCovering` drive the real kernel through `c` and `esc` and assert both directions.

**Why the footer says "comment" and not "comments".** One column longer and the hint line disappears entirely at 80 columns. `help.shouldAddItem` appends an item it has no room for whenever the ellipsis will not fit either, so `ShortHelpView` overflows the width it was given; `kernel.footer` then sets `hints = ""` because `gap < 1`. A fifth key on this pane is exactly the kind of thing that tips it. Measured across widths 80–132 with the palette linked, as the real binary links it:

| detail pane `Short` | widths where the whole hint line vanishes |
|---|---|
| before this branch (4 keys) | 90–94 |
| `c comments` | **80**, 85–89, 103–107 |
| `c comment` | 84–88, 102–106 |

The dead zone is pre-existing — it already swallows the footer at 90–94 today — and the fix is one line in `kernel.footer` (clamp `hints` with `oneLine` rather than blank it), which is not mine to make; filed as [#96](https://github.com/varijkapil13/saral/issues/96). What I would not ship is a packet that puts width 80, the documented minimum and the one the goldens test, into that zone. `TestSession_TheSmallestTerminalStillTeachesThePanesKeys` pins it.

**No mouse zone, deliberately.** The detail pane marks no zones at all — its body is drawn through a scrolling `viewport`, and neither `e` nor `t` has a mouse route either. A marker inside clipped, re-wrapped pager content records a rectangle that is wrong the moment the heading is half scrolled off, which is why the thread renders its own blocks rather than using a viewport. The thread this opens is fully clickable once you are in it (write, edit, delete, confirm, and every comment row). Giving the detail pane its first zone layer belongs to a packet that gives it one, not to a one-key fix.

## Tests

All against `pkg/jira/jiratest`; nothing touches the network.

- `c` pushes **`comment.ViewID` titled with the issue on screen** — the push itself is the assertion, not "a view appeared" — and the pushed thread renders that issue's comments and not the other issue's.
- The palette route (`CommentsMsg`) opens the same thread.
- **Write, edit and delete end to end from the detail pane**, checked against what the fake holds at each step, not against what the view says: `a` → type → `ctrl+s`, then `e` → type → `ctrl+s`, then `d` → `y`. `d` alone still leaves the comment where it is.
- 403 (`CapabilityError`), 429 (`RateLimitError`) and a transport failure on the thread's load, each arriving as its own words in the status line rather than an empty thread.
- `esc` from the thread lands on the issue, and a second `esc` on the root — driven through the real `kernel.Model`.
- A pane with no issue pushes nothing.
- Registration: the pane advertises `c`, `issue.comments` carries `c` and sits in group Issue, `comments.open` is not registered.

The kernel tests need a root to push over and pop back to, and this package may not import `internal/ui/list`; a stand-in root view registered in the test file takes the slot `docs/UX.md` gives the list, so the footer these tests read is the one the program draws.

## Goldens

Six new files, all frames of the whole program rather than the pane alone, which is what makes the footer visible:

- `session_issue_{120x38,100x28,80x20}.golden` — the detail pane, footer now ending `… t change status | c comment | ? help | esc back`. Nothing this branch does changes what the pane itself draws; the existing `issue_*.golden` files are untouched.
- `session_thread_{120x38,100x28,80x20}.golden` — after `c`: header `PROJ-6 | 1 comment` with the `write edit delete` action bar, the selected comment marked, and the thread's own footer `a write a comment | e edit this one | d delete this one`. At 80 columns both footers truncate with `...` and neither vanishes.

`internal/ui/palette/testdata/session_120x30.golden` gains four rows and reads `19 commands`: the detail pane now imports `internal/ui/comment`, so the palette's test binary links the comment commands the real binary always had, and `Comments` in *Go to* is replaced by `Comment on this issue` in *Issue*.

## Outside the owned paths

Two lines, both in sweeps whose own failure messages ask for them:

- `internal/ui/keys_test.go` — `"issue.comments": issue.ViewID`, because the new command carries a key and that table is where a command's key is held against the footer that shows it.
- `internal/ui/palette/testdata/session_120x30.golden` — regenerated, mechanical, described above.

`internal/ui/livekeys_test.go` needed nothing.

## Not fixed here

- The hint line vanishing at some widths (`kernel.footer` / `help.shouldAddItem`) — [#96](https://github.com/varijkapil13/saral/issues/96), kernel, and closed to this packet.
- `saral comment` still opens the issue-less pane, and its footer still names `a`/`e`/`d`, which all refuse. Making the thread's resting key set answer for "no issue yet" means touching the `internal/ui/livekeys_test.go` sweep that asserts a freshly built view advertises something, and after this branch nothing in the UI reaches that state.

## Checks

```
go mod tidy && git diff --exit-code go.mod go.sum   # clean
go vet ./... && golangci-lint run                   # 0 issues
go test -race -count=1 ./...                        # all packages ok
go build -trimpath -ldflags "-s -w" ./cmd/saral     # ok
python3 scripts/checkleak.py                        # nothing to compare against (no capture in tree)
```

Budgets held, unmoved: `BenchmarkFrame` 297 allocs/op, `BenchmarkKeyToFrame` 310, `BenchmarkListSteadyScroll10k` 1.
