### PR TITLE
docs(api-notes): mark every trap with whether a real site confirmed it

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -1,175 +1,305 @@
 # Jira API notes
 
-Verified against the Jira Cloud Platform REST API v3 and Agile API 1.0 in August 2026. Every entry
-here cost time to find out; read this before writing an adapter method.
+Jira Cloud Platform REST API v3 and Agile API 1.0, as of August 2026. Every entry here cost time to
+find out. Read it before writing an adapter method.
+
+**Every row says how we know it.**
+
+- `live` — seen in a response from a real Jira Cloud site. One site, read in August 2026, built to
+  hold every shape this client claims to handle: a company-managed project and a team-managed one,
+  five boards, sprints in all three states, versions released and unreleased and archived, custom
+  fields of every type, a transition with a screen and a validator, and the site language flipped to
+  German and back.
+- `schema` — taken from Atlassian's published OpenAPI and JSON schemas. Nobody has watched a real
+  site do it.
+
+A `live` row is enough to disprove a schema claim and not enough to prove a shape universal: one
+site is one site, and two rows below record a site disagreeing with *itself*. When you verify a
+`schema` row, change the word. Three defects in shipped code came from claims in this file that
+nobody had checked, so the marker is the point, not decoration.
 
 ## Hard constraints
 
-| Fact | Consequence |
-|---|---|
-| `/rest/api/3/search` returns **410 Gone** | Use `POST /rest/api/3/search/jql`. Not optional. |
-| `/search/jql` pages by opaque `nextPageToken` and returns **no `total`** | The UI must work without a count. Use `POST /rest/api/3/search/approximate-count` — no `/jql` segment — where a number is genuinely needed. Guard against a token that repeats. |
-| `/search/jql` returns almost nothing without `fields` | Always send an explicit, narrow field list. |
-| The response carries only the field keys it **actually returned** — nothing anywhere says what the endpoint did with the list you sent | The field list cannot be recovered from the answer, so the `jira.FieldMask` on `Issue.Requested` records what was *asked for*, never what the site had. "Requested and absent" means the site sent nothing for that field, and a field ID the site does not have looks exactly the same. Every consumer of the mask has to know that. |
-| The Agile API still uses `startAt`/`maxResults`/`total` | Two pagination models in one client, unified behind `Page[T]`. It also silently truncates against an unreadable instance limit. |
-| There is a **third** paging style: `/rest/api/3/plans/plan` uses `cursor`/`nextPageCursor` and *does* report a `total` and an `isLast` | It is neither of the other two. `Plans` returns a plain slice for that reason. A fourth shape — no paging at all — covers `/field`, attachment upload and the bare-array `/project/{key}/versions`, which is the one endpoint of that four the client should *not* call: use the paged `/project/{key}/version`. |
-| The Plans API lives at `/rest/api/3/plans/plan` — the doubled segment is correct | `GET /rest/api/3/plans` does not exist. |
-| v3 requires **ADF** for description, environment, comments, worklog comments and multi-line custom fields | Single-line fields take plain strings. `pkg/adf` is not optional. |
-| `PUT /rest/agile/1.0/sprint/{id}` is a **full replace** — omitted fields become null | Never expose it. Use `POST /rest/agile/1.0/sprint/{id}` for partial updates. |
-| `PUT /rest/api/3/issue/{key}/comment/{id}` takes a whole comment, and `visibility` is one of its properties | A request that names only `body` is a request for a comment with no restriction on it, which publishes a comment one role could see. The port cannot carry the restriction — `EditComment` takes a body and nothing else — so the adapter reads the comment first and echoes its `visibility` object back verbatim. That is right whichever way the endpoint would have treated the omission, and it costs one `GET` per edit. |
-| A comment's `visibility` carries **`identifier`** beside `type` and `value`, and `value` is the localised display name of the role or group | Echo the object you were given rather than rebuilding one from `type` and `value`: on a German site the role name is German, and `identifier` is the half of it no translation moves. `jira.Visibility` has no slot for the identifier, which is the other reason an edit sends back the original bytes. |
-| `GET /rest/api/3/issue/{key}/comment` pages by `startAt`/`maxResults`/`total` — the Agile shape — while living on the platform API, and names its array **`comments`** rather than `values` | Neither shared envelope in `pkg/jira/cloud/paginate.go` reads it, so it decodes its own. It sends no `isLast`, so the walk ends on the total; an envelope that reports no total at all can only be ended by a page shorter than the `maxResults` the response itself echoes, because a site may cap the number asked for without saying so anywhere else. |
-| The order comments come back in is not documented | Send `orderBy=created` when oldest-first is what the caller was promised. |
-| Sprint state machine: `future → active → closed` only, start needs both dates set, `completeDate` is never writable, a closed sprint only accepts `name` and `goal` | Validate locally and return a real error instead of a 400. |
-| `POST /rest/agile/1.0/backlog/issue` caps at **50 issues** | Chunk, and report partial progress. |
-| Attachment upload needs `X-Atlassian-Token: no-check` and a multipart part named exactly `file` | Otherwise rejected by the XSRF guard. |
-| `GET /rest/api/3/attachment/content/{id}` supports `Range`, and 303-redirects unless `redirect=false` | Free progress and resume. |
-| Dynamic webhooks (`POST /rest/api/3/webhook`) are **Connect / OAuth 2.0 apps only** | No push channel for an API-token client. Poll, scoped and backing off. |
-| The Plans API requires **Administer Jira** on every endpoint, and is experimental | Per-plan View/Edit rights in the UI do **not** grant API access. Fall back to locally defined plans. |
-| `POST /rest/api/3/bulk/issues/move` is async, ≤1000 issues, needs global **Bulk Change** plus Move in source and Create in target | Poll the returned task. |
-| The bulk-move submit response is `{"taskId": "10641"}` and nothing else — the schema is `additionalProperties: false`, so there is **no link to follow** | Progress is `GET /rest/api/3/bulk/queue/{taskId}`, which the client has to construct. That is not the generic `GET /rest/api/3/task/{taskId}`, which answers a different shape (`status`, `progress`, `submittedBy`, `elapsedRuntime`). |
-| Bulk-move progress reports `status`, `progressPercent`, `processedAccessibleIssues`, `failedAccessibleIssues`, `invalidOrInaccessibleIssueCount`, `totalIssueCount`, and epoch-millis `created`/`started`/`updated` | The failure detail is counts and issue IDs, not messages. |
-| The generic `GET /rest/api/3/task/{taskId}` answers `TaskProgressBeanObject`: `id`, `self`, `status`, `progress`, `elapsedRuntime`, `submitted`, `lastUpdate`, `submittedBy`, and optionally `description`, `message`, `started`, `finished`, `result` | The two progress bodies overlap on exactly three keys — `status`, `started`, `submittedBy` — and the third has a different **type** in each: an int64 legacy user id here, an object with an `accountId` on the bulk-move queue. A struct written for one either errors on the other or reads `status` and `started` and leaves the rest at their zero values. |
-| `submittedBy` on a task progress bean is a **numeric** user id, not an account id | It is the only place left in v3 that answers with the pre-GDPR id. There is no endpoint that turns it back into a user, so it is for display and comparison at most. |
-| A task progress bean's `submitted`/`started`/`lastUpdate`/`finished` are **epoch millis**, while the Connect variant `TaskProgress` sends the same four fields as **RFC 3339 strings** | Two shapes, one name, one letter apart in the docs. Anything reading a task's clock has to know which one it asked for. |
-| `result` is typed *unknown* in the schema, the published example sends a **string**, and a real task sends whatever its own operation documents — an object for the option-replacement tasks | Keep it as `json.RawMessage` and decode per operation. A `Result string` compiles, passes against a fixture that happens to hold a string, and fails on the first real one. |
-| The task status enum has **seven** values: `ENQUEUED`, `RUNNING`, `COMPLETE`, `FAILED`, `CANCEL_REQUESTED`, `CANCELLED`, `DEAD` | A cancelled task is read as `CANCEL_REQUESTED` for as long as it takes to stop, so a poller sees it. `jira.TaskState` is missing that one ([#59](https://github.com/varijkapil13/saral/issues/59)). |
-| There is **no release-notes API**. `ReleaseNote.jspa` is a rendered web page | Out of scope by decision. |
-| Releasing a version is one `PUT` with `released: true` — and it will happily release with open issues | Always check `unresolvedIssueCount` first and make the user decide. |
-| `editJiraIssue`-style field writes cannot change an issue's project | Cross-project moves go through the bulk-move endpoint only. |
-| Status is not a writable field | Only `POST /issue/{key}/transitions`, and the available transitions depend on current status. |
-| A key present in `fields` with the value `null` **empties that field**; a key that is absent leaves it alone | Those are two different requests and a struct with a zero value cannot say which was meant. `jira.IssuePatch` is sparse for this reason, and a fetch-edit-PUT that cannot tell "not requested" from "empty" blanks every field the read never asked for. `Issue.Requested` is the answer to which of the two a caller is holding. |
-| `POST /rest/api/3/issue` answers with `id`, `key` and `self` — **nothing else**, not even the status the workflow put the issue in | The issue as stored takes a second `GET`. That second call failing is not a reason to report the create as failed: the issue exists, and a caller's retry would make another one. |
-| `GET /issue/{key}/transitions` sends an **empty `fields` object on every transition** unless the request asks for `expand=transitions.fields` | Without it a transition with a screen and a required field looks like a move that needs nothing, and the `POST` then fails with a 400 naming a field the client never saw. |
-| A transition's `fields` is a JSON **object keyed by field id**, so it has no order, and each entry carries `fieldId`, `key` and `name` | Sort it into something stable — required first, then by id — or a form's rows move between two reads of one screen. Read the id from `fieldId`, falling back to `key` and then the map key. |
-| Every transition carries `isAvailable`, which is `false` only when the request asked for unavailable ones too | Filter on it anyway. Offering a move the site has already said cannot be made spends a round trip to earn a 400. |
-| `PUT /issue/{key}` takes `notifyUsers` as a **query parameter**; `POST /issue/{key}/transitions` has no notification control at all | The transition body is an `IssueUpdateDetails` with no room for it, so an intent to suppress mail cannot be carried through a transition. |
-| `GET /issue/{key}` accepts `expand=schema`, which answers with one entry per field on the issue | Worth sending on a single-issue read: without it a custom field's value is typed by its shape alone, which cannot tell a number from a number-shaped string or a sprint array from an option array. |
-| A select-like field is **written** as `{"id": "…"}`, and a labels-like array of bare strings is written as the strings | An id is the same on a site in any language and a `value` is not, so write the id wherever the value has one. An option with no id can only have come from an array of strings, which is the one shape that produces them. |
-| The platform and Agile APIs write date-times differently: `2021-01-17T12:34:00.000+0000` (no colon in the offset) versus `2015-04-11T15:22:00.000+10:00` (colon) | Two layouts, `2006-01-02T15:04:05.000-0700` and `2006-01-02T15:04:05.000-07:00`. One decoder cannot serve both. `/task/{id}` timestamps are epoch millis instead. |
-| The `/search/jql` response carries **three** keys in practice — `issues`, `nextPageToken`, `isLast` | There is no `total`. `names` and `schema` come back only if you send `expand=names,schema`, and each issue's own `expand` string lists them anyway, which reads as though they were expanded when they were not. Treat an absent `nextPageToken` as the end. |
-| The `nextPageToken` is **not opaque**: base64url-decoding one yields the sort column and direction, the last row's sort value, the project key, a row count, and **the full JQL string** | Never cache a token across sessions, never reuse one with a different `jql`, `fields` or sort, and never log one — it carries the query. It is not a stable identifier for a result set. |
-| `expand=schema` on `/search/jql` answers with one entry per **requested** field, keyed by field ID | That is enough to type a `customfield_NNNNN` in the same round trip, so a search does not need a second call to `/field` to decode its own answer. A query of nothing but system fields needs no schema and should not ask for one. |
-| A field's declared `schema.type` is not always the shape of its value: a multi-line text field declares `string` and stores an **ADF document**, `any` (rank, epic link) declares nothing at all, and a sprint field is an `array` of `items: json` | Read the value itself for a document and for `any`. What the schema does name and a client has no slot for is worth keeping verbatim rather than guessing at — reading a sprint as its name silently drops its state and dates. |
-| A user on a `/search/jql` response carries **no `avatarUrls`** | The same account has them elsewhere, so anything rendering an avatar fetches it separately. A list view must not depend on one being there. |
-| `status.iconUrl` is the **site root URL**, not an icon | Fetching it gets the Jira homepage. Status glyphs come from `statusCategory.key`. `issuetype.iconUrl` and `priority.iconUrl` are real images; only status is degenerate. |
-| A bare `GET /issue/{key}` returns **every field on the site**, with unset ones as explicit `null` | On a site with ninety custom fields that is ninety nulls per issue. This is the concrete reason a narrow `fields` list is not an optimisation but the normal way to call it. |
-| `fields.statusCategory` arrives as a field in its own right, beside `fields.status` | Two places carry the same answer; `status.statusCategory` is the one to read. |
-| `timetracking` is `{}` — an empty object, not `null` — on an issue with no estimates | Decoding into a struct gives zeroes, which is right; decoding into a pointer never gives nil. |
-| `statusCategory.id` is a **number** while `status.id` is a **string** | The four categories are fixed on every site: 1 `undefined`, 2 `new`, 3 `done`, 4 `indeterminate`. Branch on `key`; `name` is localised. |
-| `GET /rest/api/3/issue/createmeta?expand=…` is deprecated | Use the paginated pair, `GET /issue/createmeta/{projectIdOrKey}/issuetypes` then `…/issuetypes/{issueTypeId}`. |
-| Both halves of that pair page by `startAt`/`maxResults`/`total`, and name their arrays **`issueTypes`** and **`fields`** rather than `values` | So neither the platform's cursor envelope nor the Agile `values` envelope can decode them; `pkg/jira/cloud/meta.go` has its own. Send `maxResults` rather than inheriting whatever the site defaults to. |
-| The fields half states **no project and no issue type of its own** | The only statement of either is inside the `project` and `issuetype` fields' `allowedValues`, and the project's `key` lives only there — the response otherwise carries an id and a display name. Read the issue type from the list half instead: it is also what turns "this project has no such type" into a named answer rather than a 404 on a URL. |
-| `allowedValues` on a cascading select nests the second level under **`children`** (an array); a *stored* value of the same field nests one under **`child`** (an object) | One decoder cannot read both, so the create-screen option type is separate from the one the issue decoder uses. |
-| `operations` is stated **per field per issue type**, and an empty array means the field is on the screen to be read | It is the only statement of whether a field can be set at all — `issuetype` normally sends `[]`. A form that offers every field on the screen offers fields Jira will refuse. |
-| createmeta sends `hasDefaultValue` **and** the `defaultValue` itself, and `jira.FieldMeta` carries only the boolean | So a form can say Jira will fill a field in but not what with. Widening the port to carry it is [#68](https://github.com/varijkapil13/saral/issues/68). |
-| A `timeZone` on `/rest/api/3/myself` is not a promise this machine can load it | The name comes out of the site's own zone database and is resolved locally against Go's zoneinfo, which a slim container image may not carry at all. That failure is **local**: report it as this machine having no entry for the zone the account is set to, never as Jira failing to answer, and fall back to UTC. |
+| Source | Fact | Consequence |
+|---|---|---|
+| live | `/rest/api/3/search` is **410 Gone** on GET and POST, and so is `/rest/api/2/search` | Use `POST /rest/api/3/search/jql`. Not optional. |
+| live | v3 requires **ADF** for description, environment, comments, worklog comments and multi-line custom fields | Single-line fields take plain strings. `pkg/adf` is not optional. |
+| live | `PUT /rest/agile/1.0/sprint/{id}` is a **full replace** — and it 400s first if `state` is missing | The 400 is not a guard. A `PUT` carrying `name` and `state` succeeds and silently drops the goal. Never expose it; use `POST /rest/agile/1.0/sprint/{id}` for partial updates. |
+| live | Sprint state machine: `future → active → closed` only, start needs both dates, `completeDate` is never writable, a closed sprint takes only `name` and `goal` | Validate locally and return a real error instead of a 400. Two sprints can be active on one board at once, and a closed sprint can still hold unfinished issues — neither is a corrupt read. |
+| live | A key present in `fields` with the value `null` **empties that field**; an absent key leaves it alone | Two different requests, and a struct with a zero value cannot say which was meant. `jira.IssuePatch` is sparse for this reason. A description never set reads back `null`; one cleared with `null` reads back as an **empty ADF document** — also two different states. |
+| live | `POST /rest/api/3/issue` answers `id`, `key` and `self` and **nothing else**, not even the status the workflow put the issue in | The issue as stored takes a second `GET`. That second call failing is not a reason to report the create as failed: the issue exists, and a retry would make another one. `POST /issue/bulk` answers `{"issues":[…],"errors":[]}`. |
+| live | `POST /rest/api/3/issueLink` answers **201 with an empty body** | The new link's id needs a re-read. A `comment` in that request body lands on the **inward** issue. |
+| live | Status is not a writable field | Only `POST /issue/{key}/transitions`, and the available transitions depend on the current status. |
+| live | `POST /rest/agile/1.0/backlog/issue` **and** `POST /rest/agile/1.0/sprint/{id}/issue` both cap at **50 issues**, and a refusal is atomic | Chunk, and report partial progress. Nothing moved on the call that was refused. |
+| live | `PUT /rest/api/3/issue/{key}/comment/{id}` with **only** `body` does **not** clear a `visibility` the request omits | So an edit may send the body alone, and the read-before-edit this file used to prescribe buys nothing but a round trip. |
+| live | Echoing a comment's `visibility` back **verbatim is a 400**: the body parameters `value` and `identifier` are mutually exclusive | A read hands you both keys; a write accepts either one beside `type`. For a role, `identifier` is the role *name* — an id there is a 400 — so neither key is the language-proof half, and there is nothing to gain by preferring one. Group visibility can be disabled site-wide, and is refused outright when it is, so a comment form cannot assume both kinds are on offer. |
+| live | Attachment upload needs `X-Atlassian-Token: no-check` and a multipart part named exactly `file`. Success is **200**, and the body is an **array** | Without the header the answer is a **404 whose body is the plain string** `XSRF check failed`. With a wrongly named part it is an RFC 7807 400. Neither is the classic error envelope. |
+| live | `GET /rest/api/3/attachment/content/{id}` 303-redirects to a signed media URL whose token expires in about ten minutes, and it redirects **even when the request carries `Range`** | The `206` comes from the media host after the redirect, not from Jira. `?redirect=false` gets a 200 from Jira directly. The redirect URL is a credential: never log it, never cache it, never hand it to another process. |
+| live | `timetracking` is `{}` — an empty object, not `null` — on an issue with no estimates, and when populated it carries pretty strings beside `*Seconds` | Decode into a struct, not a pointer. Read `originalEstimateSeconds`; never parse `2d 4h`, whose day is the site's working day (see the site configuration row). |
+| live | A bare `GET /issue/{key}` returned **91 fields, 39 of them explicit `null`** | A narrow `fields` list is not an optimisation, it is the normal way to call it. |
+| live | One identifier, two JSON types, twice over: a transition is `id: "31"` with `to.id: "10036"` on `/issue/{key}/transitions` and `transitionId: 31` with `to.statusId: 10036` on the bulk-transition meta; an attachment id is a **string** in the upload response and a **number** in `GET /attachment/{id}` | Decode leniently at every boundary, and never compare an id read from one endpoint against one read from another without normalising first. |
+| live | Releasing a version is one `PUT` with `released: true`, and it releases with open issues — one site held a released version with ten of them | Always check the unresolved count first and make the user decide. That count is not on any version read; see Versions and plans. |
+| schema | `editJiraIssue`-style field writes cannot change an issue's project | Cross-project moves go through the bulk-move endpoint only. |
+| schema | `POST /rest/api/3/bulk/issues/move` is async, caps at 1000 issues, and needs global **Bulk Change** plus Move in the source and Create in the target | Poll the returned task. |
+| live | A bulk submit answers `{"taskId": "…"}` and nothing else — the schema is `additionalProperties: false`, so there is **no link to follow** | Progress is `GET /rest/api/3/bulk/queue/{taskId}`, which the client constructs. That is not the generic `GET /rest/api/3/task/{taskId}`, which answers a different shape. |
+| live | The two progress bodies overlap on exactly three keys — `status`, `started`, `submittedBy` — and `submittedBy` has a different **type** in each: a numeric legacy user id on `/task/{id}`, an object with an `accountId` on the bulk queue | A struct written for one either errors on the other or reads two keys and leaves the rest zeroed. The numeric id is the last pre-GDPR id left in v3 and nothing turns it back into a user. |
+| live | On the queue body, `failedAccessibleIssues` and `invalidOrInaccessibleIssueCount` are **absent when zero** | Absent is not a zero with a key on it. A decoder that requires them fails on a clean run. |
+| live | A task's `description` is not reliable prose — it reported zero issues for a run of sixty — and its `message` is sometimes an unresolved i18n key | Report progress from the counts. Neither of those two strings is safe to show a user. |
+| live | A task's `result` is an object for a bulk operation, and its clock — `submitted`, `started`, `lastUpdate`, `finished`, `progress` — is **epoch millis** | Keep `result` as `json.RawMessage` and decode per operation. The Connect variant `TaskProgress` sends those same fields as RFC 3339 strings: two shapes, one name. |
+| schema | The task status enum has **seven** values: `ENQUEUED`, `RUNNING`, `COMPLETE`, `FAILED`, `CANCEL_REQUESTED`, `CANCELLED`, `DEAD` | A cancelled task reads as `CANCEL_REQUESTED` for as long as it takes to stop, so a poller sees it. `jira.TaskState` is missing that one ([#59](https://github.com/varijkapil13/saral/issues/59)). |
+| schema | Dynamic webhooks (`POST /rest/api/3/webhook`) are **Connect / OAuth 2.0 apps only** | No push channel for an API-token client. Poll, scoped and backing off. |
+| schema | The Plans API requires **Administer Jira** on every endpoint, is experimental, and lives at `/rest/api/3/plans/plan` — the doubled segment is correct | Per-plan rights in the UI do not grant API access. `GET /rest/api/3/plans` does not exist. Fall back to locally defined plans. |
+| schema | There is **no release-notes API**. `ReleaseNote.jspa` is a rendered web page | Out of scope by decision. |
+| schema | A `timeZone` on `/rest/api/3/myself` is not a promise this machine can load it | The name comes from the site's zone database and is resolved against Go's zoneinfo, which a slim container image may not carry. That failure is **local**: report it as this machine having no entry for the account's zone, never as Jira failing, and fall back to UTC. |
+
+## Search and paging
+
+There are three paging models and, inside the Agile one, three envelopes.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | `/search/jql` pages by opaque `nextPageToken` and reports **no `total`**. Its envelope holds exactly `issues`, `nextPageToken`, `isLast`, and the last page carries **no token key at all** | The UI must work without a count. `POST /rest/api/3/search/approximate-count` — no `/jql` segment — where a number is genuinely needed. Treat an absent token as the end, and guard against one that repeats. |
+| live | `maxResults` is silently capped at **100** and the envelope never echoes it | Ask for a thousand, get a hundred and a token. The cap cannot be read from the response, so a walk can never distinguish truncation from a small result and must keep following tokens until one is absent. The Agile API is the opposite: asked for a thousand it echoed the thousand and returned every issue, so the truncation this file used to attribute to Agile belongs to `/search/jql`. |
+| live | A page token is bound to the sort and the JQL but **not** to `fields`. Reusing one with a different `jql` is a 400; reusing it with a different field list is a **200 carrying the new field set** | A walk that changes its mask mid-flight produces pages of two different shapes, and `Issue.Requested` is then wrong for half of them. Settle the mask before the first page. |
+| schema | The token is **not opaque**: base64url-decoding one yields the sort column and direction, the last row's sort value, the project key, a row count and the full JQL string | Never cache one across sessions, never log one — it carries the query — and never treat it as an identifier for a result set. |
+| live | `/search/jql` returns almost nothing without `fields`, and `fields: ["key"]` returns issues with **no `fields` object at all** | Always send an explicit narrow list, and let a key-only caller read the key from the issue rather than from the field set. |
+| live | Only *syntax* errors 400. An unknown field, a typo'd project key, a renamed status and an unknown account all answer **200 with zero issues** | An empty list is not evidence of an empty project. This is the most likely way this client lies to somebody. Word an empty result as "no rows for this query", never as "nothing here", and check a saved query's field ids against the catalogue before trusting its silence. |
+| live | An unbounded query is refused: `400 "Unbounded JQL queries are not allowed here"` | Every query needs a restriction clause, so nothing can ask the site for everything — the onboarding project picker included. |
+| live | Asking for a field by the wrong spelling returns nothing at all, with no error: the field id is `statusCategory`, and `statuscategory` is silently ignored | The response carries only the keys it actually returned and nothing says what the endpoint did with the list you sent. `jira.FieldMask` on `Issue.Requested` therefore records what was *asked for*, never what the site had, and "requested and absent" covers three cases at once: empty on the issue, spelled wrongly, and not on this site. Every consumer of the mask has to know that. |
+| live | The Agile API has **three** offset envelopes. `{startAt, maxResults, total, isLast}` on `/board` and `/board/{id}/sprint`; **no `total`** on `/board/{id}/epic` and `/board/{id}/version`; **no `isLast`**, and the array named **`issues`** rather than `values`, on `/board/{id}/issue`, `/board/{id}/backlog` and `/sprint/{id}/issue` | A decoder that reads only `values` turns a board or backlog response into a zero-length page **and no error** — the view renders empty and nothing reports a failure. Read `issues` as a fallback the way the platform envelope already does, treat a missing `total` as unknown rather than zero, and end a walk on a short or empty page. |
+| live | `startAt` past the end answers 200 with an empty array, and the `expand` key disappears with it | The empty page is the reliable end of an offset walk, whatever a `total` claimed. |
+| live | The comment envelope is `{startAt, maxResults, total, comments}` on the *platform* API, with **no `isLast`**; worklogs are the same shape with `worklogs` and a default `maxResults` of **20** | Three array names on three platform endpoints, so neither shared envelope in `pkg/jira/cloud/paginate.go` reads them. The walk ends on the total, and `maxResults` is capped at 100 here too. |
+| live | The order comments come back in is not documented, and `orderBy` accepts only `created` and `-created` | Send `orderBy=created` when oldest-first is what the caller was promised. |
+| schema | A **third** paging style: `/rest/api/3/plans/plan` uses `cursor`/`nextPageCursor` and *does* report a `total` and an `isLast` | It is neither of the other two, which is why `Plans` returns a plain slice. A fourth shape — no paging at all — covers `/field`, attachment upload and the bare-array `/project/{key}/versions`. |
+
+## Errors, and what a failure actually says
+
+The status is the classification; the body is the explanation, and the body has **four** shapes.
+Three of them can hand you text no user should ever see.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | The classic envelope is `{"errorMessages": […], "errors": {…}}` — loose sentences in the first, per-field messages in the second, in the order Jira wrote them | The first per-field message names the field a form should focus. Some endpoints send an empty array under `errors`, which is not a failure and carries nothing. |
+| live | **RFC 7807 is a second envelope.** An unknown route answers `{"type":"about:blank","title":"Not Found","status":404,"detail":"No endpoint GET <path>."}`, a wrong method answers 405 with `detail: "Method 'POST' is not supported."`, and a *real* endpoint uses it too — a malformed multipart upload answers 400 with its only text in `detail` | A parser that reads only `errorMessages` degrades every routing-level failure to bare status text, and routing-level failures are the class most likely to be this client's own bug. Fall back to `detail`, then `title`. |
+| live | **The Agile API puts its prose under `errors`, keyed by an internal request parameter, and sends `errorMessages: []`.** A 404 on a board configuration reads `{"errorMessages":[],"errors":{"rapidViewId":"The requested board cannot be viewed because it either does not exist or you do not have permission to view it."}}` | Joining `errorMessages` for the reason yields the empty string, so the user is told "Not Found" while the one sentence that separates *does not exist* from *you cannot see it* is routed into per-field errors — where a create or edit screen will render `rapidViewId` as though it were one of its own fields. On the Agile API, an `errors` key that is not a field on the screen is a message. |
+| live | Text in a body is not always presentable. Three shapes seen: an empty `errorMessages`, a bare token (`INVALID_INPUT`, `ATTACHMENT_VALIDATION_ERROR`), and an unresolved i18n key (`bulk.operation.progress.percent.complete`) | Anything that prints Jira's own words needs a fallback for when the words are not words. A single upper-case token or a dotted key is an enum, not a sentence. |
+| live | The XSRF guard answers **404 with a plain-text body** | A JSON decode fails on top of a status that reads as "no such issue". Classify on the status; never let a body that will not parse change the classification. |
+| live | Error text is **localised**, in both envelopes, and a sprint validation message came back in German on an account whose locale read `en_US` | Show it; never match on it. There is no error string in either envelope that is safe to branch on. |
+| live | `GET /issue/createmeta/{project}/issuetypes/{id}` for a type the project does not have answers **404 with an empty body** | There is nothing to report but the status, so the caller must supply the wording. Read the issue-type list half first and the failure becomes "this project has no such type" instead of a bare 404. |
+| live | A 429 refuses the request **before it runs**; a 5xx may have got far enough to change something | A 429 is safe to replay whatever the method; a 5xx is only safe for a request that was repeatable to begin with. Getting that backwards duplicates issues. |
+| live | `/search/jql` is a `POST` that only reads | Any blanket "never retry a POST" or "never coalesce a POST" rule needs an exception for it, or search loses both on the hottest path in the application. |
+
+## Reads: issues, fields and schemas
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | A field's declared `schema.type` is not always the shape of its value: a multi-line text field declares `string` and stores an **ADF document**, rank and epic link declare `any`, and a sprint field is an `array` of `items: json` | Read the value itself for a document and for `any`. What the schema does name and this client has no slot for is worth keeping verbatim rather than guessing at — reading a sprint as its name drops its state and its dates. |
+| live | **`schema.items` is not always a type name.** Of 22 array fields in one catalogue, three carried a **localised display label** there — one field answered `items` with its own English display name under `en_US` and with the German translation of it under `de_DE` — and two more carried an unresolved i18n key, of the shape `admin.customfield.type.something.name` | A switch on `items` takes a different branch per language and falls through entirely for the i18n-key fields. Branch on `schema.type` and `schema.custom`, neither of which moved between locales, and let an unknown `items` mean "keep the raw bytes", never "not an array". |
+| live | A `number` field comes back as a **JSON float** whatever was written: an estimate written as `5` reads `5.0` | Decode every number into a float64. An `int` field compiles, passes against a fixture somebody hand-wrote as `5`, and fails on the first real read. |
+| live | A labels-type field comes back **sorted**, not in the order it was sent | Never diff a labels write against its read to decide whether it landed. |
+| live | A user on a `/search/jql` response **does** carry `avatarUrls`, and `emailAddress`, `timeZone` and `accountType` besides | This file said the opposite. The advice survives the correction: the account's own privacy settings decide what is there, so a row that needs an avatar to lay itself out breaks on the account that hides one. |
+| live | `status.iconUrl` is the **bare site root** for a status created through `POST /rest/api/3/statuses`, and a generic placeholder image for one a project template made. Both kinds live on one site | Every value of it is useless for rendering. Status glyphs come from `statusCategory.key`. `issuetype.iconUrl` and `priority.iconUrl` are real images. |
+| live | `fields.statusCategory` arrives as a field in its own right, beside `fields.status` | Two places carry the same answer; `status.statusCategory` is the one to read. |
+| live | `statusCategory.id` is a **number** while `status.id` is a **string**. Four categories on every site: 1 `undefined`, 2 `new`, 3 `done`, 4 `indeterminate` | Branch on `key`. All four `name`s are localised. |
+| live | A select-like field is **written** as `{"id": "…"}`, and a labels-like array of bare strings as the strings | An id is the same on a site in any language and a `value` is not, so write the id wherever the value has one. An option with no id can only have come from an array of strings. |
+| live | Cascading select has **three** shapes: nested under `children` (an array) in createmeta, under `child` (an object) on a stored value, and a **flat list with an `optionId` back-reference to the parent** from `GET /field/{id}/context/{ctx}/option` | One decoder reads one of them. The create-screen option type stays separate from the issue decoder's, and the third shape needs its own or a deliberate decision not to call that endpoint. |
+| live | Setting `parent` on a company-managed issue also fills the epic-link custom field, which reads back as a **bare key string** beside the nested `parent` object | Two statements of one relationship, and a JQL search on either counts the same children. Write `parent`, read `parent`, and treat the mirror as a fallback for an issue that has only that. |
+| live | The platform and Agile APIs write date-times differently, and there are **three** live layouts, not two: `2026-09-01T14:30:00.000+0200` on platform fields (no colon in the offset), a colon form in the Agile schema, and sprint dates **UTC-normalised with `Z`** whatever offset was sent | `2006-01-02T15:04:05.000-0700` and `2006-01-02T15:04:05.000-07:00` between them do not parse a sprint boundary; that one needs `time.RFC3339`. A task's clock is epoch millis instead. One decoder cannot serve all of them. |
+| live | `expand=schema` on `/search/jql` answers one entry per **requested** field, keyed by field id, and `names`/`schema` come back only if asked for — while each issue's own `expand` string lists them either way | That is enough to type a custom field in the same round trip, so a search need not call `/field` to decode its own answer. A query of nothing but system fields should not ask. Do not read the `expand` string as evidence anything was expanded. |
+| schema | `GET /issue/{key}` accepts `expand=schema`, one entry per field on the issue | Worth sending on a single-issue read: without it a custom field's value is typed by its shape alone, which cannot tell a number from a number-shaped string, or a sprint array from an option array. |
+
+## Create screens and transitions
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | `GET /issue/{key}/transitions` omits `fields` **entirely** without `expand=transitions.fields`; with the expand it is `{}` on a screenless transition and populated on a screened one | This file had it backwards. Either way, always ask for the expand — without it a transition with a screen and a required field looks like a move that needs nothing, and the `POST` then fails with a 400 naming a field the client never saw. |
+| live | **A workflow validator's required fields are reported `required: false`.** A screened transition whose validator named two fields listed all four screen fields, with `required: true` on only one of them — and the field configuration did not require that one either | No read tells you what a validator will demand. The `POST` fails 400 with the message in **`errorMessages`** and `errors` **empty**, so a form rendering per-field errors from `errors` shows nothing at all. A transition form has to survive being told after the fact, in an administrator's own prose and language, that a field it drew as optional was required. Keep the user's input and re-present it with the message attached to the whole form. |
+| live | A transition's `fields` is a JSON **object keyed by field id**, so it has no order, and each entry carries `fieldId`, `key` and `name` | Sort it into something stable — required first, then by id — or a form's rows move between two reads of one screen. Read the id from `fieldId`, falling back to `key` and then the map key. |
+| live | `GET /rest/api/3/issue/createmeta?expand=…` is deprecated but still answers 200 | Still deprecated. Use the paginated pair, `GET /issue/createmeta/{projectIdOrKey}/issuetypes` then `…/issuetypes/{issueTypeId}`. |
+| live | Both halves of the pair page by `startAt`/`maxResults`/`total` and name their arrays **`issueTypes`** and **`fields`** rather than `values` | Neither shared envelope decodes them; `pkg/jira/cloud/meta.go` has its own. Send `maxResults` rather than inheriting the site's default. |
+| live | The fields half states **no project and no issue type of its own** | The only statement of either is inside the `project` and `issuetype` fields' `allowedValues`, and the project's `key` lives only there. Read the issue type from the list half instead. |
+| live | **The createmeta field list depends on the caller's permissions.** The same project and issue type answered 33 fields and then 34 — gaining `reporter` — because the account picked up a project role in between | A cached create schema is per token, not per project. Key the cache on both and drop it when the session's account changes. |
+| live | createmeta **omits disabled options** | Right for a picker, wrong for a renderer: an issue can still hold a disabled option, so a detail view must render an option that no create screen offers. |
+| live | `operations` is stated **per field per issue type**, and an empty array means the field is on the screen to be read | It is the only statement of whether a field can be set at all. Measured: a link field offers `add` and `copy` and no `set`; `issuetype` normally sends `[]`. A form that offers every field on the screen offers fields Jira will refuse. |
+| live | A field configuration cannot be created through the v3 API on a current Cloud site — `POST /fieldconfiguration` and `POST /fieldconfigurationscheme` are both refused site-wide, and the endpoint their message points at does not exist | The reads work, and `PUT /fieldconfiguration/{id}/fields` on the shared default configuration is reachable and site-wide. So there is no project-scoped way for a client to make a field required, and no point offering one. |
+| schema | createmeta sends `hasDefaultValue` **and** the `defaultValue` itself, and `jira.FieldMeta` carries only the boolean | A form can say Jira will fill a field in but not what with. Widening the port is [#68](https://github.com/varijkapil13/saral/issues/68). |
+| schema | Every transition carries `isAvailable`, which is `false` only when the request asked for unavailable ones too | Filter on it anyway. Offering a move the site has already refused spends a round trip to earn a 400. |
+| schema | `PUT /issue/{key}` takes `notifyUsers` as a **query parameter**; `POST /issue/{key}/transitions` has no notification control at all | An intent to suppress mail cannot be carried through a transition. |
 
 ## Things that vary per instance — never hardcode
 
-| Thing | Where to get it |
-|---|---|
-| Custom field IDs (story points, start date, target dates) | `GET /rest/api/3/field`, resolved **by `untranslatedName`, falling back to `name`** — see below |
-| Which fields a board estimates in, and whether it ranks at all | `GET /rest/agile/1.0/board/{id}/configuration`, **feature-detected** — see below |
-| Estimation field for a board | `GET /rest/agile/1.0/board/{id}/configuration` → `estimation.field.fieldId` (or `type: none`) |
-| Rank field | same response → `ranking.rankCustomFieldId` |
-| Column → status mapping | same response → `columnConfig.columns[].statuses` |
-| Required fields for create | `GET /rest/api/3/issue/createmeta` per project + issue type |
-| Available transitions | `GET /rest/api/3/issue/{key}/transitions` per issue |
-| Whether attachments are enabled | `GET /rest/api/3/configuration` |
-| Permissions | `GET /rest/api/3/mypermissions?permissions=…` |
-| The user's timezone | `GET /rest/api/3/myself` |
-| Which projects exist, and which this token can see | `GET /rest/api/3/project/search` — paginated, and the only endpoint that answers it. The port has no method for it, so the onboarding picker derives the keys from the projects on a `/search/jql` page instead, which is a shorter answer: it lists what the account has touched, not what it could reach. |
+| Source | Thing | Where to get it |
+|---|---|---|
+| live | Custom field ids | `GET /rest/api/3/field`, resolved by `untranslatedName` and then `name` — with the caveats in Localisation, which are worse than they look |
+| live | Which field a board estimates in, and whether it ranks at all | `GET /rest/agile/1.0/board/{id}/configuration`, **feature-detected** — see Boards |
+| live | Column to status mapping | same response, `columnConfig.columns[].statuses`, which is not the whole story — see Boards |
+| live | Required fields for create | `GET /issue/createmeta/{project}/issuetypes/{id}`, per project, per issue type **and per token** |
+| live | Available transitions | `GET /issue/{key}/transitions?expand=transitions.fields` per issue, and even then not the validator's demands |
+| live | Whether attachments are enabled, and how large one may be | `GET /rest/api/3/attachment/meta` answers both (`enabled`, `uploadLimit`). The size is nowhere in `/configuration` |
+| live | The site's feature switches and its working day | `GET /rest/api/3/configuration`: voting, watching, unassigned issues, sub-tasks, issue linking, time tracking and attachments, plus a `timeTrackingConfiguration` carrying working hours per day and days per week as **floats**. A "3d" estimate is three of *those* days, not seventy-two hours, so any conversion of `originalEstimateSeconds` to days reads them first |
+| live | Permissions | `GET /rest/api/3/mypermissions?permissions=…&projectKey=…` |
+| schema | The user's timezone | `GET /rest/api/3/myself` |
+| live | Which projects exist, and which this token can see | `GET /rest/api/3/project/search` — paginated, and the only endpoint that answers it. The port has no method for it, so onboarding derives keys from a `/search/jql` page instead, which answers a shorter question: what the account has touched, not what it could reach. And that page cannot be unbounded, so it cannot even ask for everything |
 
 ## Permissions, which is what the capability probe reads
 
-| Fact | Consequence |
-|---|---|
-| In the **global context** `mypermissions` reports a project permission as held if the token holds it in *any* project | An unscoped probe answers a different question from the one being asked, and answers it optimistically: it reports Move as available to a token that cannot move an issue in the project on screen. Always send `projectKey`. |
-| The `permissions` parameter is required, and an empty or unrecognised key is a **400** rather than a silently dropped one | Ask for a fixed, narrow list. Widening it speculatively is how a probe starts failing outright on a site that does not know the new key. |
-| A key that *was* asked for can still be missing from the answer, and a **404 means either "no such project" or "you may not see it"** — the endpoint does not distinguish them | Absent, `havePermission: false`, and "the call failed" are three different answers. Word all three differently; a view keyed off the wrong one is either hidden for no reason or lying about why. |
-| `BULK_CHANGE` is a `GLOBAL` permission while `MOVE_ISSUES`, `CREATE_ISSUES` and `DELETE_ISSUES` are `PROJECT` ones — each entry's `type` says which | A cross-project move needs the global one, Move in the source **and** Create in the target, so a probe scoped to one project can only half-answer it. The move flow has to re-check Create once a target is chosen. |
-| Every entry carries a localised `name` and `description` | The `name` is what the site's own administrator sees, in the site's own language, so it is the right wording for a capability's reason — and, being translated, it is never something to match on. |
-| `GET /rest/api/3/attachment/meta` answers the same question as `/configuration` with `enabled`, and adds `uploadLimit` | Narrower than reading the whole site configuration, and the only place the maximum attachment size comes from. |
+| Source | Fact | Consequence |
+|---|---|---|
+| live | The `permissions` parameter is required, and an unrecognised key fails the **whole request** with a 400 naming it | Ask for a fixed, narrow list. Widening it speculatively is how a probe starts failing outright on a site that does not know the new key. |
+| live | `BULK_CHANGE` is a `GLOBAL` permission while `MOVE_ISSUES`, `CREATE_ISSUES` and `DELETE_ISSUES` are `PROJECT` ones — each entry's `type` says which | A cross-project move needs the global one, Move in the source **and** Create in the target, so a probe scoped to one project can only half-answer it. The move flow re-checks Create once a target is chosen. |
+| live | Every entry carries a localised `name` and `description` | The `name` is what the site's own administrator sees, in the site's own language, so it is the right wording for a capability's reason — and, being translated, is never something to match on. |
+| schema | In the **global context** `mypermissions` reports a project permission as held if the token holds it in *any* project | An unscoped probe answers a different question, optimistically: it reports Move as available to a token that cannot move an issue in the project on screen. Always send `projectKey`. |
+| schema | A key that *was* asked for can still be missing from the answer, and a **404 means either "no such project" or "you may not see it"** | Absent, `havePermission: false`, and "the call failed" are three different answers. Word all three differently; a view keyed off the wrong one is either hidden for no reason or lying about why. |
 
 ## ADF
 
-| Fact | Consequence |
-|---|---|
-| The published JSON schema (`go.atlassian.com/adf-json-schema`) and the prose docs disagree, and the prose is the stale one | Model from the schema. It has node types the prose omits — `taskList`, `decisionList`, `layoutSection`, `extension`, `blockCard`, `embedCard`, `placeholder` — all of which Jira stores. |
-| Key order in the JSON is neither documented nor stable | A byte-stable round trip is only possible by keeping the original bytes. `pkg/adf` does exactly that, and re-encodes only the subtrees that changed. |
-| Marks come back from the editor in ProseMirror rank order (`link, em, strong, strike, subsup, underline, code, textColor, backgroundColor, …`) | The REST API accepts any order, but anything a human opens in the browser comes back reordered. Mark order is byte-significant and semantically meaningless — never diff on it. |
-| The validator *repairs* rather than rejects: unknown `attrs` keys are deleted and an `unsupportedNodeAttribute` mark is appended | Sending a document you rebuilt from a partial model is lossy even when it validates. Send back what you were given wherever you did not edit. |
-| `text` on a text node has `minLength: 1` | An empty text node is invalid. Drop it; never emit `"text": ""`. |
-| A node's permitted marks depend on where it sits — the schema encodes this with `_with_no_marks` / `_with_alignment` / `_root_only` variants | A paragraph at the root may carry `alignment`; the same paragraph inside a list item may carry none. |
-| `mention` carries an account id, `status` carries a colour, `date` carries epoch millis, `media` carries a collection, and a `taskItem` carries a `localId` the editor generated | None of them has a markdown spelling, so ADF → markdown → ADF cannot rebuild any of them: a mention comes back as its display text and a lozenge as bracketed text. Editing a document means reconciling against the one you were given — `adf.ParseMarkdownInto` reuses the original node for every block the author did not touch, which is the only way the ids survive. Never invent a `localId`: a made-up one is a *new* item, not the one that was there. |
-| `orderedList` numbers from **one** — `order` is a positive integer | A list stored with `order: 0` is displayed from 1, so reading a "0." back as a list starting at zero invents a document Jira does not have. |
-| ADF has **no nested tables**, and no `table`, `heading` or `rule` inside a `blockquote` or a `listItem` | Markdown can ask for every one of those. Refuse with a typed error rather than sending something the validator will silently repair into a shape nobody wrote. |
-| ADF's content model for a task or decision list is `(item | list)+` | Indenting an action item in the editor stores a sibling `taskList` *inside* the parent list, not inside the item above it. Treating that child as an item loses every checkbox under it. |
+The round trip is settled. A document holding thirty node types and thirteen marks — every panel
+kind, nested lists, tables with spans and column widths, layout columns, the three card types, task
+and decision lists, mentions, dates, status lozenges, external media, and non-ASCII text in several
+scripts — was sent, stored and read back. Jira changed **three things**: it upper-cased a hex colour
+in a custom panel's `panelColor`, and it dropped two empty `attrs: {}` objects on table nodes.
+
+So a fetch-edit-send round trip is stable, because `pkg/adf` re-emits every untouched node from the
+bytes it was given. The two normalisations only bite content this client authors itself — which is
+also why "what I sent came back different" is never evidence that a write failed.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | **The validator rejects; it does not repair.** An unknown node type, an unknown `attrs` key, a nested table, a heading inside a blockquote and a rule inside a list item each answered `400 {"errorMessages":["INVALID_INPUT"],"errors":{}}` | This file said the opposite, and the opposite was the kinder half. The refusal names no node, no path and no attribute, so a client that posts an unvalidated document can only tell the user "Jira refused the document". Validate locally and refuse with a typed error that can say *where*. |
+| live | An empty text node is not rejected — it is **deleted**, and its paragraph comes back with no content at all | The schema's `minLength: 1` on `text` is enforced by silent removal. Never emit `"text": ""`; drop the node yourself so what you hold matches what Jira stored. |
+| live | Key order is neither documented nor stable: a document came back with `marks` after `content` where it went out before | A byte-stable round trip is only possible by keeping the original bytes, which is what `pkg/adf` does, re-encoding only the subtrees that changed. |
+| live | A `media` node naming an attachment the issue does not have answers 400 `ATTACHMENT_VALIDATION_ERROR` | Media is validated against the issue, so a document cannot be moved between issues by copying its bytes. |
+| live | An empty document (`content: []`) round-trips exactly, and a `placeholder` node survives untouched | So an emptied description is a real, storable state, distinct from a description that was never set. |
+| schema | The published JSON schema (`go.atlassian.com/adf-json-schema`) and the prose docs disagree, and the prose is the stale one | Model from the schema. It has node types the prose omits — `taskList`, `decisionList`, `layoutSection`, `extension`, `blockCard`, `embedCard`, `placeholder` — all of which Jira stores. |
+| schema | Marks come back from the editor in ProseMirror rank order (`link, em, strong, strike, subsup, underline, code, textColor, backgroundColor, …`) | The REST API accepts any order, but anything a human opens in the browser comes back reordered. Mark order is byte-significant and semantically meaningless — never diff on it. |
+| schema | A node's permitted marks depend on where it sits; the schema encodes this with `_with_no_marks` / `_with_alignment` / `_root_only` variants | A paragraph at the root may carry `alignment`; the same paragraph inside a list item may carry none. |
+| schema | `mention` carries an account id, `status` a colour, `date` epoch millis, `media` a collection, and a `taskItem` a `localId` the editor generated | None has a markdown spelling, so ADF to markdown and back cannot rebuild any of them. Editing means reconciling against the document you were given: `adf.ParseMarkdownInto` reuses the original node for every block the author did not touch, which is the only way those ids survive. Never invent a `localId` — a made-up one is a *new* item. |
+| schema | `orderedList` numbers from **one**; `order` is a positive integer | A list stored with `order: 0` displays from 1, so reading a "0." back invents a document Jira does not have. |
+| schema | ADF has **no nested tables**, and no `table`, `heading` or `rule` inside a `blockquote` or a `listItem` | Markdown can ask for every one of those, and the API now confirms it refuses them. |
+| schema | The content model for a task or decision list is one-or-more of item-or-list | Indenting an action item in the editor stores a sibling `taskList` *inside* the parent list, not inside the item above it. Treating that child as an item loses every checkbox under it. |
 
 ## Localisation, which breaks resolution by name
 
-`name` is translated into the site's language — statuses, transitions, issue types, priorities,
-resolutions and custom fields all arrive in German on a German site. Anything that matches on a
-display name works on exactly one site.
+`name` is a display string and nothing else. On one site flipped from `en_US` to `de_DE` and back,
+**59 of 101 field names changed**, while every field `id`, every `untranslatedName` and every
+`clauseNames` entry stayed byte-identical. That is the rule this file repeats most often, and it now
+has numbers behind it: match on an id, never on a name.
 
-| Fact | Consequence |
-|---|---|
-| `/rest/api/3/field` sends `untranslatedName` alongside `name`, on **custom fields only** | Resolve by `untranslatedName` first and fall back to `name`. `jira.FieldByName` does this. A system field has no `untranslatedName`, so an empty query must not match one. |
-| `clauseNames` follows `untranslatedName`, never the localised `name` | JQL written from a display name does not parse. Prefer `cf[NNNNN]`, which is always in `clauseNames`. |
-| `untranslatedName` appears on `/field` and **not** in createmeta | A form builder that only has a create screen cannot know it; join to the `/field` catalogue on `fieldId`. |
-| Every person picker on a create screen carries an `autoCompleteUrl`, and it is a **site-absolute URL** | `internal/ui` takes the port and never an adapter, so a view holding one cannot call it. A picker offers what the field's own `allowedValues` states plus the authenticated account until the port grows a user search ([#69](https://github.com/varijkapil13/saral/issues/69)). |
-| Field names are not unique, and Jira signals it by adding a clause name `Name[Field Type]` | That bracketed form is the only unambiguous name; `cf[NNNNN]` is better. |
-| Statuses and transitions are localised too, and their `id` values are not | Group columns by `statusCategory.key` and move issues by transition **id**. Never by name. |
+What does *not* translate matters as much, because the previous version of this note was wrong about
+half of it.
+
+| Source | Thing | Under `de_DE` |
+|---|---|---|
+| live | Field `name` | 59 of 101 changed |
+| live | Status `name` | 9 of 15 changed — the six that did not are the ones an administrator had named |
+| live | Status category `name` | all 4 changed; `key` and `id` did not |
+| live | Priority `name` | **0 of 5** |
+| live | Resolution `name` | **0 of 4** |
+| live | Issue type `name` | **1 of 10**, and only its capitalisation |
+| live | Board column `name`, and a board's `estimation.field.displayName` | changed; the `fieldId` beside it did not |
+| live | Permission `name` and `description`, and error text in both envelopes | changed |
+| live | `untranslatedName`, `clauseNames`, `schema.type`, `schema.custom`, every id | did not move |
+
+Priorities and resolutions are per-site rows an administrator can rename, not translation keys, so
+their English spelling on a German site is a coincidence and not a guarantee. Translation is
+**partial** everywhere: a site is a mixture of Atlassian's strings, which move, and its own, which
+do not, and no read tells you which kind you are holding.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | **`untranslatedName` is a third spelling, not the `en_US` display name.** Two of the 57 custom fields in one catalogue differed from their own English `name`: one dropped a space the display name had, one differed in case | So a resolver that tries an exact case-insensitive `untranslatedName` and then an exact `name` fails **both** passes on a localised site — the first on the punctuation, the second on the translation. `jira.FieldByName` is that resolver, and a `[profiles.x.timeline]` field name resolving through it is not portable to another site or another language. Compare on a folded, space-stripped form, and prefer configuration that holds an id resolved once. |
+| live | `untranslatedName` is sent for **custom fields only** — 57 of 101 here, and not one system field | An empty query must not match anything, and a system field can only be found by its id or by its localised `name`. |
+| live | `clauseNames` follows `untranslatedName`, never the localised `name` — and is **empty on 9 of 101 fields**, eight system and one custom | So `cf[NNNNN]` is *not* always available. A field with no clause names cannot be named in JQL at all, by any spelling, and a query built from one silently matches nothing. Check the list before building a clause, and have somewhere for "this field is not searchable" to go. |
+| live | Names are not unique in either language. One site held **four separate pairs** of distinct status ids sharing a display name, because a team-managed project mints project-scoped statuses that reuse the stock names — and every pair collided again under translation. Issue types collide the same way, for the same reason | A name-keyed lookup silently picks whichever row came first, and the two are usually in different projects. Group columns by `statusCategory.key`, move issues by transition **id**, and never build a status or type index keyed by name. |
+| live | Jira flags an ambiguous field with a bracketed clause name `Name[Field Type]`, and a field `name` may itself contain brackets | So the bracketed form is not reliably parseable either. Use `cf[NNNNN]` where it exists and the id otherwise. |
+| live | `PUT /rest/api/3/mypreferences/locale` is **eventually consistent** — minutes, not seconds — and `Accept-Language` on a request is **ignored outright** | There is no per-request language, so nothing can ask for a stable one, and a read straight after the write still answers in the old language. |
+| live | The language of `name` was seen **changing mid-session** on an account whose `locale` read `en_US`, with `/rest/api/3/status` answering English and `/issue/{key}/transitions` answering German **at the same instant** | Language is a property of neither the request, nor the account, nor reliably the endpoint. This single observation is the whole argument for the rule, and the reason a display name must never be cached as though it identified anything. |
+| live | Every person picker on a create screen carries a site-absolute `autoCompleteUrl` — except a group picker, which carries none, and a labels field, whose URL is on a **different API version** | `internal/ui` takes the port and never an adapter, so a view holding one cannot call it anyway. A picker offers the field's own `allowedValues` plus the authenticated account until the port grows a user search ([#69](https://github.com/varijkapil13/saral/issues/69)). |
+| schema | `untranslatedName` appears on `/field` and **not** in createmeta | A form builder holding only a create screen cannot know it; join to the `/field` catalogue on the field id. |
 
 ## Boards differ from each other far more than the schema suggests
 
-Everything below is per-board, and absence is a normal answer rather than an unset value.
+Everything here is per-board, and absence is a normal answer rather than an unset value.
 
-| Fact | Consequence |
-|---|---|
-| A Kanban board sends **no `estimation` object at all** | `estimation.type: "none"` is a Scrum answer meaning "estimation is off". Absent means "this board does not estimate". `jira.BoardConfig.Estimation` is a pointer for exactly this. |
-| A board ordered by priority — or by anything its filter sorts on — has **no rank field**: `ranking` is present but empty | Detect on `rankCustomFieldId`, never on the presence of `ranking`. Without one, the order comes from the board's saved filter and rows cannot be reordered. Reading that order takes a separate `GET /rest/api/3/filter/{id}`. |
-| `subQuery` is Kanban-only; `estimation` is Scrum-only | Branch on board type before reading either. |
-| Column `min` and `max` are independently optional | Keep both as pointers; a default of zero means something. |
-| The Agile API's nested `self` links point at `/rest/api/2/` | Code that derives a URL by string-matching `/rest/api/3/`, or follows a `self` expecting a v3 body, is broken. |
-| `location.projectId` is a number on `GET /board`; `location.id` is a string on `GET /board/{id}/configuration` | Same project, two types, one call apart. |
+| Source | Fact | Consequence |
+|---|---|---|
+| live | **`GET /board/{id}/issue` does not apply the board's own `subQuery`.** A board whose sub-query hid resolved issues on released versions showed 16 rows in the browser while the endpoint returned 18 | A client that ignores `subQuery` draws issues the real board hides, and no parameter makes the endpoint apply it. Read it from the configuration and apply it yourself, or send it as an extra clause. |
+| live | A Kanban board sends **no `estimation` object at all**, and a board ordered by priority sends **`ranking: {}`** | `estimation.type: "none"` is a Scrum board saying estimation is off; absent means the board does not estimate. `jira.BoardConfig.Estimation` is a pointer for that, and rank is detected on `rankCustomFieldId`, never on the presence of `ranking`. Without a rank field the order comes from the saved filter and rows cannot be reordered; reading that order takes a separate `GET /rest/api/3/filter/{id}`. |
+| live | A board's estimation field may be a **system** field — an original-estimate field with no `customfield_` prefix | Nothing may assume the estimation field id starts with `customfield_`. |
+| live | **A board's estimation field need not be on the project's create screen.** A board estimating in a story-points field faced a create screen of fifteen fields that did not include it | A create form cannot offer the estimate, so either new issues arrive unestimated or the estimate is a follow-up edit. Say which; do not draw a field createmeta did not offer. |
+| live | A board created from a saved filter carries **no `location` key at all** | `jira.Board.ProjectKey` is unresolvable for such a board. Never key a board by project, and never render a project column as though every board had one. |
+| live | Column names are **localised**, two columns on one board may share a name, a column may map **no statuses**, and one column may span **two status categories** | A column's identity is its position, never its name, and a column cannot be given a category from its statuses. |
+| live | **A live status can be mapped to no column at all.** Assigning a workflow the board's column config never learned about left 21 issues in two statuses that appear in no column, and `columnConfig` gives no hint they exist. `columns[].statuses[]` carries only `id` and `self` — no name, no category | Grouping strictly by the column mapping drops rows silently. Count what fell outside and show the count; resolve a status id to a category through the catalogue, not the column. |
+| live | `subQuery` is Kanban-only; `estimation` is Scrum-only; `columnConfig.constraintType` varies per board | Branch on board type before reading either. Column `min` and `max` mean nothing under a constraint type that does not count, and are independently optional — keep both as pointers, because a default of zero means something. |
+| live | `/board/{id}/epic` reports an epic's `name` as `""`, in both project styles: the epic-name field is absent from the issue and not on its create screen, and the entry carries two separate colour keys instead | An epic's label comes from its `summary`. A board view keyed on the epic name draws a column of empty strings. |
+| live | The Agile API's nested `self` links point at `/rest/api/2/` | Code that derives a URL by string-matching `/rest/api/3/`, or follows a `self` expecting a v3 body, is broken. |
+| schema | `location.projectId` is a number on `GET /board`; `location.id` is a string on `GET /board/{id}/configuration` | Same project, two types, one call apart. |
 
-## Version and plan endpoints
+## Company-managed and team-managed are two data models behind one API
 
-| Fact | Consequence |
-|---|---|
-| `/project/{key}/versions` returns a **bare array**; `/project/{key}/version` returns a **paged envelope** | One letter apart, different top-level JSON type. Use the paged one — a project accumulates hundreds of versions. |
-| `expand=issuesstatus` is per-request, not per-version | Either every version in the page has `issuesStatusForFixVersion` or none does. Its absence never means "no issues". |
-| `issuesStatusForFixVersion` buckets by **status category**; `unresolvedIssueCount` counts by **resolution** | They disagree — an issue can be in the Done category with no resolution. Only the second is the pre-release gate. |
-| `overdue` is emitted only when true, and the date fields are independently optional | Absent means false. Do not round-trip it. |
-| `userStartDate` / `userReleaseDate` are locale display strings (`05/Jan/26`) | Render `startDate` / `releaseDate` yourself. |
-| Archived versions are filtered out of createmeta allowed values but present in `/project/{key}/version` | A fix-version picker fed from the wrong endpoint offers archived versions. |
-| Plans `id` is a **string** in the list response while the get-plan example shows a number | Decode leniently. `issueSources[].value` is a numeric project **id**, never a key. |
+| Source | Aspect | Company-managed | Team-managed |
+|---|---|---|---|
+| live | `style` / `simplified` on the project | `classic` / `false` | `next-gen` / `true` |
+| live | Issue types | from a site-wide scheme, `scope` absent | project-scoped, `scope.type: "PROJECT"` |
+| live | The sub-task type's name | **`Sub-task`** | **`Subtask`** |
+| live | Statuses | shared site-wide | minted per project, reusing the stock names, so ids collide by name |
+| live | Board `type` | `scrum` or `kanban` | `simple` |
+| live | The story-point field | the classic template's own float field | a different field of a different custom type. One site held both, and only a board's configuration says which one that board means |
+| live | Parent | writing `parent` also fills the epic-link custom field | `parent` alone |
+| live | Sub-tasks | parented | seen with **no parent at all** |
 
-Group board columns by `statusCategory` (three fixed values: To Do, In Progress, Done), never by
-status name — "In Progress" is not guaranteed to exist.
+Read the shape per project — `style` is the flag — and let nothing assume a name, a type id or a
+field id is shared between two projects on one site. A sub-task with no parent, an epic with no name
+and two story-point fields on one site are all normal answers this client has to render.
+
+## Versions and plans
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | **No version read reports the unresolved count** — not `GET /version/{id}`, not with `expand=issuesstatus`, not the paged project endpoint. It lives on `GET /rest/api/3/version/{id}/unresolvedIssueCount`, and the key there is spelled `issuesUnresolvedCount` | `jira.Version.Unresolved` can only be filled by that extra call, one per version. So the pre-release gate costs a round trip, and a version list cannot show the number for free — which is fine, because the number is only needed at the moment of releasing. |
+| live | `overdue` is emitted with an explicit **`false`** on an unreleased version and is **absent on a released one** | Absence is not "false", it is "released". Detecting overdue by key presence gets it backwards. Do not round-trip the key. |
+| live | `expand=issuesstatus` is per-request, not per-version | Either every version in the page has `issuesStatusForFixVersion` or none does. Its absence never means "no issues". |
+| live | `issuesStatusForFixVersion` buckets by **status category**; the unresolved count counts by **resolution** | They disagree — an issue can be in the Done category with no resolution. Only the count is the gate. |
+| live | Archived versions are filtered out of createmeta allowed values but present in the paged version list | A fix-version picker fed from the version list offers archived versions, so filter the list rather than swapping the source: an issue can already carry an archived version, and a detail view has to render it whatever a create screen would offer. |
+| schema | `/project/{key}/versions` returns a **bare array**; `/project/{key}/version` returns a **paged envelope** | One letter apart, different top-level JSON type. Use the paged one — a project accumulates hundreds of versions. |
+| schema | `userStartDate` / `userReleaseDate` are locale display strings | Render `startDate` / `releaseDate` yourself. |
+| schema | Plans `id` is a **string** in the list response while the get-plan example shows a number | Decode leniently. `issueSources[].value` is a numeric project **id**, never a key. |
+
+## Writes that do not read back at once
+
+One consequence, stated once: **never confirm a write by reading it back.** Say what you asked for,
+report the status the write returned, and let the next scheduled read correct the screen.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | A rank write answers 204 and the rank field's value changes immediately, but the order `/board/{id}/issue` reports lags behind it | Move the row locally and trust the 204. A confirming read can hand back the old order, and a view that re-fetches to confirm snaps the row to where the user dragged it *from*. |
+| live | `approximate-count` lags a write by seconds: straight after clearing 45 assignees it answered 42 and 104 where an exact walk said 46 and 100 | It is an estimate and named as one. Never print it beside a list it can contradict, and never use it to decide whether a write landed. |
+| live | A locale change takes minutes to appear, and to revert | See Localisation. Nothing may be tested by setting the locale and reading straight after. |
+| live | A labels write comes back sorted, and ADF normalises two things on the way in | See the ADF section. A byte difference between what you sent and what came back is not a failure. |
 
 ## Rate limiting
 
-| Fact | Consequence |
-|---|---|
-| `Retry-After` is not always a number of seconds — HTTP permits an absolute date, and Atlassian also sends **`X-RateLimit-Reset`** as an RFC 3339 instant | A client that only does `strconv.Atoi` on `Retry-After` silently falls back to its own backoff on both, and waits the wrong amount. Read seconds, then an HTTP-date, then `X-RateLimit-Reset`, and clamp an instant already in the past to zero. |
-| A 429 refuses the request **before it runs**; a 5xx may have got far enough to change something | So a 429 is safe to replay whatever the method, and a 5xx is only safe for a request that was repeatable to begin with. Getting that backwards duplicates issues. |
-| `/search/jql` is a `POST` that only reads | Any blanket "never retry a POST" or "never coalesce a POST" rule has to make an exception for it, or search loses both retries and request coalescing on the hottest path in the application. |
+| Source | Fact | Consequence |
+|---|---|---|
+| live | **`X-RateLimit-Limit` and `X-RateLimit-Remaining` are on every response**, and their values differ per endpoint | A budget is per endpoint, not per site, and a client can slow down *before* a 429 rather than after one. Read them on success, not only on failure. |
+| schema | `Retry-After` is not always a number of seconds — HTTP permits an absolute date, and Atlassian also sends **`X-RateLimit-Reset`** as an RFC 3339 instant | A client that only does `strconv.Atoi` on `Retry-After` silently falls back to its own backoff on both and waits the wrong amount. Read seconds, then an HTTP-date, then `X-RateLimit-Reset`, and clamp an instant already in the past to zero. |
 
 Honour `Retry-After` on 429. Back off exponentially with jitter, cap concurrent requests, and pause
 any poller on the first 429. Cost-based limits mean a burst of narrow requests beats one wide one.
 
 ## Still to confirm against live responses
 
-- The precise shape of `GET /rest/api/3/configuration`.
-- Whether `PUT /issue/{key}/comment/{id}` really clears a `visibility` the request omits. The
-  adapter re-sends it either way, because being wrong in that direction publishes somebody's
-  restricted comment and being wrong in the other direction costs a round trip.
-- Everything above is from the published OpenAPI schemas, not from a live site. `scripts/capture.sh`
-  has not been run yet, so the fixtures in `pkg/jira/jiratest/fixtures/` are hand-authored to those
-  schemas. Re-capture against a real instance before trusting a field name that only matters once.
+- Every row marked `schema`.
+- The Plans API end to end. It needs Administer Jira on every endpoint and the testbed account never
+  exercised it.
+- Bulk **move** in particular. Only bulk transition was run; the two share a queue, so the progress
+  bodies above are trustworthy and the move's own caps, permissions and failure detail are not.
+- Whether `Retry-After` ever arrives as an HTTP-date. No 429 was provoked.
+- Whether `isAvailable` on a transition is ever `false` without asking for unavailable ones.
+
+Fixtures under `pkg/jira/jiratest/fixtures/` are corrected from a capture's **shape** and given
+invented words; captures themselves stay in the gitignored `testdata/live/`. A shape here marked
+`live` is a shape a fixture can now be held to.
 
 Module paths, all confirmed against the proxy in August 2026: `charm.land/bubbletea/v2`,
 `charm.land/lipgloss/v2`, `charm.land/bubbles/v2` and `github.com/lrstanley/bubblezone/v2` (the v1


### PR DESCRIPTION
`docs/API-NOTES.md` is the file `AGENTS.md` points every agent at so they do not
rediscover a trap. Until today its footer admitted the whole thing came from
Atlassian's published schemas rather than a live site. A real Cloud site has now
been read — two project styles, five boards, sprints in all three states,
versions released and unreleased and archived, custom fields of every type, a
transition with a screen and a validator, and the site language flipped to German
and back — so the file now says, per row, whether the claim was **measured** or
merely **read from a schema**.

## The convention

Every table gains a leading `Source` column with one of two values:

- `live` — seen in a response from a real site.
- `schema` — from Atlassian's published OpenAPI and JSON schemas; nobody has
  watched a site do it.

The preamble says what one site does and does not prove, and "every row marked
`schema`" is now the first entry under *Still to confirm*, so the marker stays
useful as more gets verified: when you check a row, you change one word.

## Claims that were the opposite of the truth

Each of these had a consumer, and three shipped defects trace back to this file.

| Was | Is |
|---|---|
| statuses, transitions, issue types, priorities, resolutions and custom fields all arrive in German on a German site | **priorities 0 of 5 and resolutions 0 of 4 do not translate at all** — they are per-site rows, not i18n keys — and issue types moved 1 of 10, by a capital letter |
| resolve by `untranslatedName`, falling back to `name` | `untranslatedName` is a **third spelling**: two custom fields in one catalogue differed from their own English `name` by a space and by case, so an exact-match resolver fails *both* passes on a localised site. A config file that names a field by display name is not portable |
| prefer `cf[NNNNN]`, which is always in `clauseNames` | `clauseNames` is **empty on 9 of 101 fields**, one of them custom. That field cannot be named in JQL by any spelling |
| the Agile API still uses `startAt`/`maxResults`/`total` | **three** envelopes. Board and backlog reads name their array `issues` and send no `isLast` — which a `values`-only decoder turns into a zero-length page **and no error** |
| the ADF validator repairs rather than rejects | it **rejects**, with `400 {"errorMessages":["INVALID_INPUT"],"errors":{}}`, naming no node, no path and no attribute |
| `/issue/{key}/transitions` sends an empty `fields` object unless you expand | backwards: **no key at all** without the expand, `{}` with it on screenless transitions |
| the adapter re-sends a comment's `visibility` verbatim because omitting it might clear it | echoing it verbatim is a **400** (`value` and `identifier` are mutually exclusive), and omitting it does **not** clear it. Both halves of that row retire, and so does the open question under *Still to confirm* |
| a user on a `/search/jql` response carries no `avatarUrls` | it does, plus `emailAddress`, `timeZone` and `accountType`. The advice not to depend on one survives |
| `unresolvedIssueCount` guards a release | **no version read carries it.** It lives on its own endpoint, under a differently spelled key, at one call per version |
| `overdue` is emitted only when true | emitted as an explicit `false` on unreleased versions, absent on released ones — so key-presence detection is inverted |
| the Agile API silently truncates | `/search/jql` is the one that truncates: it caps `maxResults` at 100 and never echoes it. Agile returned everything it was asked for |

## What is new and load-bearing

- **Status names collide.** One site held four separate pairs of distinct status
  ids sharing a display name, because a team-managed project mints project-scoped
  statuses reusing the stock names — and every pair collides again under
  translation. Translation is also partial: nine of fifteen status names moved,
  and the six that did not were the ones an administrator had named.
- **`schema.items` is not always a type name.** Three of 22 array fields carried a
  *localised display label* there and two more an unresolved i18n key, so a switch
  on `items` takes a different branch per language. `schema.type` and
  `schema.custom` did not move.
- **`GET /board/{id}/issue` does not apply the board's own `subQuery`** — 16 rows
  in the browser, 18 from the endpoint. A client that ignores it draws issues the
  real board hides.
- A number field always reads back as a **JSON float**; a board's estimation
  field need not be on the project's **create screen**; a filter-created board
  carries **no `location`**; a createmeta field list is **per token**, not per
  project; a validator's required fields are reported `required: false` and the
  resulting 400 puts its message where a per-field form will not look.
- A **rank write is not immediately visible** on the board endpoint though the
  field value changes at once, which is now one row in a new *Writes that do not
  read back at once* section, next to `approximate-count` lagging and the locale
  preference taking minutes.
- `X-RateLimit-Limit` and `X-RateLimit-Remaining` are on **every** response and
  differ per endpoint, so a budget is per endpoint and a client can slow down
  before a 429 rather than after one.
- Error text is localised in both envelopes, and three shapes of body carry text
  that is not presentable at all: an empty message array, a bare enum token, and
  an unresolved i18n key.

## Structure

Two new sections earn their place. **Errors, and what a failure actually says**
collects the four body shapes, because three of today's defects are error-shaped:
the RFC 7807 envelope the client cannot read, the Agile 404 that routes its only
useful sentence into per-field errors, and the bodies whose text is not text.
**Company-managed and team-managed are two data models behind one API** is a
comparison table — including the same concept spelled `Sub-task` in one style and
`Subtask` in the other. Search and paging, create screens, and writes that do not
read back were split out of the single long constraints table so a reader looking
up one endpoint area finds it.

## The ADF result, which settles a design question

Over one document holding thirty node types and thirteen marks, Jira changed
**three things**: it upper-cased a hex colour in a custom panel's `panelColor`,
and it dropped two empty `attrs: {}` objects on table nodes. Because `pkg/adf`
re-emits every untouched node from the bytes it was given, a fetch-edit-send
round trip is stable, and the two normalisations only bite content this client
authors itself. The corollary is now stated: a byte difference between what you
sent and what came back is never evidence that a write failed.

## What held

The never-match-by-display-name rule is confirmed, with numbers: 59 of 101 field
names changed under `de_DE` while every id, every `untranslatedName` and every
`clauseNames` entry stayed byte-identical. `BoardConfig.Estimation` being a
pointer and rank being a capability are both guarding real shapes — one board
sends no `estimation` key, another sends `ranking: {}` and orders by priority,
and neither has a `location`. A rule known to be load-bearing is worth more than
a rule repeated.

## Verification

`python3 scripts/checkleak.py` is clean, and the prose was separately checked
against the capture files: no phrase from a real response appears in the file.
Field names, project keys, board names and status names are described by shape,
never quoted. `go test -race -count=1 ./...` is green across all eighteen
packages. `make check` runs `tidy` and `race` clean; `lint` needs
`golangci-lint`, which is not installed on this machine, and this change touches
no Go file.

Docs only — `docs/API-NOTES.md` and nothing else.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
