### PR TITLE
fix(list): show the whole project, and say what a refresh brought back

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,6 +64,24 @@ instance from day one.
   preserved verbatim. Golden-file tests over real captured ADF.
 - [x] **P1.5 — Issue list and detail views** · [#6](https://github.com/varijkapil13/saral/issues/6) · **owns** `internal/ui/{list,issue}/**`
   Virtualized table, incremental cursor paging, `142+` counts, detail pane, comment thread read-only.
+  **Every search this view offered narrowed by who you are.** Found against a real site: a project of
+  nineteen issues, three of them the owner's, and no gesture anywhere that could ask for the other
+  sixteen — the palette's three searches all carry `currentUser()`, and P3.3's facets filter rows
+  already loaded rather than widening the query. There is now a fourth search with no predicate at all (`a`, *Every issue in this project*),
+  the default falls back to it once when nothing in the project is assigned to the account rather than
+  opening on an empty screen, and `e` shows the JQL actually running and takes an edited one, which is
+  also what clicking the line that names it does. A `search` value composes the predicate and the
+  ordering apart, because `scoped()` had nothing to put an `AND` between for the one search that is
+  only an ordering.
+  `r` and `R` now say what came back — *nothing has changed, still 19 issues* as much as *2 new, 1
+  changed* — and the summary line keeps the time the rows last came from the site. Pressing `r` on a
+  query whose answer had not moved was the other half of the same afternoon: correct behaviour,
+  reported as nothing, read as a broken key.
+  **What this did not fix:** every one of these searches, and the default, is only meaningful for a
+  token that is a person. `currentUser()` for a service account resolves to an account nobody assigns
+  anything to, so *My issues* is reliably empty and the fallback fires on every project — which is the
+  right behaviour and the wrong default. Filed as
+  [#102](https://github.com/varijkapil13/saral/issues/102).
 - [x] **P1.6 — First-run onboarding** · [#7](https://github.com/varijkapil13/saral/issues/7) · **owns** `internal/ui/onboarding/**`
   Site, email, token, project picker; writes the profile; explains what the probe found.
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -26,7 +26,7 @@ The mechanisms that make familiarity pay off, in the order a user meets them:
 
 | Stage | Mechanism |
 |---|---|
-| First minute | Onboarding writes the profile, then drops you on your own issues. `?` explains the current view only. |
+| First minute | Onboarding writes the profile, then drops you on your own issues — or on the project itself, where nothing in it is assigned to you, because an empty first screen reads as a broken program. `?` explains the current view only. |
 | First hour | The footer teaches the six keys that matter here. Mouse works, so nothing is blocked on learning. |
 | First week | Frecency: projects, assignees, versions and labels reorder so your usual choices are first. |
 | | Hints: after you reach an action through the palette three times, the status line notes its key. Built in P3.1 ([#12](https://github.com/varijkapil13/saral/issues/12)) rather than with the footer: the count, the call site and the frecency table are one piece of data, and P3.1 already owns it. `kernel.CommandRanMsg{ID, Keys}` is the signal it hangs on, and `Command.Keys` is the key it names — a command nothing binds is never given one, and the line is said once rather than on every run after the third. |
@@ -81,8 +81,10 @@ palette                ctrl+k         everything, fuzzy; opens over what you wer
                                       the one global a view taking typing cannot swallow
 search in view         /              filter rows live
 clear that filter      ctrl+g         from the browsing state; esc does it while still typing
+every issue here       a              widen the search to the whole of the session's project
+edit this search       e              show the JQL on screen and run an edited one
 save this search       s              bind the query on screen to a number key
-refresh                r / R          current view / purge and refetch
+refresh                r / R          current view / purge and refetch. both say what came back
 ```
 
 Vim keys and arrows are both always bound. `j/k` and `↑/↓` are not a preference to configure.
@@ -184,6 +186,7 @@ arithmetic (see `docs/ARCHITECTURE.md`). This table is what the program does.
 | double-click a row | open it, same as `enter` — and only when both clicks are one gesture |
 | click a status, type or assignee cell | show only the rows with that value; click it again to show them all |
 | wheel | scroll the pane under the pointer, not the focused one |
+| click the line that names the search | show its JQL and offer to change it, the same as `e` |
 | click a footer entry | switch view |
 | click anything else a view draws | do what it says — write, send, delete, confirm, put aside, pick a value, go back to an onboarding step |
 
@@ -256,6 +259,13 @@ the mouse — click, wheel, drag or release — reaches the view while the help 
   move task percentage) and elapsed time when it does not.
 - Rate limiting is shown as a countdown, not an error, and any poller pauses itself.
 - Stale data is badged rather than hidden. Seeing yesterday's board beats seeing nothing.
+- **A refresh says what came back, including when that is nothing.** `r` and `R` are the two keys
+  whose whole job is invisible when the answer has not moved, and a refresh that reports nothing is
+  indistinguishable from one that never ran — which is exactly how a working `r` was read as broken.
+  So the status line names the outcome in the words of the thing asked for (*refreshed* against
+  *refetched from scratch*, since `R` does strictly more), and the summary line keeps the time the
+  rows last came from the site, because a status line goes away and a question about how old the
+  screen is comes back.
 - Errors state what failed and what to do. `403` becomes "You need the Bulk Change permission to move
   issues between projects", which is the capability `Reason` verbatim.
 - **The status line is transient, so nothing that has to persist may live only there.** It is one

--- a/internal/ui/keys_test.go
+++ b/internal/ui/keys_test.go
@@ -24,6 +24,8 @@ var keyOwners = map[string]string{
 	"issue.edit":        issue.ViewID,
 	"issue.transition":  issue.ViewID,
 	"issues.save-query": list.ViewID,
+	"issues.edit-query": list.ViewID,
+	"issues.all":        list.ViewID,
 	"issues.open":       list.ViewID,
 }
 

--- a/internal/ui/list/bench_test.go
+++ b/internal/ui/list/bench_test.go
@@ -182,6 +182,23 @@ func BenchmarkFilterKeystroke10k(b *testing.B) {
 	}
 }
 
+// BenchmarkQueryPromptKeystroke10k is the other prompt this view draws under
+// the rows. It costs what the filter does not: nothing is re-matched, so the
+// rows behind it are a memo hit and the line itself is all that is rebuilt.
+func BenchmarkQueryPromptKeystroke10k(b *testing.B) {
+	m := loaded(b, 10000, 120, 40)
+	next, _ := m.Update(keyPress("e"))
+	m, _ = next.(*Model)
+	keys := []tea.Msg{tea.KeyPressMsg{Code: 'x', Text: "x"}, tea.KeyPressMsg{Code: tea.KeyBackspace}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		next, _ := m.Update(keys[i%2])
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+}
+
 func TestScrolling_CostsTheSameOnTenThousandRowsAsOnTwenty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/list/cmds.go
+++ b/internal/ui/list/cmds.go
@@ -19,6 +19,7 @@ const pageSize = 50
 // loadedMsg carries a first page, replacing whatever the list held.
 type loadedMsg struct {
 	gen     int
+	why     why
 	page    jira.Page[jira.Issue]
 	missing []string
 	stored  error
@@ -36,15 +37,19 @@ type pagedMsg struct {
 // principle 5 is that a background refresh patches rows and nothing else.
 type patchedMsg struct {
 	gen    int
+	why    why
 	issues []jira.Issue
 	page   jira.Page[jira.Issue]
 	stored error
 }
 
 // failedMsg is any search that did not produce rows. The error travels whole so
-// that the status line can use the wording the error itself carries.
+// that the status line can use the wording the error itself carries, and what
+// the request was for travels with it so that a refusal is one of the answers a
+// refresh gives rather than an error from nowhere in particular.
 type failedMsg struct {
 	gen int
+	why why
 	err error
 }
 
@@ -75,14 +80,14 @@ func notStored(err error) tea.Cmd {
 }
 
 // load fetches the first page of a query.
-func load(ctx context.Context, search *app.Search, cache app.Cache, jql string, gen int) tea.Cmd {
+func load(ctx context.Context, search *app.Search, cache app.Cache, jql string, gen int, w why) tea.Cmd {
 	return func() tea.Msg {
 		res, err := search.Run(ctx, request(jql))
 		if err != nil {
-			return failedMsg{gen: gen, err: err}
+			return failedMsg{gen: gen, why: w, err: err}
 		}
 		return loadedMsg{
-			gen: gen, page: res.Page, missing: res.Missing,
+			gen: gen, why: w, page: res.Page, missing: res.Missing,
 			stored: keep(cache, jql, res.Page.Items, res.Page.HasMore()),
 		}
 	}
@@ -106,23 +111,23 @@ func more(ctx context.Context, cache app.Cache, jql string, have []jira.Issue, p
 // reload re-reads the rows the list already has, walking as many pages as it
 // took to get them. It exists so that a refresh can patch rows in place rather
 // than throw the user's position away and start again at row one.
-func reload(ctx context.Context, search *app.Search, cache app.Cache, jql string, want, gen int) tea.Cmd {
+func reload(ctx context.Context, search *app.Search, cache app.Cache, jql string, want, gen int, w why) tea.Cmd {
 	return func() tea.Msg {
 		res, err := search.Run(ctx, request(jql))
 		if err != nil {
-			return failedMsg{gen: gen, err: err}
+			return failedMsg{gen: gen, why: w, err: err}
 		}
 		page := res.Page
 		issues := slices.Clone(page.Items)
 		for len(issues) < want && page.HasMore() {
 			page, err = page.Next(ctx)
 			if err != nil {
-				return failedMsg{gen: gen, err: err}
+				return failedMsg{gen: gen, why: w, err: err}
 			}
 			issues = append(issues, page.Items...)
 		}
 		return patchedMsg{
-			gen: gen, issues: issues, page: page,
+			gen: gen, why: w, issues: issues, page: page,
 			stored: keep(cache, jql, issues, page.HasMore()),
 		}
 	}

--- a/internal/ui/list/empty_test.go
+++ b/internal/ui/list/empty_test.go
@@ -69,7 +69,9 @@ var emptyPanes = []struct {
 		name:  "an answer with no rows in it",
 		file:  "none",
 		build: func(t *testing.T, w, h int) *Model { return newDriver(t, testDeps(newFake(0)), w, h).m },
-		says:  []string{"Nothing matches this search.", "currentUser()", "0 issues"},
+		// The search named here is the whole project: a default that found nothing
+		// assigned to the account widens to it before anybody sees this pane.
+		says: []string{"Nothing matches this search.", `project = "PROJ" ORDER BY updated DESC`, "0 issues"},
 	},
 	{
 		name: "a search that failed",

--- a/internal/ui/list/keys.go
+++ b/internal/ui/list/keys.go
@@ -16,6 +16,8 @@ type keyMap struct {
 	Bottom   kernel.Binding
 	Open     kernel.Binding
 	Filter   kernel.Binding
+	All      kernel.Binding
+	Edit     kernel.Binding
 	Save     kernel.Binding
 	Accept   kernel.Binding
 	Clear    kernel.Binding
@@ -23,6 +25,10 @@ type keyMap struct {
 	// one of its keys: the kernel keeps that for itself in a root view, so naming
 	// it here would advertise a stroke that never arrives.
 	Unfilter kernel.Binding
+	// Run and Keep answer the prompt that shows the search on screen: one runs
+	// what has been typed into it, the other leaves the search alone.
+	Run  kernel.Binding
+	Keep kernel.Binding
 	// Slot, Take and Drop answer the gesture that binds the search on screen to
 	// a number key. bindKey reads the digit and the y itself, because every other
 	// key ends the gesture and a table would have to enumerate the alphabet to
@@ -45,10 +51,14 @@ func defaultKeys() keyMap {
 		Bottom:   kernel.Bind([]string{"G", "end"}, "G", "last row"),
 		Open:     kernel.Bind([]string{"enter"}, "enter", "open"),
 		Filter:   kernel.Bind([]string{"/"}, "/", "filter"),
+		All:      kernel.Bind([]string{"a"}, "a", "all issues"),
+		Edit:     kernel.Bind([]string{"e"}, "e", "edit this search"),
 		Save:     kernel.Bind([]string{"s"}, "s", "save this query to a key"),
 		Accept:   kernel.Bind([]string{"enter"}, "enter", "keep filter"),
 		Clear:    kernel.Bind([]string{"esc", "ctrl+g"}, "esc", "clear filter"),
 		Unfilter: kernel.Bind([]string{"ctrl+g"}, "ctrl+g", "clear filter"),
+		Run:      kernel.Bind([]string{"enter"}, "enter", "run this search"),
+		Keep:     kernel.Bind([]string{"esc", "ctrl+g"}, "esc", "keep the one on screen"),
 		Slot:     kernel.Bind(digits, "1-9", "the key to bind it to"),
 		Take:     kernel.Bind([]string{"y"}, "y", "take the key"),
 		Drop:     kernel.Bind([]string{"esc"}, "esc", "leave it alone"),
@@ -64,12 +74,16 @@ func (k keyMap) keySet() kernel.KeySet { return k.browsing(false) }
 
 // browsing is the resting state, with or without a filter already narrowing the
 // rows. The narrowed one offers the key that clears it.
+//
+// The two that reach another search are in the overlay and not the hint line: a
+// fifth entry there is enough to push the whole line past what an eighty-column
+// footer holds, and the kernel drops the line rather than shortening it.
 func (k keyMap) browsing(narrowed bool) kernel.KeySet {
 	short := []kernel.Binding{k.Down, k.Up, k.Open, k.Filter}
-	actions := []kernel.Binding{k.Open, k.Filter, k.Save}
+	actions := []kernel.Binding{k.Open, k.Filter, k.All, k.Edit, k.Save}
 	if narrowed {
 		short = []kernel.Binding{k.Down, k.Up, k.Open, k.Unfilter}
-		actions = []kernel.Binding{k.Open, k.Filter, k.Unfilter, k.Save}
+		actions = []kernel.Binding{k.Open, k.Filter, k.Unfilter, k.All, k.Edit, k.Save}
 	}
 	return kernel.KeySet{
 		Short: short,
@@ -81,9 +95,9 @@ func (k keyMap) browsing(narrowed bool) kernel.KeySet {
 	}
 }
 
-// keyState is which of the view's four states the keys belong to. It doubles as
-// the generation the chrome memoizes on, so a state that is added has to be
-// added here to be drawn.
+// keyState is which of the view's states the keys belong to. It doubles as the
+// generation the chrome memoizes on, so a state that is added has to be added
+// here to be drawn.
 type keyState int
 
 const (
@@ -92,6 +106,7 @@ const (
 	keysFiltering
 	keysPickingSlot
 	keysConfirmingSlot
+	keysAsking
 	keyStates
 )
 
@@ -114,18 +129,25 @@ var liveSets = func() [keyStates]kernel.KeySet {
 		Short: []kernel.Binding{k.Take, k.Drop},
 		Full:  [][]kernel.Binding{{k.Take, k.Drop}},
 	}
+	sets[keysAsking] = kernel.KeySet{
+		Short: []kernel.Binding{k.Run, k.Keep},
+		Full:  [][]kernel.Binding{{k.Run, k.Keep}},
+	}
 	return sets
 }()
 
 // LiveKeys reports the keys that work in the state the list is actually in. An
-// open filter answers enter and esc and nothing else; the gesture that binds a
-// number key answers a digit, then a y; a list already narrowed by a filter
-// offers the key that widens it again.
+// open filter answers enter and esc and nothing else; the prompt holding the
+// search answers the same two strokes for two other things; the gesture that
+// binds a number key answers a digit, then a y; a list already narrowed by a
+// filter offers the key that widens it again.
 func (m *Model) LiveKeys() (set kernel.KeySet, gen int) {
 	state := keysBrowsing
 	switch {
 	case m.filtering:
 		state = keysFiltering
+	case m.asking:
+		state = keysAsking
 	case m.bind == bindPick:
 		state = keysPickingSlot
 	case m.bind == bindConfirm:
@@ -151,26 +173,33 @@ const (
 	actBottom
 	actOpen
 	actFilter
+	actAll
+	actEdit
 	actSave
 	actAccept
 	actClear
+	actRun
+	actKeep
 )
 
 // tables turn the bindings into a keystroke lookup, built once. The bindings
 // stay the single source of truth for what a key does and for what the footer
 // says it does, and a keystroke costs one map probe rather than a walk over
 // every binding — which on this path is per keypress, at ten thousand rows.
-func (k keyMap) tables() (normal, filtering map[string]action) {
+func (k keyMap) tables() (normal, filtering, asking map[string]action) {
 	normal = table(
 		binding{k.Down, actDown}, binding{k.Up, actUp},
 		binding{k.PageDown, actPageDown}, binding{k.PageUp, actPageUp},
 		binding{k.HalfDown, actHalfDown}, binding{k.HalfUp, actHalfUp},
 		binding{k.Go, actGo}, binding{k.Top, actTop}, binding{k.Bottom, actBottom},
 		binding{k.Open, actOpen}, binding{k.Filter, actFilter},
-		binding{k.Unfilter, actClear}, binding{k.Save, actSave},
+		binding{k.Unfilter, actClear},
+		binding{k.All, actAll}, binding{k.Edit, actEdit},
+		binding{k.Save, actSave},
 	)
 	filtering = table(binding{k.Accept, actAccept}, binding{k.Clear, actClear})
-	return normal, filtering
+	asking = table(binding{k.Run, actRun}, binding{k.Keep, actKeep})
+	return normal, filtering, asking
 }
 
 type binding struct {

--- a/internal/ui/list/keys_test.go
+++ b/internal/ui/list/keys_test.go
@@ -22,6 +22,7 @@ func TestLiveKeys_EveryStateGolden(t *testing.T) {
 		{"filter open", keysFiltering},
 		{"picking the number key", keysPickingSlot},
 		{"confirming a number key that is taken", keysConfirmingSlot},
+		{"editing the search on screen", keysAsking},
 	}
 	if len(named) != int(keyStates) {
 		t.Fatalf("the list has %d key states and this test names %d", keyStates, len(named))
@@ -48,6 +49,7 @@ func TestLiveKeys_FollowWhatTheListIsDoing(t *testing.T) {
 		{"filter open", func() { m.filtering = true }, keysFiltering},
 		{"picking a key", func() { m.filtering, m.bind = false, bindPick }, keysPickingSlot},
 		{"confirming a key", func() { m.bind = bindConfirm }, keysConfirmingSlot},
+		{"editing the search", func() { m.bind, m.asking = bindNone, true }, keysAsking},
 	} {
 		tc.enter()
 		set, gen := m.LiveKeys()

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -49,6 +49,7 @@ type Model struct {
 	cache    app.Cache
 	normal   map[string]action
 	inFilter map[string]action
+	inAsk    map[string]action
 	styles   *styles
 	rows     *rowCache
 
@@ -84,14 +85,26 @@ type Model struct {
 	filter    textinput.Model
 	query     string
 
+	// asking is the prompt that shows the search on screen and takes an edited
+	// one, so that what is being run is readable and changeable from the view
+	// rather than only from the palette.
+	asking bool
+	ask    textinput.Model
+
 	// facet is the cell somebody clicked, and what the rows stay narrowed to
 	// until they click it again.
 	facet facet
 
-	// defaulted records that the search on screen is still the one New derived
-	// from the session's project. A project switch retargets that search and
-	// leaves alone one the user asked for.
+	// defaulted records that the search on screen is still the one this view
+	// chose from the session's project. A project switch retargets that search
+	// and leaves alone one the user asked for.
 	defaulted bool
+
+	// widened records that the default has already fallen back to the whole
+	// project for want of anything assigned to this account. It stops an empty
+	// project being asked the same question twice, and a project switch clears
+	// it because that derives a fresh default.
+	widened bool
 
 	// saved is the kernel's set of saved queries, as this view was built and as
 	// the kernel last changed it, kept so that binding a key can name what that
@@ -111,6 +124,11 @@ type Model struct {
 	// kernel.Fail writes is replaced by the next keypress, so the pane keeps its
 	// own copy of the reason for as long as it is empty.
 	failure error
+
+	// checked is when what is on screen last came from the site, and the zero
+	// time until anything has. The summary line's stamp is drawn from it: the
+	// status line a refresh writes goes away, and this does not.
+	checked time.Time
 
 	// stale marks the rows on screen as older than they should be: they came off
 	// disk past their TTL, or the refresh that would have replaced them failed.
@@ -141,16 +159,18 @@ const (
 	bindConfirm
 )
 
-// WantsRawKeys is true while the filter is open, and while a number key is
+// WantsRawKeys is true while either prompt is open, and while a number key is
 // being picked. Without it the kernel matches its own bindings first, so a
 // query loses every digit, r triggers a refetch, esc cannot cancel, and q quits
 // the program out from under the typing — and the digit that was meant to bind
 // a key would run whatever is already on it instead.
-func (m *Model) WantsRawKeys() bool { return m.filtering || m.bind != bindNone }
+func (m *Model) WantsRawKeys() bool { return m.filtering || m.asking || m.bind != bindNone }
 
 // New builds the issue list. The query it opens on is the user's own work,
-// narrowed to the session's project when there is one; both halves are resolved
-// at runtime, so nothing about the site is written down here.
+// narrowed to the session's project when there is one — and the project itself
+// where that comes back empty, which widen does once the site has answered.
+// Every half of it is resolved at runtime, so nothing about the site is written
+// down here.
 func New(d kernel.Deps) kernel.View {
 	m := &Model{
 		deps:   d,
@@ -158,6 +178,7 @@ func New(d kernel.Deps) kernel.View {
 		styles: newStyles(d.Theme),
 		rows:   newRowCache(rowCacheLimit),
 		filter: newFilterInput(),
+		ask:    newAskInput(),
 		saved:  d.Saved,
 		poll:   PollInterval(),
 	}
@@ -170,7 +191,7 @@ func New(d kernel.Deps) kernel.View {
 	}
 	m.zones = widget.NewZoner(d.Zones)
 	m.clicks = widget.NewClicks(d.Now)
-	m.normal, m.inFilter = defaultKeys().tables()
+	m.normal, m.inFilter, m.inAsk = defaultKeys().tables()
 	m.jql, m.title = defaultQuery(d.Project)
 	m.defaulted = true
 	m.relayout()
@@ -199,18 +220,6 @@ func (m *Model) fromCache() {
 	m.rows.reset()
 	m.relayout()
 	m.refilter()
-}
-
-func defaultQuery(project string) (jql, title string) {
-	if strings.TrimSpace(project) == "" {
-		return "assignee = currentUser() ORDER BY updated DESC", "My issues"
-	}
-	return "project = " + quote(project) + " AND assignee = currentUser() ORDER BY updated DESC",
-		"My issues in " + project
-}
-
-func quote(s string) string {
-	return strconv.Quote(strings.ReplaceAll(s, `"`, ""))
 }
 
 func newFilterInput() textinput.Model {
@@ -252,7 +261,7 @@ func (m *Model) revalidate() tea.Cmd {
 	if !m.stale {
 		return nil
 	}
-	return m.refresh(false)
+	return m.refetch(whyBackground)
 }
 
 // Update handles one message.
@@ -293,6 +302,9 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case SaveQueryMsg:
 		m.startBind()
 
+	case EditQueryMsg:
+		cmd = m.startAsk()
+
 	case FacetMsg:
 		cmd = m.facetMsg(msg)
 
@@ -331,11 +343,14 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 func (m *Model) setFocus(on bool) tea.Cmd {
 	m.focused = on
 	switch {
-	case !m.filtering:
-	case on:
+	case m.filtering && on:
 		_ = m.filter.Focus()
-	default:
+	case m.filtering:
 		m.filter.Blur()
+	case m.asking && on:
+		_ = m.ask.Focus()
+	case m.asking:
+		m.ask.Blur()
 	}
 	if on {
 		return m.pollTick()
@@ -348,6 +363,9 @@ func (m *Model) resize(w, h int) tea.Cmd {
 		return nil
 	}
 	m.width, m.height = w, h
+	if m.asking {
+		m.ask.SetWidth(m.askWidth())
+	}
 	m.relayout()
 	m.scrollToCursor()
 	return m.pageAheadIfNeeded()
@@ -387,7 +405,7 @@ func (m *Model) rowsHeight() int {
 	if m.keptFilter() {
 		h--
 	}
-	if m.filtering || m.bind != bindNone {
+	if m.filtering || m.asking || m.bind != bindNone {
 		h--
 	}
 	return max(h, 1)
@@ -418,20 +436,32 @@ func (m *Model) stop() {
 
 func (m *Model) current(gen int) bool { return gen == m.gen }
 
-func (m *Model) load() tea.Cmd {
+func (m *Model) load() tea.Cmd { return m.loadFor(whyOpen) }
+
+func (m *Model) loadFor(w why) tea.Cmd {
 	if m.search == nil {
 		return nil
 	}
 	ctx, gen := m.begin()
-	return withCancel(m.cancel, load(ctx, m.search, m.cache, m.jql, gen))
+	return withCancel(m.cancel, load(ctx, m.search, m.cache, m.jql, gen, w))
 }
 
 func (m *Model) refresh(purge bool) tea.Cmd {
+	if purge {
+		return m.refetch(whyPurge)
+	}
+	return m.refetch(whyRefresh)
+}
+
+// refetch re-reads the search on screen. What it was asked for travels with the
+// request, because a poll, a revalidation and somebody pressing r all arrive
+// here and only one of them has anybody waiting to be told what came back.
+func (m *Model) refetch(w why) tea.Cmd {
 	if m.search == nil {
 		return nil
 	}
 	var said tea.Cmd
-	if purge {
+	if w == whyPurge {
 		m.search.Invalidate()
 		if m.cache != nil {
 			if err := m.cache.Forget(m.jql); err != nil {
@@ -440,10 +470,10 @@ func (m *Model) refresh(purge bool) tea.Cmd {
 		}
 	}
 	if !m.loaded {
-		return tea.Batch(said, m.load())
+		return tea.Batch(said, m.loadFor(w))
 	}
 	ctx, gen := m.begin()
-	return tea.Batch(said, withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues), gen)))
+	return tea.Batch(said, withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues), gen, w)))
 }
 
 func (m *Model) retarget(msg QueryMsg) tea.Cmd {
@@ -461,6 +491,7 @@ func (m *Model) reproject(project string) tea.Cmd {
 	if !m.defaulted {
 		return nil
 	}
+	m.widened = false
 	jql, title := defaultQuery(project)
 	return m.setQuery(jql, title, true)
 }
@@ -477,6 +508,7 @@ func (m *Model) setQuery(jql, title string, byDefault bool) tea.Cmd {
 	m.issues, m.page, m.missing, m.view, m.needles = nil, jira.Page[jira.Issue]{}, nil, nil, nil
 	m.cursor, m.top, m.loaded = 0, 0, false
 	m.cachedMore, m.stale, m.failure = false, false, nil
+	m.checked = time.Time{}
 	m.facet = facet{}
 	m.rows.reset()
 	m.refilter()
@@ -500,15 +532,20 @@ func (m *Model) loadedPage(msg loadedMsg) tea.Cmd {
 	if !m.current(msg.gen) {
 		return nil
 	}
+	before := m.issues
 	m.loading, m.loaded = false, true
 	m.issues, m.needles = slices.Clone(msg.page.Items), nil
 	m.page, m.missing = msg.page, msg.missing
-	m.cachedMore, m.stale = false, false
+	m.cachedMore, m.stale, m.checked = false, false, m.now()
 	m.rows.reset()
 	m.relayout()
 	m.refilter()
 	m.cursor, m.top = 0, 0
-	return tea.Batch(m.missingFields(), notStored(msg.stored), m.pageAheadIfNeeded(), m.pollTick())
+	if wider := m.widen(); wider != nil {
+		return tea.Batch(notStored(msg.stored), wider)
+	}
+	return tea.Batch(m.missingFields(), notStored(msg.stored),
+		refreshed(msg.why, before, m.issues), m.pageAheadIfNeeded(), m.pollTick())
 }
 
 func (m *Model) nextPage(msg pagedMsg) tea.Cmd {
@@ -518,7 +555,7 @@ func (m *Model) nextPage(msg pagedMsg) tea.Cmd {
 	m.loading = false
 	m.issues, m.needles = append(m.issues, msg.page.Items...), nil
 	m.page = msg.page
-	m.cachedMore, m.stale = false, false
+	m.cachedMore, m.stale, m.checked = false, false, m.now()
 	m.relayout()
 	m.refilter()
 	return tea.Batch(notStored(msg.stored), m.pageAheadIfNeeded(), m.pollTick())
@@ -531,14 +568,15 @@ func (m *Model) patch(msg patchedMsg) tea.Cmd {
 		return nil
 	}
 	m.loading, m.loaded = false, true
-	under := m.selectedKey()
+	under, before := m.selectedKey(), m.issues
 	m.issues, m.page, m.needles = msg.issues, msg.page, nil
-	m.cachedMore, m.stale = false, false
+	m.cachedMore, m.stale, m.checked = false, false, m.now()
 	m.rows.reset()
 	m.relayout()
 	m.refilter()
 	m.restore(under)
-	return tea.Batch(notStored(msg.stored), m.pageAheadIfNeeded(), m.pollTick())
+	return tea.Batch(notStored(msg.stored), refreshed(msg.why, before, m.issues),
+		m.pageAheadIfNeeded(), m.pollTick())
 }
 
 // failed keeps whatever is on screen. Rows that are already drawn are the last
@@ -562,7 +600,7 @@ func (m *Model) failed(msg failedMsg) tea.Cmd {
 	if errors.As(msg.err, &limit) {
 		m.pollPaused = true
 	}
-	return tea.Batch(kernel.Fail(msg.err), m.pollTick())
+	return tea.Batch(failure(msg.why, msg.err), m.pollTick())
 }
 
 // missingFields reports the projection fields this site has no field for, which
@@ -590,7 +628,7 @@ func (m *Model) pageAheadIfNeeded() tea.Cmd {
 	// Rows that came off disk carry no cursor to follow, so the page after them
 	// is reached by asking the search again and walking to where they end.
 	if !m.page.HasMore() {
-		return withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues)+pageSize, gen))
+		return withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues)+pageSize, gen, whyPage))
 	}
 	return withCancel(m.cancel, more(ctx, m.cache, m.jql, m.issues, m.page, gen))
 }
@@ -718,6 +756,9 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 	if m.filtering {
 		return m.filterKey(msg, stroke)
 	}
+	if m.asking {
+		return m.askKey(msg, stroke)
+	}
 	if m.bind != bindNone {
 		return m.bindKey(stroke)
 	}
@@ -755,9 +796,13 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 		return m.startFilter()
 	case actClear:
 		return m.clearFilter()
+	case actAll:
+		return m.showEverything()
+	case actEdit:
+		return m.startAsk()
 	case actSave:
 		m.startBind()
-	case actNone, actAccept:
+	case actNone, actAccept, actRun, actKeep:
 	}
 	return nil
 }
@@ -891,6 +936,10 @@ func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
 	if msg.Button != tea.MouseLeft {
 		return nil
 	}
+	if m.zones.Hit(titleZone, msg) {
+		m.clicks.Forget()
+		return m.startAsk()
+	}
 	for i := m.top; i < min(m.top+m.rowsHeight(), len(m.view)); i++ {
 		iss := &m.issues[m.view[i]]
 		if cmd, narrowed := m.clickFacet(msg, iss); narrowed {
@@ -958,6 +1007,9 @@ func (m *Model) View() string {
 	if m.filtering {
 		lines = append(lines, m.filter.View())
 	}
+	if m.asking {
+		lines = append(lines, m.askPrompt())
+	}
 	if m.bind != bindNone {
 		lines = append(lines, m.bindPrompt())
 	}
@@ -1006,6 +1058,7 @@ type summaryKey struct {
 	filtered        bool
 	stale           bool
 	failed          bool
+	checked         int64
 }
 
 func (m *Model) summaryKey() summaryKey {
@@ -1013,7 +1066,7 @@ func (m *Model) summaryKey() summaryKey {
 		title: m.title, width: m.width, gen: m.styles.gen,
 		issues: len(m.issues), visible: len(m.view), more: m.hasMore(),
 		loading: m.loading, loaded: m.loaded, filtered: m.filtered(),
-		stale: m.stale, failed: m.failure != nil,
+		stale: m.stale, failed: m.failure != nil, checked: m.checked.UnixNano(),
 	}
 }
 
@@ -1031,12 +1084,25 @@ func (m *Model) summaryLine() string {
 	if m.stale {
 		badge = m.deps.Theme.StaleBadge.Render(staleLabel)
 	}
-	right := ansi.StringWidth(badge) + ansi.StringWidth(count)
+	stamp := m.checkedLabel()
+	right := ansi.StringWidth(stamp) + ansi.StringWidth(badge) + ansi.StringWidth(count)
 	title := ansi.Truncate(m.title, max(m.width-right-1, 1), ell)
 	pad := max(m.width-ansi.StringWidth(title)-right, 1)
-	m.summary = m.styles.title.Render(title) + strings.Repeat(" ", pad) + badge + m.styles.count.Render(count)
+	m.summary = m.zones.Mark(titleZone, m.styles.title.Render(title)) +
+		strings.Repeat(" ", pad) + stamp + badge + m.styles.count.Render(count)
 	m.sumKey = key
 	return m.summary
+}
+
+// checkedLabel says when what is on screen last came from the site, in the
+// account's own timezone like every other instant this view draws. It is the
+// half of an observable refresh that stays: pressing r twice a minute apart
+// leaves two different times behind, whatever the answer was both times.
+func (m *Model) checkedLabel() string {
+	if m.checked.IsZero() {
+		return ""
+	}
+	return m.styles.muted.Render("checked " + m.checked.In(m.deps.Caps.Location()).Format("15:04") + "  ")
 }
 
 // staleLabel is a word and not a glyph: the glyph beside the count already means

--- a/internal/ui/list/poll.go
+++ b/internal/ui/list/poll.go
@@ -47,7 +47,7 @@ func (m *Model) pollTick() tea.Cmd {
 // polled acts on a tick: re-read what is on screen, which patches the rows and
 // leaves the cursor, the scroll and the filter alone.
 //
-// A poll while the user is typing into the filter or picking a number key is
+// A poll while the user is typing into either prompt or picking a number key is
 // dropped rather than run: the rows would move under a gesture that is half
 // finished. The next tick is lined up anyway, so the poller does not stop
 // because somebody paused over a keystroke.
@@ -56,8 +56,8 @@ func (m *Model) polled(msg pollMsg) tea.Cmd {
 	switch {
 	case m.pollPaused || !m.focused:
 		return nil
-	case !m.current(msg.gen) || m.loading || m.filtering || m.bind != bindNone:
+	case !m.current(msg.gen) || m.loading || m.filtering || m.asking || m.bind != bindNone:
 		return m.pollTick()
 	}
-	return m.refresh(false)
+	return m.refetch(whyBackground)
 }

--- a/internal/ui/list/refresh.go
+++ b/internal/ui/list/refresh.go
@@ -1,0 +1,128 @@
+package list
+
+import (
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// why is what a fetch was for. One reload serves a refresh, a revalidation of
+// rows off disk, a poll and the page walked on from stored rows, so what lands
+// is reported as the thing somebody asked for rather than as the mechanism that
+// happened to carry it.
+type why uint8
+
+const (
+	// whyOpen is the first read of a search, whose rows are their own report.
+	whyOpen why = iota
+	whyRefresh
+	whyPurge
+	// whyPage is the next page, which the count already accounts for.
+	whyPage
+	// whyBackground is a poll or a revalidation: nobody pressed anything, so
+	// nothing is said unless it fails.
+	whyBackground
+)
+
+// words are the two things a fetch is called in a status line: what it did when
+// it worked, and what did not work when it did not. Both are empty for a fetch
+// nobody asked for, which is how those stay silent.
+func (w why) words() (did, failed string) {
+	switch w {
+	case whyRefresh:
+		return "refreshed", "the refresh failed"
+	case whyPurge:
+		return "refetched from scratch", "the refetch failed"
+	case whyOpen, whyPage, whyBackground:
+		return "", ""
+	}
+	return "", ""
+}
+
+// change is what a fetch brought back held against what was on screen before
+// it. It is the whole point of the line a refresh writes: a refresh that found
+// nothing new is indistinguishable from one that never ran unless it says so.
+type change struct{ added, gone, updated int }
+
+func (c change) any() bool { return c.added > 0 || c.gone > 0 || c.updated > 0 }
+
+// text names what moved, leaving out whichever of the three did not.
+func (c change) text() string {
+	parts := make([]string, 0, 3)
+	for _, part := range [...]struct {
+		n    int
+		word string
+	}{{c.added, "new"}, {c.updated, "changed"}, {c.gone, "gone"}} {
+		if part.n > 0 {
+			parts = append(parts, strconv.Itoa(part.n)+" "+part.word)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// diff compares two reads of the same search by key and by when each issue was
+// last touched, which is as much as a list projection knows about a row.
+func diff(before, after []jira.Issue) change {
+	was := make(map[string]int64, len(before))
+	for i := range before {
+		was[before[i].Key] = before[i].Updated.UnixNano()
+	}
+	var c change
+	for i := range after {
+		when, had := was[after[i].Key]
+		switch {
+		case !had:
+			c.added++
+		case when != after[i].Updated.UnixNano():
+			c.updated++
+		}
+		delete(was, after[i].Key)
+	}
+	c.gone = len(was)
+	return c
+}
+
+// refreshed is the status line a landed refresh writes. "Nothing has changed" is
+// said out loud, because that is the outcome a silent refresh cannot be told
+// apart from.
+func refreshed(w why, before, after []jira.Issue) tea.Cmd {
+	did, _ := w.words()
+	if did == "" {
+		return nil
+	}
+	switch c := diff(before, after); {
+	case len(after) == 0:
+		return kernel.Status(did + ": still nothing matches this search")
+	case len(before) == 0:
+		return kernel.Status(did + ": " + issueCount(len(after)))
+	case !c.any():
+		return kernel.Status(did + ": nothing has changed, still " + issueCount(len(after)))
+	default:
+		return kernel.Status(did + ": " + c.text() + ", now " + issueCount(len(after)))
+	}
+}
+
+// failure says what did not work in the words the error itself carries. A
+// refresh names itself first, so that a refusal is one of the three answers r
+// can give rather than an error that might have come from anywhere.
+func failure(w why, err error) tea.Cmd {
+	_, failed := w.words()
+	if failed == "" || err == nil {
+		return kernel.Fail(err)
+	}
+	text, _ := jira.Reason(err)
+	return func() tea.Msg {
+		return kernel.StatusMsg{Text: failed + ": " + text, Level: kernel.LevelError}
+	}
+}
+
+func issueCount(n int) string {
+	if n == 1 {
+		return "1 issue"
+	}
+	return strconv.Itoa(n) + " issues"
+}

--- a/internal/ui/list/refresh_test.go
+++ b/internal/ui/list/refresh_test.go
@@ -1,0 +1,333 @@
+package list
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// movingClock is a clock a test can wind on, so that what a refresh leaves in
+// the summary line can be held against what was there before it.
+func movingClock(start time.Time) (now func() time.Time, wind func(time.Duration)) {
+	at := new(atomic.Int64)
+	at.Store(start.UnixNano())
+	return func() time.Time { return time.Unix(0, at.Load()).UTC() },
+		func(d time.Duration) { at.Add(int64(d)) }
+}
+
+func TestRefresh_SaysNothingChangedRatherThanNothingAtAll(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(40)), 120, 30)
+	dr.key("j", "j", "j")
+	under, cursor, top := dr.m.selectedKey(), dr.m.cursor, dr.m.top
+
+	dr.send(kernel.RefreshMsg{})
+
+	status := dr.lastStatus()
+	if status.Level != kernel.LevelInfo {
+		t.Errorf("a refresh that worked was reported at level %d", status.Level)
+	}
+	mustContain(t, status.Text, "refreshed", "nothing has changed")
+	if !strings.Contains(status.Text, "issues") {
+		t.Errorf("the line reads %q and does not say how much came back", status.Text)
+	}
+	switch {
+	case dr.m.cursor != cursor:
+		t.Errorf("the refresh moved the cursor to %d, want %d", dr.m.cursor, cursor)
+	case dr.m.top != top:
+		t.Errorf("the refresh moved the scroll to %d, want %d", dr.m.top, top)
+	case dr.m.selectedKey() != under:
+		t.Errorf("the refresh left the cursor on %s, want %s", dr.m.selectedKey(), under)
+	}
+}
+
+func TestRefresh_SaysWhatChangedWhenSomethingDid(t *testing.T) {
+	t.Parallel()
+
+	f := asAda(40)
+	dr := newDriver(t, testDeps(f), 120, 30)
+	under := dr.m.selectedKey()
+	if under == "" {
+		t.Fatal("there is no row to change")
+	}
+
+	summary := "Renamed by somebody else"
+	if err := f.UpdateIssue(t.Context(), under, jira.IssuePatch{Summary: &summary}); err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+	dr.send(kernel.RefreshMsg{})
+
+	status := dr.lastStatus()
+	mustContain(t, status.Text, "refreshed", "1 changed")
+	mustNotContain(t, status.Text, "nothing has changed")
+	mustContain(t, dr.view(), summary)
+}
+
+func TestRefresh_ReportsAFailureAsAFailedRefreshAndKeepsTheRows(t *testing.T) {
+	t.Parallel()
+
+	f := asAda(40)
+	dr := newDriver(t, testDeps(f), 120, 30)
+	before := len(dr.m.issues)
+
+	f.FailNext(&jira.TransportError{Op: "search", Err: errors.New("dial tcp: no such host")})
+	dr.send(kernel.RefreshMsg{})
+
+	status := dr.lastStatus()
+	if status.Level != kernel.LevelError {
+		t.Errorf("a refusal was reported at level %d, want an error", status.Level)
+	}
+	mustContain(t, status.Text, "the refresh failed", "no such host")
+	if got := len(dr.m.issues); got != before {
+		t.Errorf("a failed refresh left %d of %d rows", got, before)
+	}
+	mustContain(t, dr.view(), staleLabel)
+}
+
+func TestRefresh_APurgeSaysSomethingDifferentFromARefresh(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(40)), 120, 30)
+
+	dr.send(kernel.RefreshMsg{})
+	plain := dr.lastStatus().Text
+	dr.send(kernel.RefreshMsg{Purge: true})
+	purged := dr.lastStatus().Text
+
+	if plain == purged {
+		t.Fatalf("r and R both say %q, so one cannot be told from the other", plain)
+	}
+	mustContain(t, plain, "refreshed")
+	mustContain(t, purged, "refetched")
+}
+
+func TestRefresh_APurgeThatFailsSaysWhichOfTheTwoItWas(t *testing.T) {
+	t.Parallel()
+
+	f := asAda(40)
+	dr := newDriver(t, testDeps(f), 120, 30)
+
+	f.FailNextN(4, &jira.RateLimitError{RetryAfter: 30 * time.Second})
+	dr.send(kernel.RefreshMsg{Purge: true})
+
+	status := dr.lastStatus()
+	if status.Level != kernel.LevelError {
+		t.Errorf("a refused purge was reported at level %d, want an error", status.Level)
+	}
+	mustContain(t, status.Text, "the refetch failed", "retry in 30s")
+}
+
+func TestRefresh_LeavesTheTimeItLandedInTheSummaryLine(t *testing.T) {
+	t.Parallel()
+
+	now, wind := movingClock(time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC))
+	d := testDeps(asAda(12))
+	d.Now = now
+	dr := newDriver(t, d, 120, 30)
+
+	mustContain(t, dr.view(), "checked 09:00")
+
+	wind(37 * time.Minute)
+	dr.send(kernel.RefreshMsg{})
+
+	mustContain(t, dr.view(), "checked 09:37")
+	mustNotContain(t, dr.view(), "checked 09:00")
+}
+
+func TestRefresh_RowsOffDiskAreNotClaimedToHaveBeenChecked(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(asAda(12)), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), false, false)
+
+	view, ok := New(deps).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	next, _ := view.Update(kernel.SizeMsg{Width: 120, Height: 20})
+	m, _ := next.(*Model)
+
+	mustNotContain(t, m.View(), "checked")
+}
+
+// Paging and polling are not refreshes, and a line that narrated them would be
+// noise on every scroll and on every tick.
+func TestRefresh_ScrollingOntoAnotherPageSaysNothing(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(60, jiratest.WithPageSize(20))), 120, 30)
+	dr.statuses = nil
+
+	for range 12 {
+		dr.key("j")
+	}
+
+	if len(dr.m.issues) <= 20 {
+		t.Fatal("nothing was paged, so this proves nothing")
+	}
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "refreshed") || strings.Contains(status.Text, "refetched") {
+			t.Errorf("paging reported itself as a refresh: %q", status.Text)
+		}
+	}
+}
+
+func TestRefresh_APollSaysNothing(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(40)), 120, 30)
+	dr.statuses = nil
+
+	dr.send(pollMsg{gen: dr.m.gen})
+
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "refreshed") || strings.Contains(status.Text, "refetched") {
+			t.Errorf("a poll nobody asked for reported itself: %q", status.Text)
+		}
+	}
+	if dr.m.checked.IsZero() {
+		t.Error("a poll that landed left no record of when it did")
+	}
+}
+
+func TestRefresh_RevalidatingRowsOffDiskSaysNothing(t *testing.T) {
+	t.Parallel()
+
+	cache := newFakeCache()
+	deps := withCache(testDeps(asAda(12)), cache)
+	jql, _ := defaultQuery(deps.Project)
+	cache.hold(jql, storedRows(4), true, false)
+
+	dr := newDriver(t, deps, 120, 20)
+
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "refreshed") {
+			t.Errorf("a revalidation nobody asked for reported itself: %q", status.Text)
+		}
+	}
+}
+
+func TestRefreshed_DistinguishesEveryOutcomeItCanReport(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC)
+	rows := func(spec ...string) []jira.Issue {
+		out := make([]jira.Issue, 0, len(spec))
+		for i, s := range spec {
+			key, when := s, at
+			if k, bump, ok := strings.Cut(s, "@"); ok {
+				key = k
+				when = at.Add(time.Duration(len(bump)) * time.Hour)
+			}
+			out = append(out, jira.Issue{Key: key, Updated: when, Summary: strconv.Itoa(i)})
+		}
+		return out
+	}
+
+	tests := []struct {
+		name         string
+		w            why
+		before       []jira.Issue
+		after        []jira.Issue
+		want, unwant string
+	}{
+		{
+			name: "nothing moved", w: whyRefresh,
+			before: rows("A", "B"), after: rows("A", "B"),
+			want: "refreshed: nothing has changed, still 2 issues",
+		},
+		{
+			name: "one row was touched", w: whyRefresh,
+			before: rows("A", "B"), after: rows("A", "B@x"),
+			want: "refreshed: 1 changed, now 2 issues",
+		},
+		{
+			name: "one arrived and one left", w: whyRefresh,
+			before: rows("A", "B"), after: rows("A", "C"),
+			want: "refreshed: 1 new, 1 gone, now 2 issues",
+		},
+		{
+			name: "all three at once", w: whyRefresh,
+			before: rows("A", "B"), after: rows("A@x", "C", "D"),
+			want: "refreshed: 2 new, 1 changed, 1 gone, now 3 issues",
+		},
+		{
+			name: "the answer is still nothing", w: whyRefresh,
+			before: nil, after: nil,
+			want: "refreshed: still nothing matches this search",
+		},
+		{
+			name: "an answer where there was none", w: whyRefresh,
+			before: nil, after: rows("A"),
+			want: "refreshed: 1 issue",
+		},
+		{
+			name: "everything went away", w: whyRefresh,
+			before: rows("A", "B"), after: nil,
+			want: "refreshed: still nothing matches this search",
+		},
+		{
+			name: "a purge names itself", w: whyPurge,
+			before: rows("A"), after: rows("A"),
+			want: "refetched from scratch: nothing has changed, still 1 issue",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := refreshed(tc.w, tc.before, tc.after)
+			if cmd == nil {
+				t.Fatalf("%s reported nothing at all", tc.name)
+			}
+			status, ok := cmd().(kernel.StatusMsg)
+			if !ok {
+				t.Fatalf("the report is a %T, not a status line", cmd())
+			}
+			if status.Text != tc.want {
+				t.Errorf("the line reads %q, want %q", status.Text, tc.want)
+			}
+		})
+	}
+}
+
+// The frame a refresh that changed nothing leaves behind, which is the frame
+// that read as a broken key: the status line names the outcome and the summary
+// line keeps the time it was checked.
+func TestRefresh_QuietOutcomeGolden(t *testing.T) {
+	t.Parallel()
+
+	for name, size := range map[string]struct{ w, h int }{
+		"120x30": {120, 30},
+		"80x20":  {80, 20},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := start(t, testDeps(asAda(12)), size.w, size.h)
+			m = keys(t, m, "r")
+			golden(t, "list_refreshed_"+name+".golden", frame(m))
+		})
+	}
+}
+
+func TestRefreshed_SaysNothingForAFetchNobodyAskedFor(t *testing.T) {
+	t.Parallel()
+
+	rows := []jira.Issue{{Key: "A"}}
+	for _, w := range []why{whyOpen, whyPage, whyBackground} {
+		if cmd := refreshed(w, nil, rows); cmd != nil {
+			t.Errorf("a fetch of kind %d narrated itself: %v", w, cmd())
+		}
+	}
+}

--- a/internal/ui/list/register.go
+++ b/internal/ui/list/register.go
@@ -1,8 +1,6 @@
 package list
 
 import (
-	"strings"
-
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
@@ -10,6 +8,7 @@ import (
 
 func init() {
 	const slot = 1
+	keys := defaultKeys()
 	kernel.RegisterView(kernel.ViewSpec{
 		ID:          ViewID,
 		Title:       "Issues",
@@ -17,7 +16,7 @@ func init() {
 		RunsQueries: true,
 		New:         New,
 	})
-	kernel.RegisterKeys(ViewID, defaultKeys().keySet())
+	kernel.RegisterKeys(ViewID, keys.keySet())
 	kernel.RegisterCommand(kernel.Command{
 		ID:    "issues.open",
 		Title: "Issues",
@@ -26,10 +25,19 @@ func init() {
 		Run:   func(kernel.Deps) tea.Cmd { return kernel.Open(ViewID) },
 	})
 	kernel.RegisterCommand(kernel.Command{
+		ID:    "issues.edit-query",
+		Title: "Edit this search",
+		Group: "Search",
+		Keys:  []string{keys.Edit.Help().Key},
+		Run: func(kernel.Deps) tea.Cmd {
+			return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(EditQueryMsg{}))
+		},
+	})
+	kernel.RegisterCommand(kernel.Command{
 		ID:    "issues.save-query",
 		Title: "Save this query to a number key",
 		Group: "Search",
-		Keys:  []string{defaultKeys().Save.Help().Key},
+		Keys:  []string{keys.Save.Help().Key},
 		Run: func(kernel.Deps) tea.Cmd {
 			return tea.Sequence(kernel.Open(ViewID), kernel.Broadcast(SaveQueryMsg{}))
 		},
@@ -65,30 +73,22 @@ func init() {
 			},
 		})
 	}
-	for _, q := range []struct{ id, title, jql string }{
-		{"issues.mine", "My issues", "assignee = currentUser() ORDER BY updated DESC"},
-		{"issues.reported", "Issues I reported", "reporter = currentUser() ORDER BY created DESC"},
-		{"issues.unassigned", "Unassigned issues", "assignee IS EMPTY ORDER BY created DESC"},
-	} {
+	// The searches themselves. Each is composed against the project the session
+	// is on at the moment it runs, and titled after what it is about to show.
+	bound := map[string][]string{everyIssue.id: {keys.All.Help().Key}}
+	for _, s := range searches {
 		kernel.RegisterCommand(kernel.Command{
-			ID:    q.id,
-			Title: q.title,
+			ID:    s.id,
+			Title: s.palette(),
 			Group: "Search",
+			Keys:  bound[s.id],
 			Run: func(d kernel.Deps) tea.Cmd {
+				jql, title := s.at(d.Project)
 				return tea.Sequence(
 					kernel.Open(ViewID),
-					kernel.Broadcast(QueryMsg{JQL: scoped(d.Project, q.jql), Title: q.title}),
+					kernel.Broadcast(QueryMsg{JQL: jql, Title: title}),
 				)
 			},
 		})
 	}
-}
-
-// scoped narrows a query to the session's project when there is one. The key is
-// whatever the session was opened against; nothing about it is written down.
-func scoped(project, jql string) string {
-	if strings.TrimSpace(project) == "" {
-		return jql
-	}
-	return "project = " + quote(project) + " AND " + jql
 }

--- a/internal/ui/list/search.go
+++ b/internal/ui/list/search.go
@@ -1,0 +1,227 @@
+package list
+
+import (
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// search is one of the searches this view offers by name: the predicate half,
+// which is empty for every issue there is, and the order to read the answer in.
+// The two are kept apart because a search with no predicate has no AND to hang
+// an ORDER BY off, and "every issue in this project" is exactly that search.
+type search struct {
+	id   string
+	name string
+	// command is what the palette calls it, where that is not the name the view
+	// puts on screen.
+	command string
+	where   string
+	order   string
+}
+
+// The searches every session offers. Nothing here names a project, a status or
+// a field: the project is whatever the session is scoped to and goes in at run
+// time.
+var (
+	everyIssue = search{
+		id: "issues.all", name: "All issues", command: "Every issue in this project",
+		order: "ORDER BY updated DESC",
+	}
+	myIssues = search{
+		id: "issues.mine", name: "My issues",
+		where: "assignee = currentUser()", order: "ORDER BY updated DESC",
+	}
+	iReported = search{
+		id: "issues.reported", name: "Issues I reported",
+		where: "reporter = currentUser()", order: "ORDER BY created DESC",
+	}
+	nobodysIssues = search{
+		id: "issues.unassigned", name: "Unassigned issues",
+		where: "assignee IS EMPTY", order: "ORDER BY created DESC",
+	}
+)
+
+var searches = []search{everyIssue, myIssues, iReported, nobodysIssues}
+
+// palette is what the command palette calls the search.
+func (s search) palette() string {
+	if s.command != "" {
+		return s.command
+	}
+	return s.name
+}
+
+// at composes the search for the project the session is on, and names it after
+// what it is about to put on screen.
+func (s search) at(project string) (jql, title string) {
+	jql = strings.TrimSpace(scoped(project, s.where) + " " + s.order)
+	if p := strings.TrimSpace(project); p != "" {
+		return jql, s.name + " in " + p
+	}
+	return jql, s.name
+}
+
+// scoped narrows a clause to the session's project when there is one. An empty
+// clause is every issue in that project, so there is nothing to put an AND
+// between. The key is whatever the session was opened against; nothing about it
+// is written down.
+func scoped(project, clause string) string {
+	p, c := strings.TrimSpace(project), strings.TrimSpace(clause)
+	switch {
+	case p == "":
+		return c
+	case c == "":
+		return "project = " + quote(p)
+	}
+	return "project = " + quote(p) + " AND " + c
+}
+
+func quote(s string) string {
+	return strconv.Quote(strings.ReplaceAll(s, `"`, ""))
+}
+
+// defaultQuery is what a session opens on: the account's own work, narrowed to
+// the project the session is scoped to. An account with nothing of its own in
+// that project meets the project itself instead — see widen.
+func defaultQuery(project string) (jql, title string) { return myIssues.at(project) }
+
+// showEverything runs the whole of the session's project. It is the one search
+// the three that were here could not express: they all narrow by who you are,
+// and a token that is nobody in particular matches none of them.
+func (m *Model) showEverything() tea.Cmd {
+	jql, title := everyIssue.at(m.deps.Project)
+	if jql == m.jql {
+		return kernel.Status(title + " is already what is on screen")
+	}
+	return m.setQuery(jql, title, false)
+}
+
+// widen answers the first load of the search this view chose itself coming back
+// with nothing. An account with nothing assigned to it in a project met an empty
+// screen and read it as a broken program, so it meets the project instead —
+// once, and told why. A search the user ran is never widened, and a project that
+// is itself empty says so rather than being asked again.
+func (m *Model) widen() tea.Cmd {
+	project := strings.TrimSpace(m.deps.Project)
+	if !m.defaulted || m.widened || len(m.issues) > 0 || project == "" {
+		return nil
+	}
+	jql, title := everyIssue.at(project)
+	if jql == m.jql {
+		return nil
+	}
+	m.widened = true
+	return tea.Batch(
+		kernel.Status("nothing in "+project+" is assigned to you, so this is every issue in it"),
+		m.setQuery(jql, title, true),
+	)
+}
+
+// --- the search on screen, shown and edited where it is ---------------------
+
+// EditQueryMsg opens the prompt that shows the search on screen and runs an
+// edited one. It is exported so that the palette reaches the same gesture the
+// key does rather than a second implementation of it.
+type EditQueryMsg struct{}
+
+// askPrefix is the prompt's own label. It names what is being typed, which is
+// half of why the prompt exists: until it is opened, the only account of the
+// search on screen is the title's summary of it.
+const askPrefix = "jql "
+
+const askHint = "  enter runs it, esc keeps this one"
+
+func newAskInput() textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = askPrefix
+	ti.Placeholder = "a search to run"
+	return ti
+}
+
+// askRoom is how wide the prompt line's editable half is, leaving the hint the
+// columns it needs. The search gives way on a narrow terminal, never the keys
+// that answer.
+func (m *Model) askRoom() int { return max(m.width-ansi.StringWidth(askHint), 8) }
+
+// askWidth is what the text input itself is given, so that the prompt's label
+// and its editable half together fill the room left over.
+func (m *Model) askWidth() int { return max(m.askRoom()-ansi.StringWidth(askPrefix), 4) }
+
+func (m *Model) startAsk() tea.Cmd {
+	m.asking = true
+	m.ask.SetValue(m.jql)
+	// The width goes on before the cursor moves, so that a search too long for
+	// the room ends up windowed on the end somebody is about to type at rather
+	// than on its start with the cursor off screen.
+	m.ask.SetWidth(m.askWidth())
+	m.ask.CursorEnd()
+	_ = m.ask.Focus()
+	m.clampScroll()
+	return nil
+}
+
+func (m *Model) closeAsk() {
+	m.asking = false
+	m.ask.Blur()
+	m.clampScroll()
+}
+
+// askKey takes the prompt's keys. Everything the prompt's own table does not
+// claim is text, which is why the view claims raw keys while it is open.
+func (m *Model) askKey(msg tea.KeyPressMsg, stroke string) tea.Cmd {
+	switch m.inAsk[stroke] {
+	case actRun:
+		asked := strings.TrimSpace(m.ask.Value())
+		m.closeAsk()
+		return m.runAsked(asked)
+	case actKeep:
+		m.closeAsk()
+		return nil
+	default:
+	}
+	// The text input's own command is a cursor blink, dropped here for the same
+	// reason the filter drops it: it is a timer this view would then own.
+	m.ask, _ = m.ask.Update(msg)
+	return nil
+}
+
+// runAsked runs what the prompt was left holding. An edited search is titled
+// after itself, because the words that named the old one no longer describe what
+// is on screen.
+func (m *Model) runAsked(jql string) tea.Cmd {
+	switch jql {
+	case "":
+		return kernel.Warn("an empty search is not one, so " + strconv.Quote(m.title) + " is still on screen")
+	case m.jql:
+		return nil
+	}
+	return m.setQuery(jql, jql, false)
+}
+
+// askPrompt is the line the prompt puts under the rows: the search itself, as
+// the site will be asked it, and what enter will do with it.
+//
+// The text input pads itself to its own width, so what is cut here to make room
+// for the hint is that padding — the input has already windowed a search too
+// long to fit, and cutting with no ellipsis is what keeps one out of the middle
+// of a row of spaces.
+func (m *Model) askPrompt() string {
+	room, line := m.askRoom(), m.ask.View()
+	if w := ansi.StringWidth(line); w < room {
+		line += strings.Repeat(" ", room-w)
+	} else {
+		line = ansi.Truncate(line, room, "")
+	}
+	return line + m.styles.muted.Render(askHint)
+}
+
+// titleZone is the summary line's own name. Clicking what says which search is
+// on screen opens the prompt that changes it, so the search is reachable by
+// pointer as well as by key and from the palette.
+const titleZone = "title"

--- a/internal/ui/list/search_test.go
+++ b/internal/ui/list/search_test.go
@@ -1,0 +1,513 @@
+package list
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// ada is somebody the generated issues are actually assigned to, so a session
+// as her has work of her own and a session as the fake's default account —
+// which owns none of it — has none. That second case is the one the site this
+// was found on looked like: nineteen issues, three of them yours.
+var ada = jira.User{AccountID: "acct-ada", DisplayName: "Ada Lovelace", Active: true, TimeZone: time.UTC}
+
+// asMe is a project nothing in is assigned to the account asking.
+func asMe(issues int) *jiratest.Fake { return newFake(issues) }
+
+// asAda is the same project with work of the account's own in it.
+func asAda(issues int) *jiratest.Fake { return newFake(issues, jiratest.WithMe(ada)) }
+
+func TestList_ShowsEveryIssueInTheProjectIncludingWorkAssignedToNobody(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+	mine := len(dr.m.issues)
+	if mine == 0 {
+		t.Fatal("the account has nothing of its own, so this proves nothing about widening")
+	}
+
+	dr.key("a")
+
+	if strings.Contains(dr.m.jql, "currentUser()") {
+		t.Errorf("the whole-project search is %q, which still narrows by who you are", dr.m.jql)
+	}
+	if dr.m.title != "All issues in PROJ" {
+		t.Errorf("the search is titled %q, want All issues in PROJ", dr.m.title)
+	}
+	if len(dr.m.issues) <= mine {
+		t.Fatalf("the whole project holds %d issues against the %d assigned to the account", len(dr.m.issues), mine)
+	}
+
+	var unowned, somebodyElses string
+	for i := range dr.m.issues {
+		switch iss := &dr.m.issues[i]; {
+		case iss.Assignee == nil:
+			unowned = iss.Key
+		case iss.Assignee.AccountID != ada.AccountID:
+			somebodyElses = iss.Key
+		}
+	}
+	if unowned == "" {
+		t.Error("no issue assigned to nobody came back; that is the regression this search exists for")
+	}
+	if somebodyElses == "" {
+		t.Error("no issue assigned to somebody else came back")
+	}
+	mustContain(t, dr.view(), unowned, somebodyElses)
+}
+
+func TestList_TheWholeProjectSearchIsReachableFromThePaletteToo(t *testing.T) {
+	t.Parallel()
+
+	var all kernel.Command
+	for _, cmd := range kernel.Commands() {
+		if cmd.ID == "issues.all" {
+			all = cmd
+		}
+	}
+	if all.ID == "" {
+		t.Fatal("issues.all is not in the command registry, so the palette cannot reach the whole project")
+	}
+	if all.Group != "Search" {
+		t.Errorf("the command is grouped under %q, want Search beside the other three", all.Group)
+	}
+	if len(all.Keys) != 1 || all.Keys[0] != "a" {
+		t.Errorf("the command teaches the keys %v, want the one the view's own footer shows", all.Keys)
+	}
+
+	var query QueryMsg
+	for _, msg := range collect(all.Run(kernel.Deps{Project: "PROJ"})) {
+		if got, ok := msg.(kernel.BroadcastMsg); ok {
+			query, _ = got.Msg.(QueryMsg)
+		}
+	}
+	if !strings.Contains(query.JQL, `project = "PROJ"`) || strings.Contains(query.JQL, "currentUser()") {
+		t.Errorf("the command asks for %q, want the session's project and nothing about who is asking", query.JQL)
+	}
+	if query.Title != "All issues in PROJ" {
+		t.Errorf("the command titles it %q, want All issues in PROJ", query.Title)
+	}
+}
+
+func TestList_AskingForTheWholeProjectTwiceSaysSoRatherThanSearchingAgain(t *testing.T) {
+	t.Parallel()
+
+	f := asAda(12)
+	dr := newDriver(t, testDeps(f), 120, 30)
+	dr.key("a")
+	before := countCalls(f, "Search")
+
+	dr.key("a")
+
+	if got := countCalls(f, "Search"); got != before {
+		t.Errorf("asking for the search already on screen produced %d more searches", got-before)
+	}
+	if status := dr.lastStatus(); !strings.Contains(status.Text, "already") {
+		t.Errorf("the status line reads %q, want it to say the search is the one on screen", status.Text)
+	}
+}
+
+// The default is the account's own work, because that is what a daily driver
+// opens on. It only stops being the default when it would be an empty screen.
+func TestList_OpensOnTheAccountsOwnWorkWhenThereIsAny(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+
+	if dr.m.title != "My issues in PROJ" {
+		t.Errorf("the list opened on %q, want My issues in PROJ", dr.m.title)
+	}
+	if !strings.Contains(dr.m.jql, "currentUser()") {
+		t.Errorf("the opening query is %q, want the account's own work", dr.m.jql)
+	}
+	if dr.m.widened {
+		t.Error("a default with rows in it widened anyway")
+	}
+}
+
+func TestList_OpensOnTheProjectWhenNothingInItIsAssignedToTheAccount(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asMe(12)), 120, 30)
+
+	if strings.Contains(dr.m.jql, "currentUser()") {
+		t.Errorf("the list is still asking for %q, so it opened on an empty screen", dr.m.jql)
+	}
+	if dr.m.title != "All issues in PROJ" {
+		t.Errorf("the list is titled %q, want All issues in PROJ", dr.m.title)
+	}
+	if len(dr.m.issues) != 12 {
+		t.Errorf("the widened search holds %d rows, want the 12 in the project", len(dr.m.issues))
+	}
+	var said bool
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "assigned to you") {
+			said = true
+		}
+	}
+	if !said {
+		t.Errorf("nothing explained why the search on screen is not the one asked for: %+v", dr.statuses)
+	}
+}
+
+func TestList_DoesNotWidenAgainWhenTheProjectItselfIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	f := asMe(0)
+	dr := newDriver(t, testDeps(f), 120, 30)
+
+	if got := countCalls(f, "Search"); got > 2 {
+		t.Errorf("an empty project was searched %d times; the fallback must be tried once", got)
+	}
+	if !dr.m.widened {
+		t.Fatal("the fallback never ran at all")
+	}
+	mustContain(t, dr.view(), "Nothing matches this search.")
+}
+
+func TestList_DoesNotWidenASearchTheUserRan(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+	empty := `project = "PROJ" AND status = "Nothing" ORDER BY key`
+	dr.send(QueryMsg{JQL: empty, Title: "Nothing"})
+
+	if dr.m.jql != empty {
+		t.Errorf("a search the user ran was replaced with %q", dr.m.jql)
+	}
+	if dr.m.title != "Nothing" {
+		t.Errorf("the title is %q, want the user's own", dr.m.title)
+	}
+}
+
+func TestList_AProjectSwitchGetsTheFallbackBack(t *testing.T) {
+	t.Parallel()
+
+	// Ada has work in PROJ and none in a two-issue OTHER, so the switch is the
+	// case the fallback exists for and the opening frame is not.
+	f := jiratest.New(
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithProject("OTHER", jiratest.Kanban),
+		jiratest.WithIssues(append(jiratest.Gen(12), jiratest.GenFor("OTHER", 2)...)),
+		jiratest.WithMe(ada),
+	)
+	dr := newDriver(t, testDeps(f), 120, 30)
+	if dr.m.title != "My issues in PROJ" {
+		t.Fatalf("the list opened on %q", dr.m.title)
+	}
+
+	dr.send(kernel.ProjectMsg{Project: "OTHER"})
+
+	if dr.m.title != "All issues in OTHER" {
+		t.Errorf("after the switch the list is titled %q, want All issues in OTHER", dr.m.title)
+	}
+	if len(dr.m.issues) != 2 {
+		t.Errorf("the widened search holds %d rows, want the 2 in OTHER", len(dr.m.issues))
+	}
+}
+
+func TestList_WithNoProjectDoesNotWidenToTheWholeSite(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(asMe(12))
+	d.Project = ""
+	dr := newDriver(t, d, 120, 30)
+
+	if strings.Contains(dr.m.jql, "project =") {
+		t.Errorf("an unscoped session widened to %q, naming a project it was never given", dr.m.jql)
+	}
+	if !strings.Contains(dr.m.jql, "currentUser()") {
+		t.Errorf("the query is %q, want the account's own work left alone", dr.m.jql)
+	}
+	if dr.m.title != "My issues" {
+		t.Errorf("the search is titled %q, want My issues", dr.m.title)
+	}
+}
+
+func TestScoped_ComposesTheProjectAndTheClauseWithoutInventingEither(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		project string
+		clause  string
+		want    string
+	}{
+		{"a project and a clause", "PROJ", "assignee = currentUser()", `project = "PROJ" AND assignee = currentUser()`},
+		{"a project and no clause at all", "PROJ", "", `project = "PROJ"`},
+		{"a clause and no project", "", "assignee IS EMPTY", "assignee IS EMPTY"},
+		{"neither", "", "", ""},
+		{"a key somebody typed a quote into", `PR"OJ`, "", `project = "PROJ"`},
+		{"a key with room around it", "  PROJ  ", "", `project = "PROJ"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := scoped(tc.project, tc.clause); got != tc.want {
+				t.Errorf("scoped(%q, %q) = %q, want %q", tc.project, tc.clause, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSearches_NameTheProjectTheyAreAboutAndOrderThemselves(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range searches {
+		t.Run(s.id, func(t *testing.T) {
+			t.Parallel()
+
+			jql, title := s.at("PROJ")
+			if !strings.HasPrefix(jql, `project = "PROJ"`) {
+				t.Errorf("%s composes %q, which is not scoped to the session's project", s.id, jql)
+			}
+			if !strings.Contains(jql, "ORDER BY") {
+				t.Errorf("%s composes %q with no ordering, so the site picks one", s.id, jql)
+			}
+			if strings.Contains(jql, "AND ORDER BY") {
+				t.Errorf("%s composes %q, which is not JQL", s.id, jql)
+			}
+			if !strings.HasSuffix(title, " in PROJ") {
+				t.Errorf("%s is titled %q, which does not say what is on screen", s.id, title)
+			}
+			unscoped, plain := s.at("")
+			if strings.Contains(unscoped, "project =") {
+				t.Errorf("%s composes %q with no project to name", s.id, unscoped)
+			}
+			if strings.HasSuffix(plain, " in ") {
+				t.Errorf("%s is titled %q", s.id, plain)
+			}
+		})
+	}
+}
+
+// --- the search on screen, shown and edited where it is ---------------------
+
+func TestList_TheQueryPromptShowsTheSearchThatIsActuallyRunning(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+	want := dr.m.jql
+
+	dr.key("e")
+
+	if !dr.m.asking {
+		t.Fatal("e did not open the prompt")
+	}
+	if got := dr.m.ask.Value(); got != want {
+		t.Errorf("the prompt holds %q, want the search on screen %q", got, want)
+	}
+	mustContain(t, dr.view(), "currentUser()", "enter runs it")
+	if !dr.m.WantsRawKeys() {
+		t.Error("the view is not claiming raw keys, so the kernel will eat what is typed into the prompt")
+	}
+}
+
+func TestList_RunsTheSearchTypedIntoThePromptAndTitlesItAfterItself(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+	dr.key("e")
+	for range len(dr.m.ask.Value()) {
+		dr.send(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	}
+	dr.typeText(`project = "PROJ" AND status = "Shipped" ORDER BY key`)
+	dr.key("enter")
+
+	if dr.m.asking {
+		t.Error("enter left the prompt open")
+	}
+	if dr.m.jql != `project = "PROJ" AND status = "Shipped" ORDER BY key` {
+		t.Fatalf("the list is running %q", dr.m.jql)
+	}
+	if dr.m.title != dr.m.jql {
+		t.Errorf("the search is titled %q, want the search itself so the line says what is on screen", dr.m.title)
+	}
+	if len(dr.m.issues) == 0 {
+		t.Fatal("the typed search found nothing at all")
+	}
+	for i := range dr.m.issues {
+		if dr.m.issues[i].Status.Name != "Shipped" {
+			t.Fatalf("%s is not in the result of the search that was typed", dr.m.issues[i].Key)
+		}
+	}
+	mustContain(t, dr.view(), "Shipped")
+}
+
+func TestList_LeavingThePromptKeepsTheSearchThatWasOnScreen(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+	was, wasTitled := dr.m.jql, dr.m.title
+	dr.key("e")
+	dr.typeText(" AND nonsense")
+	dr.key("esc")
+
+	if dr.m.asking {
+		t.Error("esc left the prompt open")
+	}
+	if dr.m.jql != was || dr.m.title != wasTitled {
+		t.Errorf("esc left the list running %q titled %q, want %q titled %q", dr.m.jql, dr.m.title, was, wasTitled)
+	}
+}
+
+func TestList_AnEmptyPromptRunsNothingAndSaysWhatIsStillOnScreen(t *testing.T) {
+	t.Parallel()
+
+	dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+	was, wasTitled := dr.m.jql, dr.m.title
+	dr.key("e")
+	for range len(dr.m.ask.Value()) {
+		dr.send(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	}
+	dr.key("enter")
+
+	if dr.m.jql != was {
+		t.Errorf("an empty prompt ran %q", dr.m.jql)
+	}
+	if status := dr.lastStatus(); status.Level != kernel.LevelWarn || !strings.Contains(status.Text, wasTitled) {
+		t.Errorf("the status line reads %+v, want a warning naming the search still on screen", status)
+	}
+}
+
+// The prompt is typed through the kernel, which binds q, r, R, ? and the digits
+// for itself. A JQL query is mostly digits and quotes, so a prompt the kernel
+// can reach into is one that runs something other than what was typed.
+func TestQueryPrompt_ReceivesEveryCharacterIncludingTheKernelsOwnBindings(t *testing.T) {
+	t.Parallel()
+
+	m := start(t, testDeps(asAda(40)), 120, 30)
+	m = keys(t, m, "e")
+	for _, r := range "q2rR?" {
+		m = send(t, m, keyPress(string(r)))
+	}
+
+	shown := frame(m)
+	if !strings.Contains(shown, "q2rR?") {
+		t.Errorf("the prompt reads something other than what was typed:\n%s", shown)
+	}
+	if strings.Contains(shown, "nothing is bound to 2") {
+		t.Errorf("a digit reached the kernel's slot binding:\n%s", shown)
+	}
+	m = keys(t, m, "esc")
+	if got := frame(m); strings.Contains(got, "q2rR?") {
+		t.Errorf("esc did not put the prompt away:\n%s", got)
+	}
+}
+
+func TestList_TheSearchIsAlsoEditableFromThePaletteAndByPointer(t *testing.T) {
+	t.Parallel()
+
+	d := testDeps(asAda(12))
+	m := start(t, d, 120, 30, kernel.WithMouse(true))
+	m = send(t, m, kernel.BroadcastMsg{Msg: EditQueryMsg{}})
+	mustContain(t, frame(m), "enter runs it")
+
+	m = keys(t, m, "esc")
+	_ = m.Frame() // registering the zones is a side effect of drawing them
+
+	var id string
+	eventually(t, func() bool {
+		id = zoneNamed(d, "title")
+		return id != ""
+	})
+	at := d.Zones.Get(id)
+	m = send(t, m, tea.MouseClickMsg{X: at.StartX + 1, Y: at.StartY, Button: tea.MouseLeft})
+
+	if got := frame(m); !strings.Contains(got, "enter runs it") {
+		t.Errorf("clicking the line that names the search did not offer to change it:\n%s", got)
+	}
+}
+
+// zoneNamed finds a zone id the list marked. The prefix is handed out by the
+// manager per component, so it is discovered rather than assumed, and the
+// manager records a zone on its own goroutine, so it is looked for until it
+// appears.
+func zoneNamed(d kernel.Deps, name string) string {
+	for i := 1; i < 4096; i++ {
+		id := "zone_" + strconv.Itoa(i) + "__" + name
+		if !d.Zones.Get(id).IsZero() {
+			return id
+		}
+	}
+	return ""
+}
+
+func TestList_TheTitleAlwaysNamesWhatIsOnScreen(t *testing.T) {
+	t.Parallel()
+
+	typed := `project = "PROJ" AND status = "Shipped" ORDER BY key`
+	tests := []struct {
+		name  string
+		reach func(*driver)
+		want  string
+	}{
+		{"the account's own work", func(*driver) {}, "My issues in PROJ"},
+		{"every issue in the project", func(dr *driver) { dr.key("a") }, "All issues in PROJ"},
+		{"a saved search the kernel dispatched", func(dr *driver) {
+			dr.send(kernel.RunQueryMsg{JQL: typed, Title: "Shipped work"})
+		}, "Shipped work"},
+		{"a search typed into the prompt", func(dr *driver) {
+			dr.key("e")
+			for range len(dr.m.ask.Value()) {
+				dr.send(tea.KeyPressMsg{Code: tea.KeyBackspace})
+			}
+			dr.typeText(typed)
+			dr.key("enter")
+		}, typed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dr := newDriver(t, testDeps(asAda(12)), 120, 30)
+			tc.reach(dr)
+			if dr.m.title != tc.want {
+				t.Errorf("the list is titled %q, want %q", dr.m.title, tc.want)
+			}
+			mustContain(t, dr.view(), tc.want)
+		})
+	}
+}
+
+func TestList_QueryPromptGolden(t *testing.T) {
+	t.Parallel()
+
+	for name, size := range map[string]struct{ w, h int }{
+		"120x30": {120, 30},
+		"100x24": {100, 24},
+		"80x20":  {80, 20},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dr := newDriver(t, testDeps(asAda(12)), size.w, size.h)
+			dr.key("e")
+			golden(t, "list_query_"+name+".golden", dr.view())
+		})
+	}
+}
+
+func TestList_WidenedGolden(t *testing.T) {
+	t.Parallel()
+
+	for name, size := range map[string]struct{ w, h int }{
+		"120x30": {120, 30},
+		"80x20":  {80, 20},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := start(t, testDeps(asMe(12)), size.w, size.h)
+			golden(t, "list_widened_"+name+".golden", frame(m))
+		})
+	}
+}

--- a/internal/ui/list/testdata/keys.golden
+++ b/internal/ui/list/testdata/keys.golden
@@ -2,12 +2,12 @@ browsing
   short  ↓/j down · ↑/k up · enter open · / filter
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
   full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
-  full   [enter open, / filter, s save this query to a key]
+  full   [enter open, / filter, a all issues, e edit this search, s save this query to a key]
 a filter kept on the rows
   short  ↓/j down · ↑/k up · enter open · ctrl+g clear filter
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
   full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
-  full   [enter open, / filter, ctrl+g clear filter, s save this query to a key]
+  full   [enter open, / filter, ctrl+g clear filter, a all issues, e edit this search, s save this query to a key]
 filter open
   short  enter keep filter · esc clear filter
   full   [enter keep filter, esc clear filter]
@@ -17,3 +17,6 @@ picking the number key
 confirming a number key that is taken
   short  y take the key · esc leave it alone
   full   [y take the key, esc leave it alone]
+editing the search on screen
+  short  enter run this search · esc keep the one on screen
+  full   [enter run this search, esc keep the one on screen]

--- a/internal/ui/list/testdata/list_100x30.golden
+++ b/internal/ui/list/testdata/list_100x30.golden
@@ -1,5 +1,5 @@
  saral | Issues                                                        PROJ | example.atlassian.net 
-All issues                                                                                 12 issues
+All issues                                                                  checked 09:00  12 issues
   KEY      SUMMARY                           TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-1   Add the nightly export            Epic       Building      Grace Hopper      02 Mar 12:00
   PROJ-2   Rework webhook retries            Chore      Shipped       Alan Turing       02 Mar 14:00
@@ -26,5 +26,5 @@ All issues                                                                      
                                                                                                     
                                                                                                     
                                                                                                     
-                                                                                                    
+ nothing in PROJ is assigned to you, so this is every issue in it                                   
  g1 Issues                               ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_80x20.golden
+++ b/internal/ui/list/testdata/list_80x20.golden
@@ -1,5 +1,5 @@
  saral | Issues                                    PROJ | example.atlassian.net 
-All issues                                                             12 issues
+All issues                                              checked 09:00  12 issues
   KEY      SUMMARY                                       TYPE       STATUS      
 > PROJ-1   Add the nightly export                        Epic       Building    
   PROJ-2   Rework webhook retries                        Chore      Shipped     
@@ -16,5 +16,5 @@ All issues                                                             12 issues
                                                                                 
                                                                                 
                                                                                 
-                                                                                
+ nothing in PROJ is assigned to you, so this is every issue in it               
  g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_bind_confirm_120x20.golden
+++ b/internal/ui/list/testdata/list_bind_confirm_120x20.golden
@@ -1,4 +1,4 @@
-All issues                                                                                                     12 issues
+All issues                                                                                      checked 09:00  12 issues
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
   PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00

--- a/internal/ui/list/testdata/list_bind_pick_120x20.golden
+++ b/internal/ui/list/testdata/list_bind_pick_120x20.golden
@@ -1,4 +1,4 @@
-All issues                                                                                                     12 issues
+All issues                                                                                      checked 09:00  12 issues
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
   PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00

--- a/internal/ui/list/testdata/list_empty_none_120x30.golden
+++ b/internal/ui/list/testdata/list_empty_none_120x30.golden
@@ -1,7 +1,7 @@
-My issues in PROJ                                                                                               0 issues
+All issues in PROJ                                                                               checked 09:00  0 issues
   KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
   Nothing matches this search.
-  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC
+  project = "PROJ" ORDER BY updated DESC
 
 
 

--- a/internal/ui/list/testdata/list_empty_none_80x20.golden
+++ b/internal/ui/list/testdata/list_empty_none_80x20.golden
@@ -1,7 +1,7 @@
-My issues in PROJ                                                       0 issues
+All issues in PROJ                                       checked 09:00  0 issues
   KEY     SUMMARY                                        TYPE       STATUS      
   Nothing matches this search.
-  project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC
+  project = "PROJ" ORDER BY updated DESC
 
 
 

--- a/internal/ui/list/testdata/list_facet_120x30.golden
+++ b/internal/ui/list/testdata/list_facet_120x30.golden
@@ -1,4 +1,4 @@
-All issues                                                                                                       4 of 12
+All issues                                                                                        checked 09:00  4 of 12
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
   PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00

--- a/internal/ui/list/testdata/list_filter_120x30.golden
+++ b/internal/ui/list/testdata/list_filter_120x30.golden
@@ -1,4 +1,4 @@
-All issues                                                                                                       3 of 40
+All issues                                                                                        checked 09:00  3 of 40
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
   PROJ-22  Add the login flow                                    Defect     Building      Grace Hopper      03 Mar 13:00

--- a/internal/ui/list/testdata/list_kept_filter_120x30.golden
+++ b/internal/ui/list/testdata/list_kept_filter_120x30.golden
@@ -1,4 +1,4 @@
-All issues                                                                                                       3 of 40
+All issues                                                                                        checked 09:00  3 of 40
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
   PROJ-22  Add the login flow                                    Defect     Building      Grace Hopper      03 Mar 13:00

--- a/internal/ui/list/testdata/list_no_caps_120x30.golden
+++ b/internal/ui/list/testdata/list_no_caps_120x30.golden
@@ -1,5 +1,5 @@
  saral | Issues                                                                            PROJ | example.atlassian.net 
-All issues                                                                                                     12 issues
+All issues                                                                                      checked 09:00  12 issues
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
 > PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
   PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
@@ -26,5 +26,5 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
+ nothing in PROJ is assigned to you, so this is every issue in it                                                       
  g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_query_100x24.golden
+++ b/internal/ui/list/testdata/list_query_100x24.golden
@@ -1,0 +1,24 @@
+My issues in PROJ                                                            checked 09:00  3 issues
+  KEY     SUMMARY                            TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-9  Rework the mobile layout           Story      Triage        Ada Lovelace      03 Mar 04:00
+  PROJ-6  Speed up session expiry            Story      Triage        Ada Lovelace      02 Mar 22:00
+  PROJ-3  Investigate the onboarding wizard  Story      Triage        Ada Lovelace      02 Mar 16:00
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+jql t = "PROJ" AND assignee = currentUser() ORDER BY updated DESC  enter runs it, esc keeps this one

--- a/internal/ui/list/testdata/list_query_120x30.golden
+++ b/internal/ui/list/testdata/list_query_120x30.golden
@@ -1,0 +1,30 @@
+My issues in PROJ                                                                                checked 09:00  3 issues
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-9  Rework the mobile layout                               Story      Triage        Ada Lovelace      03 Mar 04:00
+  PROJ-6  Speed up session expiry                                Story      Triage        Ada Lovelace      02 Mar 22:00
+  PROJ-3  Investigate the onboarding wizard                      Story      Triage        Ada Lovelace      02 Mar 16:00
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+jql project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC                enter runs it, esc keeps this one

--- a/internal/ui/list/testdata/list_query_80x20.golden
+++ b/internal/ui/list/testdata/list_query_80x20.golden
@@ -1,0 +1,20 @@
+My issues in PROJ                                        checked 09:00  3 issues
+  KEY     SUMMARY                                        TYPE       STATUS      
+> PROJ-9  Rework the mobile layout                       Story      Triage      
+  PROJ-6  Speed up session expiry                        Story      Triage      
+  PROJ-3  Investigate the onboarding wizard              Story      Triage      
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+jql nee = currentUser() ORDER BY updated DESC  enter runs it, esc keeps this one

--- a/internal/ui/list/testdata/list_refreshed_120x30.golden
+++ b/internal/ui/list/testdata/list_refreshed_120x30.golden
@@ -1,18 +1,9 @@
  saral | Issues                                                                            PROJ | example.atlassian.net 
-All issues                                                                                      checked 09:00  12 issues
-  KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
-> PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
-  PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
-  PROJ-3   Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
-  PROJ-4   Document CSV import                                   Defect     Building      unassigned        02 Mar 18:00
-  PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00
-  PROJ-6   Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
-  PROJ-7   Fix the search index                                  Defect     Building      Grace Hopper      03 Mar 00:00
-  PROJ-8   Add invoice rounding                                  Chore      Shipped       unassigned        03 Mar 02:00
-  PROJ-9   Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
-  PROJ-10  Investigate the release checklist                     Defect     Building      Grace Hopper      03 Mar 06:00
-  PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
-  PROJ-12  Retire the nightly export                             Story      Triage        unassigned        03 Mar 10:00
+My issues in PROJ                                                                                checked 09:00  3 issues
+  KEY     SUMMARY                                                TYPE       STATUS        ASSIGNEE          UPDATED     
+> PROJ-9  Rework the mobile layout                               Story      Triage        Ada Lovelace      03 Mar 04:00
+  PROJ-6  Speed up session expiry                                Story      Triage        Ada Lovelace      02 Mar 22:00
+  PROJ-3  Investigate the onboarding wizard                      Story      Triage        Ada Lovelace      02 Mar 16:00
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -35,6 +26,5 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
- nothing in PROJ is assigned to you, so this is every issue in it                                                       
+ refreshed: nothing has changed, still 3 issues                                                                         
  g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_refreshed_80x20.golden
+++ b/internal/ui/list/testdata/list_refreshed_80x20.golden
@@ -1,0 +1,20 @@
+ saral | Issues                                    PROJ | example.atlassian.net 
+My issues in PROJ                                        checked 09:00  3 issues
+  KEY     SUMMARY                                        TYPE       STATUS      
+> PROJ-9  Rework the mobile layout                       Story      Triage      
+  PROJ-6  Speed up session expiry                        Story      Triage      
+  PROJ-3  Investigate the onboarding wizard              Story      Triage      
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+ refreshed: nothing has changed, still 3 issues                                 
+ g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_widened_120x30.golden
+++ b/internal/ui/list/testdata/list_widened_120x30.golden
@@ -1,9 +1,18 @@
- saral | Issues                                                                           OTHER | example.atlassian.net 
-My issues in OTHER                                                                               checked 09:00  3 issues
+ saral | Issues                                                                            PROJ | example.atlassian.net 
+All issues in PROJ                                                                              checked 09:00  12 issues
   KEY      SUMMARY                                               TYPE       STATUS        ASSIGNEE          UPDATED     
-> OTHER-9  Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
-  OTHER-6  Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
-  OTHER-3  Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
+> PROJ-12  Retire the nightly export                             Story      Triage        unassigned        03 Mar 10:00
+  PROJ-11  Document the login flow                               Epic       Shipped       Alan Turing       03 Mar 08:00
+  PROJ-10  Investigate the release checklist                     Defect     Building      Grace Hopper      03 Mar 06:00
+  PROJ-9   Rework the mobile layout                              Story      Triage        Ada Lovelace      03 Mar 04:00
+  PROJ-8   Add invoice rounding                                  Chore      Shipped       unassigned        03 Mar 02:00
+  PROJ-7   Fix the search index                                  Defect     Building      Grace Hopper      03 Mar 00:00
+  PROJ-6   Speed up session expiry                               Story      Triage        Ada Lovelace      02 Mar 22:00
+  PROJ-5   Retire the audit trail                                Chore      Shipped       Alan Turing       02 Mar 20:00
+  PROJ-4   Document CSV import                                   Defect     Building      unassigned        02 Mar 18:00
+  PROJ-3   Investigate the onboarding wizard                     Story      Triage        Ada Lovelace      02 Mar 16:00
+  PROJ-2   Rework webhook retries                                Chore      Shipped       Alan Turing       02 Mar 14:00
+  PROJ-1   Add the nightly export                                Epic       Building      Grace Hopper      02 Mar 12:00
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -17,14 +26,5 @@ My issues in OTHER                                                              
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
- this session is scoped to OTHER                                                                                        
+ nothing in PROJ is assigned to you, so this is every issue in it                                                       
  g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/list/testdata/list_widened_80x20.golden
+++ b/internal/ui/list/testdata/list_widened_80x20.golden
@@ -1,0 +1,20 @@
+ saral | Issues                                    PROJ | example.atlassian.net 
+All issues in PROJ                                      checked 09:00  12 issues
+  KEY      SUMMARY                                       TYPE       STATUS      
+> PROJ-12  Retire the nightly export                     Story      Triage      
+  PROJ-11  Document the login flow                       Epic       Shipped     
+  PROJ-10  Investigate the release checklist             Defect     Building    
+  PROJ-9   Rework the mobile layout                      Story      Triage      
+  PROJ-8   Add invoice rounding                          Chore      Shipped     
+  PROJ-7   Fix the search index                          Defect     Building    
+  PROJ-6   Speed up session expiry                       Story      Triage      
+  PROJ-5   Retire the audit trail                        Chore      Shipped     
+  PROJ-4   Document CSV import                           Defect     Building    
+  PROJ-3   Investigate the onboarding wizard             Story      Triage      
+  PROJ-2   Rework webhook retries                        Chore      Shipped     
+  PROJ-1   Add the nightly export                        Epic       Building    
+                                                                                
+                                                                                
+                                                                                
+ nothing in PROJ is assigned to you, so this is every issue in it               
+ g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -1,6 +1,6 @@
  saral | Commands                                                                          PROJ | example.atlassian.net 
 > what do you want to do?                                                                                               
------------------------------------------------------------------------------------------------------------- 20 commands
+------------------------------------------------------------------------------------------------------------ 22 commands
 > Follow the terminal's own colours             Appearance                                                              
   Turn colour off                               Appearance                                                              
   Use the dark theme                            Appearance                                                              
@@ -13,6 +13,8 @@
   Comment on this issue                         Issue                                                                  c
   Edit this issue                               Issue                                                                  e
   Clear the filter on these rows                Search                                                                  
+  Edit this search                              Search                                                                 e
+  Every issue in this project                   Search                                                                 a
   Issues I reported                             Search                                                                  
   My issues                                     Search                                                                  
   Save this query to a number key               Search                                                                 s
@@ -21,8 +23,6 @@
   Show only rows with this row's status         Search                                                                  
   Show only rows with this row's type           Search                                                                  
   Unassigned issues                             Search                                                                  
-                                                                                                                        
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         


### PR DESCRIPTION
Two things the owner hit against a real site, in the same afternoon.

## 1 — You could not ask the app to show you a project

A project of nineteen issues, three of them his, and the list could only ever show those three. Every search this view offered narrowed by who you are (`assignee = currentUser()`, `reporter = currentUser()`, `assignee IS EMPTY`), and P3.3's facets filter rows already loaded rather than widening the query, so nothing anywhere could ask for the other sixteen. His words were "filtered to me, and there is no way to remove this filter", which was exactly right.

**A fourth search with no predicate at all.** `a` in the view, *Every issue in this project* in the palette beside the other three, titled *All issues in PROJ* on screen. Asking for it when it is already on screen says so rather than searching again.

A `search` value now carries the predicate and the ordering apart, and `scoped()` takes an empty clause to mean the whole project. That is the reason for the shape: `scoped(project, jql)` had nothing to put an `AND` between for the one search that is *only* an ordering, and gluing `project = "X" AND` onto `ORDER BY updated DESC` is not JQL. The same value composes all four searches *and* `defaultQuery`, so the palette entry for *My issues* and the search a session opens on cannot drift, and there is still no project key, status or field name written down anywhere.

**What it opens on, and why.** The default stays the account's own work — that is what a daily driver wants on screen, and `docs/UX.md` promises it — but it falls back to the whole project **once**, when the site says nothing there is assigned to the account, and says why:

```
All issues in PROJ                                      checked 09:00  12 issues
...
 nothing in PROJ is assigned to you, so this is every issue in it
```

A brand-new user with nothing assigned used to open on an empty list and conclude the program was broken, which is close to what happened here. Always opening on the project was the other candidate and loses the thing that makes the default worth having on day one; a profile setting was the third and needs `internal/config`, which this packet does not own — it is the better long-term answer and is named in the issue below.

The fallback is deliberately narrow. It is tried only for the search this view chose itself, never for one the user ran; only when there is a project to widen *to*, so an unscoped session is left alone rather than being pointed at the whole site; and once per project, so an empty project says *Nothing matches this search* instead of being asked the same question twice. A project switch derives a fresh default and re-arms it.

**The search is readable and changeable from the view.** `e` puts the JQL that is actually running on a line under the rows, editable, and `enter` runs it:

```
jql project = "PROJ" AND assignee = currentUser() ORDER BY updated DESC       enter runs it, esc keeps this one
```

Reachable three ways, as principle 3 asks: the key, *Edit this search* in the palette, and clicking the line that names the search — the summary line carries a zone of its own now, marked inside the memo the way the rows are. An edited search is titled after itself, so the line still says what is on screen. The view claims raw keys while the prompt is open, which a JQL query full of digits and quotes needs.

## 2 — A refresh was indistinguishable from a no-op

`r` set the rows and returned. On success it reported **nothing**, so pressing it on a query whose three answers had not moved looked exactly like a key that does not work.

The three outcomes are now distinct, and *nothing changed* is the one that mattered:

| | |
|---|---|
| nothing moved | `refreshed: nothing has changed, still 19 issues` |
| rows moved | `refreshed: 2 new, 1 changed, now 21 issues` |
| it failed | `the refresh failed: dial tcp: no such host` |

`R` says *refetched from scratch* and *the refetch failed*, because it does strictly more — it invalidates the field catalogue and drops the stored copy. The delta is computed by key and by `updated`, which is as much as a list projection knows about a row.

**Nothing narrates a fetch nobody asked for.** One `reload` serves a refresh, a revalidation of rows off disk, a poll and the page walked on from stored rows, so what the request was *for* now travels with it. A line on every scroll and every poll tick is noise, and a poll that narrated itself would be the spinner problem in another form.

**And the frame keeps its own record.** The summary line carries `checked 09:00` — the time what is on screen last came from the site, in the account's timezone like every other instant this view draws. A status line goes away on the next keypress and the question about how old the screen is comes back. Rows that came off disk and have not been confirmed say `stale` and nothing else, which is a different answer.

No spinner: the rows are already on screen and being patched, which is what principle 1 asks for. The cursor, the scroll offset and the filter are untouched by all of it — asserted, not assumed.

## Tests

New: `search_test.go` and `refresh_test.go`.

- The whole-project search brings back an issue assigned to nobody **and** one assigned to somebody else, which is the regression itself, and its JQL carries no `currentUser()`.
- The default is *My issues in PROJ* where there is any, and *All issues in PROJ* where there is none; the fallback does not fire twice, does not fire for a search the user ran, does not fire without a project, and comes back after a project switch.
- `r` with nothing changed says so and leaves the cursor and scroll offset exactly where they were; `r` after an issue was renamed says `1 changed`; `r` that is refused says `the refresh failed` and keeps the rows, badged; `R` and `r` cannot say the same thing. Paging, polling and revalidating say nothing.
- `refreshed` has its own table over all eight outcomes it can word, since *2 new, 1 changed, 1 gone* has more shapes than an end-to-end test wants to build.
- The title names what is on screen for all four ways of getting a search there.
- `scoped` has a table, including the empty clause and a project key somebody typed a quote into.
- Goldens: the prompt at 120×30, 100×24 and 80×20; the widened default and the quiet refresh at 120×30 and 80×20.

The fake made this easy to reproduce, and it is worth knowing why: `jiratest`'s default account is `acct-me`, and `Gen` assigns to ada, grace and alan. So `assignee = currentUser()` against the default fixture matches **zero** issues — the owner's site, in a fixture, already committed. `asAda` is the session that has work of its own; `asMe` is the one that does not.

`internal/ui/list` is what this touches, plus two things outside it that adding a command with a key requires and whose own tests ask for: one `keyOwners` line in `internal/ui/keys_test.go`, and the palette's session golden, which lists the registry. `internal/ui/kernel`, `internal/app`, `pkg` and `cmd` are untouched.

## Budgets

Steady scroll is still 1 alloc/op with and without the mouse — the summary line is memoized on a key that now includes the checked stamp, and the title's zone marker lives inside that memo. The kernel's `BenchmarkFrame` and `BenchmarkKeyToFrame` do not see this package. New: `BenchmarkQueryPromptKeystroke10k`, 15 µs and 42 allocs per keystroke against the 16 ms budget.

## One footer note worth reading

`a` and `e` are in the help overlay's action row, not the hint line. A fifth entry in `Short` is enough to push the line past what an eighty-column footer holds, and `kernel.footer` drops the whole line rather than shortening it — so putting the widening key in the footer costs every hint at the documented minimum size. That is [#96](https://github.com/varijkapil13/saral/issues/96), and this stays out of its way.

## Not fixed here

Every one of these searches, the new one aside, assumes `currentUser()` means somebody. For a token belonging to a service account it resolves to an account nobody assigns work to, so *My issues* is reliably empty and the fallback fires on every project — the right behaviour and the wrong default to be recovering from every time. Filed with the three things a fix has to decide: [#102](https://github.com/varijkapil13/saral/issues/102).

Rebased onto [#95](https://github.com/varijkapil13/saral/pull/95). The two changes meet in three places and all three are resolved rather than merged around: `keysNarrowed` and `keysAsking` are separate states with separate generations, `rowsHeight` accounts for both lines, and the *nothing matches* pane names the search on screen — which is now the widened one, so that test's expectation moved with it.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
