### PR TITLE
fix(jira): resolve a field name on a translated site, and read the two error envelopes a site really answers in

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -428,6 +428,30 @@ feature. Each is one PR, small and tested, in the paths it names.
   Adjacent, in the same path: a filter accepted with `enter` had the count reading `1 of 3` as its
   only trace and no way off it, since `esc` in a root view belongs to the kernel. It is named under
   the rows the way a clicked cell is, `ctrl+g` clears it, and the palette carries the same gesture.
+- [x] **F2 — What a real Jira answers, and what the fixtures invented** ·
+  [#98](https://github.com/varijkapil13/saral/issues/98),
+  [#99](https://github.com/varijkapil13/saral/issues/99),
+  [#100](https://github.com/varijkapil13/saral/issues/100),
+  [#101](https://github.com/varijkapil13/saral/issues/101) · **owns**
+  `pkg/jira/{types,errors}.go`, `pkg/jira/cloud/{client,paginate,field}.go`,
+  `pkg/jira/jiratest/{fixtures/**,server.go}` and the tests for all of those, `docs/ROADMAP.md`
+  A disposable Cloud site built to cover every shape this client claims to handle — three project
+  types, five boards, sprints in all three states, 15 custom field types and an en_US↔de_DE flip —
+  measured four things the fixtures had invented their way around. Every one of them got through
+  because the invented fixture was self-consistent, so the fixture shapes are corrected here as well.
+  A field name resolved through two spellings and a site sends three: `untranslatedName` is neither
+  the English display name nor the translated one, so a profile naming what an English screen shows
+  matched nothing on a German site. `jira.ResolveField` reaches the third spelling and says whether a
+  name is unknown or shared, because two distinct fields can answer to one string and returning
+  either is a value read from a field nobody named. `FieldByName` keeps its signature and refuses an
+  ambiguous name instead of taking the first.
+  The Agile API writes its sentence into `errors` under a **URL parameter** name, and routing-level
+  failures answer RFC 7807 instead of Jira's own envelope: `parseErrorBody` reads all three, a 404
+  now carries the site's own words, and nothing keyed like a parameter becomes a message on an input
+  the user cannot act on. No classification moved — the status stays the authority.
+  `/board/{id}/issue` and `/backlog` name their array `issues`, which the offset decoder did not read,
+  so a board read decoded to no rows and reported no error. Three envelopes exist, one per shape, and
+  there is now a fixture and a terminating walk for each.
 
 ## Batch 4 — Attachments · parallel ×3
 

--- a/pkg/jira/cloud/client.go
+++ b/pkg/jira/cloud/client.go
@@ -23,6 +23,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/varijkapil13/saral/pkg/jira"
 
@@ -450,7 +452,7 @@ func cause(err error) error {
 // apiError maps a response Jira refused. The status is the authority: a body
 // that will not parse costs the detail, never the classification.
 func (c *Client) apiError(r request, resp *response) error {
-	detail := parseErrorBody(resp.body)
+	detail := parseErrorBody(resp.status, resp.body)
 	kind, id := r.target()
 	switch resp.status {
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
@@ -462,7 +464,7 @@ func (c *Client) apiError(r request, resp *response) error {
 			Reason: detail.reasonOr("Jira refused " + r.op() + ": this token is not permitted to do it"),
 		}
 	case http.StatusNotFound, http.StatusGone:
-		return &jira.NotFoundError{Kind: kind, ID: id}
+		return &jira.NotFoundError{Kind: kind, ID: id, Detail: detail.reason()}
 	case http.StatusConflict:
 		return &jira.ConflictError{Resource: kind + " " + id, Detail: detail.reason()}
 	case http.StatusTooManyRequests:
@@ -479,9 +481,8 @@ func (c *Client) apiError(r request, resp *response) error {
 	}
 }
 
-// jiraError is the error envelope both APIs use: per-field messages under
-// errors, loose ones under errorMessages, and a bare message on the Agile
-// endpoints that answer in their own shape.
+// jiraError is what a refused response said, sorted into the messages to put in
+// front of somebody and the ones a form can attach to a widget.
 type jiraError struct {
 	fields   []jira.FieldError
 	messages []string
@@ -496,20 +497,68 @@ func (e jiraError) reasonOr(fallback string) string {
 	return fallback
 }
 
-func parseErrorBody(body []byte) jiraError {
+// parseErrorBody reads the three envelopes a Jira Cloud site refuses in.
+//
+// The platform API sends errorMessages and errors, the latter keyed by field.
+// The Agile API sends the same two keys but writes its sentence into errors
+// under the name of a URL parameter, leaving errorMessages empty. Anything that
+// never reaches a Jira handler at all — an unknown route, a method a route does
+// not take — answers RFC 7807 problem+json, where the sentence is detail and
+// title only spells out the status.
+//
+// Nothing here may read the text of a message: the messages are localised, so a
+// rule that depends on their wording holds on an English site only.
+func parseErrorBody(status int, body []byte) jiraError {
 	var envelope struct {
 		ErrorMessages []string        `json:"errorMessages"`
 		Errors        json.RawMessage `json:"errors"`
 		Message       string          `json:"message"`
+		Detail        string          `json:"detail"`
+		Title         string          `json:"title"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return jiraError{}
 	}
-	out := jiraError{messages: envelope.ErrorMessages, fields: parseFieldErrors(envelope.Errors)}
+	out := jiraError{messages: slices.Clone(envelope.ErrorMessages)}
 	if envelope.Message != "" {
 		out.messages = append(out.messages, envelope.Message)
 	}
+	if envelope.Detail != "" {
+		out.messages = append(out.messages, envelope.Detail)
+	}
+	if len(out.messages) == 0 && envelope.Title != "" {
+		out.messages = append(out.messages, envelope.Title)
+	}
+	for _, entry := range parseFieldErrors(envelope.Errors) {
+		if rejectsValues(status) && namesAField(entry.Field) {
+			out.fields = append(out.fields, entry)
+			continue
+		}
+		out.messages = append(out.messages, entry.Message)
+	}
 	return out
+}
+
+// rejectsValues reports whether this status is Jira saying the values in the
+// request are wrong, which is the only kind of refusal a field error can belong
+// to. On every other status an entry under errors is a reason.
+func rejectsValues(status int) bool {
+	return status == http.StatusBadRequest || status == http.StatusUnprocessableEntity
+}
+
+// namesAField reports whether a key under errors names something a form can
+// annotate. Jira spells a URL parameter in camel case ending in Id —
+// rapidViewId, boardId, sprintId — and no field in a site's catalogue is spelt
+// that way, while a display name ending in "Id" has a space before it. Anything
+// this turns down still reaches the user as a reason, which is the side to err on:
+// the other one puts a sentence on an input nobody can act on.
+func namesAField(key string) bool {
+	trimmed := strings.TrimSuffix(key, "OrKey")
+	if len(trimmed) < 3 || !strings.HasSuffix(trimmed, "Id") {
+		return key != ""
+	}
+	before, _ := utf8.DecodeLastRuneInString(strings.TrimSuffix(trimmed, "Id"))
+	return !unicode.IsLower(before) && !unicode.IsDigit(before)
 }
 
 // parseFieldErrors reads the errors object in the order Jira wrote it, which a

--- a/pkg/jira/cloud/client_test.go
+++ b/pkg/jira/cloud/client_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -811,6 +813,218 @@ func TestEncodeBody_MarshalsOnceAndPassesRawBytesThrough(t *testing.T) {
 	}
 }
 
+// The Agile API leaves errorMessages empty and writes its sentence into errors,
+// keyed by the name of a URL parameter. On a 404 that sentence is the only thing
+// that says which of "no such board" and "not yours" happened.
+func TestDo_KeepsTheSentenceAnAgile404WritesUnderAURLParameter(t *testing.T) {
+	t.Parallel()
+
+	const boardPath = "/rest/agile/1.0/board/99999/configuration"
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, boardPath, http.StatusNotFound, "not_found_board.json"))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+	_, err := c.do(t.Context(), request{method: http.MethodGet, path: boardPath, kind: "board", id: "99999"})
+
+	var missing *jira.NotFoundError
+	if !errors.As(err, &missing) {
+		t.Fatalf("got %T (%v), want a *jira.NotFoundError", err, err)
+	}
+	want := agileBoardReason(t)
+	if missing.Detail != want {
+		t.Errorf("Detail = %q, want the site's own sentence %q", missing.Detail, want)
+	}
+	said := missing.Error()
+	if !strings.Contains(said, want) {
+		t.Errorf("the sentence a user reads is %q, and the site's own is not in it", said)
+	}
+	if !strings.Contains(said, "board 99999") {
+		t.Errorf("the sentence no longer names what was looked for: %q", said)
+	}
+}
+
+// The same body under the statuses that mean "your values are wrong". rapidViewId
+// is a URL parameter, so its sentence is a reason: no form has an input by that
+// name.
+func TestDo_DoesNotTurnAURLParameterIntoAFieldError(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnprocessableEntity} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			const boardPath = "/rest/agile/1.0/board/10/configuration"
+			s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, boardPath, status, "not_found_board.json"))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			_, err := c.do(t.Context(), request{method: http.MethodGet, path: boardPath})
+
+			var invalid *jira.ValidationError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("got %T (%v), want a *jira.ValidationError", err, err)
+			}
+			if len(invalid.Fields) != 0 {
+				t.Errorf("Fields = %v, want none: rapidViewId is a URL parameter, not an input", invalid.Fields)
+			}
+			if _, ok := invalid.For("rapidViewId"); ok {
+				t.Error("a form asking about rapidViewId is told there is a message for it")
+			}
+			if want := agileBoardReason(t); !slices.Contains(invalid.Messages, want) {
+				t.Errorf("Messages = %v, want the site's sentence %q among them", invalid.Messages, want)
+			}
+		})
+	}
+}
+
+func TestParseErrorBody_SortsFieldKeysFromParameterKeys(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"errors":{"summary":"a","customfield_10032":"b","fixVersions":"c","External Id":"d","rapidViewId":"e","boardId":"f","issueIdOrKey":"g"}}`
+
+	fields := func(status int) []string {
+		found := parseErrorBody(status, []byte(body)).fields
+		out := make([]string, 0, len(found))
+		for _, f := range found {
+			out = append(out, f.Field)
+		}
+		return out
+	}
+
+	wantFields := []string{"summary", "customfield_10032", "fixVersions", "External Id"}
+	if got := fields(http.StatusBadRequest); !slices.Equal(got, wantFields) {
+		t.Errorf("fields on a 400 = %v, want %v in Jira's own order", got, wantFields)
+	}
+	if got := fields(http.StatusNotFound); len(got) != 0 {
+		t.Errorf("fields on a 404 = %v, want none: a 404 is not a rejected value", got)
+	}
+
+	messages := parseErrorBody(http.StatusBadRequest, []byte(body)).messages
+	if want := []string{"e", "f", "g"}; !slices.Equal(messages, want) {
+		t.Errorf("messages = %v, want the parameter-keyed sentences %v", messages, want)
+	}
+}
+
+// Anything that reaches the site and no handler answers RFC 7807, where detail is
+// the only part that says anything.
+func TestDo_ReadsTheProblemJSONARoutingFailureAnswers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		fixture string
+		assert  func(t *testing.T, err error)
+	}{
+		{
+			name:    "a path no endpoint serves",
+			status:  http.StatusNotFound,
+			fixture: "problem_no_endpoint.json",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var missing *jira.NotFoundError
+				if !errors.As(err, &missing) {
+					t.Fatalf("got %T (%v), want a *jira.NotFoundError", err, err)
+				}
+				if want := problemDetail(t, "problem_no_endpoint.json"); missing.Detail != want {
+					t.Errorf("Detail = %q, want the body's own detail %q", missing.Detail, want)
+				}
+			},
+		},
+		{
+			name:    "a method the endpoint does not take",
+			status:  http.StatusMethodNotAllowed,
+			fixture: "problem_method_not_allowed.json",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var broken *jira.TransportError
+				if !errors.As(err, &broken) {
+					t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+				}
+				want := problemDetail(t, "problem_method_not_allowed.json")
+				if !strings.Contains(broken.Error(), want) {
+					t.Errorf("the sentence is %q, want the body's own detail %q in it", broken.Error(), want)
+				}
+				if strings.Contains(broken.Error(), http.StatusText(http.StatusMethodNotAllowed)) {
+					t.Errorf("the sentence fell back to the status text: %q", broken.Error())
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const path = "/rest/agile/1.0/board/10/swimlane"
+			s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, path, tt.status, tt.fixture))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			_, err := c.do(t.Context(), request{method: http.MethodGet, path: path, kind: "swimlane", id: "10"})
+			if err == nil {
+				t.Fatalf("HTTP %d came back as a success", tt.status)
+			}
+			tt.assert(t, err)
+		})
+	}
+}
+
+// A problem body carrying nothing but a title has only the status spelt out to
+// offer, which still beats nothing.
+func TestParseErrorBody_FallsBackToTheProblemTitleAndNeverToItsInstance(t *testing.T) {
+	t.Parallel()
+
+	got := parseErrorBody(http.StatusNotFound, []byte(`{"type":"about:blank","title":"Not Found","status":404,"instance":"/rest/api/3/nope"}`))
+	if reason := got.reason(); reason != "Not Found" {
+		t.Errorf("reason = %q, want the title", reason)
+	}
+	withDetail := parseErrorBody(http.StatusNotFound, []byte(`{"title":"Not Found","detail":"No endpoint GET /x.","instance":"/x"}`))
+	if reason := withDetail.reason(); reason != "No endpoint GET /x." {
+		t.Errorf("reason = %q, want only the detail: the title adds nothing to it", reason)
+	}
+}
+
+// agileBoardReason is the sentence the fixture puts under its URL parameter, read
+// from the fixture so the assertion cannot drift from it.
+func agileBoardReason(t *testing.T) string {
+	t.Helper()
+	var body struct {
+		Errors map[string]string `json:"errors"`
+	}
+	if err := json.Unmarshal(fixtureBytes(t, "not_found_board.json"), &body); err != nil {
+		t.Fatalf("decoding not_found_board.json: %v", err)
+	}
+	reason, ok := body.Errors["rapidViewId"]
+	if !ok {
+		t.Fatal("not_found_board.json carries no rapidViewId, which is the shape being tested")
+	}
+	return reason
+}
+
+func problemDetail(t *testing.T, name string) string {
+	t.Helper()
+	var body struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(fixtureBytes(t, name), &body); err != nil {
+		t.Fatalf("decoding %s: %v", name, err)
+	}
+	if body.Detail == "" {
+		t.Fatalf("%s carries no detail", name)
+	}
+	return body.Detail
+}
+
+func fixtureBytes(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := jiratest.Fixture(name)
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return b
+}
+
 func TestParseFieldErrors_SurvivesAnErrorsKeyThatIsNotAnObject(t *testing.T) {
 	t.Parallel()
 
@@ -829,7 +1043,7 @@ func TestParseFieldErrors_SurvivesAnErrorsKeyThatIsNotAnObject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := len(parseErrorBody([]byte(tt.body)).fields); got != tt.want {
+			if got := len(parseErrorBody(http.StatusBadRequest, []byte(tt.body)).fields); got != tt.want {
 				t.Errorf("got %d field messages out of %s, want %d", got, tt.body, tt.want)
 			}
 		})

--- a/pkg/jira/cloud/field_test.go
+++ b/pkg/jira/cloud/field_test.go
@@ -55,6 +55,55 @@ func TestFields_ReadsTheCatalogueASiteSpecificIDIsResolvedThrough(t *testing.T) 
 	}
 }
 
+// The catalogue as a German site sends it. A profile is written once and used
+// against whatever site is configured, so the name in it is the English display
+// name — which is on neither the wire nor a translated screen.
+func TestFields_ResolveANameWrittenInEnglishAgainstALocalisedCatalogue(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithFixture(http.MethodGet, fieldPath, "field_localised.json"))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Fields(t.Context())
+	if err != nil {
+		t.Fatalf("reading the catalogue: %v", err)
+	}
+
+	windows, err := jira.ResolveField(got, "Release Windows")
+	if err != nil {
+		t.Fatalf("resolving the English display name: %v; the catalogue reads %v", err, fieldNames(got))
+	}
+	if windows.ID != "customfield_10071" {
+		t.Errorf("Release Windows resolved to %q, want this site's own ID for it", windows.ID)
+	}
+	if windows.Name == "Release Windows" {
+		t.Error("the catalogue is not the localised one, so this proves nothing")
+	}
+
+	points, err := jira.ResolveField(got, "Story Points")
+	if err != nil {
+		t.Fatalf("resolving an untranslated name: %v", err)
+	}
+	if points.ID != "customfield_10032" {
+		t.Errorf("Story Points resolved to %q", points.ID)
+	}
+
+	// Two fields whose display names collapsed into one string under translation.
+	var shared *jira.FieldNameError
+	if _, err := jira.ResolveField(got, "Restschätzung"); !errors.As(err, &shared) || !shared.Ambiguous() {
+		t.Fatalf("resolving a name two fields share gave %v, want an ambiguous *jira.FieldNameError", err)
+	}
+
+	forms, err := jira.ResolveField(got, "Intake forms")
+	if err != nil {
+		t.Fatalf("resolving a field that sends no clause names: %v", err)
+	}
+	if len(forms.ClauseNames) != 0 {
+		t.Errorf("ClauseNames = %v, want none: this field cannot be named in JQL at all", forms.ClauseNames)
+	}
+}
+
 func TestFields_ReportsARefusalRateLimitAndTransportFailureAsThemselves(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/jira/cloud/paginate.go
+++ b/pkg/jira/cloud/paginate.go
@@ -95,12 +95,28 @@ func decodeTokenPage[W any](resp *response, op string) (items []W, next string, 
 // platform API never reports. Both total and isLast are pointers because an
 // endpoint may send neither, and a zero total means something different from a
 // missing one.
+//
+// There are three of these envelopes and no endpoint says which one it answers
+// in. /board/{id}/issue and /board/{id}/backlog name their array issues and send
+// no isLast; /board/{id}/version and /board/{id}/epic name theirs values and
+// send no total; the rest send all four keys. So every combination has to decode,
+// and the walk has to end on each of them.
 type agileEnvelope[W any] struct {
 	StartAt    int   `json:"startAt"`
 	MaxResults int   `json:"maxResults"`
 	Total      *int  `json:"total"`
 	IsLast     *bool `json:"isLast"`
+	Issues     []W   `json:"issues"`
 	Values     []W   `json:"values"`
+}
+
+// items is whichever array arrived. An endpoint sends one or the other and never
+// both, the same way the cursor-paginated endpoints do.
+func (e agileEnvelope[W]) items() []W {
+	if e.Issues != nil {
+		return e.Issues
+	}
+	return e.Values
 }
 
 // total is the count the endpoint reported, or a negative number when it
@@ -120,7 +136,7 @@ func decodeAgilePage[W any](resp *response, op string) (items []W, total int, is
 	if err := resp.decode(op, &envelope); err != nil {
 		return nil, -1, false, err
 	}
-	return envelope.Values, envelope.total(), envelope.last(), nil
+	return envelope.items(), envelope.total(), envelope.last(), nil
 }
 
 // pagedQuery copies a query and puts an offset on it, which is how every Agile

--- a/pkg/jira/cloud/paginate_test.go
+++ b/pkg/jira/cloud/paginate_test.go
@@ -365,6 +365,122 @@ func TestDecodeAgilePage_ReportsNoTotalWhenTheEndpointSendsNone(t *testing.T) {
 	}
 }
 
+// The two endpoints a board view is read from name their array issues, like
+// /search/jql does and unlike every other Agile endpoint.
+func TestDecodeAgilePage_ReadsTheIssuesKeyTheBoardEndpointsUse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantItems int
+		wantTotal int
+		wantLast  bool
+	}{
+		{
+			name:      "the board's issues, counted and with no isLast",
+			body:      `{"expand":"schema,names","startAt":0,"maxResults":50,"total":2,"issues":[{"id":1},{"id":2}]}`,
+			wantItems: 2, wantTotal: 2,
+		},
+		{
+			name:      "the backlog, which answers the same shape",
+			body:      `{"expand":"schema,names","startAt":0,"maxResults":50,"total":1,"issues":[{"id":1}]}`,
+			wantItems: 1, wantTotal: 1,
+		},
+		{
+			name:      "an epic page, which names values and reports no total",
+			body:      `{"startAt":0,"maxResults":50,"isLast":true,"values":[{"id":1}]}`,
+			wantItems: 1, wantTotal: -1, wantLast: true,
+		},
+		{
+			name:      "an empty page of issues",
+			body:      `{"startAt":2,"maxResults":50,"total":2,"issues":[]}`,
+			wantItems: 0, wantTotal: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			items, total, last, err := decodeAgilePage[wireSprint](&response{status: http.StatusOK, body: []byte(tt.body)}, "GET /x")
+			if err != nil {
+				t.Fatalf("decoding %s: %v", tt.body, err)
+			}
+			if len(items) != tt.wantItems || total != tt.wantTotal || last != tt.wantLast {
+				t.Errorf("decoded %d items, total %d, isLast %t; want %d, %d, %t",
+					len(items), total, last, tt.wantItems, tt.wantTotal, tt.wantLast)
+			}
+		})
+	}
+}
+
+func TestOffsetPages_ExhaustsAnAgileEnvelopeMissingEitherKeyThatEndsAWalk(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		path      string
+		wantItems int
+		wantCount int
+	}{
+		{name: "board issues, which end the walk on a total and send no isLast", path: "/rest/agile/1.0/board/10/issue", wantItems: 3, wantCount: 3},
+		{name: "the backlog, the same shape again", path: "/rest/agile/1.0/board/10/backlog", wantItems: 3, wantCount: 3},
+		{name: "board epics, which end it on isLast and send no total", path: "/rest/agile/1.0/board/10/epic", wantItems: 2, wantCount: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer()
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL())
+			first, err := offsetPages(t.Context(), c,
+				func(startAt int) request {
+					return request{method: http.MethodGet, path: tt.path, query: pagedQuery(nil, startAt, 50)}
+				},
+				func(resp *response) ([]wireIssue, int, bool, error) {
+					return decodeAgilePage[wireIssue](resp, http.MethodGet+" "+tt.path)
+				})
+			if err != nil {
+				t.Fatalf("reading the first page: %v", err)
+			}
+
+			if len(first.Items) != tt.wantItems {
+				t.Fatalf("decoded %d rows, want the %d in the fixture: %v", len(first.Items), tt.wantItems, keysOf(first.Items))
+			}
+			for i, issue := range first.Items {
+				if issue.Key == "" {
+					t.Errorf("row %d decoded with no key, so the array was read as the wrong shape", i)
+				}
+			}
+			count, counted := first.Count()
+			if counted != (tt.wantCount >= 0) {
+				t.Errorf("Count() reported %t, want %t", counted, tt.wantCount >= 0)
+			}
+			if counted && count != tt.wantCount {
+				t.Errorf("Count() = %d, want %d", count, tt.wantCount)
+			}
+			if first.HasMore() {
+				t.Error("the page reports more to fetch, and the fixture is the whole answer")
+			}
+
+			all, err := jira.Collect(t.Context(), first, 0)
+			if err != nil {
+				t.Fatalf("walking the pages: %v", err)
+			}
+			if len(all) != tt.wantItems {
+				t.Errorf("collected %d rows, want %d", len(all), tt.wantItems)
+			}
+			if served := len(s.Requests()); served != 1 {
+				t.Errorf("the site served %d requests, want the one page it takes", served)
+			}
+		})
+	}
+}
+
 func TestDecodeTokenPage_ReadsEitherItemsKeyAndHonoursIsLast(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/jira/errors.go
+++ b/pkg/jira/errors.go
@@ -111,12 +111,21 @@ func (e *TransportError) Unwrap() error { return e.Err }
 
 // NotFoundError reports a 404, which for Jira also covers "exists but you may
 // not see it" — the API deliberately does not distinguish the two.
+//
+// Detail is whatever the site said about it, in its own words and its own
+// language, and is empty when it said nothing. It is worth showing: a 404 is the
+// answer to both a wrong id and a missing permission, and the sentence is the
+// only thing that ever tells them apart.
 type NotFoundError struct {
-	Kind string
-	ID   string
+	Kind   string
+	ID     string
+	Detail string
 }
 
 func (e *NotFoundError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("%s %s: %s", e.Kind, e.ID, e.Detail)
+	}
 	return fmt.Sprintf("%s %s does not exist, or you cannot see it", e.Kind, e.ID)
 }
 

--- a/pkg/jira/jiratest/fixtures/README.md
+++ b/pkg/jira/jiratest/fixtures/README.md
@@ -29,3 +29,35 @@ The `task_*.json` set describes one run of the operation Atlassian's docs point 
 replacing a custom-field select option across issues. It reuses the invented `Rollout Phase` field and
 its options from `createmeta_task.json`, and numbers its task differently from the bulk-move one —
 they are separate registries, and a shared id would read as one task answering at both endpoints.
+
+## The Agile API pages three different ways
+
+There is one envelope per shape here, because no endpoint announces which one it answers in and a
+decoder that reads only the common one comes back empty rather than failing:
+
+| fixture | array | `total` | `isLast` | stands for |
+|---|---|---|---|---|
+| `board_issues.json` | `issues` | yes | **no** | `/board/{id}/issue`, `/board/{id}/backlog` |
+| `board_epics.json` | `values` | **no** | yes | `/board/{id}/epic`, `/board/{id}/version` |
+| `sprint_page.json` | `values` | yes | yes | `/board/{id}/sprint`, `/board` |
+
+`board_issues.json` is served on both the board and the backlog route: the two answer the same
+envelope, and its issues carry an Agile `self` (`/rest/agile/1.0/issue/{id}`) with `/rest/api/2`
+links inside them, which is what that endpoint really sends.
+
+## A site refuses in two different envelopes
+
+`not_found_board.json` is the Agile one: `errorMessages` empty, and the sentence in `errors` under
+the name of a **URL parameter** rather than a field. Nothing keyed like that may become a form-field
+error — no input is called `rapidViewId`.
+
+`problem_no_endpoint.json` and `problem_method_not_allowed.json` are RFC 7807 `problem+json`, which is
+what answers a request that reached the site and no handler. `detail` is the only part that says
+anything; `title` is the status spelt out. The fixture server answers an unrouted path this way too,
+because a real site does.
+
+`field_localised.json` is the field catalogue as a site whose language is not English sends it: display
+names translated, `untranslatedName` not, one field spelling it as a single run-together word so it
+matches neither the translated name nor the English one, two fields whose display names have collapsed
+into a single string, and a field with an empty `clauseNames`, which is the site saying it cannot be
+named in JQL at all.

--- a/pkg/jira/jiratest/fixtures/board_epics.json
+++ b/pkg/jira/jiratest/fixtures/board_epics.json
@@ -1,0 +1,29 @@
+{
+  "maxResults": 50,
+  "startAt": 0,
+  "isLast": true,
+  "values": [
+    {
+      "id": 10007,
+      "key": "EX-7",
+      "self": "https://example.atlassian.net/rest/agile/1.0/epic/10007",
+      "name": "",
+      "summary": "Retry policy",
+      "color": {
+        "key": "color_4"
+      },
+      "done": false
+    },
+    {
+      "id": 10008,
+      "key": "EX-8",
+      "self": "https://example.atlassian.net/rest/agile/1.0/epic/10008",
+      "name": "",
+      "summary": "Offline cache",
+      "color": {
+        "key": "color_11"
+      },
+      "done": true
+    }
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/board_issues.json
+++ b/pkg/jira/jiratest/fixtures/board_issues.json
@@ -1,0 +1,107 @@
+{
+  "expand": "schema,names",
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 3,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10001",
+      "self": "https://example.atlassian.net/rest/agile/1.0/issue/10001",
+      "key": "EX-1",
+      "fields": {
+        "summary": "Retry a failed upload on a 502",
+        "status": {
+          "self": "https://example.atlassian.net/rest/api/2/status/10001",
+          "description": "",
+          "iconUrl": "https://example.atlassian.net/images/icons/statuses/generic.png",
+          "name": "In Review",
+          "id": "10001",
+          "statusCategory": {
+            "self": "https://example.atlassian.net/rest/api/2/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+          }
+        },
+        "issuetype": {
+          "self": "https://example.atlassian.net/rest/api/2/issuetype/10001",
+          "id": "10001",
+          "description": "A task that needs to be done.",
+          "iconUrl": "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+          "name": "Task",
+          "subtask": false,
+          "hierarchyLevel": 0
+        },
+        "customfield_10032": 5.0
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10002",
+      "self": "https://example.atlassian.net/rest/agile/1.0/issue/10002",
+      "key": "EX-2",
+      "fields": {
+        "summary": "Cache the field catalogue between runs",
+        "status": {
+          "self": "https://example.atlassian.net/rest/api/2/status/10000",
+          "description": "",
+          "iconUrl": "https://example.atlassian.net/images/icons/statuses/generic.png",
+          "name": "Backlog",
+          "id": "10000",
+          "statusCategory": {
+            "self": "https://example.atlassian.net/rest/api/2/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+          }
+        },
+        "issuetype": {
+          "self": "https://example.atlassian.net/rest/api/2/issuetype/10001",
+          "id": "10001",
+          "description": "A task that needs to be done.",
+          "iconUrl": "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+          "name": "Task",
+          "subtask": false,
+          "hierarchyLevel": 0
+        },
+        "customfield_10032": null
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10003",
+      "self": "https://example.atlassian.net/rest/agile/1.0/issue/10003",
+      "key": "EX-3",
+      "fields": {
+        "summary": "Retire the legacy export job",
+        "status": {
+          "self": "https://example.atlassian.net/rest/api/2/status/10002",
+          "description": "",
+          "iconUrl": "https://example.atlassian.net/images/icons/statuses/generic.png",
+          "name": "Released",
+          "id": "10002",
+          "statusCategory": {
+            "self": "https://example.atlassian.net/rest/api/2/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+          }
+        },
+        "issuetype": {
+          "self": "https://example.atlassian.net/rest/api/2/issuetype/10004",
+          "id": "10004",
+          "description": "A problem or error.",
+          "iconUrl": "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium",
+          "name": "Bug",
+          "subtask": false,
+          "hierarchyLevel": 0
+        },
+        "customfield_10032": 2.0
+      }
+    }
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/field_localised.json
+++ b/pkg/jira/jiratest/fixtures/field_localised.json
@@ -1,0 +1,108 @@
+[
+  {
+    "id": "summary",
+    "key": "summary",
+    "name": "Kurztitel",
+    "custom": false,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": ["summary"],
+    "schema": {
+      "type": "string",
+      "system": "summary"
+    }
+  },
+  {
+    "id": "duedate",
+    "key": "duedate",
+    "name": "Zieltag",
+    "custom": false,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": ["due", "duedate"],
+    "schema": {
+      "type": "date",
+      "system": "duedate"
+    }
+  },
+  {
+    "id": "timeestimate",
+    "key": "timeestimate",
+    "name": "Restschätzung",
+    "custom": false,
+    "orderable": false,
+    "navigable": true,
+    "searchable": false,
+    "clauseNames": ["remainingEstimate", "timeestimate"],
+    "schema": {
+      "type": "number",
+      "system": "timeestimate"
+    }
+  },
+  {
+    "id": "aggregatetimeestimate",
+    "key": "aggregatetimeestimate",
+    "name": "Restschätzung",
+    "custom": false,
+    "orderable": false,
+    "navigable": true,
+    "searchable": false,
+    "clauseNames": [],
+    "schema": {
+      "type": "number",
+      "system": "aggregatetimeestimate"
+    }
+  },
+  {
+    "id": "customfield_10032",
+    "key": "customfield_10032",
+    "name": "Story-Punkte",
+    "untranslatedName": "Story Points",
+    "custom": true,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": ["cf[10032]", "Story Points"],
+    "schema": {
+      "type": "number",
+      "custom": "com.atlassian.jira.plugin.system.customfieldtypes:float",
+      "customId": 10032
+    }
+  },
+  {
+    "id": "customfield_10071",
+    "key": "customfield_10071",
+    "name": "Freigabefenster",
+    "untranslatedName": "ReleaseWindows",
+    "custom": true,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": ["cf[10071]", "ReleaseWindows"],
+    "schema": {
+      "type": "array",
+      "items": "Freigabefenster",
+      "custom": "com.atlassian.jira.plugin.system.customfieldtypes:release-windows",
+      "customId": 10071
+    }
+  },
+  {
+    "id": "customfield_10072",
+    "key": "customfield_10072",
+    "name": "Intake forms",
+    "untranslatedName": "Intake forms",
+    "custom": true,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [],
+    "schema": {
+      "type": "array",
+      "items": "Formulare",
+      "custom": "com.atlassian.jira.plugins.proforma-managed-fields:proforma-forms-field-cftype",
+      "customId": 10072
+    }
+  }
+]

--- a/pkg/jira/jiratest/fixtures/not_found_board.json
+++ b/pkg/jira/jiratest/fixtures/not_found_board.json
@@ -1,0 +1,6 @@
+{
+  "errorMessages": [],
+  "errors": {
+    "rapidViewId": "The board asked for cannot be opened: either there is no such board, or this account may not see it."
+  }
+}

--- a/pkg/jira/jiratest/fixtures/problem_method_not_allowed.json
+++ b/pkg/jira/jiratest/fixtures/problem_method_not_allowed.json
@@ -1,0 +1,7 @@
+{
+  "type": "about:blank",
+  "title": "Method Not Allowed",
+  "status": 405,
+  "detail": "Method 'POST' is not supported.",
+  "instance": "/rest/agile/1.0/board/10/configuration"
+}

--- a/pkg/jira/jiratest/fixtures/problem_no_endpoint.json
+++ b/pkg/jira/jiratest/fixtures/problem_no_endpoint.json
@@ -1,0 +1,7 @@
+{
+  "type": "about:blank",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "No endpoint GET /rest/agile/1.0/board/10/swimlane.",
+  "instance": "/rest/agile/1.0/board/10/swimlane"
+}

--- a/pkg/jira/jiratest/fixtures_test.go
+++ b/pkg/jira/jiratest/fixtures_test.go
@@ -181,6 +181,8 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 		"board.json",
 		"board_config_estimation.json",
 		"board_config_no_estimation.json",
+		"board_epics.json",
+		"board_issues.json",
 		"bulkmove_submit.json",
 		"bulkmove_task_complete.json",
 		"bulkmove_task_enqueued.json",
@@ -192,12 +194,16 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 		"createmeta_issuetypes.json",
 		"createmeta_task.json",
 		"field.json",
+		"field_localised.json",
 		"issue_rich_adf.json",
 		"mypermissions_admin.json",
 		"mypermissions_basic.json",
 		"myself.json",
+		"not_found_board.json",
 		"plans_403.json",
 		"plans_ok.json",
+		"problem_method_not_allowed.json",
+		"problem_no_endpoint.json",
 		"rate_limited.json",
 		"search_page1.json",
 		"search_page2.json",
@@ -213,6 +219,193 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 	got := slices.Sorted(maps.Keys(srvJSONFixtures(t)))
 	if !slices.Equal(got, want) {
 		t.Errorf("fixture set drifted:\n got %v\nwant %v", got, want)
+	}
+}
+
+// Three paging envelopes, and no endpoint says which one it answers in.
+func TestFixtures_CoverAllThreeAgilePagingEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fixture  string
+		array    string
+		absent   []string
+		required []string
+	}{
+		{
+			name: "the board's issues and its backlog", fixture: "board_issues.json",
+			array: "issues", absent: []string{"isLast", "values"}, required: []string{"startAt", "maxResults", "total"},
+		},
+		{
+			name: "an epic page", fixture: "board_epics.json",
+			array: "values", absent: []string{"total", "issues"}, required: []string{"startAt", "maxResults", "isLast"},
+		},
+		{
+			name: "a sprint page, which sends all four", fixture: "sprint_page.json",
+			array: "values", absent: []string{"issues"}, required: []string{"startAt", "maxResults", "total", "isLast"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := srvDecode(t, srvFixture(t, tt.fixture))
+
+			rows, ok := body[tt.array].([]any)
+			if !ok {
+				t.Fatalf("%s does not name its array %q", tt.fixture, tt.array)
+			}
+			if len(rows) == 0 {
+				t.Errorf("%s has no rows, so nothing decodes it wrongly and passes", tt.fixture)
+			}
+			for _, key := range tt.required {
+				if _, ok := body[key]; !ok {
+					t.Errorf("%s sends no %s", tt.fixture, key)
+				}
+			}
+			for _, key := range tt.absent {
+				if _, ok := body[key]; ok {
+					t.Errorf("%s sends %s, and the endpoint it stands for does not", tt.fixture, key)
+				}
+			}
+		})
+	}
+}
+
+// The last page of a cursor walk says isLast and stops sending a token, so a
+// decoder that only reads one of the two still terminates.
+func TestFixtures_TheLastSearchPageSaysIsLastAndSendsNoToken(t *testing.T) {
+	t.Parallel()
+
+	last := srvDecode(t, srvFixture(t, "search_page2.json"))
+	if isLast, _ := last["isLast"].(bool); !isLast {
+		t.Errorf("search_page2.json isLast = %v, want true", last["isLast"])
+	}
+	if _, ok := last["nextPageToken"]; ok {
+		t.Error("the last page still carries a nextPageToken key, and a real one omits it entirely")
+	}
+
+	first := srvDecode(t, srvFixture(t, "search_page1.json"))
+	if token, _ := first["nextPageToken"].(string); token == "" {
+		t.Error("search_page1.json hands out no token, so the walk it stands for is one page long")
+	}
+}
+
+// The shapes a lookup by display name cannot resolve, all of which a real
+// catalogue carries.
+func TestFixtures_TheLocalisedCatalogueCarriesTheNamesThatDoNotResolve(t *testing.T) {
+	t.Parallel()
+
+	var fields []struct {
+		ID               string   `json:"id"`
+		Name             string   `json:"name"`
+		UntranslatedName string   `json:"untranslatedName"`
+		Custom           bool     `json:"custom"`
+		ClauseNames      []string `json:"clauseNames"`
+	}
+	if err := json.Unmarshal(srvFixture(t, "field_localised.json"), &fields); err != nil {
+		t.Fatalf("decoding field_localised.json: %v", err)
+	}
+
+	var compressed, unJQLable, translated int
+	names := make(map[string]int)
+	for _, f := range fields {
+		names[strings.ToLower(f.Name)]++
+		if f.ClauseNames != nil && len(f.ClauseNames) == 0 {
+			unJQLable++
+		}
+		if !f.Custom {
+			if f.UntranslatedName != "" {
+				t.Errorf("%s is a system field carrying an untranslatedName, which Jira sends on custom fields only", f.ID)
+			}
+			continue
+		}
+		if f.UntranslatedName == "" {
+			t.Errorf("%s is a custom field with no untranslatedName", f.ID)
+		}
+		if !strings.EqualFold(f.UntranslatedName, f.Name) {
+			translated++
+		}
+		if srvRunTogetherRe.MatchString(f.UntranslatedName) {
+			compressed++
+		}
+	}
+
+	if compressed == 0 {
+		t.Error("no field spells its untranslatedName as one run-together word, which is the case a lookup by display name misses: the English screen puts a space in it")
+	}
+	if unJQLable == 0 {
+		t.Error("no field sends an empty clauseNames, so nothing proves a field can be unaddressable in JQL")
+	}
+	if translated == 0 {
+		t.Error("no field's display name differs from its untranslated one, so this is not a localised catalogue")
+	}
+	var collisions int
+	for _, count := range names {
+		if count > 1 {
+			collisions++
+		}
+	}
+	if collisions == 0 {
+		t.Error("no two fields share a display name, which is what translation does to two of a site's statuses")
+	}
+}
+
+// srvRunTogetherRe is the compressed spelling untranslatedName uses: two words
+// with the separator taken out, which is never what a screen displays.
+var srvRunTogetherRe = regexp.MustCompile(`[a-z][A-Z]`)
+
+func TestFixtures_CarryBothEnvelopesASiteRefusesIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the Agile shape, whose sentence is under a URL parameter", func(t *testing.T) {
+		t.Parallel()
+		body := srvDecode(t, srvFixture(t, "not_found_board.json"))
+
+		if msgs, _ := body["errorMessages"].([]any); len(msgs) != 0 {
+			t.Errorf("errorMessages = %v, want the empty array the endpoint sends", msgs)
+		}
+		errs, ok := body["errors"].(map[string]any)
+		if !ok || len(errs) == 0 {
+			t.Fatalf("errors = %v, want the object holding the reason", body["errors"])
+		}
+		for key, value := range errs {
+			if !strings.HasSuffix(key, "Id") {
+				t.Errorf("errors is keyed by %q; the shape being pinned is a URL parameter name", key)
+			}
+			if sentence, _ := value.(string); len(sentence) < 20 {
+				t.Errorf("%q carries %q, which is not the sentence a user has to read", key, sentence)
+			}
+		}
+	})
+
+	for _, name := range []string{"problem_no_endpoint.json", "problem_method_not_allowed.json"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			body := srvDecode(t, srvFixture(t, name))
+
+			for _, key := range []string{"type", "title", "status", "detail", "instance"} {
+				if _, ok := body[key]; !ok {
+					t.Errorf("%s sends no %s", name, key)
+				}
+			}
+			for _, key := range []string{"errorMessages", "errors", "message"} {
+				if _, ok := body[key]; ok {
+					t.Errorf("%s carries %s, and a problem+json body does not", name, key)
+				}
+			}
+			if kind, _ := body["type"].(string); kind != "about:blank" {
+				t.Errorf("type = %q, want about:blank", kind)
+			}
+			status, _ := body["status"].(float64)
+			if title, _ := body["title"].(string); title != http.StatusText(int(status)) {
+				t.Errorf("title = %q, want the status %d spelt out", title, int(status))
+			}
+			if detail, _ := body["detail"].(string); detail == "" {
+				t.Errorf("%s carries no detail, which is the only part that says anything", name)
+			}
+		})
 	}
 }
 

--- a/pkg/jira/jiratest/server.go
+++ b/pkg/jira/jiratest/server.go
@@ -226,6 +226,12 @@ var srvDefaultRoutes = []srvRoute{
 	{http.MethodGet, "/rest/agile/1.0/board", srvFixtureHandler(http.StatusOK, "board.json")},
 	{http.MethodGet, "/rest/agile/1.0/board/{id}/configuration", srvFixtureHandler(http.StatusOK, "board_config_estimation.json")},
 	{http.MethodGet, "/rest/agile/1.0/board/{id}/sprint", srvFixtureHandler(http.StatusOK, "sprint_page.json")},
+	// Three Agile paging envelopes, one per shape: these two name their array
+	// issues and send no isLast, the epics send no total, and the sprints above
+	// send all four keys.
+	{http.MethodGet, "/rest/agile/1.0/board/{id}/issue", srvFixtureHandler(http.StatusOK, "board_issues.json")},
+	{http.MethodGet, "/rest/agile/1.0/board/{id}/backlog", srvFixtureHandler(http.StatusOK, "board_issues.json")},
+	{http.MethodGet, "/rest/agile/1.0/board/{id}/epic", srvFixtureHandler(http.StatusOK, "board_epics.json")},
 	// 403 is the normal answer — the Plans API needs Administer Jira — so it is
 	// the default. A test that wants the reachable case overrides the route:
 	//   WithFixture(http.MethodGet, "/rest/api/3/plans/plan", "plans_ok.json")
@@ -297,8 +303,11 @@ func srvCreateMeta(w http.ResponseWriter, r *http.Request) {
 	srvServeFixture(w, http.StatusOK, name)
 }
 
+// srvNotFound answers a path no route covers. A real site answers that in RFC
+// 7807 rather than in Jira's own error shape, because the request never reached a
+// Jira handler at all.
 func srvNotFound(w http.ResponseWriter, r *http.Request) {
-	srvWriteError(w, http.StatusNotFound, "No route matches "+r.Method+" "+r.URL.Path+" on this fixture server.")
+	srvWriteProblem(w, http.StatusNotFound, "No endpoint "+r.Method+" "+r.URL.Path+".", r.URL.Path)
 }
 
 func srvFixtureHandler(status int, fixture string) http.HandlerFunc {
@@ -340,6 +349,34 @@ func srvWriteError(w http.ResponseWriter, status int, message string) {
 		return
 	}
 	srvWriteJSON(w, status, body)
+}
+
+// srvProblemBody is RFC 7807, which is what answers a request that reached the
+// site and no handler. type is always about:blank and title is only the status
+// spelt out; detail is the only part that says anything.
+type srvProblemBody struct {
+	Type     string `json:"type"`
+	Title    string `json:"title"`
+	Status   int    `json:"status"`
+	Detail   string `json:"detail"`
+	Instance string `json:"instance"`
+}
+
+func srvWriteProblem(w http.ResponseWriter, status int, detail, instance string) {
+	body, err := json.Marshal(srvProblemBody{
+		Type:     "about:blank",
+		Title:    http.StatusText(status),
+		Status:   status,
+		Detail:   detail,
+		Instance: instance,
+	})
+	if err != nil {
+		http.Error(w, detail, status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
 }
 
 func srvWriteJSON(w http.ResponseWriter, status int, body []byte) {

--- a/pkg/jira/jiratest/server_test.go
+++ b/pkg/jira/jiratest/server_test.go
@@ -92,6 +92,9 @@ func TestServer_ServesEveryDefaultRouteWithItsFixture(t *testing.T) {
 		{"boards", http.MethodGet, "/rest/agile/1.0/board?projectKeyOrId=EX", http.StatusOK, "board.json"},
 		{"board configuration", http.MethodGet, "/rest/agile/1.0/board/10/configuration", http.StatusOK, "board_config_estimation.json"},
 		{"board sprints", http.MethodGet, "/rest/agile/1.0/board/10/sprint", http.StatusOK, "sprint_page.json"},
+		{"board issues", http.MethodGet, "/rest/agile/1.0/board/10/issue", http.StatusOK, "board_issues.json"},
+		{"board backlog", http.MethodGet, "/rest/agile/1.0/board/10/backlog", http.StatusOK, "board_issues.json"},
+		{"board epics", http.MethodGet, "/rest/agile/1.0/board/10/epic", http.StatusOK, "board_epics.json"},
 		{"plans refused", http.MethodGet, "/rest/api/3/plans/plan", http.StatusForbidden, "plans_403.json"},
 		{"bulk move submitted", http.MethodPost, "/rest/api/3/bulk/issues/move", http.StatusCreated, "bulkmove_submit.json"},
 		{"generic task", http.MethodGet, "/rest/api/3/task/11072", http.StatusOK, "task_complete.json"},
@@ -159,23 +162,33 @@ func TestServer_RefusesAPageTokenItNeverIssued(t *testing.T) {
 	}
 }
 
-func TestServer_UnroutedPathAnswersAJiraShapedNotFound(t *testing.T) {
+// A request that reaches the site and no handler is answered in RFC 7807, not in
+// Jira's own error shape.
+func TestServer_UnroutedPathAnswersTheProblemJSONARealSiteAnswers(t *testing.T) {
 	t.Parallel()
 	s := srvNewServer(t)
 
-	got := srvDo(t, s, http.MethodGet, "/rest/api/3/there/is/no/such/thing", "")
+	const target = "/rest/api/3/there/is/no/such/thing"
+	got := srvDo(t, s, http.MethodGet, target, "")
 	if got.status != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", got.status)
 	}
-	if ct := got.header.Get("Content-Type"); ct != "application/json" {
-		t.Fatalf("Content-Type = %q, want application/json", ct)
+	if ct := got.header.Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("Content-Type = %q, want application/problem+json", ct)
 	}
 	body := srvDecode(t, got.body)
-	if msgs, _ := body["errorMessages"].([]any); len(msgs) == 0 {
-		t.Error("the 404 carries no errorMessages")
+	if _, ok := body["errorMessages"]; ok {
+		t.Error("the body carries errorMessages, which is the envelope a Jira handler answers in")
 	}
-	if _, ok := body["errors"]; !ok {
-		t.Error("the 404 has no errors object")
+	detail, _ := body["detail"].(string)
+	if !strings.Contains(detail, http.MethodGet) || !strings.Contains(detail, target) {
+		t.Errorf("detail = %q, want the method and path that reached no endpoint", detail)
+	}
+	if title, _ := body["title"].(string); title != http.StatusText(http.StatusNotFound) {
+		t.Errorf("title = %q, want the status spelt out", title)
+	}
+	if status, _ := body["status"].(float64); int(status) != http.StatusNotFound {
+		t.Errorf("status in the body = %v, want 404", status)
 	}
 }
 

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/varijkapil13/saral/pkg/adf"
 )
@@ -186,14 +187,17 @@ type Field struct {
 	Name string
 	// UntranslatedName is the name Jira gives the field regardless of site
 	// language, and it is what appears in ClauseNames. Jira sends it for custom
-	// fields only, so it is empty on every system field.
+	// fields only, so it is empty on every system field. It is not the field's
+	// English display name either: a field displayed as "Release Windows" can be
+	// "ReleaseWindows" here, on an English site and a German one alike.
 	UntranslatedName string
 	Custom           bool
 	Navigable        bool
 	Searchable       bool
 	Orderable        bool
 	// ClauseNames are the identifiers this field can be written as in JQL. They
-	// follow UntranslatedName, not Name.
+	// follow UntranslatedName, not Name. A field may send none, which is the
+	// site saying it cannot be named in JQL at all — not even as cf[NNNNN].
 	ClauseNames []string
 	// Schema is absent on a few system fields — parent, issuekey, thumbnail —
 	// which is Jira saying they are not written through the generic field path.
@@ -211,28 +215,117 @@ type FieldRef struct {
 	Schema FieldSchema
 }
 
-// FieldByName finds a field by name, case-insensitively.
+// FieldNameError reports that a name did not resolve to exactly one field on
+// this site.
 //
-// UntranslatedName is tried before Name, because Name is localised: a site in
-// German calls the story point field something else, and configuration that
-// names "Story Points" has to keep working there. Names are not unique either,
-// so the first match in catalogue order wins and a caller that cares should
-// disambiguate on Schema.
+// Matches holds the candidates when the name was ambiguous and is empty when no
+// field carried it at all. That is the distinction a caller has to be able to put
+// in front of somebody: one is a name to correct, the other is a name that has to
+// be said a different way.
+type FieldNameError struct {
+	Name    string
+	Matches []Field
+}
+
+// Ambiguous reports whether the name belongs to more than one field.
+func (e *FieldNameError) Ambiguous() bool { return len(e.Matches) > 1 }
+
+func (e *FieldNameError) Error() string {
+	if !e.Ambiguous() {
+		return fmt.Sprintf("no field on this site is called %q", e.Name)
+	}
+	ids := make([]string, 0, len(e.Matches))
+	for i := range e.Matches {
+		ids = append(ids, e.Matches[i].ID)
+	}
+	return fmt.Sprintf("%q is the name of %d fields on this site (%s), so it does not say which one",
+		e.Name, len(e.Matches), strings.Join(ids, ", "))
+}
+
+// ResolveField turns a field name written down somewhere — a profile, a saved
+// query, a board's estimation setting — into the one field on this site that it
+// means, or says why it cannot.
+//
+// A site spells one field's name up to three ways and shows only two of them at
+// a time. UntranslatedName does not move with the site language but is sent for
+// custom fields only, and it is not the English display name either: a field
+// displayed as "Release Windows" in English can be "Freigabefenster" in German
+// and "ReleaseWindows" in UntranslatedName on both. So a name is compared four
+// ways, in this order, and the first way that matches anything decides:
+//
+//  1. UntranslatedName, ignoring case
+//  2. Name, ignoring case
+//  3. UntranslatedName, ignoring case and every separator
+//  4. Name, ignoring case and every separator
+//
+// The last two are what carry a display name copied off an English site onto a
+// translated one. They come last so that a name a field really displays always
+// beats a name reconstructed from one.
+//
+// Two different fields matching at the same level is unresolvable rather than a
+// coin toss. Display names are not unique — a catalogue can hold two fields
+// called the same thing, and translation collapses distinct names into one — and
+// answering with either of them reads or writes a field nobody named.
+func ResolveField(fields []Field, name string) (Field, error) {
+	wanted := strings.TrimSpace(name)
+	if wanted == "" {
+		return Field{}, &FieldNameError{Name: name}
+	}
+	folded := foldFieldName(wanted)
+	for _, matches := range []func(Field) bool{
+		func(f Field) bool { return f.UntranslatedName != "" && strings.EqualFold(f.UntranslatedName, wanted) },
+		func(f Field) bool { return strings.EqualFold(f.Name, wanted) },
+		func(f Field) bool { return folded != "" && foldFieldName(f.UntranslatedName) == folded },
+		func(f Field) bool { return folded != "" && foldFieldName(f.Name) == folded },
+	} {
+		switch found := fieldsMatching(fields, matches); len(found) {
+		case 0:
+		case 1:
+			return found[0], nil
+		default:
+			return Field{}, &FieldNameError{Name: wanted, Matches: found}
+		}
+	}
+	return Field{}, &FieldNameError{Name: wanted}
+}
+
+// FieldByName finds the one field a name means, and reports whether exactly one
+// field means it. Prefer ResolveField where the caller can say something useful
+// about why a name did not resolve — an ambiguous name and an unknown one need
+// different answers from the person who wrote it down.
 func FieldByName(fields []Field, name string) (Field, bool) {
-	if strings.TrimSpace(name) == "" {
-		return Field{}, false
-	}
+	field, err := ResolveField(fields, name)
+	return field, err == nil
+}
+
+// fieldsMatching collects the distinct fields a rule matches. One field listed
+// twice is one field; two ids are two candidates.
+func fieldsMatching(fields []Field, matches func(Field) bool) []Field {
+	var out []Field
 	for i := range fields {
-		if fields[i].UntranslatedName != "" && strings.EqualFold(fields[i].UntranslatedName, name) {
-			return fields[i], true
+		if !matches(fields[i]) {
+			continue
+		}
+		if slices.ContainsFunc(out, func(seen Field) bool { return seen.ID == fields[i].ID }) {
+			continue
+		}
+		out = append(out, fields[i])
+	}
+	return out
+}
+
+// foldFieldName reduces a name to its letters and digits, lowercased, so that a
+// display name matches the compressed spelling UntranslatedName uses for the
+// same field.
+func foldFieldName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
 		}
 	}
-	for i := range fields {
-		if strings.EqualFold(fields[i].Name, name) {
-			return fields[i], true
-		}
-	}
-	return Field{}, false
+	return b.String()
 }
 
 // FieldKind is which slot of a FieldValue carries the value.

--- a/pkg/jira/types_test.go
+++ b/pkg/jira/types_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 	_ "time/tzdata"
@@ -938,7 +939,7 @@ func TestGraphicsMode_StringNamesEveryMode(t *testing.T) {
 	}
 }
 
-func TestFieldByName_IsCaseInsensitiveAndTakesTheFirstMatch(t *testing.T) {
+func TestFieldByName_IsCaseInsensitiveAndAnswersNothingForANameTwoFieldsShare(t *testing.T) {
 	t.Parallel()
 
 	catalogue := []jira.Field{
@@ -955,7 +956,7 @@ func TestFieldByName_IsCaseInsensitiveAndTakesTheFirstMatch(t *testing.T) {
 	}{
 		{name: "an exact name", lookup: "Summary", wantID: "summary", found: true},
 		{name: "a name in the wrong case", lookup: "sUmMaRy", wantID: "summary", found: true},
-		{name: "a name two fields share", lookup: "story points", wantID: "customfield_10016", found: true},
+		{name: "a name two fields share, which therefore names neither", lookup: "story points", found: false},
 		{name: "a name no field has", lookup: "Sprint", found: false},
 		{name: "no name at all", lookup: "", found: false},
 	}
@@ -1167,4 +1168,130 @@ func TestFieldByName_PrefersTheUntranslatedNameBecauseNameIsLocalised(t *testing
 func FieldByNameHelper(t *testing.T, fields []jira.Field, name string) (jira.Field, bool) {
 	t.Helper()
 	return jira.FieldByName(fields, name)
+}
+
+// A site spells one field's name three ways — the untranslated one, the display
+// name in English and the display name in the site's language — and puts only two
+// of them on the wire at a time. The untranslated one is not the English display
+// name, so a name copied off an English site has to be reachable from the pair a
+// German site sends.
+func TestResolveField_FindsAnEnglishDisplayNameOnASiteThatSendsNeither(t *testing.T) {
+	t.Parallel()
+
+	// A German read of a catalogue whose customfield_10071 is displayed as
+	// "Release Windows" on the English read of the same site.
+	fields := []jira.Field{
+		{ID: "summary", Name: "Kurztitel"},
+		{ID: "customfield_10032", Name: "Story-Punkte", UntranslatedName: "Story Points", Custom: true},
+		{ID: "customfield_10071", Name: "Freigabefenster", UntranslatedName: "ReleaseWindows", Custom: true},
+	}
+
+	tests := []struct {
+		name   string
+		lookup string
+		wantID string
+	}{
+		{name: "the untranslated name, which is what a portable profile writes", lookup: "Story Points", wantID: "customfield_10032"},
+		{name: "the name this site displays", lookup: "Freigabefenster", wantID: "customfield_10071"},
+		{name: "the name an English site displays", lookup: "Release Windows", wantID: "customfield_10071"},
+		{name: "the same, in the case somebody typed it in", lookup: "release windows", wantID: "customfield_10071"},
+		{name: "a system field, which sends no untranslated name at all", lookup: "Kurztitel", wantID: "summary"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := jira.ResolveField(fields, tt.lookup)
+			if err != nil {
+				t.Fatalf("ResolveField(%q): %v", tt.lookup, err)
+			}
+			if got.ID != tt.wantID {
+				t.Errorf("ResolveField(%q) = %q, want %q", tt.lookup, got.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestResolveField_SaysWhetherANameIsUnknownOrSharedByTwoFields(t *testing.T) {
+	t.Parallel()
+
+	// Two distinct fields whose display names have collapsed into one string,
+	// which is what translation does: two of a German site's statuses answer to
+	// one German word.
+	fields := []jira.Field{
+		{ID: "timeestimate", Name: "Restschätzung"},
+		{ID: "aggregatetimeestimate", Name: "Restschätzung"},
+		{ID: "customfield_10032", Name: "Story-Punkte", UntranslatedName: "Story Points", Custom: true},
+	}
+
+	tests := []struct {
+		name          string
+		lookup        string
+		wantAmbiguous bool
+		wantIDs       []string
+	}{
+		{
+			name: "a name two fields share", lookup: "Restschätzung",
+			wantAmbiguous: true, wantIDs: []string{"timeestimate", "aggregatetimeestimate"},
+		},
+		{
+			name: "the same name in another case", lookup: "restschätzung",
+			wantAmbiguous: true, wantIDs: []string{"timeestimate", "aggregatetimeestimate"},
+		},
+		{name: "a name nothing carries", lookup: "Sprint"},
+		{name: "no name at all", lookup: "  "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := jira.ResolveField(fields, tt.lookup)
+			if err == nil {
+				t.Fatalf("ResolveField(%q) = %q, want an error", tt.lookup, got.ID)
+			}
+			if got.ID != "" {
+				t.Errorf("ResolveField(%q) answered %q as well as failing", tt.lookup, got.ID)
+			}
+			var unresolved *jira.FieldNameError
+			if !errors.As(err, &unresolved) {
+				t.Fatalf("got %T (%v), want a *jira.FieldNameError", err, err)
+			}
+			if unresolved.Ambiguous() != tt.wantAmbiguous {
+				t.Errorf("Ambiguous() = %t, want %t: %v", unresolved.Ambiguous(), tt.wantAmbiguous, err)
+			}
+			ids := make([]string, 0, len(unresolved.Matches))
+			for _, f := range unresolved.Matches {
+				ids = append(ids, f.ID)
+			}
+			if !slices.Equal(ids, tt.wantIDs) {
+				t.Errorf("Matches = %v, want %v", ids, tt.wantIDs)
+			}
+			for _, id := range tt.wantIDs {
+				if !strings.Contains(err.Error(), id) {
+					t.Errorf("the message %q does not name the candidate %q", err, id)
+				}
+			}
+		})
+	}
+}
+
+// Ignoring separators is the last thing tried, so relaxing the comparison cannot
+// move a lookup that a name somebody can actually see already answered.
+func TestResolveField_TriesADisplayedNameBeforeOneReconstructedFromASeparator(t *testing.T) {
+	t.Parallel()
+
+	fields := []jira.Field{
+		{ID: "customfield_10080", Name: "Signoff tier", UntranslatedName: "Signoff-Tier", Custom: true},
+		{ID: "customfield_10081", Name: "SignoffTier", UntranslatedName: "Approval tier", Custom: true},
+	}
+
+	got, err := jira.ResolveField(fields, "signofftier")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got.ID != "customfield_10081" {
+		t.Errorf("ResolveField = %q, want the field that displays that name", got.ID)
+	}
 }


### PR DESCRIPTION
Closes #98, closes #99, closes #100, closes #101.

A disposable Cloud site was built out to cover every shape this client claims to handle — a
team-managed project, a company-managed one, a Kanban one, five boards, ~250 issues, sprints in all
three states, 15 custom field types, a transition with a required screen and a validator, and a
deliberate en_US↔de_DE flip. Four things this code believed turned out to be false, and every one of
them was invisible because the fixture that stood in for the site was invented and self-consistent. So
the fixtures are corrected here alongside the code, from measured shapes and with invented words.

Four issues, one PR: they share `pkg/jira/jiratest/fixtures/**` and its manifest test, which
`docs/PARALLEL.md` names as the one file two packets cannot both add to.

## 1 · A field name written in a profile could not resolve on a translated site (#98)

A site spells one field's name **three** ways and puts two of them on the wire at a time:
`untranslatedName`, the English display name, and the localised display name. `untranslatedName` is
not the English one — a field displayed as two words in English can be a single run-together word
there. The old lookup tried `untranslatedName` then `name`, both `EqualFold`, so a profile naming what
an English screen shows matched nothing on a German site: the first pass failed on a missing space, the
second on the German. 59 of the site's 101 field names moved under the flip; `untranslatedName`,
`clauseNames` and every id did not move at all.

`jira.ResolveField` compares a name four ways and the first level that matches anything decides:
`untranslatedName` ignoring case, `name` ignoring case, then each of those again ignoring case **and
every separator**. The last two are what carry an English display name onto a translated site, and
they come last so a name a field really displays always beats one reconstructed from a compressed
spelling.

Two different fields matching at one level is a `*jira.FieldNameError` carrying the candidates, with
`Ambiguous()` to tell "correct this name" from "this name means two things". Names are not unique —
the committed `field.json` already had two fields sharing one display name, and on a German site two
of this testbed's statuses answer to a single German string — and answering with either is a value
read from or written to a field nobody named.

**Consumers**, checked by name rather than by compiling: `FieldByName` keeps its `(Field, bool)`
signature and both callers already treat `false` as "did not resolve" —
`internal/app.Search.Resolve` puts the name in `Missing`, `jiratest`'s `fakeRefByName` skips the
field. Neither needed a change to be correct; both get the fix for free and neither can now be handed
the wrong field. `pkg/jira/port.go` is untouched: no method changed.

## 2 and 3 · Two error envelopes the client could not read (#99, #100)

The Agile API leaves `errorMessages` empty and writes its sentence into `errors` **keyed by a URL
parameter**:

```
GET /rest/agile/1.0/board/99999/configuration
404 {"errorMessages":[],"errors":{"rapidViewId":"…either does not exist or you do not have permission…"}}
```

`reason()` joined the empty array, so the site's own words were dropped — and `rapidViewId` became a
`jira.FieldError`, which on a validation status is a message hung on an input that does not exist.

And anything that reaches the site and no handler answers RFC 7807 instead, on both an unknown route
and a wrong method, where `detail` names the route or the method and is the only part that says
anything. The parser read neither, so every routing-level failure — the class most likely to be this
client's own fault — degraded to `Not Found` / `Method Not Allowed`.

`parseErrorBody` now reads all three shapes. Telling a field key from a parameter key is mechanical and
never textual, because messages are localised: only the two statuses that mean "your values are wrong"
can carry a field error at all, and within those, a key spelt as camel case ending in `Id` is a
parameter — `rapidViewId`, `boardId`, `sprintId` — which no field id in the 101-field catalogue is,
while a display name ending in "Id" has a space before it. Anything turned down still reaches the user
as a reason, so no sentence is lost either way; the cost of being wrong is a message in the status line
rather than one on an unreachable widget. `jira.NotFoundError` gained `Detail`, which is the only thing
that ever separates "no such board" from "not yours".

No error type moved and nothing is classified differently: `apiError` still treats the status as the
authority, and a body that will not parse still costs the detail and never the classification.

## 4 · A board or backlog read decoded to nothing and reported no error (#101)

`/board/{id}/issue` and `/board/{id}/backlog` name their array `issues`, and the offset envelope
declared only `values` — where `tokenEnvelope` beside it has had both for two batches. A board read
came back as a zero-length page with `total: 18` and no error, which renders as a board with nothing
on it. It has the fallback now.

There are three Agile paging envelopes and no endpoint says which one it answers in:

| endpoint | array | `total` | `isLast` |
|---|---|---|---|
| `/board/{id}/issue`, `/board/{id}/backlog` | `issues` | yes | **no** |
| `/board/{id}/version`, `/board/{id}/epic` | `values` | **no** | yes |
| `/board/{id}/sprint`, `/board` | `values` | yes | yes |

Both keys were already pointers, so absence had somewhere to go — but nothing checked that the walk
*ends* on each shape. It does, and each is now exercised end to end through the fixture server rather
than assumed.

## Fixtures, and the fixture server

Six new files, shapes measured and words invented, all six in the manifest test:

- `board_issues.json` — the `issues`/no-`isLast` envelope, served on both the board and the backlog
  route because the two answer the same thing. Its issues carry an Agile `self` with `/rest/api/2`
  links inside them, which is what that endpoint really sends.
- `board_epics.json` — the `values`/no-`total` envelope, with the empty `name` an epic page reports.
- `not_found_board.json` — the Agile refusal: `errorMessages` empty, the sentence under a URL parameter.
- `problem_no_endpoint.json`, `problem_method_not_allowed.json` — RFC 7807, 404 and 405.
- `field_localised.json` — the catalogue as a non-English site sends it: display names translated and
  `untranslatedName` not, one field spelling it as a single run-together word, two fields whose display
  names have collapsed into one string, `schema.items` localised, and a field with an **empty**
  `clauseNames`, which is the site saying it cannot be named in JQL at all — not even as `cf[NNNNN]`.
  9 of the real site's 101 fields send that.

`jiratest.Server` answers an unrouted path in problem+json now, because a real site does; replaying
Jira's own envelope there is what let a client that reads neither shape pass. `search_page2.json`
already agreed with the site about a last page — `isLast: true` and no `nextPageToken` key at all —
and there is now a test that says so, so it cannot drift.

## Tests

One per defect, each written against the fixed code and then run against main's behaviour restored
behind the new API. What each said before the fix:

| test | on main |
|---|---|
| `TestResolveField_FindsAnEnglishDisplayNameOnASiteThatSendsNeither` | `ResolveField("Release Windows"): no field on this site is called "Release Windows"` |
| `TestFields_ResolveANameWrittenInEnglishAgainstALocalisedCatalogue` | same, through the wire bytes: `the catalogue reads [Kurztitel Zieltag Restschätzung Restschätzung Story-Punkte Freigabefenster Intake forms]` |
| `TestResolveField_SaysWhetherANameIsUnknownOrSharedByTwoFields` | `ResolveField("Restschätzung") = "timeestimate", want an error` |
| `TestFieldByName_…AnswersNothingForANameTwoFieldsShare` | `FieldByName("story points") found = true, want false` |
| `TestDo_KeepsTheSentenceAnAgile404WritesUnderAURLParameter` | `Detail = "", want the site's own sentence` · `the sentence a user reads is "board 99999 does not exist, or you cannot see it", and the site's own is not in it` |
| `TestDo_DoesNotTurnAURLParameterIntoAFieldError` | `Fields = [{rapidViewId …}], want none: rapidViewId is a URL parameter, not an input` · `a form asking about rapidViewId is told there is a message for it` |
| `TestParseErrorBody_SortsFieldKeysFromParameterKeys` | `fields on a 404 = [summary customfield_10032 fixVersions External Id rapidViewId boardId issueIdOrKey], want none` |
| `TestDo_ReadsTheProblemJSONARoutingFailureAnswers` | `the sentence fell back to the status text: "… failed with HTTP 405: Method Not Allowed"` · `Detail = "", want "No endpoint GET …"` |
| `TestParseErrorBody_FallsBackToTheProblemTitleAndNeverToItsInstance` | `reason = "", want the title` |
| `TestDecodeAgilePage_ReadsTheIssuesKeyTheBoardEndpointsUse` | `decoded 0 items, total 2, isLast false; want 2, 2, false` |
| `TestOffsetPages_ExhaustsAnAgileEnvelopeMissingEitherKeyThatEndsAWalk` | `decoded 0 rows, want the 3 in the fixture: []` |

Plus the fixture-shape tests, which fail on main because the shapes were not there: the three paging
envelopes, both refusal envelopes, the last search page, and the catalogue carrying each name shape a
display-name lookup cannot resolve.

One existing expectation changed rather than being weakened:
`TestFieldByName_IsCaseInsensitiveAndTakesTheFirstMatch` asserted that a name two fields share
resolves to the first of them. That is the guess this PR removes, so the case now expects nothing and
the test is named for it. `TestServer_UnroutedPathAnswersAJiraShapedNotFound` asserted the envelope a
real site does not use there, and now asserts the one it does.

## Verification

`go mod tidy` clean · `go vet ./...` · `golangci-lint run` → 0 issues · `go test -race -count=1 ./...`
green across all 18 packages · `go build -trimpath -ldflags "-s -w"` → 11M · `scripts/checkleak.py`
clean.

Run against the real captures as well as the empty default, checkleak reports three strings from the
new fixtures: `In Review` and `A problem or error.`, which are the invented site's own vocabulary and
identical to what `search_page1.json` has carried since Batch 0, and `Not Found` in a problem+json
`title`. The last one is HTTP's own reason phrase and belongs in checkleak's `STOCK`; `scripts/**` is
not one of this packet's owned paths, so it is filed as
[#106](https://github.com/varijkapil13/saral/issues/106) rather than edited here.

## Left as issues, deliberately

- **[#106](https://github.com/varijkapil13/saral/issues/106)** — checkleak's `STOCK` has no HTTP reason
  phrases.
- **`docs/API-NOTES.md` is owned by another packet in flight and is untouched.** Two rows in it are now
  wrong and one is incomplete: the localisation section says priorities and resolutions are translated
  (measured: 0 of 5 and 0 of 4 moved; issue types moved 1 of 10, only `Sub-task`→`Sub-Task`); it says
  `cf[NNNNN]` "is always in `clauseNames`" (9 of 101 fields send an empty `clauseNames`); and the row
  saying `jira.FieldByName` resolves by `untranslatedName` first and falls back to `name` describes
  exactly the two passes that missed the field. Noted on #98 for whoever holds that file.
- `internal/app.Search.Resolve` files an ambiguous name under `Missing` alongside an unknown one, so
  the user is told a name did not resolve but not that it resolved to two things. `ResolveField` can
  now say which; adopting it is a change in `internal/app`, outside this packet.
- The one other name-keyed lookup in the tree is `jiratest`'s resolution-by-name helper in `fake.go`,
  which this packet does not own. It is a test double and does not reach a site.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
