### PR TITLE
feat(footer): one row that says what you can do here, and never drops the way out

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,7 +221,7 @@ func init() {
 	kernel.RegisterView(kernel.ViewSpec{
 		ID:       "board",
 		Title:    "Board",
-		Slot:     2,                       // footer position, reached with g2
+		Slot:     2,                       // the digit g reaches it with; see docs/UX.md
 		Requires: kernel.CapBoards,        // hidden when absent
 		New:      func(d kernel.Deps) kernel.View { return New(d) },
 	})
@@ -232,7 +232,7 @@ Three registries, all with the same conflict-free property:
 
 | Registry | Registered by | Consumed by |
 |---|---|---|
-| `RegisterView` | each view package's `register.go` | footer, view stack, `saral <view>` |
+| `RegisterView` | each view package's `register.go` | view stack, the go-to digits, `saral <view>` |
 | `RegisterCommand` | any package | command palette (`ctrl+k`) |
 | `RegisterKeys` | each view, scoped to itself | help overlay, footer hints — the view's resting state; `kernel.KeyReporter` is how a view answers for the state it is actually in |
 
@@ -296,6 +296,53 @@ whole run: the view's resting state, and the whole answer for a view whose keys 
 and the `?` overlay ask the focused view first and fall back to the registry, so a static view pays
 nothing. The registry entry stays the thing `internal/ui`'s command sweep holds a palette entry's key
 against, which is why it must not be empty.
+
+A `KeySet` is partitioned rather than ordered:
+
+```go
+type KeySet struct {
+	Acts  []Binding   // what can be done here, most-used first, terse — the footer's middle cell
+	Short []Binding   // the one-line bubbles/help form; the footer's fallback when Acts is empty
+	Full  [][]Binding // the ? overlay, one inner slice per column — the motions and the sentences
+}
+```
+
+`Acts` is the footer and `Full` is the explanation, and they are deliberately not the same list twice:
+one row shared with the root cell and the globals has space for *edit*, and the overlay has space for
+*edit fields*. `kernel.Terse(b, desc)` makes the short copy from the long binding so the key itself is
+spelt once. `mergeKeys` builds the overlay so that every key appears exactly once: the actions lead,
+in the order the row shows them but carrying the longest description any column gives that key, and
+the remaining columns are drawn with the actions taken out. Listing each action twice — once terse and
+once in full — cost two columns and pushed the globals off the right of a 120-column screen. A state that genuinely offers nothing — a save in flight, a site being asked — names no `Acts`
+and the footer falls back to the globals; `internal/ui/livekeys_test.go` holds every other state to
+naming one, and holds every advertised action to a first stroke `kernel.Stroke` can turn back into the
+keypress a click delivers.
+
+The footer draws one row in three cells and gives them up in a fixed order — actions into a `+N` from
+the right, then the root cell, then the descriptions, and never the globals. `docs/UX.md` has the
+reasoning and the renderings. Each entry is a zone under the kernel's own prefix, and a click on one
+is fed back through the kernel's own key handling as that binding's first stroke, so the key, the
+palette entry and the pointer are one implementation.
+
+### Reaching outside the terminal
+
+`internal/ui/kernel/external.go` holds the three things a view needs that are not Jira and not the
+terminal, so that five packets do not each write their own:
+
+```go
+func Copy(text, what string) tea.Cmd            // OSC 52, and says what it copied
+func OpenURL(link string) tea.Cmd               // the desktop's own handler
+func IssueURL(site, key string) (string, error) // the browse link, or a refusal
+```
+
+Two things they exist to get right. **A clipboard write cannot be confirmed**: it is an escape
+sequence out to the terminal, and a terminal or multiplexer that refuses it drops it silently, so
+there is no error to report and a copy that never happened looks exactly like one that did. `Copy`
+therefore names what it copied on the status line itself rather than trusting a caller to remember.
+And **`Deps.Site` is not a hostname**: it is whatever a profile was written with, nothing after
+onboarding checks its shape, so it may carry a scheme, a port or the context path a Data Center
+install is served under. `IssueURL` parses rather than concatenates, and refuses what is not a site
+rather than building a link to somebody else's website.
 
 Two constraints come with it, and both fail silently:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -407,6 +407,27 @@ This is the batch that earns the habit. Deliberately ahead of the remaining feat
   you reach an action through the palette three times, the status line notes its key" needs the
   counter, the call site and the frecency table that packet already owns, and W0-b landed
   `CommandRanMsg{ID, Keys}` as the signal. A second counter in the chrome would be a second answer.
+- [x] **P3.6 — An inventory of what you can do to the thing in front of you** · [#96](https://github.com/varijkapil13/saral/issues/96), [#16](https://github.com/varijkapil13/saral/issues/16) · **owns** `internal/ui/kernel/{view,kernel,keys,external}.go`, `internal/ui/kernel/{chrome_test,kernel_test,mouse_test,footer_test,external_test}.go` and `internal/ui/kernel/testdata/**`, `internal/ui/{keys_test,livekeys_test,footer_test}.go` and `internal/ui/testdata/**`, the `keys*.go` and `testdata/keys.golden` of `internal/ui/{list,issue,comment,form,onboarding,palette}`, `docs/{UX,ARCHITECTURE,ROADMAP}.md`
+  The footer was over capacity and dropped the ways out. Seven reserved view slots cost 81 columns
+  against the 80 this program documents as its minimum, so `? help`, `esc back` and `ctrl+k commands`
+  were past the ellipsis — and at 100 columns the help component overflowed by one column and the
+  kernel threw the whole row away, which a committed golden had encoded as twelve bytes. The row is now
+  three cells — the root you are in, what can be done here, and the globals — given up in a fixed order
+  that never reaches the globals: actions fold into a `+N` from the right, then the root cell goes, then
+  the actions lose their descriptions.
+  `KeySet` gains `Acts`, filled in all seven key scopes with the actions those views already had, terse,
+  most-used first; the motions moved to `?`, which now leads with the actions, spelt out, and lists
+  every key exactly once. **No new keys** — a pure re-partition. Every entry is a zone and a click on one is fed back through the
+  kernel's own key handling as the binding's first stroke, so key, palette and pointer are one
+  implementation.
+  **Two claims the pane made were false, in opposite directions.** `ctrl+f` and `ctrl+b` were
+  advertised on the issue detail pane and bound by nothing — `m.key()` never matched its own
+  PageUp/PageDown, which worked only because the widget happened to bind the same strokes — while the
+  viewport's bare `f`, `b`, `u` and `d` worked and were named nowhere at all. The keymap now says what
+  the widget answers to.
+  Also landed for P3.7–P3.11: `kernel.{Copy,OpenURL,IssueURL}`. An OSC 52 write cannot be confirmed, so
+  `Copy` names what it copied rather than trusting a caller to; and `Deps.Site` may carry a scheme, a
+  port or a context path, so `IssueURL` parses rather than concatenating and refuses what is not a site.
 
 ## First-run corrections · found by running against a site
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -8,9 +8,9 @@ for six months.
 
 1. **First paint is instant, always.** Cached data appears before the network is touched. A spinner
    is a failure of caching, not a loading state.
-2. **The footer only shows keys that work right now.** No greyed-out lists of everything. Context
-   determines the hints, and the hints come from the key registry so they can never drift from
-   reality.
+2. **The footer only shows keys that work right now**, and it shows what you can *do* before where
+   you can go. No greyed-out lists of everything. Context determines the hints, and the hints come
+   from the key registry so they can never drift from reality.
 3. **Every action is reachable three ways** — a key, the command palette, and the mouse. Nothing is
    keyboard-only, and nothing is mouse-only.
 4. **Nothing destructive without a named confirmation.** The confirm shows what will change, in
@@ -27,7 +27,7 @@ The mechanisms that make familiarity pay off, in the order a user meets them:
 | Stage | Mechanism |
 |---|---|
 | First minute | Onboarding writes the profile, then drops you on your own issues — or on the project itself, where nothing in it is assigned to you, because an empty first screen reads as a broken program. `?` explains the current view only. |
-| First hour | The footer teaches the six keys that matter here. Mouse works, so nothing is blocked on learning. |
+| First hour | The footer teaches what can be done to the thing in front of you, most-used first. Mouse works, so nothing is blocked on learning. |
 | First week | Frecency: projects, assignees, versions and labels reorder so your usual choices are first. |
 | | Hints: after you reach an action through the palette three times, the status line notes its key. Built in P3.1 ([#12](https://github.com/varijkapil13/saral/issues/12)) rather than with the footer: the count, the call site and the frecency table are one piece of data, and P3.1 already owns it. `kernel.CommandRanMsg{ID, Keys}` is the signal it hangs on, and `Command.Keys` is the key it names — a command nothing binds is never given one, and the line is said once rather than on every run after the third. |
 | Ongoing | JQL history with fuzzy recall; saved queries bound to `1`–`9` and kept in the profile. |
@@ -61,6 +61,46 @@ different places, and each of those is the one on screen at the time. A state wi
 to offer — a save in flight, a site being asked — says so by advertising nothing, and the footer falls
 back to the globals rather than naming a key that is being refused. `docs/ARCHITECTURE.md` has the
 interface and the generation counter the memoized chrome needs.
+
+### The row at the bottom
+
+One row, three cells, at every width. It is never two rows, because the constraint is width and not
+height: a second row would be truncated the same way and would cost a view a line it needs more —
+at 80×20 the body is 17 rows with a status line up, and the issue list has as few as 13 live rows in it.
+
+| cell | what it holds |
+|---|---|
+| root | the **root** view's title — where `esc` lands, and what a click there goes back to |
+| actions | what can be done to the thing on screen, most-used first, terse; whatever is left over becomes `+N` |
+| globals | `? ctrl+k esc`, or `q` at the bottom of the stack — bare keys, and never given up |
+
+```
+ Issues  e edit  t status  c comment  y copy  o open              ? ctrl+k esc
+ Issues  enter open  c comment  e edit  t status  / filter  +3    ? ctrl+k q
+```
+
+**The order things are given up in is the point.** Actions fold into a `+N` from the right, then the
+root cell goes, then the actions lose their descriptions and keep their keys. The globals never go.
+That order exists because the previous row gave up exactly the wrong end first: seven view slots cost
+81 columns against the 80 this program documents as its minimum, so `? help`, `esc back` and
+`ctrl+k commands` were all past the ellipsis, and at some widths the row overflowed by one column and
+was dropped whole. Somebody ran the program at 80 columns for a week and was never told the command
+palette existed ([#96](https://github.com/varijkapil13/saral/issues/96)).
+
+**The motions are not on the row.** The issue pane answers sixteen strokes and thirteen of them only
+move the cursor; a row that lists them in the order they were declared spends itself on scrolling.
+`?` lists them, and it leads with the actions — spelt out, because the overlay has room for *edit
+fields* where the row had room for *edit*. Every key appears there exactly once.
+
+**Every entry on the row is clickable**, and a click is delivered to the view as the first stroke of
+the binding it advertises — so the key, the palette entry and the pointer are one implementation and
+cannot drift. `+N` opens `?`, which is where what it stands for is listed.
+
+The digits keep their place on the row where they work: in a root view the bound saved queries are
+the first entry in the actions cell, named after the query. **The view slots are not on the row.**
+One row cannot hold nine destinations and the actions as well, the destinations are the half needed
+least often, and the header already says what is on top — so `g1`–`g9` are taught by `?` and by the
+palette's *Go to* rows, and the row names only the root you are in.
 
 The theme is switched from the palette — *use the dark theme*, *follow the terminal's own colours* —
 and the choice is written back into the profile it came from. There is no key for it: every letter
@@ -143,7 +183,8 @@ either takes a digit for itself or hands the view both keys in the order they we
 away, and a view that is taking typing gets the keys before any of this happens.
 
 The footer advertises only what works: the digits that actually have a query bound, named after the
-query, and the view slots as `g1`–`g9`.
+query. The slots themselves are not on the row — see *The row at the bottom* — so a slot is still
+allocated here rather than picked, and `?` and the palette are where its digit is taught.
 
 | Slot | View | Arrives with |
 |---|---|---|
@@ -187,7 +228,10 @@ arithmetic (see `docs/ARCHITECTURE.md`). This table is what the program does.
 | click a status, type or assignee cell | show only the rows with that value; click it again to show them all |
 | wheel | scroll the pane under the pointer, not the focused one |
 | click the line that names the search | show its JQL and offer to change it, the same as `e` |
-| click a footer entry | switch view |
+| click the footer's root cell | go back to that root, the same as `esc` from a pushed view |
+| click a footer action | do it — the view is handed the first stroke of the key that entry names |
+| click the footer's `+N` | open `?`, which lists what did not fit |
+| click the footer while `?` is up | close the overlay — the one entry the row has there |
 | click anything else a view draws | do what it says — write, send, delete, confirm, put aside, pick a value, go back to an onboarding step |
 
 **A double-click is timed, because nothing else can time it.** `tea.MouseClickMsg` carries a

--- a/internal/ui/comment/keys.go
+++ b/internal/ui/comment/keys.go
@@ -52,7 +52,11 @@ func defaultKeys() keyMap {
 // stale hint behind.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Write, k.Edit, k.Delete},
+		Acts: []kernel.Binding{
+			kernel.Terse(k.Write, "write"),
+			kernel.Terse(k.Edit, "edit"),
+			kernel.Terse(k.Delete, "delete"),
+		},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
@@ -68,12 +72,12 @@ var liveSets = func() [3]kernel.KeySet {
 	return [3]kernel.KeySet{
 		browsing: k.keySet(),
 		writing: {
-			Short: []kernel.Binding{k.Send, k.Cancel},
-			Full:  [][]kernel.Binding{{k.Send, k.Cancel}},
+			Acts: []kernel.Binding{k.Send, k.Cancel},
+			Full: [][]kernel.Binding{{k.Send, k.Cancel}},
 		},
 		confirming: {
-			Short: []kernel.Binding{k.Confirm, k.Keep},
-			Full:  [][]kernel.Binding{{k.Confirm, k.Keep}},
+			Acts: []kernel.Binding{k.Confirm, k.Keep},
+			Full: [][]kernel.Binding{{k.Confirm, k.Keep}},
 		},
 	}
 }()

--- a/internal/ui/comment/keys_test.go
+++ b/internal/ui/comment/keys_test.go
@@ -54,7 +54,7 @@ func TestLiveKeys_FollowTheModeTheThreadIsIn(t *testing.T) {
 				tc.name, other, gen)
 		}
 		seen[gen] = tc.name
-		if len(set.Short) == 0 {
+		if len(set.Acts) == 0 {
 			t.Errorf("%s advertises nothing at all", tc.name)
 		}
 	}
@@ -64,9 +64,9 @@ func TestLiveKeys_FollowTheModeTheThreadIsIn(t *testing.T) {
 // appear while the thread is being read, and the other way round.
 func TestLiveKeys_TheModesShareNoAdvertisedKey(t *testing.T) {
 	t.Parallel()
-	read := shortOf(liveSets[browsing])
-	write := shortOf(liveSets[writing])
-	confirm := shortOf(liveSets[confirming])
+	read := actsOf(liveSets[browsing])
+	write := actsOf(liveSets[writing])
+	confirm := actsOf(liveSets[confirming])
 	for _, pair := range [][2]string{{read, write}, {read, confirm}, {write, confirm}} {
 		for _, label := range strings.Split(pair[0], " · ") {
 			if strings.Contains(pair[1], label) {
@@ -85,8 +85,8 @@ func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
 	}
 }
 
-func shortOf(set kernel.KeySet) string {
-	return strings.Join(labels(set.Short), " · ")
+func actsOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Acts), " · ")
 }
 
 func labels(bindings []kernel.Binding) []string {
@@ -98,7 +98,7 @@ func labels(bindings []kernel.Binding) []string {
 }
 
 func writeKeySet(b *strings.Builder, set kernel.KeySet) {
-	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	fmt.Fprintf(b, "  acts   %s\n", actsOf(set))
 	for _, column := range set.Full {
 		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
 	}

--- a/internal/ui/comment/testdata/keys.golden
+++ b/internal/ui/comment/testdata/keys.golden
@@ -1,11 +1,11 @@
 reading the thread
-  short  ↓/j down · ↑/k up · a write a comment · e edit this one · d delete this one
+  acts   a write · e edit · d delete
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
   full   [ctrl+d half page down, ctrl+u half page up, g g oldest, G newest]
   full   [a write a comment, e edit this one, d delete this one]
 writing a comment
-  short  ctrl+s send · esc put it aside
+  acts   ctrl+s send · esc put it aside
   full   [ctrl+s send, esc put it aside]
 confirming a deletion
-  short  y delete it · esc keep it
+  acts   y delete it · esc keep it
   full   [y delete it, esc keep it]

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -1,0 +1,180 @@
+package ui
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/list"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files")
+
+// This is the only place the whole program's chrome can be drawn: the kernel may
+// not import a view, a view package sees only itself, and the row is shared by all
+// of them. It is also the only build with the palette registered, so it is the
+// only place ctrl+k is honestly on the row.
+func viewsUnderTest() []string {
+	scopes := append([]string(nil), kernel.KeyScopes()...)
+	scopes = append(scopes, kernel.PaletteViewID)
+	sort.Strings(scopes)
+	return scopes
+}
+
+// build makes one view the way the program does. The two panes that are opened
+// with an issue are given one; the rest are built from the registry.
+func build(t *testing.T, id string) kernel.View {
+	t.Helper()
+	if construct, ok := keyReporters[id]; ok {
+		return construct(depsFor(t))
+	}
+	if static, ok := staticKeys[id]; ok {
+		return static.build(depsFor(t))
+	}
+	spec, ok := kernel.LookupView(id)
+	if !ok || spec.New == nil {
+		t.Fatalf("%s is registered with nothing that builds it", id)
+	}
+	return spec.New(depsFor(t))
+}
+
+// kernelWith is the program with one view on top, at one size. The root
+// underneath is always the issue list, because that is where a session starts and
+// what esc walks back to.
+func kernelWith(t *testing.T, id string, w, h int) kernel.Model {
+	t.Helper()
+	m, err := kernel.New(depsFor(t), kernel.WithSize(w, h),
+		kernel.WithInitialView(list.ViewID), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	m = next.(kernel.Model)
+	if id != list.ViewID {
+		next, _ = m.Update(kernel.PushMsg{ID: id, Title: id, View: build(t, id)})
+		m = next.(kernel.Model)
+	}
+	return m
+}
+
+func footerOf(t *testing.T, id string, w, h int) string {
+	t.Helper()
+	frame := ansi.Strip(kernelWith(t, id, w, h).Frame())
+	lines := strings.Split(strings.TrimRight(frame, "\n"), "\n")
+	return lines[len(lines)-1]
+}
+
+// Every view at the three sizes docs/UX.md cares about. Eighty is the documented
+// minimum; a hundred is the width at which the help component overflows this row
+// by exactly one column, which is where it used to be dropped whole.
+func TestFooter_EveryViewAtEveryWidth(t *testing.T) {
+	sweepEnv(t)
+	for _, size := range []struct {
+		label string
+		w, h  int
+	}{{"80x20", 80, 20}, {"100x28", 100, 28}, {"120x38", 120, 38}} {
+		t.Run(size.label, func(t *testing.T) {
+			var b strings.Builder
+			for _, id := range viewsUnderTest() {
+				fmt.Fprintf(&b, "%s\n%s\n", id, footerOf(t, id, size.w, size.h))
+			}
+			golden(t, "footer_"+size.label+".golden", b.String())
+		})
+	}
+}
+
+// The other half of the row: what ? says once the motions have moved into it.
+// Every view's overlay leads with the actions the row shows, spelt out, and then
+// the strokes the row has no space for. Nothing appears twice, which is what
+// pushed the globals off the right of the screen while it did.
+//
+// A view taking typing is left out: ? is a character there, so it has no overlay.
+func TestHelpOverlay_EveryView(t *testing.T) {
+	sweepEnv(t)
+	var b strings.Builder
+	for _, id := range viewsUnderTest() {
+		if c, ok := build(t, id).(kernel.KeyCapturer); ok && c.WantsRawKeys() {
+			continue
+		}
+		fmt.Fprintf(&b, "%s\n%s\n\n", id, overlayOf(t, id, 120, 38))
+	}
+	golden(t, "overlay_120x38.golden", b.String())
+}
+
+// overlayOf is the body of the frame with the overlay up, trimmed of the blank
+// rows below it so that a change in a view's height does not rewrite this.
+func overlayOf(t *testing.T, id string, w, h int) string {
+	t.Helper()
+	m := kernelWith(t, id, w, h)
+	next, _ := m.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
+	rows := strings.Split(ansi.Strip(next.(kernel.Model).Frame()), "\n")
+	kept := make([]string, 0, len(rows))
+	for _, row := range rows[1 : len(rows)-1] {
+		if strings.TrimSpace(row) != "" {
+			kept = append(kept, strings.TrimRight(row, " "))
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+// The regression, over the real views rather than a stub: at every width a
+// terminal may be, every view still says how to get out. The globals are the row's
+// last cell, so a row that lost them lost them off the right-hand end.
+func TestFooter_EveryViewKeepsTheWayOutAtEveryWidth(t *testing.T) {
+	sweepEnv(t)
+	for _, id := range viewsUnderTest() {
+		away := wayOut(t, id)
+		for width := kernel.MinWidth; width <= 132; width++ {
+			row := footerOf(t, id, width, 24)
+			if !strings.HasSuffix(row, away) {
+				t.Fatalf("%s at %d columns does not end in the way out:\n%q", id, width, row)
+			}
+			if got := ansi.StringWidth(row); got > width {
+				t.Fatalf("%s at %d columns draws a %d-column row, which wraps:\n%q", id, width, got, row)
+			}
+		}
+	}
+}
+
+// wayOut is the globals cell this view is entitled to. A view taking typing has
+// swallowed every global but the one it is not allowed to, so its row honestly
+// ends there; anything else offers help, the palette, and either back or quit.
+func wayOut(t *testing.T, id string) string {
+	t.Helper()
+	if c, ok := build(t, id).(kernel.KeyCapturer); ok && c.WantsRawKeys() {
+		return "ctrl+k"
+	}
+	if id == list.ViewID {
+		return "? ctrl+k q"
+	}
+	return "? ctrl+k esc"
+}
+
+func golden(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("%v — run: go test ./internal/ui -update", err)
+	}
+	if string(want) != got {
+		t.Errorf("differs from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}

--- a/internal/ui/form/keys.go
+++ b/internal/ui/form/keys.go
@@ -62,7 +62,12 @@ func defaultKeys() keyMap {
 // cannot go stale.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Edit, k.Submit},
+		Acts: []kernel.Binding{
+			kernel.Terse(k.Edit, "edit"),
+			kernel.Terse(k.Clear, "empty"),
+			kernel.Terse(k.Submit, "create"),
+			kernel.Terse(k.Retype, "type"),
+		},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp, k.Top, k.Bottom},
 			{k.Edit, k.Clear, k.Submit, k.Retype},
@@ -88,22 +93,26 @@ const (
 var liveSets = func() [keyStates]kernel.KeySet {
 	k := defaultKeys()
 	var sets [keyStates]kernel.KeySet
+	// The editors keep their keys terse for the same reason the field list does:
+	// "close the editor, keeping what is typed" is forty-three columns, and a row
+	// that gives that up gives up the way out of the editor with it.
+	keepAndClose := kernel.Terse(k.Done, "keep and close")
 	sets[keysTypes] = kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Choose},
-		Full:  [][]kernel.Binding{{k.Down, k.Up, k.Top, k.Bottom, k.Choose}},
+		Acts: []kernel.Binding{k.Choose},
+		Full: [][]kernel.Binding{{k.Down, k.Up, k.Top, k.Bottom, k.Choose}},
 	}
 	sets[keysFields] = k.keySet()
 	sets[keysText] = kernel.KeySet{
-		Short: []kernel.Binding{k.Accept, k.Done},
-		Full:  [][]kernel.Binding{{k.Accept, k.Done}},
+		Acts: []kernel.Binding{kernel.Terse(k.Accept, "take it"), keepAndClose},
+		Full: [][]kernel.Binding{{k.Accept, k.Done}},
 	}
 	sets[keysDoc] = kernel.KeySet{
-		Short: []kernel.Binding{k.DocDone, k.Done},
-		Full:  [][]kernel.Binding{{k.DocDone, k.Done}},
+		Acts: []kernel.Binding{kernel.Terse(k.DocDone, "finish"), keepAndClose},
+		Full: [][]kernel.Binding{{k.DocDone, k.Done}},
 	}
 	sets[keysChoosing] = kernel.KeySet{
-		Short: []kernel.Binding{k.Next, k.Prev, k.Toggle, k.Accept, k.Done},
-		Full:  [][]kernel.Binding{{k.Next, k.Prev, k.PageDown, k.PageUp}, {k.Toggle, k.Accept, k.Done}},
+		Acts: []kernel.Binding{kernel.Terse(k.Toggle, "pick"), kernel.Terse(k.Accept, "take it"), keepAndClose},
+		Full: [][]kernel.Binding{{k.Next, k.Prev, k.PageDown, k.PageUp}, {k.Toggle, k.Accept, k.Done}},
 	}
 	return sets
 }()

--- a/internal/ui/form/keys_test.go
+++ b/internal/ui/form/keys_test.go
@@ -60,7 +60,7 @@ func TestLiveKeys_FollowWhatTheFormIsShowing(t *testing.T) {
 				tc.name, other, gen)
 		}
 		seen[gen] = tc.name
-		if len(set.Short) == 0 {
+		if len(set.Acts) == 0 {
 			t.Errorf("%s advertises nothing at all", tc.name)
 		}
 	}
@@ -71,16 +71,29 @@ func TestLiveKeys_FollowWhatTheFormIsShowing(t *testing.T) {
 // is telling the user the stroke does something it does not.
 func TestLiveKeys_CtrlDIsNamedForWhatItDoesInThisState(t *testing.T) {
 	t.Parallel()
-	fields := shortOf(liveSets[keysFields]) + " " + strings.Join(labels(liveSets[keysFields].Full[1]), ", ")
-	doc := shortOf(liveSets[keysDoc])
+	fields := wholeOf(liveSets[keysFields])
+	doc := wholeOf(liveSets[keysDoc])
 	switch {
-	case !strings.Contains(fields, "ctrl+d empty this field"):
+	case !strings.Contains(fields, "ctrl+d empty"):
 		t.Errorf("the field list stopped naming ctrl+d: %s", fields)
-	case !strings.Contains(doc, "ctrl+d finish this text"):
+	case !strings.Contains(doc, "ctrl+d finish"):
 		t.Errorf("the long-text pane does not name the key that closes it: %s", doc)
-	case strings.Contains(doc, "empty this field"):
+	case strings.Contains(doc, "empty"):
 		t.Errorf("the long-text pane advertises the field list's ctrl+d: %s", doc)
+	case strings.Contains(fields, "finish"):
+		t.Errorf("the field list advertises the long-text pane's ctrl+d: %s", fields)
 	}
+}
+
+// wholeOf is everything a state advertises, the terse row and the overlay
+// together: a stroke has one meaning per state and both halves have to agree.
+func wholeOf(set kernel.KeySet) string {
+	parts := make([]string, 0, 1+len(set.Full))
+	parts = append(parts, actsOf(set))
+	for _, column := range set.Full {
+		parts = append(parts, strings.Join(labels(column), ", "))
+	}
+	return strings.Join(parts, " · ")
 }
 
 // AllocsPerRun measures the whole process, so this one cannot run beside
@@ -92,8 +105,8 @@ func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
 	}
 }
 
-func shortOf(set kernel.KeySet) string {
-	return strings.Join(labels(set.Short), " · ")
+func actsOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Acts), " · ")
 }
 
 func labels(bindings []kernel.Binding) []string {
@@ -105,7 +118,7 @@ func labels(bindings []kernel.Binding) []string {
 }
 
 func writeKeySet(b *strings.Builder, set kernel.KeySet) {
-	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	fmt.Fprintf(b, "  acts   %s\n", actsOf(set))
 	for _, column := range set.Full {
 		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
 	}

--- a/internal/ui/form/testdata/keys.golden
+++ b/internal/ui/form/testdata/keys.golden
@@ -1,17 +1,17 @@
 choosing an issue type
-  short  ↓/j down · ↑/k up · enter use this issue type
+  acts   enter use this issue type
   full   [↓/j down, ↑/k up, home first row, end last row, enter use this issue type]
 the field list
-  short  ↓/j down · ↑/k up · enter edit this field · ctrl+s create the issue
+  acts   enter edit · ctrl+d empty · ctrl+s create · ctrl+t type
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up, home first row, end last row]
   full   [enter edit this field, ctrl+d empty this field, ctrl+s create the issue, ctrl+t change the issue type]
 a one-line field open
-  short  enter take this value · esc close the editor, keeping what is typed
+  acts   enter take it · esc keep and close
   full   [enter take this value, esc close the editor, keeping what is typed]
 the long-text pane open
-  short  ctrl+d finish this text · esc close the editor, keeping what is typed
+  acts   ctrl+d finish · esc keep and close
   full   [ctrl+d finish this text, esc close the editor, keeping what is typed]
 the value chooser open
-  short  ↓ next value · ↑ previous value · tab pick or unpick · enter take this value · esc close the editor, keeping what is typed
+  acts   tab pick · enter take it · esc keep and close
   full   [↓ next value, ↑ previous value, pgdn page down, pgup page up]
   full   [tab pick or unpick, enter take this value, esc close the editor, keeping what is typed]

--- a/internal/ui/issue/comments_kernel_test.go
+++ b/internal/ui/issue/comments_kernel_test.go
@@ -128,12 +128,12 @@ func TestSession_TheThreadOpensOverTheIssueAndEscComesBack(t *testing.T) {
 	s.press("c")
 	mustContain(t, s.frame(), "The conversation you came for.")
 	mustContain(t, s.title(), "PROJ-2")
-	mustContain(t, s.footer(), "a write a comment")
+	mustContain(t, s.footer(), "a write")
 
 	s.press("esc")
 	mustContain(t, s.frame(), "PROJ-2", "Comments (1)")
 	mustContain(t, s.footer(), "c comment")
-	mustNotContain(t, s.footer(), "a write a comment")
+	mustNotContain(t, s.footer(), "a write")
 
 	s.press("esc")
 	mustContain(t, s.frame(), "the rows this issue was opened from")
@@ -150,7 +150,7 @@ func TestSession_TheFooterNamesTheKeyOnlyWhereItOpensTheThread(t *testing.T) {
 	mustContain(t, s.footer(), "c comment")
 
 	s.press("c")
-	mustContain(t, s.footer(), "a write a comment")
+	mustContain(t, s.footer(), "a write")
 	mustNotContain(t, s.footer(), "c comment")
 
 	s.press("esc")
@@ -194,17 +194,18 @@ func TestSession_WhatIsWrittenInTheThreadIsThereWhenYouComeBack(t *testing.T) {
 	mustContain(t, s.frame(), "Comments (1)", "Written without leaving the issue.")
 }
 
-// The hint line is one row that the help component overflows rather than
-// truncates once it runs out of room, and the kernel then draws none of it. A
-// fifth key on this pane is exactly the kind of thing that tips it, so the
-// smallest terminal docs/UX.md supports is held to still teaching the keys.
+// The row is one line shared by three cells, and the smallest terminal
+// docs/UX.md supports is where it has to give something up. Every action this pane
+// offers survives there, and so does every way out. This build registers no
+// palette, so ctrl+k is honestly absent from the globals.
 func TestSession_TheSmallestTerminalStillTeachesThePanesKeys(t *testing.T) {
 	t.Parallel()
 
 	f := newFake(12)
 	s := boot(t, testDeps(f), seedOf(t, f, "PROJ-7"), kernel.MinWidth, kernel.MinHeight)
 
-	mustContain(t, s.footer(), "down", "up", "edit fields")
+	mustContain(t, s.footer(), "Issues", "e edit", "t status", "c comment", "? esc")
+	mustNotContain(t, s.footer(), "…")
 }
 
 func TestSession_Frames(t *testing.T) {

--- a/internal/ui/issue/edit_keys.go
+++ b/internal/ui/issue/edit_keys.go
@@ -56,7 +56,12 @@ func defaultEditKeys() editKeyMap {
 // waiting to be answered.
 func (k editKeyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Act, k.Save},
+		Acts: []kernel.Binding{
+			kernel.Terse(k.Act, "change"),
+			kernel.Terse(k.Clear, "empty"),
+			k.Save,
+			kernel.Terse(k.Discard, "discard"),
+		},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.Act, k.Clear},
 			{k.Prev, k.Next},
@@ -74,22 +79,25 @@ var editLiveSets = func() [5]kernel.KeySet {
 	reread := kernel.Bind([]string{"y"}, "y", "re-read it and put your edits back on top")
 	notYet := kernel.Bind([]string{"esc"}, "esc", "do not save yet")
 	asItIs := kernel.Bind([]string{"esc"}, "esc", "leave it as it is for now")
+	// A prompt keeps its words. The row is over capacity when a view offers a
+	// list of things to do; two answers to one question always fit, and the
+	// wording is the whole point of asking.
 	return [5]kernel.KeySet{
 		stageBrowse: k.keySet(),
 		stageTyping: {
-			Short: []kernel.Binding{k.Accept, k.Cancel},
-			Full:  [][]kernel.Binding{{k.Accept, k.Cancel}},
+			Acts: []kernel.Binding{k.Accept, k.Cancel},
+			Full: [][]kernel.Binding{{k.Accept, k.Cancel}},
 		},
 		stageConfirm: {
-			Short: []kernel.Binding{k.Yes, notYet},
-			Full:  [][]kernel.Binding{{k.Yes, notYet}},
+			Acts: []kernel.Binding{k.Yes, notYet},
+			Full: [][]kernel.Binding{{k.Yes, notYet}},
 		},
 		// A save in flight answers nothing of its own, and the footer then shows
 		// the globals alone, which is the truth.
 		stageSaving: {},
 		stageConflict: {
-			Short: []kernel.Binding{reread, asItIs},
-			Full:  [][]kernel.Binding{{reread, asItIs}},
+			Acts: []kernel.Binding{reread, asItIs},
+			Full: [][]kernel.Binding{{reread, asItIs}},
 		},
 	}
 }()
@@ -127,8 +135,8 @@ func defaultMoveKeys() moveKeyMap {
 // keySet is the resting state: the list of moves this issue can make from here.
 func (k moveKeyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Act},
-		Full:  [][]kernel.Binding{{k.Down, k.Up, k.Act}},
+		Acts: []kernel.Binding{k.Act},
+		Full: [][]kernel.Binding{{k.Down, k.Up, k.Act}},
 	}
 }
 
@@ -141,12 +149,16 @@ var moveLiveSets = func() [4]kernel.KeySet {
 	return [4]kernel.KeySet{
 		moveList: k.keySet(),
 		moveScreen: {
-			Short: []kernel.Binding{k.Down, k.Up, k.Prev, k.Next, filled},
-			Full:  [][]kernel.Binding{{k.Down, k.Up, k.Prev, k.Next}, {filled, k.Cancel}},
+			Acts: []kernel.Binding{
+				kernel.Terse(k.Prev, "previous"),
+				kernel.Terse(k.Next, "next"),
+				filled,
+			},
+			Full: [][]kernel.Binding{{k.Down, k.Up, k.Prev, k.Next}, {filled, k.Cancel}},
 		},
 		moveConfirm: {
-			Short: []kernel.Binding{k.Yes, k.Cancel},
-			Full:  [][]kernel.Binding{{k.Yes, k.Cancel}},
+			Acts: []kernel.Binding{k.Yes, k.Cancel},
+			Full: [][]kernel.Binding{{k.Yes, k.Cancel}},
 		},
 		moveDoing: {},
 	}

--- a/internal/ui/issue/keys.go
+++ b/internal/ui/issue/keys.go
@@ -19,12 +19,15 @@ type keyMap struct {
 
 func defaultKeys() keyMap {
 	return keyMap{
-		Up:       kernel.Bind([]string{"k", "up"}, "↑/k", "up"),
-		Down:     kernel.Bind([]string{"j", "down"}, "↓/j", "down"),
-		PageUp:   kernel.Bind([]string{"pgup", "ctrl+b"}, "pgup", "page up"),
-		PageDown: kernel.Bind([]string{"pgdown", "ctrl+f", "space"}, "pgdn", "page down"),
-		HalfUp:   kernel.Bind([]string{"ctrl+u"}, "ctrl+u", "half page up"),
-		HalfDown: kernel.Bind([]string{"ctrl+d"}, "ctrl+d", "half page down"),
+		Up:   kernel.Bind([]string{"k", "up"}, "↑/k", "up"),
+		Down: kernel.Bind([]string{"j", "down"}, "↓/j", "down"),
+		// The pager is the widget's and key() hands it every stroke it did not
+		// take, so these four have to spell what viewport.DefaultKeyMap answers
+		// to. A stroke written here that the widget does not bind does nothing.
+		PageUp:   kernel.Bind([]string{"pgup", "b"}, "b/pgup", "page up"),
+		PageDown: kernel.Bind([]string{"pgdown", "space", "f"}, "f/pgdn", "page down"),
+		HalfUp:   kernel.Bind([]string{"u", "ctrl+u"}, "u/ctrl+u", "half page up"),
+		HalfDown: kernel.Bind([]string{"d", "ctrl+d"}, "d/ctrl+d", "half page down"),
 		Go:       kernel.Bind([]string{"g"}, "g", "go to"),
 		Top:      kernel.Bind([]string{"home"}, "g g", "top"),
 		Bottom:   kernel.Bind([]string{"G", "end"}, "G", "bottom"),
@@ -34,9 +37,16 @@ func defaultKeys() keyMap {
 	}
 }
 
+// keySet is the pane's whole answer: what can be done to the issue on screen in
+// Acts, and the thirteen strokes that only move around inside it in the overlay,
+// which is the one with room for them.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Edit, k.Move, k.Comments},
+		Acts: []kernel.Binding{
+			kernel.Terse(k.Edit, "edit"),
+			kernel.Terse(k.Move, "status"),
+			k.Comments,
+		},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},

--- a/internal/ui/issue/keys_test.go
+++ b/internal/ui/issue/keys_test.go
@@ -80,7 +80,7 @@ func TestLiveKeys_FollowTheStageTheEditorIsIn(t *testing.T) {
 		}
 		seen[gen] = tc.name
 		if tc.stage == stageSaving && !set.IsZero() {
-			t.Errorf("a save in flight advertises %s, none of which answers", shortOf(set))
+			t.Errorf("a save in flight advertises %s, none of which answers", actsOf(set))
 		}
 	}
 }
@@ -112,10 +112,10 @@ func TestLiveKeys_FollowTheStageThePickerIsIn(t *testing.T) {
 		}
 		seen[gen] = tc.name
 	}
-	if !strings.Contains(shortOf(moveLiveSets[moveScreen]), "next value") {
+	if !strings.Contains(actsOf(moveLiveSets[moveScreen]), "→/l next") {
 		t.Error("the transition screen does not advertise the key that fills a field in")
 	}
-	if strings.Contains(shortOf(moveLiveSets[moveList]), "next value") {
+	if strings.Contains(actsOf(moveLiveSets[moveList]), "→/l next") {
 		t.Error("the list of moves advertises a key that only the screen answers")
 	}
 }
@@ -124,8 +124,8 @@ func TestLiveKeys_FollowTheStageThePickerIsIn(t *testing.T) {
 // The label has to come from the stage, or one of the two is a lie.
 func TestLiveKeys_YIsNamedForTheQuestionItIsAnswering(t *testing.T) {
 	t.Parallel()
-	confirm := shortOf(editLiveSets[stageConfirm])
-	conflict := shortOf(editLiveSets[stageConflict])
+	confirm := actsOf(editLiveSets[stageConfirm])
+	conflict := actsOf(editLiveSets[stageConflict])
 	switch {
 	case !strings.Contains(confirm, "y go ahead"):
 		t.Errorf("a save waiting to be confirmed does not name y: %s", confirm)
@@ -158,8 +158,8 @@ func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
 	}
 }
 
-func shortOf(set kernel.KeySet) string {
-	return strings.Join(labels(set.Short), " · ")
+func actsOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Acts), " · ")
 }
 
 func labels(bindings []kernel.Binding) []string {
@@ -175,7 +175,7 @@ func writeKeySet(b *strings.Builder, set kernel.KeySet) {
 		b.WriteString("    nothing of its own; the globals are all that answer\n")
 		return
 	}
-	fmt.Fprintf(b, "    short  %s\n", shortOf(set))
+	fmt.Fprintf(b, "    acts   %s\n", actsOf(set))
 	for _, column := range set.Full {
 		fmt.Fprintf(b, "    full   [%s]\n", strings.Join(labels(column), ", "))
 	}

--- a/internal/ui/issue/testdata/keys.golden
+++ b/internal/ui/issue/testdata/keys.golden
@@ -1,30 +1,30 @@
 editing an issue's fields
   the field list
-    short  ↓/j down · ↑/k up · enter change this field · ctrl+s save
+    acts   enter change · del empty · ctrl+s save · X discard
     full   [↓/j down, ↑/k up, enter change this field, del empty this field]
     full   [←/h previous value, →/l next value]
     full   [ctrl+s save, X discard changes]
   a field taking typing
-    short  enter keep this value · esc leave the value alone
+    acts   enter keep this value · esc leave the value alone
     full   [enter keep this value, esc leave the value alone]
   waiting for the go-ahead to save
-    short  y go ahead · esc do not save yet
+    acts   y go ahead · esc do not save yet
     full   [y go ahead, esc do not save yet]
   saving
     nothing of its own; the globals are all that answer
   somebody else changed it first
-    short  y re-read it and put your edits back on top · esc leave it as it is for now
+    acts   y re-read it and put your edits back on top · esc leave it as it is for now
     full   [y re-read it and put your edits back on top, esc leave it as it is for now]
 changing an issue's status
   the moves this issue can make
-    short  ↓/j down · ↑/k up · enter choose
+    acts   enter choose
     full   [↓/j down, ↑/k up, enter choose]
   the transition screen
-    short  ↓/j down · ↑/k up · ←/h previous value · →/l next value · enter use these values
+    acts   ←/h previous · →/l next · enter use these values
     full   [↓/j down, ↑/k up, ←/h previous value, →/l next value]
     full   [enter use these values, esc back]
   waiting for the go-ahead to move
-    short  y go ahead · esc back
+    acts   y go ahead · esc back
     full   [y go ahead, esc back]
   moving
     nothing of its own; the globals are all that answer

--- a/internal/ui/issue/testdata/session_issue_100x28.golden
+++ b/internal/ui/issue/testdata/session_issue_100x28.golden
@@ -25,4 +25,4 @@ Comments (1)
                                                                                                     
                                                                                                     
                                                                                                     
- g1 Issues       ↓/j down | ↑/k up | e edit fields | t change status | c comment | ? help | esc back
+ Issues  e edit  t status  c comment                                                           ? esc

--- a/internal/ui/issue/testdata/session_issue_120x38.golden
+++ b/internal/ui/issue/testdata/session_issue_120x38.golden
@@ -35,4 +35,4 @@ Comments (1)
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Issues                           ↓/j down | ↑/k up | e edit fields | t change status | c comment | ? help | esc back
+ Issues  e edit  t status  c comment                                                                               ? esc

--- a/internal/ui/issue/testdata/session_issue_80x20.golden
+++ b/internal/ui/issue/testdata/session_issue_80x20.golden
@@ -17,4 +17,4 @@ Details
 Comments (1)                                                                    
   Sam Tester | 02 Mar 2026 09:00                                                
     A comment worth a line or two, and a second sentence to wrap.               
- g1 Issues   ↓/j down | ↑/k up | e edit fields | t change status | c comment ...
+ Issues  e edit  t status  c comment                                       ? esc

--- a/internal/ui/issue/testdata/session_thread_100x28.golden
+++ b/internal/ui/issue/testdata/session_thread_100x28.golden
@@ -25,4 +25,4 @@ PROJ-6 | 1 comment                                                              
                                                                                                     
                                                                                                     
                                                                                                     
- g1 Issues  
+ Issues  a write  e edit  d delete                                                             ? esc

--- a/internal/ui/issue/testdata/session_thread_120x38.golden
+++ b/internal/ui/issue/testdata/session_thread_120x38.golden
@@ -35,4 +35,4 @@ PROJ-6 | 1 comment                                                              
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Issues               ↓/j down | ↑/k up | a write a comment | e edit this one | d delete this one | ? help | esc back
+ Issues  a write  e edit  d delete                                                                                 ? esc

--- a/internal/ui/issue/testdata/session_thread_80x20.golden
+++ b/internal/ui/issue/testdata/session_thread_80x20.golden
@@ -17,4 +17,4 @@ PROJ-6 | 1 comment                                           write  edit  delete
                                                                                 
                                                                                 
                                                                                 
- g1 Issues           ↓/j down | ↑/k up | a write a comment | e edit this one ...
+ Issues  a write  e edit  d delete                                         ? esc

--- a/internal/ui/kernel/chrome_test.go
+++ b/internal/ui/kernel/chrome_test.go
@@ -35,12 +35,15 @@ func (r *reporterView) LiveKeys() (set KeySet, gen int) {
 func twoStateReporter(id string) *reporterView {
 	return &reporterView{id: id, sets: []KeySet{
 		{
-			Short: []Binding{Bind([]string{"enter"}, "enter", "open"), Bind([]string{"/"}, "/", "filter")},
-			Full:  [][]Binding{{Bind([]string{"enter"}, "enter", "open"), Bind([]string{"/"}, "/", "filter")}},
+			Acts: []Binding{Bind([]string{"enter"}, "enter", "open"), Bind([]string{"/"}, "/", "filter")},
+			Full: [][]Binding{
+				{Bind([]string{"j"}, "↓/j", "down"), Bind([]string{"k"}, "↑/k", "up")},
+				{Bind([]string{"enter"}, "enter", "open the row under the cursor"), Bind([]string{"/"}, "/", "filter these rows")},
+			},
 		},
 		{
-			Short: []Binding{Bind([]string{"enter"}, "enter", "keep filter"), Bind([]string{"esc"}, "esc", "clear filter")},
-			Full:  [][]Binding{{Bind([]string{"enter"}, "enter", "keep filter"), Bind([]string{"esc"}, "esc", "clear filter")}},
+			Acts: []Binding{Bind([]string{"enter"}, "enter", "keep filter"), Bind([]string{"esc"}, "esc", "clear filter")},
+			Full: [][]Binding{{Bind([]string{"enter"}, "enter", "keep filter"), Bind([]string{"esc"}, "esc", "clear filter")}},
 		},
 	}}
 }
@@ -151,6 +154,7 @@ func TestFrame_GoldenPerState(t *testing.T) {
 				view.state = state
 				RegisterView(reporterSpec("board", 1, view))
 				RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+				RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
 
 				m := newAt(t, testDeps(), size.w, size.h)
 				golden(t, "chrome_"+name+"_"+size.label+".golden", ansi.Strip(m.Frame()))

--- a/internal/ui/kernel/external.go
+++ b/internal/ui/kernel/external.go
@@ -1,0 +1,122 @@
+package kernel
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Copy puts text on the system clipboard and says what it put there.
+//
+// The write is an OSC 52 escape sequence out to the terminal, and it cannot be
+// confirmed: a terminal or a multiplexer that does not allow the sequence drops
+// it without a word, so there is no error to report and a copy that never
+// happened is indistinguishable from one that did. Naming what was copied is the
+// only thing that separates them — somebody who reads "copied PROJ-142", pastes,
+// and gets nothing knows to look at their terminal rather than at Saral. That is
+// why saying so is this function's job rather than the caller's to remember.
+func Copy(text, what string) tea.Cmd {
+	if text == "" {
+		return Warn("there is nothing here to copy")
+	}
+	if what == "" {
+		what = text
+	}
+	return tea.Batch(tea.SetClipboard(text), Status("copied "+what))
+}
+
+// OpenURL hands a link to whatever this desktop opens links with, and names the
+// link either way. The handler is started rather than waited on, so a browser
+// that takes two seconds to appear does not hold a frame, and a platform with no
+// handler Saral knows says the address instead of failing quietly.
+func OpenURL(link string) tea.Cmd {
+	name, args, known := opener(runtime.GOOS, link)
+	if !known {
+		return Warn("Saral does not know how to open a link on " + runtime.GOOS + "; the address is " + link)
+	}
+	return func() tea.Msg {
+		cmd := exec.Command(name, args...)
+		if err := cmd.Start(); err != nil {
+			return StatusMsg{Text: "could not open " + link + ": " + err.Error(), Level: LevelError}
+		}
+		// Nothing here waits on a browser, but something has to reap it.
+		go func() { _ = cmd.Wait() }()
+		return StatusMsg{Text: "opened " + link}
+	}
+}
+
+func opener(goos, link string) (name string, args []string, known bool) {
+	switch goos {
+	case "darwin":
+		return "open", []string{link}, true
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", link}, true
+	case "linux", "freebsd", "netbsd", "openbsd", "dragonfly":
+		return "xdg-open", []string{link}, true
+	default:
+		return "", nil, false
+	}
+}
+
+// IssueURL is where an issue lives on the site this session is talking to.
+//
+// Deps.Site is whatever a profile was written with and nothing past onboarding
+// checks its shape, so this copes with a scheme already on the front, a port, the
+// context path a Data Center install can be served under, and a trailing slash.
+// It refuses rather than guesses: a link built out of a site that is not one is a
+// browser tab full of somebody else's website.
+func IssueURL(site, key string) (string, error) {
+	key = strings.TrimSpace(key)
+	switch {
+	case key == "":
+		return "", errors.New("there is no issue here to open")
+	case strings.ContainsAny(key, "/?#%\\ \t"):
+		return "", fmt.Errorf("%q is not an issue key", key)
+	}
+	base, err := siteURL(site)
+	if err != nil {
+		return "", err
+	}
+	base.Path = path.Join(base.Path, "browse", key)
+	return base.String(), nil
+}
+
+// siteURL turns whatever a profile calls the site into something a browser can
+// open. A bare host is the common case and gets https; anything that names no
+// host, or a scheme a browser would not follow, is refused.
+func siteURL(site string) (*url.URL, error) {
+	site = strings.TrimSpace(site)
+	if site == "" {
+		return nil, errors.New("this session was not told which site it is talking to")
+	}
+	if scheme, _, absolute := strings.Cut(site, "://"); absolute {
+		if scheme != "http" && scheme != "https" {
+			return nil, fmt.Errorf("%q is not a site a browser would open", site)
+		}
+	} else {
+		// No //, so what is left is a host with an optional port and path. A colon
+		// followed by anything but a digit is an opaque URI scheme rather than a
+		// port, and prefixing https to one of those builds a link to nowhere.
+		if _, after, colon := strings.Cut(site, ":"); colon && !startsWithDigit(after) {
+			return nil, fmt.Errorf("%q is not a site a browser would open", site)
+		}
+		site = "https://" + site
+	}
+	u, err := url.Parse(site)
+	if err != nil {
+		return nil, fmt.Errorf("%q is not a site a link can be built from: %w", site, err)
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("%q names no host", site)
+	}
+	u.User, u.RawQuery, u.Fragment = nil, "", ""
+	return u, nil
+}
+
+func startsWithDigit(s string) bool { return s != "" && s[0] >= '0' && s[0] <= '9' }

--- a/internal/ui/kernel/external_test.go
+++ b/internal/ui/kernel/external_test.go
@@ -1,0 +1,138 @@
+package kernel
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Deps.Site is whatever a profile was written with, and onboarding accepts a bare
+// host. Every other shape here is one somebody will type or paste at some point,
+// and concatenating "https://" + site + "/browse/" gets three of them wrong.
+func TestIssueURL_CopesWithEveryShapeAProfileCanHold(t *testing.T) {
+	for name, tc := range map[string]struct {
+		site, key, want string
+	}{
+		"a bare host":        {"example.atlassian.net", "PROJ-1", "https://example.atlassian.net/browse/PROJ-1"},
+		"a scheme already":   {"https://example.atlassian.net", "PROJ-1", "https://example.atlassian.net/browse/PROJ-1"},
+		"plain http":         {"http://jira.internal", "PROJ-1", "http://jira.internal/browse/PROJ-1"},
+		"a port":             {"jira.internal:8080", "PROJ-1", "https://jira.internal:8080/browse/PROJ-1"},
+		"a context path":     {"jira.internal:8080/jira", "PROJ-1", "https://jira.internal:8080/jira/browse/PROJ-1"},
+		"a trailing slash":   {"example.atlassian.net/", "PROJ-1", "https://example.atlassian.net/browse/PROJ-1"},
+		"a scheme and both":  {"http://jira.internal:8080/jira/", "AB-42", "http://jira.internal:8080/jira/browse/AB-42"},
+		"surrounding spaces": {"  example.atlassian.net  ", "PROJ-1", "https://example.atlassian.net/browse/PROJ-1"},
+		"a query to drop":    {"https://example.atlassian.net/?foo=bar", "PROJ-1", "https://example.atlassian.net/browse/PROJ-1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := IssueURL(tc.site, tc.key)
+			if err != nil {
+				t.Fatalf("IssueURL(%q, %q): %v", tc.site, tc.key, err)
+			}
+			if got != tc.want {
+				t.Errorf("IssueURL(%q, %q) = %q, want %q", tc.site, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// It refuses rather than guesses. A link built out of something that is not a
+// site is a browser tab full of somebody else's website.
+func TestIssueURL_RefusesWhatItCannotBuildALinkFrom(t *testing.T) {
+	for name, tc := range map[string]struct{ site, key, says string }{
+		"no site at all":     {"", "PROJ-1", "which site"},
+		"no issue":           {"example.atlassian.net", "", "no issue"},
+		"a key with a path":  {"example.atlassian.net", "PROJ-1/../../etc", "not an issue key"},
+		"a key with a space": {"example.atlassian.net", "PROJ 1", "not an issue key"},
+		"a scheme nobody op": {"javascript:alert(1)", "PROJ-1", "would open"},
+		"no host":            {"https://", "PROJ-1", "names no host"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := IssueURL(tc.site, tc.key)
+			if err == nil {
+				t.Fatalf("IssueURL(%q, %q) built %q", tc.site, tc.key, got)
+			}
+			if !strings.Contains(err.Error(), tc.says) {
+				t.Errorf("the refusal reads %q, which does not say %q", err, tc.says)
+			}
+		})
+	}
+}
+
+// An OSC 52 write cannot be confirmed: a terminal or a multiplexer that refuses
+// the sequence drops it silently. Saying what was copied is the only thing that
+// tells a working copy from one that never happened.
+func TestCopy_NamesWhatItPutOnTheClipboard(t *testing.T) {
+	note, found := statusOf(Copy("PROJ-1", "PROJ-1"))
+	if !found {
+		t.Fatal("copying said nothing, so a silent failure looks like success")
+	}
+	if !strings.Contains(note.Text, "PROJ-1") {
+		t.Errorf("the status line reads %q and does not name what was copied", note.Text)
+	}
+	if note.Level != LevelInfo {
+		t.Errorf("a copy is reported at level %d, want info", note.Level)
+	}
+
+	named, _ := statusOf(Copy("https://example.atlassian.net/browse/PROJ-1", "the link to PROJ-1"))
+	if !strings.Contains(named.Text, "the link to PROJ-1") {
+		t.Errorf("the status line reads %q rather than the phrase the caller gave it", named.Text)
+	}
+
+	empty, found := statusOf(Copy("", "nothing"))
+	if !found || empty.Level != LevelWarn {
+		t.Errorf("copying nothing reported %+v; there is nothing to put on a clipboard", empty)
+	}
+}
+
+func TestOpener_KnowsAHandlerForTheDesktopsThisRunsOn(t *testing.T) {
+	for _, goos := range []string{"darwin", "windows", "linux", "freebsd", "netbsd", "openbsd", "dragonfly"} {
+		name, args, known := opener(goos, "https://example.atlassian.net/browse/PROJ-1")
+		switch {
+		case !known:
+			t.Errorf("%s has no handler, so a link there is never opened", goos)
+		case name == "":
+			t.Errorf("%s names an empty command", goos)
+		case len(args) == 0:
+			t.Errorf("%s passes the handler no link", goos)
+		case !strings.Contains(args[len(args)-1], "PROJ-1"):
+			t.Errorf("%s passes %v, which does not end in the link", goos, args)
+		}
+	}
+	if _, _, known := opener("plan9", "https://example.atlassian.net"); known {
+		t.Error("a platform with no handler claimed one")
+	}
+}
+
+// A platform Saral has no handler for says the address rather than failing
+// quietly: reading it off the screen is worse than clicking it, and better than
+// nothing happening.
+func TestOpenURL_SaysTheAddressWhenItCannotOpenIt(t *testing.T) {
+	if cmd := OpenURL("https://example.atlassian.net/browse/PROJ-1"); cmd == nil {
+		t.Fatal("opening a link produced no command at all")
+	}
+	note, found := statusOf(Warn("Saral does not know how to open a link on plan9; the address is x"))
+	if !found || !strings.Contains(note.Text, "the address is") {
+		t.Errorf("the refusal reads %+v and does not carry the address", note)
+	}
+}
+
+// statusOf runs a command and finds the status message in it, batch or not.
+// Nothing here runs a clipboard write or a browser: both are messages the
+// program hands back to Bubble Tea rather than work done in the command.
+func statusOf(cmd tea.Cmd) (StatusMsg, bool) {
+	if cmd == nil {
+		return StatusMsg{}, false
+	}
+	switch msg := cmd().(type) {
+	case StatusMsg:
+		return msg, true
+	case tea.BatchMsg:
+		for _, c := range msg {
+			if note, ok := statusOf(c); ok {
+				return note, true
+			}
+		}
+	}
+	return StatusMsg{}, false
+}

--- a/internal/ui/kernel/footer_test.go
+++ b/internal/ui/kernel/footer_test.go
@@ -1,0 +1,307 @@
+package kernel
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// actingView offers an inventory and remembers the keys it was handed, which is
+// what a click on a footer action has to arrive as.
+type actingView struct {
+	set  KeySet
+	keys []string
+}
+
+func (v *actingView) Init() tea.Cmd { return nil }
+
+func (v *actingView) Update(msg tea.Msg) (View, tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok {
+		v.keys = append(v.keys, key.String())
+	}
+	return v, nil
+}
+
+func (v *actingView) View() string                    { return "board body" }
+func (v *actingView) LiveKeys() (set KeySet, gen int) { return v.set, 0 }
+func (v *actingView) took(stroke string) bool {
+	return strings.Contains(strings.Join(v.keys, " "), stroke)
+}
+func act(key, desc string) Binding { return Bind([]string{key}, key, desc) }
+func acting(acts ...Binding) *actingView {
+	return &actingView{set: KeySet{Acts: acts, Full: [][]Binding{acts}}}
+}
+func actingSpec(v *actingView, slot int) ViewSpec {
+	return ViewSpec{ID: "board", Title: "Board", Slot: slot, New: func(Deps) View { return v }}
+}
+
+// The regression, stated as a property: whatever else the row gives up, the way
+// out survives. This is the row an eighty-column terminal used to throw away
+// whole, which is how the program ran for a week without ever saying the command
+// palette existed.
+func TestFooter_TheGlobalsSurviveEveryWidth(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(actingSpec(acting(
+		act("enter", "open the row under the cursor"),
+		act("e", "edit the fields of this issue"),
+		act("t", "change the status of this issue"),
+		act("c", "read and write the comments"),
+		act("/", "filter these rows down"),
+		act("a", "widen to every issue in the project"),
+		act("s", "save this search to a number key"),
+	), 1))
+	RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
+
+	for width := MinWidth; width <= 132; width++ {
+		m := newAt(t, testDeps(), width, 24)
+		footer := lastLine(ansi.Strip(m.Frame()))
+		if !strings.HasSuffix(footer, "? ctrl+k q") {
+			t.Fatalf("at %d columns the row does not end in the globals:\n%q", width, footer)
+		}
+		if got := ansi.StringWidth(footer); got > width {
+			t.Fatalf("at %d columns the row is %d wide, so it wraps and pushes itself off the screen:\n%q",
+				width, got, footer)
+		}
+	}
+}
+
+// Each rung of the ladder, at the width that reaches it. The order is the design:
+// actions fold into a +N from the right, then the root cell goes, then the
+// actions lose their descriptions, and the globals never go at all.
+func TestFooter_GivesThingsUpInOrder(t *testing.T) {
+	long := "a description far too long for one row to hold beside anything"
+	for name, tc := range map[string]struct {
+		acts []Binding
+		want string
+	}{
+		"everything fits": {
+			acts: []Binding{act("e", "edit"), act("t", "status")},
+			want: " Board  e edit  t status                                              ? ctrl+k q",
+		},
+		"what is left over folds into a count": {
+			acts: []Binding{
+				act("enter", "open"), act("e", "edit"), act("t", "status"),
+				act("c", "comment"), act("/", "filter"), act("a", "all"), act("s", "save"),
+			},
+			want: " Board  enter open  e edit  t status  c comment  / filter  a all  +1  ? ctrl+k q",
+		},
+		"the root cell goes before the last action does": {
+			acts: []Binding{act("e", long)},
+			want: "e " + long + "      ? ctrl+k q",
+		},
+		"the descriptions go last": {
+			acts: []Binding{act("e", long+" whatsoever")},
+			want: "e                                                                     ? ctrl+k q",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			RegisterView(actingSpec(acting(tc.acts...), 1))
+			RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
+
+			m := newAt(t, testDeps(), MinWidth, 24)
+			if got := lastLine(ansi.Strip(m.Frame())); got != tc.want {
+				t.Errorf("at %d columns\n got %q\nwant %q", MinWidth, got, tc.want)
+			}
+		})
+	}
+}
+
+// docs/UX.md principle 3: every action reachable three ways. A click on one is
+// delivered as the key it advertises, so the pointer and the keyboard are one
+// implementation and cannot drift.
+func TestFooter_ClickingAnActionArrivesAtTheViewAsItsKey(t *testing.T) {
+	view := &actingView{set: KeySet{
+		Acts: []Binding{Bind([]string{"ctrl+s", "s"}, "ctrl+s", "save")},
+		Full: [][]Binding{{Bind([]string{"ctrl+s", "s"}, "ctrl+s", "save")}},
+	}}
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(actingSpec(view, 1))
+
+	m := newAt(t, testDeps(), 120, 30, WithMouse(true))
+	_ = m.Frame()
+
+	prefix := m.zonePrefix
+	eventually(t, func() bool { return !m.deps.Zones.Get(prefix + actZone + "ctrl+s").IsZero() })
+
+	info := m.deps.Zones.Get(prefix + actZone + "ctrl+s")
+	click := tea.MouseClickMsg{X: info.StartX, Y: info.StartY, Button: tea.MouseLeft}
+	if _, _ = m.Update(click); !view.took("ctrl+s") {
+		t.Errorf("clicking the action did not reach the view as its first stroke: %v", view.keys)
+	}
+}
+
+// The row's zones are minted from a label rather than a position, and the click
+// handler walks the whole inventory rather than only what was drawn — so what
+// stops an action that folded into a +N from answering where it used to be is
+// bubblezone rebuilding its positions from each scanned frame. That is worth
+// holding: without it, shrinking a terminal would leave every dropped action
+// clickable in the gap it used to occupy.
+func TestFooter_AnActionThatLeftTheRowStopsAnsweringToWhereItWas(t *testing.T) {
+	view := acting(
+		act("enter", "open"), act("e", "edit"), act("t", "status"),
+		act("c", "comment"), act("/", "filter"), act("a", "all"), act("s", "save"),
+	)
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(actingSpec(view, 1))
+	RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
+
+	m := newAt(t, testDeps(), 120, 24, WithMouse(true))
+	_ = m.Frame()
+	prefix := m.zonePrefix
+	eventually(t, func() bool { return !m.deps.Zones.Get(prefix + actZone + "s").IsZero() })
+	was := m.deps.Zones.Get(prefix + actZone + "s")
+
+	next, _ := m.Update(tea.WindowSizeMsg{Width: MinWidth, Height: 24})
+	m = next.(Model)
+	row := lastLine(ansi.Strip(m.Frame()))
+	if strings.Contains(row, "s save") {
+		t.Fatalf("s save still fits at %d columns, so this proves nothing:\n%s", MinWidth, row)
+	}
+
+	if now := m.deps.Zones.Get(prefix + actZone + "s"); !now.IsZero() {
+		t.Errorf("s save is off the row and still has bounds %+v", now)
+	}
+
+	view.keys = nil
+	click := tea.MouseClickMsg{X: was.StartX, Y: was.StartY, Button: tea.MouseLeft}
+	if _, _ = m.Update(click); view.took("s") {
+		t.Errorf("clicking where s save used to be ran it: %v", view.keys)
+	}
+}
+
+// The +N is the only trace of what was left out, so it has to lead somewhere.
+func TestFooter_ClickingTheCountOpensTheOverlayThatListsWhatItHides(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(actingSpec(acting(
+		act("e", "edit the fields of this issue"),
+		act("t", "change the status of this issue"),
+		act("c", "read and write the comments"),
+	), 1))
+
+	m := newAt(t, testDeps(), MinWidth, 24, WithMouse(true))
+	if got := lastLine(ansi.Strip(m.Frame())); !strings.Contains(got, "+") {
+		t.Fatalf("nothing was left out at %d columns, so this proves nothing:\n%s", MinWidth, got)
+	}
+	prefix := m.zonePrefix
+	eventually(t, func() bool { return !m.deps.Zones.Get(prefix + overflowZone).IsZero() })
+
+	info := m.deps.Zones.Get(prefix + overflowZone)
+	click := tea.MouseClickMsg{X: info.StartX, Y: info.StartY, Button: tea.MouseLeft}
+	next, _ := m.Update(click)
+	if got := ansi.Strip(next.(Model).Frame()); !strings.Contains(got, "read and write the comments") {
+		t.Errorf("clicking the count did not open the overlay that lists what it stands for:\n%s", got)
+	}
+}
+
+// The overlay leads with what somebody came to do. It used to lead with how to
+// scroll, because that is the order the bindings happened to be written in.
+func TestHelpOverlay_LeadsWithTheActionsRatherThanTheMotions(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	view := acting(act("enter", "open"), act("/", "filter"))
+	view.set.Full = [][]Binding{
+		{Bind([]string{"j"}, "↓/j", "down"), Bind([]string{"k"}, "↑/k", "up")},
+		{act("enter", "open the row under the cursor"), act("/", "filter these rows")},
+	}
+	RegisterView(actingSpec(view, 1))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "?")
+	frame := ansi.Strip(m.Frame())
+	first := strings.SplitN(frame, "\n", 3)[1]
+	if !strings.HasPrefix(strings.TrimLeft(first, " "), "enter open") {
+		t.Errorf("the overlay does not lead with the actions:\n%s", first)
+	}
+	if !strings.Contains(frame, "open the row under the cursor") {
+		t.Errorf("the overlay dropped the sentence the row had no space for:\n%s", frame)
+	}
+	if !strings.Contains(frame, "down") {
+		t.Errorf("the overlay dropped the motions the row no longer carries:\n%s", frame)
+	}
+}
+
+// The row says "? close help" while the overlay is up, so pointing at it has to
+// close the overlay. Nothing else on the chrome answers there.
+func TestFooter_ClickingCloseHelpClosesTheOverlay(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(actingSpec(acting(act("e", "edit")), 1))
+
+	m := newAt(t, testDeps(), 120, 30, WithMouse(true))
+	m, _ = press(m, "?")
+	_ = m.Frame()
+	if !m.showHelp {
+		t.Fatal("the overlay did not open")
+	}
+
+	prefix := m.zonePrefix
+	eventually(t, func() bool { return !m.deps.Zones.Get(prefix + actZone + "?").IsZero() })
+	info := m.deps.Zones.Get(prefix + actZone + "?")
+
+	next, _ := m.Update(tea.MouseClickMsg{X: info.StartX, Y: info.StartY, Button: tea.MouseLeft})
+	if next.(Model).showHelp {
+		t.Error("clicking the entry that says how to close the overlay left it up")
+	}
+
+	m, _ = press(m, "?", "?")
+	root := m.deps.Zones.Get(prefix + rootZone)
+	m.showHelp = true
+	after, _ := m.Update(tea.MouseClickMsg{X: root.StartX + 1, Y: root.StartY, Button: tea.MouseLeft})
+	if !after.(Model).showHelp {
+		t.Error("clicking the root cell under an overlay switched view and left the overlay covering it")
+	}
+}
+
+func TestStroke_IsTheInverseOfHowAKeyIsSpelt(t *testing.T) {
+	for _, stroke := range []string{
+		"enter", "esc", "tab", "shift+tab", "space", "delete", "up", "down", "left", "right",
+		"home", "end", "pgup", "pgdown", "ctrl+b", "ctrl+d", "ctrl+f", "ctrl+g", "ctrl+k",
+		"ctrl+n", "ctrl+p", "ctrl+r", "ctrl+s", "ctrl+t", "ctrl+u",
+		"a", "b", "c", "d", "e", "f", "j", "k", "s", "t", "u", "y", "G", "R", "X", "/", "?", "1", "9",
+	} {
+		key, ok := Stroke(Bind([]string{stroke}, stroke, "does something"))
+		if !ok {
+			t.Errorf("%q cannot be turned back into a keypress, so a click on it does nothing", stroke)
+			continue
+		}
+		if got := key.String(); got != stroke {
+			t.Errorf("%q comes back as %q, so a click on it would arrive as a different key", stroke, got)
+		}
+	}
+	if _, ok := Stroke(Bind(nil, "", "nothing")); ok {
+		t.Error("a binding with no strokes reported one")
+	}
+	if _, ok := Stroke(Bind([]string{"f13"}, "f13", "unknown")); ok {
+		t.Error("a stroke this package does not spell was turned into a keypress anyway")
+	}
+}
+
+// The three cells at the three sizes the goldens cover elsewhere, drawn by the
+// kernel alone so that a change here is visible without a view to blame.
+func TestFooter_Golden(t *testing.T) {
+	for _, size := range []struct {
+		label string
+		w, h  int
+	}{{"80x20", 80, 20}, {"100x28", 100, 28}, {"120x38", 120, 38}} {
+		t.Run(size.label, func(t *testing.T) {
+			resetRegistry()
+			t.Cleanup(resetRegistry)
+			RegisterView(actingSpec(acting(
+				act("enter", "open"), act("e", "edit"), act("t", "status"),
+				act("c", "comment"), act("/", "filter"), act("a", "all"), act("s", "save"),
+			), 1))
+			RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
+
+			m := newAt(t, testDeps(), size.w, size.h)
+			golden(t, "footer_"+size.label+".golden", lastLine(ansi.Strip(m.Frame()))+"\n")
+		})
+	}
+}

--- a/internal/ui/kernel/footer_test.go
+++ b/internal/ui/kernel/footer_test.go
@@ -165,9 +165,9 @@ func TestFooter_AnActionThatLeftTheRowStopsAnsweringToWhereItWas(t *testing.T) {
 		t.Fatalf("s save still fits at %d columns, so this proves nothing:\n%s", MinWidth, row)
 	}
 
-	if now := m.deps.Zones.Get(prefix + actZone + "s"); !now.IsZero() {
-		t.Errorf("s save is off the row and still has bounds %+v", now)
-	}
+	// bubblezone purges the zones a frame no longer carries on its own
+	// goroutine, so the absence arrives after the frame does.
+	eventually(t, func() bool { return m.deps.Zones.Get(prefix + actZone + "s").IsZero() })
 
 	view.keys = nil
 	click := tea.MouseClickMsg{X: was.StartX, Y: was.StartY, Button: tea.MouseLeft}

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -153,7 +153,7 @@ func WithSize(w, h int) Option {
 	return func(m *Model) { m.width, m.height = w, h }
 }
 
-// WithInitialView opens a specific view rather than the first footer slot.
+// WithInitialView opens a specific view rather than the first allocated slot.
 func WithInitialView(id string) Option {
 	return func(m *Model) { m.initialView = id }
 }
@@ -426,20 +426,55 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // forwards them: nothing is reporting, so nothing arrives, and a view handed one
 // anyway looks its zones up in a manager that is disabled and misses.
 func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if click, ok := msg.(tea.MouseClickMsg); ok && m.mouse && click.Button == tea.MouseLeft {
+		if next, cmd, hit := m.clickFooter(click); hit {
+			return next, cmd
+		}
+	}
 	if m.showHelp {
 		return m, nil
 	}
-	if click, ok := msg.(tea.MouseClickMsg); ok && m.mouse && click.Button == tea.MouseLeft {
-		for _, spec := range m.roots {
-			if spec.Slot == 0 || !m.available(spec) {
-				continue
-			}
-			if m.deps.Zones.Get(m.zonePrefix + "slot:" + spec.ID).InBounds(click) {
-				return m.open(spec.ID)
-			}
+	return m.forwardTop(msg)
+}
+
+// clickFooter resolves a click on the chrome. An action is delivered as the key
+// it advertises rather than as a second way of doing it, which is the only way
+// docs/UX.md's three routes to an action stay one implementation.
+//
+// While the overlay is up the row offers one action — the key that closes it — and
+// the other two cells are left alone: switching root view under an overlay would
+// leave it covering a view nobody asked to see.
+func (m Model) clickFooter(click tea.MouseClickMsg) (tea.Model, tea.Cmd, bool) {
+	if len(m.stack) == 0 {
+		return m, nil, false
+	}
+	if !m.showHelp {
+		if m.deps.Zones.Get(m.zonePrefix + rootZone).InBounds(click) {
+			return withHit(m.open(m.stack[0].spec.ID))
+		}
+		if m.deps.Zones.Get(m.zonePrefix + overflowZone).InBounds(click) {
+			// The overlay is where the actions that did not fit are listed.
+			m.showHelp = true
+			return m, m.resizeAll(), true
 		}
 	}
-	return m.forwardTop(msg)
+	// An action that is not on the row has no zone in the frame just scanned, so
+	// the lookup misses and the click falls through to the view.
+	for _, b := range m.footerActs() {
+		if !m.deps.Zones.Get(m.zonePrefix + actZone + b.Help().Key).InBounds(click) {
+			continue
+		}
+		press, ok := Stroke(b)
+		if !ok {
+			return m, nil, true
+		}
+		return withHit(m.handleKey(press))
+	}
+	return m, nil, false
+}
+
+func withHit(model tea.Model, cmd tea.Cmd) (tea.Model, tea.Cmd, bool) {
+	return model, cmd, true
 }
 
 // capturing reports whether the focused view is taking typing right now.
@@ -1116,79 +1151,248 @@ func oneLine(s string, width int, ellipsis string) string {
 	return ansi.Truncate(s, width, ellipsis)
 }
 
-// footer draws the view slots and the hints for the keys that work right now.
-// Both come from the registries, so neither can drift from what is real.
-func (m Model) footer() string {
-	t := m.deps.Theme
-	slots := make([]string, 0, len(m.roots))
-	for _, spec := range m.roots {
-		if spec.Slot == 0 || !m.available(spec) {
-			continue
-		}
-		style := t.SlotOff
-		if len(m.stack) > 0 && m.stack[0].spec.ID == spec.ID {
-			style = t.SlotOn
-		}
-		label := slotGesture(m.keys, spec.Slot) + " " + spec.Title
-		slots = append(slots, m.deps.Zones.Mark(m.zonePrefix+"slot:"+spec.ID, style.Render(label)))
-	}
-	left := strings.Join(slots, "")
+// footerSep separates two entries in the action cell. The root cell carries its
+// own padding, so whatever follows it takes one space rather than two.
+const footerSep = "  "
 
-	hints := m.hintLine(m.width - lipgloss.Width(left) - 1)
-	gap := m.width - lipgloss.Width(left) - lipgloss.Width(hints)
-	if gap < 1 {
-		gap = 1
-		hints = ""
+// The zones the footer mints, under the kernel's own prefix. A click on an action
+// is delivered as the key that action advertises, so the key, the palette and the
+// pointer stay one implementation of the same thing.
+const (
+	rootZone     = "root"
+	actZone      = "act:"
+	overflowZone = "overflow"
+)
+
+// footerLevel is one rung of the ladder the row climbs down when it will not
+// fit: whether the root cell is still drawn, and whether the actions still carry
+// their descriptions.
+type footerLevel struct{ root, terse bool }
+
+// footerLevels is the order things are given up in. Actions fold into a +N at
+// every rung; the root cell goes before the descriptions do, because a row of
+// bare keys with nothing saying where you are is harder to read than a shorter
+// list of named ones. The globals are not on this ladder.
+var footerLevels = [3]footerLevel{{root: true}, {}, {terse: true}}
+
+// footer draws one row in three cells: the root this session is in, what can be
+// done to whatever is in front of you, and the globals.
+//
+// Only the globals are guaranteed a place, and the order the rest are given up in
+// is footerLevels. The inventory a view offers outgrows eighty columns, which is
+// the width docs/UX.md supports, so something has to go; the way out is not it.
+// There is no second row at any width either: the constraint is width rather than
+// height, so another row would be truncated the same way while costing a view one
+// line in thirteen.
+func (m Model) footer() string {
+	globals, globalsW := m.globalCell()
+	acts := m.footerActs()
+	root, rootW := m.rootCell()
+
+	room := m.width - globalsW
+	if globalsW > 0 {
+		room--
 	}
-	return t.Footer.MaxWidth(m.width).Render(left + strings.Repeat(" ", gap) + hints)
+	left, leftW := "", 0
+	for rung, level := range footerLevels {
+		labels := footerLabels(acts, level.terse)
+		// A rung that cannot name a single action has nothing to show for
+		// itself, so the row drops the root cell and then the descriptions
+		// instead. The last rung takes what it gets: at eighty columns that is
+		// unreachable, and a row that cannot be drawn is worse than a count.
+		least := min(1, len(labels))
+		if rung == len(footerLevels)-1 {
+			least = 0
+		}
+		cell, cellW := "", 0
+		if level.root {
+			cell, cellW = root, rootW
+		}
+		fitted := false
+		for named := len(labels); named >= least; named-- {
+			left, leftW = m.drawLeft(cell, cellW, labels, named)
+			if leftW <= room {
+				fitted = true
+				break
+			}
+		}
+		if fitted {
+			break
+		}
+	}
+	line := left
+	if globals != "" {
+		gap := m.width - leftW - globalsW
+		if gap < 1 {
+			gap = 1
+		}
+		line += strings.Repeat(" ", gap) + globals
+	}
+	return m.deps.Theme.Footer.MaxWidth(m.width).Render(line)
 }
 
-// SlotGesture is the gesture that reaches a footer slot, spelt the way the
-// footer spells it. A registrar naming the key for a command that opens a view
-// derives it from the view's slot with this, so that moving a view between slots
-// cannot leave a command teaching the key of a different one.
+// globalCell is the way out, and nothing takes it away. It is bare keys: there is
+// no honest version of this row with room for "help", "commands" and "back" as
+// well, and those sentences are one keystroke away in the overlay ? opens.
+func (m Model) globalCell() (cell string, width int) {
+	// The overlay swallows every global but the one that closes it, and a latched
+	// gesture holds all of them until it is finished or thrown away. Both say so
+	// in the action cell instead.
+	if m.showHelp || m.prefixSet {
+		return "", 0
+	}
+	_, palette := LookupView(PaletteViewID)
+	capturing := m.capturing()
+	keys := make([]string, 0, 3)
+	if !capturing {
+		keys = append(keys, m.keys.Help.Help().Key)
+	}
+	if palette {
+		keys = append(keys, m.keys.Palette.Help().Key)
+	}
+	switch {
+	case capturing:
+		// A view with the keyboard swallows the rest, and docs/UX.md asks the
+		// footer to show only what works right now — which cuts both ways.
+	case len(m.stack) > 1:
+		keys = append(keys, m.keys.Back.Help().Key)
+	default:
+		keys = append(keys, m.keys.Quit.Help().Key)
+	}
+	if len(keys) == 0 {
+		return "", 0
+	}
+	plain := strings.Join(keys, " ")
+	return m.deps.Theme.HintKey.Render(plain), ansi.StringWidth(plain)
+}
+
+// footerActs is the inventory the middle cell names. Two of the kernel's own
+// states answer for themselves, because both have taken the view's keys away;
+// everything else is what the focused view says works right now.
+func (m Model) footerActs() []Binding {
+	switch {
+	case m.showHelp:
+		return []Binding{Bind([]string{"?", "esc", "q"}, "?", "close help")}
+	case m.prefixSet:
+		return []Binding{
+			Bind(m.keys.Slot.Keys(), "1-9", "switch view"),
+			Bind(m.keys.Back.Keys(), "esc", "cancel"),
+		}
+	}
+	set, _ := m.viewKeys()
+	acts := set.Acts
+	if len(acts) == 0 {
+		acts = set.Short
+	}
+	// The digits are the one action a root view has that no view registered: they
+	// run the profile's own searches. A view taking typing is spending them.
+	if bound := m.boundQueries(); len(bound) > 0 && !m.capturing() {
+		return append([]Binding{savedHint(bound)}, acts...)
+	}
+	return acts
+}
+
+// rootCell names the root the session is in: where esc lands, and what a click
+// here goes back to. The header already says what is on top of it, so this is
+// orientation rather than a second copy of that title.
+func (m Model) rootCell() (cell string, width int) {
+	if len(m.stack) == 0 {
+		return "", 0
+	}
+	title := m.stack[0].spec.Title
+	if title == "" {
+		title = m.stack[0].spec.ID
+	}
+	rendered := m.deps.Theme.SlotOn.Render(title)
+	return m.deps.Zones.Mark(m.zonePrefix+rootZone, rendered), lipgloss.Width(rendered)
+}
+
+// footerLabel is one action as the row spells it: the key, what it does unless
+// the row has given descriptions up, and the zone a click resolves through. A
+// terse row keeps the key and drops what it does, which is the last thing given
+// up before a +N — a key with no name is still a key somebody can press and then
+// find in the overlay.
+type footerLabel struct{ key, desc, zone string }
+
+func footerLabels(acts []Binding, terse bool) []footerLabel {
+	out := make([]footerLabel, 0, len(acts))
+	for _, b := range acts {
+		if !b.Enabled() {
+			continue
+		}
+		h := b.Help()
+		label := footerLabel{key: h.Key, desc: h.Desc, zone: actZone + h.Key}
+		if terse {
+			label.desc = ""
+		}
+		out = append(out, label)
+	}
+	return out
+}
+
+func (l footerLabel) width() int {
+	if l.desc == "" {
+		return ansi.StringWidth(l.key)
+	}
+	return ansi.StringWidth(l.key) + 1 + ansi.StringWidth(l.desc)
+}
+
+// drawLeft renders the root cell and the first named actions, folding the rest
+// into a +N the overlay then lists in full. Measuring and drawing are one walk,
+// so the width the caller checks is the width of the row it gets.
+func (m Model) drawLeft(root string, rootW int, labels []footerLabel, named int) (row string, width int) {
+	t := m.deps.Theme
+	var out strings.Builder
+	out.WriteString(root)
+	width, drawn := rootW, 0
+	lead := func() (string, int) {
+		switch {
+		case drawn > 0:
+			return footerSep, len(footerSep)
+		case width > 0:
+			return " ", 1
+		default:
+			return "", 0
+		}
+	}
+	for _, label := range labels[:named] {
+		sep, sepW := lead()
+		entry := t.HintKey.Render(label.key)
+		if label.desc != "" {
+			entry += " " + t.HintDesc.Render(label.desc)
+		}
+		out.WriteString(sep)
+		out.WriteString(m.deps.Zones.Mark(m.zonePrefix+label.zone, entry))
+		width += sepW + label.width()
+		drawn++
+	}
+	if rest := len(labels) - named; rest > 0 {
+		sep, sepW := lead()
+		count := "+" + strconv.Itoa(rest)
+		out.WriteString(sep)
+		out.WriteString(m.deps.Zones.Mark(m.zonePrefix+overflowZone, t.HintKey.Render(count)))
+		width += sepW + len(count)
+	}
+	return out.String(), width
+}
+
+// SlotGesture is the gesture that reaches a footer slot, built from the keymap
+// the kernel runs rather than written down. A registrar naming the key for a
+// command that opens a view derives it from the view's slot with this, so that
+// moving a view between slots cannot leave a command teaching the key of a
+// different one.
+//
+// The footer no longer spells it out. One row cannot hold nine destinations and
+// the actions as well, and the destinations are the half a user needs least
+// often, so the digits are taught by the ? overlay and by the palette rows that
+// carry them.
 //
 // It answers for the default keymap, which is the only one an init() can know
-// about; the footer asks for the keymap the session is actually running.
+// about.
 func SlotGesture(slot int) string { return slotGesture(DefaultGlobalKeys(), slot) }
 
 func slotGesture(g GlobalKeys, slot int) string {
 	return g.Go.Keys()[0] + strconv.Itoa(slot)
-}
-
-// hintLine shows only the keys that work right now, in the space the footer
-// slots left over. The help component truncates with its own ellipsis rather
-// than the line wrapping.
-func (m Model) hintLine(width int) string {
-	if width < 8 {
-		return ""
-	}
-	h := m.deps.Theme.HelpModel
-	h.ShowAll = false
-	h.SetWidth(width)
-	if m.showHelp {
-		return h.View(keyMap{short: []Binding{Bind([]string{"?", "esc", "q"}, "?", "close help")}})
-	}
-	if m.prefixSet {
-		// The globals are unreachable until the gesture finishes, so the line
-		// shows what can finish it rather than what it has taken away.
-		return h.View(keyMap{short: []Binding{
-			Bind(m.keys.Slot.Keys(), "1-9", "switch view"),
-			Bind(m.keys.Back.Keys(), "esc", "cancel"),
-		}})
-	}
-	set, _ := m.viewKeys()
-	if m.capturing() {
-		// The globals are unreachable while the view has the keyboard, bar the
-		// one key it is not allowed to swallow, and docs/UX.md asks the footer to
-		// show only what works right now — which cuts both ways.
-		short := set.Short
-		if _, ok := LookupView(PaletteViewID); ok {
-			short = append(append([]Binding(nil), short...), m.keys.Palette)
-		}
-		return h.View(keyMap{short: short})
-	}
-	return h.View(mergeKeys(set, m.liveGlobals()))
 }
 
 // liveGlobals is the global keymap with the entries that would do nothing right

--- a/internal/ui/kernel/kernel_test.go
+++ b/internal/ui/kernel/kernel_test.go
@@ -326,7 +326,10 @@ func TestTheme_OnlyFollowsTheTerminalWhenTheModeIsAuto(t *testing.T) {
 	}
 }
 
-func TestCapabilities_ARefreshedProbeRebuildsTheFooter(t *testing.T) {
+// The footer names one destination — the root the session is in — so a probe that
+// grants a capability is held to the thing that actually changed: the view can be
+// reached, where before the gesture that reaches it said why it could not.
+func TestCapabilities_ARefreshedProbeMakesItsViewReachable(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)
 	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
@@ -335,34 +338,44 @@ func TestCapabilities_ARefreshedProbeRebuildsTheFooter(t *testing.T) {
 	d := testDeps()
 	d.Caps.Plans = jira.Capability{Reason: "no"}
 	m := newAt(t, d, 140, 30)
-	if strings.Contains(ansi.Strip(m.Frame()), "Plans") {
-		t.Fatal("Plans should start hidden")
+	m, _ = press(m, "g", "2")
+	if got := ansi.Strip(m.Frame()); strings.Contains(got, "plans body") {
+		t.Fatalf("Plans opened without the capability:\n%s", got)
 	}
 
-	caps := fullCaps()
-	next, _ := m.Update(CapabilitiesMsg{Caps: caps})
-	if !strings.Contains(ansi.Strip(next.(Model).Frame()), "Plans") {
-		t.Error("a granted capability did not bring its view back")
+	next, _ := m.Update(CapabilitiesMsg{Caps: fullCaps()})
+	m, _ = press(next.(Model), "g", "2")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "plans body") {
+		t.Errorf("a granted capability did not bring its view back:\n%s", got)
 	}
 }
 
-func TestMouse_ClickingAFooterSlotSwitchesView(t *testing.T) {
+// The root cell is where esc lands, and clicking it is the same gesture: the
+// footer says which root a pushed view came from, so pointing at it goes back
+// there rather than nowhere.
+func TestMouse_ClickingTheRootCellGoesBackToTheRoot(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)
 	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
-	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
 
 	m := newAt(t, testDeps(), 120, 30, WithMouse(true))
-	_ = m.Frame() // registering the zones is a side effect of drawing them
+	next, _ := m.Update(PushMsg{ID: "detail", Title: "PROJ-1", View: &stubView{id: "detail"}})
+	m = next.(Model)
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "detail body") {
+		t.Fatalf("the pushed view is not on top:\n%s", got)
+	}
+	if got := lastLine(ansi.Strip(m.Frame())); !strings.Contains(got, "Board") {
+		t.Fatalf("the footer does not name the root a click would go back to:\n%s", got)
+	}
 
 	prefix := m.zonePrefix
-	eventually(t, func() bool { return !m.deps.Zones.Get(prefix + "slot:backlog").IsZero() })
+	eventually(t, func() bool { return !m.deps.Zones.Get(prefix + rootZone).IsZero() })
 
-	info := m.deps.Zones.Get(prefix + "slot:backlog")
+	info := m.deps.Zones.Get(prefix + rootZone)
 	click := tea.MouseClickMsg{X: info.StartX + 1, Y: info.StartY, Button: tea.MouseLeft}
-	next, _ := m.Update(click)
-	if got := ansi.Strip(next.(Model).Frame()); !strings.Contains(got, "backlog body") {
-		t.Errorf("clicking the footer did not switch view:\n%s", got)
+	next, _ = m.Update(click)
+	if got := ansi.Strip(next.(Model).Frame()); !strings.Contains(got, "board body") {
+		t.Errorf("clicking the root cell did not come back to the root:\n%s", got)
 	}
 }
 
@@ -626,7 +639,7 @@ func TestFooter_DoesNotAdvertiseThePaletteWhenItIsNotInTheBuild(t *testing.T) {
 	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
 
 	m := newAt(t, testDeps(), 140, 30)
-	if got := lastLine(ansi.Strip(m.Frame())); strings.Contains(got, "commands") {
+	if got := lastLine(ansi.Strip(m.Frame())); strings.Contains(got, "ctrl+k") {
 		t.Errorf("the palette is advertised but not registered:\n%s", got)
 	}
 
@@ -634,7 +647,7 @@ func TestFooter_DoesNotAdvertiseThePaletteWhenItIsNotInTheBuild(t *testing.T) {
 	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
 	RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
 	m = newAt(t, testDeps(), 140, 30)
-	if got := lastLine(ansi.Strip(m.Frame())); !strings.Contains(got, "commands") {
+	if got := lastLine(ansi.Strip(m.Frame())); !strings.Contains(got, "ctrl+k") {
 		t.Errorf("the palette is registered but not advertised:\n%s", got)
 	}
 }
@@ -778,7 +791,7 @@ func TestFooter_SaysNothingAboutGlobalsAViewIsSwallowing(t *testing.T) {
 	RegisterKeys("board", KeySet{Short: []Binding{Bind([]string{"ctrl+g"}, "ctrl+g", "clear filter")}})
 
 	m := newAt(t, testDeps(), 140, 30)
-	if got := lastLine(ansi.Strip(m.Frame())); !strings.Contains(got, "quit") {
+	if got := lastLine(ansi.Strip(m.Frame())); !strings.HasSuffix(got, "? q") {
 		t.Fatalf("the globals should show while nothing is capturing:\n%s", got)
 	}
 
@@ -787,7 +800,7 @@ func TestFooter_SaysNothingAboutGlobalsAViewIsSwallowing(t *testing.T) {
 	if !strings.Contains(got, "clear filter") {
 		t.Errorf("the view's own keys vanished:\n%s", got)
 	}
-	if strings.Contains(got, "quit") || strings.Contains(got, "help") {
+	if strings.Contains(got, "? ") || strings.HasSuffix(got, "q") {
 		t.Errorf("the footer advertises globals the view is swallowing:\n%s", got)
 	}
 }

--- a/internal/ui/kernel/keys.go
+++ b/internal/ui/kernel/keys.go
@@ -1,7 +1,11 @@
 package kernel
 
 import (
+	"strings"
+	"unicode/utf8"
+
 	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
 )
 
 // Binding is a keybinding. It is aliased so that a view package registers keys
@@ -12,6 +16,17 @@ type Binding = key.Binding
 // help, and what it does.
 func Bind(keys []string, shown, desc string) Binding {
 	return key.NewBinding(key.WithKeys(keys...), key.WithHelp(shown, desc))
+}
+
+// Terse relabels a binding for the footer's action cell: the same strokes, the
+// same key label, and a description short enough for a row shared with the root
+// cell and the globals. The binding it was made from keeps the sentence, and that
+// is what the ? overlay lists — "edit" on the row, "edit fields" in the overlay.
+//
+// It takes a binding rather than a pair of strings so that a key cannot be spelt
+// twice: what a view tells the user to press has one source.
+func Terse(b Binding, desc string) Binding {
+	return Bind(b.Keys(), b.Help().Key, desc)
 }
 
 // Matches reports whether a key press triggers any of the bindings. A disabled
@@ -75,11 +90,134 @@ type keyMap struct {
 func (k keyMap) ShortHelp() []Binding  { return k.short }
 func (k keyMap) FullHelp() [][]Binding { return k.full }
 
+// mergeKeys builds what the ? overlay lists, and it lists every key exactly once.
+//
+// The actions lead, in the order the row shows them, because what somebody opened
+// the pane to do matters more than how to scroll it — but spelt out: the row has
+// space for "edit" and the overlay has space for "edit fields", so the description
+// comes from the view's Full entry for the same key. The rest of Full is drawn
+// with the actions taken out of it, and a column with nothing left is not drawn at
+// all. Without that the overlay carried each action twice, once terse and once in
+// full, and two columns of it pushed the globals off the right of the screen.
 func mergeKeys(view, global KeySet) keyMap {
 	km := keyMap{
 		short: append(append([]Binding(nil), view.Short...), global.Short...),
-		full:  append([][]Binding(nil), view.Full...),
+		full:  make([][]Binding, 0, len(view.Full)+len(global.Full)+1),
+	}
+	if len(view.Acts) > 0 {
+		km.full = append(km.full, spellOut(view.Acts, view.Full))
+	}
+	for _, column := range view.Full {
+		if rest := without(column, view.Acts); len(rest) > 0 {
+			km.full = append(km.full, rest)
+		}
 	}
 	km.full = append(km.full, global.Full...)
 	return km
+}
+
+// spellOut is the actions with the longest description any column gives the same
+// key, so that the overlay says what the row had no room to.
+func spellOut(acts []Binding, full [][]Binding) []Binding {
+	out := make([]Binding, len(acts))
+	for i, act := range acts {
+		out[i] = act
+		for _, column := range full {
+			for _, b := range column {
+				if b.Help().Key == act.Help().Key && len(b.Help().Desc) > len(out[i].Help().Desc) {
+					out[i] = b
+				}
+			}
+		}
+	}
+	return out
+}
+
+// without is a column with the keys the leading column has already named taken
+// out. Comparison is by label, because that is what a reader sees.
+func without(column, acts []Binding) []Binding {
+	out := make([]Binding, 0, len(column))
+	for _, b := range column {
+		named := false
+		for _, act := range acts {
+			if act.Help().Key == b.Help().Key {
+				named = true
+				break
+			}
+		}
+		if !named {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// Stroke turns a binding's first stroke back into the keypress that triggers it,
+// so that clicking what the footer advertises arrives at the view as the key it
+// named rather than as a second code path. It is the inverse of the spelling
+// tea.Key.String produces, which is what key.Matches compares against.
+//
+// It reports false for a stroke it cannot spell rather than sending a key that
+// means something else: an unrecognised name would arrive as its first rune.
+func Stroke(b Binding) (tea.KeyPressMsg, bool) {
+	keys := b.Keys()
+	if len(keys) == 0 {
+		return tea.KeyPressMsg{}, false
+	}
+	return parseStroke(keys[0])
+}
+
+// namedKeys spells the keys that are not a single rune. It covers what this
+// program binds; anything outside it is refused rather than guessed at.
+var namedKeys = map[string]rune{
+	"enter":     tea.KeyEnter,
+	"tab":       tea.KeyTab,
+	"esc":       tea.KeyEscape,
+	"space":     tea.KeySpace,
+	"backspace": tea.KeyBackspace,
+	"delete":    tea.KeyDelete,
+	"insert":    tea.KeyInsert,
+	"up":        tea.KeyUp,
+	"down":      tea.KeyDown,
+	"left":      tea.KeyLeft,
+	"right":     tea.KeyRight,
+	"home":      tea.KeyHome,
+	"end":       tea.KeyEnd,
+	"pgup":      tea.KeyPgUp,
+	"pgdown":    tea.KeyPgDown,
+}
+
+var strokeMods = []struct {
+	prefix string
+	mod    tea.KeyMod
+}{
+	{"ctrl+", tea.ModCtrl},
+	{"alt+", tea.ModAlt},
+	{"shift+", tea.ModShift},
+}
+
+func parseStroke(s string) (tea.KeyPressMsg, bool) {
+	var mod tea.KeyMod
+	for again := true; again; {
+		again = false
+		for _, m := range strokeMods {
+			if rest, cut := strings.CutPrefix(s, m.prefix); cut {
+				s, mod, again = rest, mod|m.mod, true
+				break
+			}
+		}
+	}
+	if code, named := namedKeys[s]; named {
+		return tea.KeyPressMsg{Code: code, Mod: mod}, true
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	if size != len(s) || r == utf8.RuneError {
+		return tea.KeyPressMsg{}, false
+	}
+	// Text is what a field types; a modified key produces none.
+	press := tea.KeyPressMsg{Code: r, Mod: mod}
+	if mod == 0 {
+		press.Text = s
+	}
+	return press, true
 }

--- a/internal/ui/kernel/palette_test.go
+++ b/internal/ui/kernel/palette_test.go
@@ -165,15 +165,33 @@ func TestPalette_ADraftUnderItStillRefusesAViewSwitch(t *testing.T) {
 	}
 }
 
-func TestSlotGesture_IsSpeltTheWayTheFooterSpellsIt(t *testing.T) {
+// The footer names one destination and spends the rest of its row on actions, so
+// the gesture is now taught by the overlay and by the palette row carrying it.
+// What still has to hold is that the gesture works and reaches the view whose
+// slot it was built from — a command teaching g3 must not open something else.
+func TestSlotGesture_ReachesTheViewWhoseSlotItWasBuiltFrom(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)
 	RegisterView(spec("board", 3, "", &stubView{id: "board"}))
+	RegisterView(spec("backlog", 4, "", &stubView{id: "backlog"}))
+
+	gesture := SlotGesture(3)
+	if gesture != "g3" {
+		t.Fatalf("SlotGesture(3) is %q; the keymap the kernel runs spells it g3", gesture)
+	}
 
 	m := newAt(t, testDeps(), 120, 30)
-	gesture := SlotGesture(3)
-	if got := lastLine(ansi.Strip(m.Frame())); !strings.Contains(got, gesture+" Board") {
-		t.Errorf("the footer does not show %q, so a command teaching it teaches a key nothing shows:\n%s", gesture, got)
+	m, _ = press(m, "g", "4")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "backlog body") {
+		t.Fatalf("g4 did not reach slot 4:\n%s", got)
+	}
+	m, _ = press(m, gesture[:1], gesture[1:])
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "board body") {
+		t.Errorf("%q does not reach the view holding slot 3:\n%s", gesture, got)
+	}
+	m, _ = press(m, "?")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "switch view") {
+		t.Errorf("the overlay does not teach the digits the footer stopped spelling out:\n%s", got)
 	}
 }
 
@@ -209,10 +227,10 @@ func TestFooter_StillOffersThePaletteToAViewThatIsTakingTyping(t *testing.T) {
 
 	m := newAt(t, testDeps(), 140, 30)
 	got := lastLine(ansi.Strip(m.Frame()))
-	if !strings.Contains(got, "commands") {
+	if !strings.HasSuffix(got, "ctrl+k") {
 		t.Errorf("the one global that still works while typing is not offered, so nobody finds it there:\n%s", got)
 	}
-	if strings.Contains(got, "quit") || strings.Contains(got, "help") {
+	if strings.Contains(got, "? ctrl+k") || strings.HasSuffix(got, "q") {
 		t.Errorf("the footer advertises globals the view is swallowing:\n%s", got)
 	}
 }

--- a/internal/ui/kernel/testdata/chrome_filtering_120x30.golden
+++ b/internal/ui/kernel/testdata/chrome_filtering_120x30.golden
@@ -27,4 +27,4 @@ board body
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Board  g2 Backlog                                                               enter keep filter | esc clear filter
+ Board  enter keep filter  esc clear filter                                                                       ctrl+k

--- a/internal/ui/kernel/testdata/chrome_filtering_80x20.golden
+++ b/internal/ui/kernel/testdata/chrome_filtering_80x20.golden
@@ -17,4 +17,4 @@ board body
                                                                                 
                                                                                 
                                                                                 
- g1 Board  g2 Backlog                       enter keep filter | esc clear filter
+ Board  enter keep filter  esc clear filter                               ctrl+k

--- a/internal/ui/kernel/testdata/chrome_resting_120x30.golden
+++ b/internal/ui/kernel/testdata/chrome_resting_120x30.golden
@@ -27,4 +27,4 @@ board body
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Board  g2 Backlog                                                                              enter open | / filter
+ Board  enter open  / filter                                                                                      ctrl+k

--- a/internal/ui/kernel/testdata/chrome_resting_80x20.golden
+++ b/internal/ui/kernel/testdata/chrome_resting_80x20.golden
@@ -17,4 +17,4 @@ board body
                                                                                 
                                                                                 
                                                                                 
- g1 Board  g2 Backlog                                      enter open | / filter
+ Board  enter open  / filter                                              ctrl+k

--- a/internal/ui/kernel/testdata/footer_100x28.golden
+++ b/internal/ui/kernel/testdata/footer_100x28.golden
@@ -1,0 +1,1 @@
+ Board  enter open  e edit  t status  c comment  / filter  a all  s save                  ? ctrl+k q

--- a/internal/ui/kernel/testdata/footer_120x38.golden
+++ b/internal/ui/kernel/testdata/footer_120x38.golden
@@ -1,0 +1,1 @@
+ Board  enter open  e edit  t status  c comment  / filter  a all  s save                                      ? ctrl+k q

--- a/internal/ui/kernel/testdata/footer_80x20.golden
+++ b/internal/ui/kernel/testdata/footer_80x20.golden
@@ -1,0 +1,1 @@
+ Board  enter open  e edit  t status  c comment  / filter  a all  +1  ? ctrl+k q

--- a/internal/ui/kernel/testdata/frame_120x40.golden
+++ b/internal/ui/kernel/testdata/frame_120x40.golden
@@ -37,4 +37,4 @@ PROJ-2  Fix the other thing
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Board  g2 Backlog                                                            enter open | / filter | ? help | q quit
+ Board  enter open  / filter                                                                                         ? q

--- a/internal/ui/kernel/testdata/frame_80x20.golden
+++ b/internal/ui/kernel/testdata/frame_80x20.golden
@@ -17,4 +17,4 @@ PROJ-2  Fix the other thing
                                                                                 
                                                                                 
                                                                                 
- g1 Board  g2 Backlog                    enter open | / filter | ? help | q quit
+ Board  enter open  / filter                                                 ? q

--- a/internal/ui/kernel/testdata/help_filtering.golden
+++ b/internal/ui/kernel/testdata/help_filtering.golden
@@ -27,4 +27,4 @@ esc   clear filter    g 1-9 switch view           ?      help
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Board                                                                                                   ? close help
+ Board  ? close help

--- a/internal/ui/kernel/testdata/help_resting.golden
+++ b/internal/ui/kernel/testdata/help_resting.golden
@@ -1,9 +1,9 @@
  saral | Board                                                                                    example.atlassian.net 
-enter open      1-9   saved query           ctrl+k commands                                                             
-/     filter    g 1-9 switch view           ?      help                                                                 
-                esc   back                  q      quit                                                                 
-                r     refresh                                                                                           
-                R     refetch everything                                                                                
+enter open the row under the cursor    ↓/j down    1-9   saved query           ctrl+k commands                          
+/     filter these rows                ↑/k up      g 1-9 switch view           ?      help                              
+                                                   esc   back                  q      quit                              
+                                                   r     refresh                                                        
+                                                   R     refetch everything                                             
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -27,4 +27,4 @@ enter open      1-9   saved query           ctrl+k commands
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Board                                                                                                   ? close help
+ Board  ? close help

--- a/internal/ui/kernel/view.go
+++ b/internal/ui/kernel/view.go
@@ -28,9 +28,10 @@ type ViewSpec struct {
 	// ID is the view's stable name. It is what `saral <id>` opens and what
 	// RegisterKeys scopes keys to.
 	ID string
-	// Title is the footer label.
+	// Title names the view in the header, and in the footer when it is the root
+	// the stack sits on.
 	Title string
-	// Slot is the footer position, 1-9, reached with g and the digit. Zero means
+	// Slot is the digit g reaches this view with, 1-9. Zero means
 	// the view is reachable only by being pushed or opened by name. The
 	// allocation is written down in docs/UX.md; the registry rejects a duplicate.
 	Slot int
@@ -95,7 +96,11 @@ type Deps struct {
 	// has nowhere to keep one. Every view has to draw without it: a first run has
 	// nothing on disk, and another copy of Saral may be holding the file.
 	Cache app.Cache
-	// Site is the host this session is talking to, for display only.
+	// Site is what the profile calls the site this session is talking to. It is
+	// drawn in the header and it is what IssueURL builds a browse link from, so
+	// it is not display-only — but nothing after onboarding checks its shape, so
+	// it may carry a scheme, a port or a context path and anything reading it has
+	// to cope with all three rather than concatenating.
 	Site string
 	// Now is the clock. Tests inject a fixed one.
 	Now func() time.Time
@@ -107,15 +112,32 @@ type Deps struct {
 	SaveQueries func(app.SavedQueries) error
 }
 
-// KeySet is a view's keys, scoped to itself. Short is the footer hint line, in
-// order; Full is the help overlay, one inner slice per column.
+// KeySet is a view's keys, scoped to itself.
+//
+// Acts is the inventory of what can be done to the thing on screen, most-used
+// first, and it is the footer's middle cell. Full is the help overlay, one inner
+// slice per column, and it is where the motions and the whole sentence live.
+//
+// The two are not the same list written twice. The footer is one row shared with
+// the root cell and the globals, so a label there is two or three words — "edit",
+// not "edit fields" — and it names an action rather than a way of moving around.
+// The overlay has the room to say what a key really does, and it leads with Acts
+// so that what a user came to do is above how to scroll.
+//
+// Short is the one-line form bubbles/help renders, and the footer falls back to
+// it for a set that names no Acts. Every view in this build names Acts; the
+// fallback is what keeps a key set that has not been partitioned yet from
+// drawing an empty footer.
 type KeySet struct {
+	Acts  []Binding
 	Short []Binding
 	Full  [][]Binding
 }
 
 // IsZero reports whether the set carries no bindings.
-func (k KeySet) IsZero() bool { return len(k.Short) == 0 && len(k.Full) == 0 }
+func (k KeySet) IsZero() bool {
+	return len(k.Acts) == 0 && len(k.Short) == 0 && len(k.Full) == 0
+}
 
 // KeyReporter is the optional interface a view implements when the keys that
 // work in it depend on what it is doing. RegisterKeys is init-time and refuses a

--- a/internal/ui/keys_test.go
+++ b/internal/ui/keys_test.go
@@ -76,10 +76,17 @@ func checkKey(t *testing.T, id, owner, k string) {
 
 // labelsOf splits a key set into what it tells the user to press and what it
 // merely answers to. "a c" is one binding whose label is "a".
+//
+// Acts is walked as well as Short and Full, and it is the half that matters: it
+// is the footer, so a command teaching a key nothing in Acts shows is teaching a
+// key the row the user is looking at does not carry.
 func labelsOf(set kernel.KeySet) (shown, matched []string) {
 	each := func(b kernel.Binding) {
 		shown = append(shown, b.Help().Key)
 		matched = append(matched, b.Keys()...)
+	}
+	for _, b := range set.Acts {
+		each(b)
 	}
 	for _, b := range set.Short {
 		each(b)

--- a/internal/ui/list/empty_test.go
+++ b/internal/ui/list/empty_test.go
@@ -270,8 +270,8 @@ func TestFilter_IsNamedUnderTheRowsAndClearedFromBrowsing(t *testing.T) {
 	if gen != int(keysNarrowed) {
 		t.Errorf("a kept filter reports key state %d, want %d", gen, keysNarrowed)
 	}
-	if !strings.Contains(shortOf(set), "clear filter") {
-		t.Errorf("the footer of a narrowed list does not offer the key that widens it: %s", shortOf(set))
+	if !strings.Contains(actsOf(set), "ctrl+g clear") {
+		t.Errorf("the footer of a narrowed list does not offer the key that widens it: %s", actsOf(set))
 	}
 
 	dr.key("ctrl+g")
@@ -280,8 +280,8 @@ func TestFilter_IsNamedUnderTheRowsAndClearedFromBrowsing(t *testing.T) {
 		t.Errorf("%d of %d rows came back", got, len(dr.m.issues))
 	}
 	mustNotContain(t, dr.view(), "only rows matching")
-	if state, _ := dr.m.LiveKeys(); shortOf(state) != shortOf(liveSets[keysBrowsing]) {
-		t.Errorf("the footer still advertises a filter there is none of: %s", shortOf(state))
+	if state, _ := dr.m.LiveKeys(); actsOf(state) != actsOf(liveSets[keysBrowsing]) {
+		t.Errorf("the footer still advertises a filter there is none of: %s", actsOf(state))
 	}
 }
 

--- a/internal/ui/list/keys.go
+++ b/internal/ui/list/keys.go
@@ -75,18 +75,19 @@ func (k keyMap) keySet() kernel.KeySet { return k.browsing(false) }
 // browsing is the resting state, with or without a filter already narrowing the
 // rows. The narrowed one offers the key that clears it.
 //
-// The two that reach another search are in the overlay and not the hint line: a
-// fifth entry there is enough to push the whole line past what an eighty-column
-// footer holds, and the kernel drops the line rather than shortening it.
+// Everything the list can do is offered, in the order it gets used. Nothing is
+// left out of the inventory to make it fit: whatever the row cannot hold folds
+// into a +N, and the overlay lists it.
 func (k keyMap) browsing(narrowed bool) kernel.KeySet {
-	short := []kernel.Binding{k.Down, k.Up, k.Open, k.Filter}
+	all, search, save := kernel.Terse(k.All, "all"), kernel.Terse(k.Edit, "search"), kernel.Terse(k.Save, "save")
+	acts := []kernel.Binding{k.Open, k.Filter, all, search, save}
 	actions := []kernel.Binding{k.Open, k.Filter, k.All, k.Edit, k.Save}
 	if narrowed {
-		short = []kernel.Binding{k.Down, k.Up, k.Open, k.Unfilter}
+		acts = []kernel.Binding{k.Open, k.Filter, kernel.Terse(k.Unfilter, "clear"), all, search, save}
 		actions = []kernel.Binding{k.Open, k.Filter, k.Unfilter, k.All, k.Edit, k.Save}
 	}
 	return kernel.KeySet{
-		Short: short,
+		Acts: acts,
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
@@ -117,21 +118,23 @@ var liveSets = func() [keyStates]kernel.KeySet {
 	var sets [keyStates]kernel.KeySet
 	sets[keysBrowsing] = k.keySet()
 	sets[keysNarrowed] = k.browsing(true)
+	// A prompt keeps its words: two answers to one question always fit, and what
+	// they are called is the whole point of asking.
 	sets[keysFiltering] = kernel.KeySet{
-		Short: []kernel.Binding{k.Accept, k.Clear},
-		Full:  [][]kernel.Binding{{k.Accept, k.Clear}},
+		Acts: []kernel.Binding{k.Accept, k.Clear},
+		Full: [][]kernel.Binding{{k.Accept, k.Clear}},
 	}
 	sets[keysPickingSlot] = kernel.KeySet{
-		Short: []kernel.Binding{k.Slot, k.Drop},
-		Full:  [][]kernel.Binding{{k.Slot, k.Drop}},
+		Acts: []kernel.Binding{k.Slot, k.Drop},
+		Full: [][]kernel.Binding{{k.Slot, k.Drop}},
 	}
 	sets[keysConfirmingSlot] = kernel.KeySet{
-		Short: []kernel.Binding{k.Take, k.Drop},
-		Full:  [][]kernel.Binding{{k.Take, k.Drop}},
+		Acts: []kernel.Binding{k.Take, k.Drop},
+		Full: [][]kernel.Binding{{k.Take, k.Drop}},
 	}
 	sets[keysAsking] = kernel.KeySet{
-		Short: []kernel.Binding{k.Run, k.Keep},
-		Full:  [][]kernel.Binding{{k.Run, k.Keep}},
+		Acts: []kernel.Binding{k.Run, k.Keep},
+		Full: [][]kernel.Binding{{k.Run, k.Keep}},
 	}
 	return sets
 }()

--- a/internal/ui/list/keys_test.go
+++ b/internal/ui/list/keys_test.go
@@ -61,7 +61,7 @@ func TestLiveKeys_FollowWhatTheListIsDoing(t *testing.T) {
 				tc.name, other, gen)
 		}
 		seen[gen] = tc.name
-		if len(set.Short) == 0 {
+		if len(set.Acts) == 0 {
 			t.Errorf("%s advertises nothing at all", tc.name)
 		}
 	}
@@ -78,11 +78,11 @@ func TestLiveKeys_TheFilterKeyChangesWhatIsAdvertised(t *testing.T) {
 	if gen != int(keysFiltering) {
 		t.Fatalf("pressing / left the keys in state %d", gen)
 	}
-	if shortOf(before) == shortOf(after) {
-		t.Errorf("the same keys are advertised with the filter open and closed: %s", shortOf(after))
+	if actsOf(before) == actsOf(after) {
+		t.Errorf("the same keys are advertised with the filter open and closed: %s", actsOf(after))
 	}
-	if !strings.Contains(shortOf(after), "clear filter") {
-		t.Errorf("an open filter does not advertise the key that closes it: %s", shortOf(after))
+	if !strings.Contains(actsOf(after), "clear filter") {
+		t.Errorf("an open filter does not advertise the key that closes it: %s", actsOf(after))
 	}
 }
 
@@ -104,8 +104,8 @@ func newModel(t *testing.T) *Model {
 	return m
 }
 
-func shortOf(set kernel.KeySet) string {
-	return strings.Join(labels(set.Short), " · ")
+func actsOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Acts), " · ")
 }
 
 func labels(bindings []kernel.Binding) []string {
@@ -117,7 +117,7 @@ func labels(bindings []kernel.Binding) []string {
 }
 
 func writeKeySet(b *strings.Builder, set kernel.KeySet) {
-	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	fmt.Fprintf(b, "  acts   %s\n", actsOf(set))
 	for _, column := range set.Full {
 		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
 	}

--- a/internal/ui/list/testdata/keys.golden
+++ b/internal/ui/list/testdata/keys.golden
@@ -1,22 +1,22 @@
 browsing
-  short  ↓/j down · ↑/k up · enter open · / filter
+  acts   enter open · / filter · a all · e search · s save
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
   full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
   full   [enter open, / filter, a all issues, e edit this search, s save this query to a key]
 a filter kept on the rows
-  short  ↓/j down · ↑/k up · enter open · ctrl+g clear filter
+  acts   enter open · / filter · ctrl+g clear · a all · e search · s save
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
   full   [ctrl+d half page down, ctrl+u half page up, g g first row, G last row]
   full   [enter open, / filter, ctrl+g clear filter, a all issues, e edit this search, s save this query to a key]
 filter open
-  short  enter keep filter · esc clear filter
+  acts   enter keep filter · esc clear filter
   full   [enter keep filter, esc clear filter]
 picking the number key
-  short  1-9 the key to bind it to · esc leave it alone
+  acts   1-9 the key to bind it to · esc leave it alone
   full   [1-9 the key to bind it to, esc leave it alone]
 confirming a number key that is taken
-  short  y take the key · esc leave it alone
+  acts   y take the key · esc leave it alone
   full   [y take the key, esc leave it alone]
 editing the search on screen
-  short  enter run this search · esc keep the one on screen
+  acts   enter run this search · esc keep the one on screen
   full   [enter run this search, esc keep the one on screen]

--- a/internal/ui/list/testdata/list_100x30.golden
+++ b/internal/ui/list/testdata/list_100x30.golden
@@ -27,4 +27,4 @@ All issues                                                                  chec
                                                                                                     
                                                                                                     
  nothing in PROJ is assigned to you, so this is every issue in it                                   
- g1 Issues                               ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                           ? q

--- a/internal/ui/list/testdata/list_120x40.golden
+++ b/internal/ui/list/testdata/list_120x40.golden
@@ -37,4 +37,4 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
  nothing in PROJ is assigned to you, so this is every issue in it                                                       
- g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                                               ? q

--- a/internal/ui/list/testdata/list_80x20.golden
+++ b/internal/ui/list/testdata/list_80x20.golden
@@ -17,4 +17,4 @@ All issues                                              checked 09:00  12 issues
                                                                                 
                                                                                 
  nothing in PROJ is assigned to you, so this is every issue in it               
- g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                       ? q

--- a/internal/ui/list/testdata/list_no_caps_120x30.golden
+++ b/internal/ui/list/testdata/list_no_caps_120x30.golden
@@ -27,4 +27,4 @@ All issues                                                                      
                                                                                                                         
                                                                                                                         
  nothing in PROJ is assigned to you, so this is every issue in it                                                       
- g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                                               ? q

--- a/internal/ui/list/testdata/list_refreshed_120x30.golden
+++ b/internal/ui/list/testdata/list_refreshed_120x30.golden
@@ -27,4 +27,4 @@ My issues in PROJ                                                               
                                                                                                                         
                                                                                                                         
  refreshed: nothing has changed, still 3 issues                                                                         
- g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                                               ? q

--- a/internal/ui/list/testdata/list_refreshed_80x20.golden
+++ b/internal/ui/list/testdata/list_refreshed_80x20.golden
@@ -17,4 +17,4 @@ My issues in PROJ                                        checked 09:00  3 issues
                                                                                 
                                                                                 
  refreshed: nothing has changed, still 3 issues                                 
- g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                       ? q

--- a/internal/ui/list/testdata/list_stale_120x30.golden
+++ b/internal/ui/list/testdata/list_stale_120x30.golden
@@ -27,4 +27,4 @@ My issues in PROJ                                                               
                                                                                                                         
                                                                                                                         
 search failed: dial tcp: no such host                                                                                   
- g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                                               ? q

--- a/internal/ui/list/testdata/list_switched_120x30.golden
+++ b/internal/ui/list/testdata/list_switched_120x30.golden
@@ -27,4 +27,4 @@ My issues in OTHER                                                              
                                                                                                                         
                                                                                                                         
  this session is scoped to OTHER                                                                                        
- g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                                               ? q

--- a/internal/ui/list/testdata/list_widened_120x30.golden
+++ b/internal/ui/list/testdata/list_widened_120x30.golden
@@ -27,4 +27,4 @@ All issues in PROJ                                                              
                                                                                                                         
                                                                                                                         
  nothing in PROJ is assigned to you, so this is every issue in it                                                       
- g1 Issues                                                   ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                                                               ? q

--- a/internal/ui/list/testdata/list_widened_80x20.golden
+++ b/internal/ui/list/testdata/list_widened_80x20.golden
@@ -17,4 +17,4 @@ All issues in PROJ                                      checked 09:00  12 issues
                                                                                 
                                                                                 
  nothing in PROJ is assigned to you, so this is every issue in it               
- g1 Issues           ↓/j down | ↑/k up | enter open | / filter | ? help | q quit
+ Issues  enter open  / filter  a all  e search  s save                       ? q

--- a/internal/ui/livekeys_test.go
+++ b/internal/ui/livekeys_test.go
@@ -112,6 +112,75 @@ func TestLiveKeys_AFreshlyBuiltViewAdvertisesSomething(t *testing.T) {
 	}
 }
 
+// actionFree names the states that deliberately offer nothing to do, with the
+// reason. A state waiting on a site has no action of its own and says so by
+// advertising none, which is a different thing from a view that never got round
+// to naming its actions.
+//
+// The states themselves are private to their packages, so each package holds its
+// own states to this; what belongs here is the record of which views have one at
+// all, so that a seventh view cannot quietly join them.
+var actionFree = map[string]string{
+	issue.EditViewID:  "a save in flight refuses every key until the site answers",
+	issue.MoveViewID:  "a transition in flight refuses every key until the site answers",
+	onboarding.ViewID: "a step being checked against the site refuses enter and shift+tab both",
+}
+
+// Every state a footer can be drawn from has to name what can be done in it, or
+// the row is the globals and nothing else. What this can reach from above the
+// views is the state each one opens in and the resting set each one registered;
+// the rest is held by each package over its own states.
+func TestLiveKeys_EveryReportingStateNamesAnActionOrIsListedWithAReason(t *testing.T) {
+	sweepEnv(t)
+	for _, scope := range kernel.KeyScopes() {
+		if got := kernel.KeysFor(scope).Acts; len(got) == 0 {
+			t.Errorf("%s registered a resting set that names no action, so its footer is a row of globals "+
+				"and the command sweep has nothing to hold a palette entry's key against", scope)
+		}
+	}
+	for scope, build := range keyReporters {
+		reporter, ok := build(depsFor(t)).(kernel.KeyReporter)
+		if !ok {
+			continue
+		}
+		set, _ := reporter.LiveKeys()
+		if len(set.Acts) == 0 && actionFree[scope] == "" {
+			t.Errorf("%s opens in a state that names no action and is not listed as action-free with a reason", scope)
+		}
+	}
+	for scope, why := range actionFree {
+		if _, reports := keyReporters[scope]; !reports {
+			t.Errorf("actionFree names %q, which does not report its live keys, so it has no states to be free of", scope)
+		}
+		if why == "" {
+			t.Errorf("%s is listed action-free with no reason", scope)
+		}
+	}
+}
+
+// Two things every advertised action owes the mouse and the footer's zone map: a
+// first stroke the kernel can turn back into the keypress a click delivers, and a
+// key label no other action in the same state shares, because the zone a click
+// resolves to is minted from that label.
+func TestLiveKeys_EveryAdvertisedActionCanBeClicked(t *testing.T) {
+	sweepEnv(t)
+	for _, scope := range kernel.KeyScopes() {
+		seen := make(map[string]string)
+		for _, b := range kernel.KeysFor(scope).Acts {
+			label := b.Help().Key
+			if other, clash := seen[label]; clash {
+				t.Errorf("%s advertises %q for both %q and %q; the footer mints one zone per label, "+
+					"so a click on it reaches whichever came first", scope, label, other, b.Help().Desc)
+			}
+			seen[label] = b.Help().Desc
+			if _, ok := kernel.Stroke(b); !ok {
+				t.Errorf("%s advertises %q on %v, which the kernel cannot spell back into a keypress, "+
+					"so clicking it does nothing", scope, label, b.Keys())
+			}
+		}
+	}
+}
+
 // seed is the row a list would have handed over: a key and nothing else, which
 // is all these panes need to be built.
 func seed() jira.Issue {

--- a/internal/ui/onboarding/keys.go
+++ b/internal/ui/onboarding/keys.go
@@ -31,8 +31,8 @@ func defaultKeys() keyMap {
 // keySet is the resting state: a step with a field in it, part way through.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
-		Short: []kernel.Binding{k.Continue, k.Back},
-		Full:  [][]kernel.Binding{{k.Continue, k.Back, k.Retry}},
+		Acts: []kernel.Binding{k.Continue, k.Back},
+		Full: [][]kernel.Binding{{k.Continue, k.Back, k.Retry}},
 	}
 }
 
@@ -61,31 +61,33 @@ var liveSets = func() [keyStates]kernel.KeySet {
 	// The first step has nowhere to go back to, and back() knows it, so the
 	// footer says so by leaving the key out.
 	sets[keysFirstStep] = kernel.KeySet{
-		Short: []kernel.Binding{k.Continue},
-		Full:  [][]kernel.Binding{{k.Continue}},
+		Acts: []kernel.Binding{k.Continue},
+		Full: [][]kernel.Binding{{k.Continue}},
 	}
 	// A site that could not be reached is the commonest way this flow fails, and
 	// it fails on the one step with nothing behind it.
 	sets[keysFirstStepFailed] = kernel.KeySet{
-		Short: []kernel.Binding{k.Retry, k.Continue},
-		Full:  [][]kernel.Binding{{k.Retry, k.Continue}},
+		Acts: []kernel.Binding{k.Retry, k.Continue},
+		Full: [][]kernel.Binding{{k.Retry, k.Continue}},
 	}
 	sets[keysTyping] = k.keySet()
+	// The arrows are the action on this step rather than a way of moving around
+	// it: they are how the option is picked, on the first screen anybody sees.
 	sets[keysChoosing] = kernel.KeySet{
-		Short: []kernel.Binding{k.Choose, k.Continue, k.Back},
-		Full:  [][]kernel.Binding{{k.Choose, k.Continue, k.Back, k.Retry}},
+		Acts: []kernel.Binding{k.Choose, k.Continue, k.Back},
+		Full: [][]kernel.Binding{{k.Choose, k.Continue, k.Back, k.Retry}},
 	}
 	sets[keysReview] = kernel.KeySet{
-		Short: []kernel.Binding{k.Write, k.Back},
-		Full:  [][]kernel.Binding{{k.Write, k.Back}},
+		Acts: []kernel.Binding{k.Write, k.Back},
+		Full: [][]kernel.Binding{{k.Write, k.Back}},
 	}
 	sets[keysDone] = kernel.KeySet{
-		Short: []kernel.Binding{k.Finish},
-		Full:  [][]kernel.Binding{{k.Finish}},
+		Acts: []kernel.Binding{k.Finish},
+		Full: [][]kernel.Binding{{k.Finish}},
 	}
 	sets[keysFailed] = kernel.KeySet{
-		Short: []kernel.Binding{k.Retry, k.Back},
-		Full:  [][]kernel.Binding{{k.Retry, k.Back, k.Continue}},
+		Acts: []kernel.Binding{k.Retry, k.Back},
+		Full: [][]kernel.Binding{{k.Retry, k.Back, k.Continue}},
 	}
 	// Nothing this view offers works while it is waiting on a site: enter and
 	// shift+tab are both refused until the answer comes back, so the footer

--- a/internal/ui/onboarding/keys_test.go
+++ b/internal/ui/onboarding/keys_test.go
@@ -75,7 +75,7 @@ func TestLiveKeys_FollowTheStepTheUserIsOn(t *testing.T) {
 		}
 		seen[gen] = tc.state
 		if tc.state == keysBusy && !set.IsZero() {
-			t.Errorf("a step waiting on the site advertises %s, none of which answers", shortOf(set))
+			t.Errorf("a step waiting on the site advertises %s, none of which answers", actsOf(set))
 		}
 	}
 }
@@ -86,11 +86,11 @@ func TestLiveKeys_FollowTheStepTheUserIsOn(t *testing.T) {
 func TestLiveKeys_TheFirstStepDoesNotOfferAWayBack(t *testing.T) {
 	t.Parallel()
 	for _, state := range []keyState{keysFirstStep, keysFirstStepFailed} {
-		if got := shortOf(liveSets[state]); strings.Contains(got, "back") {
+		if got := actsOf(liveSets[state]); strings.Contains(got, "back") {
 			t.Errorf("the first step offers a way back: %s", got)
 		}
 	}
-	if got := shortOf(liveSets[keysTyping]); !strings.Contains(got, "back") {
+	if got := actsOf(liveSets[keysTyping]); !strings.Contains(got, "back") {
 		t.Errorf("a later step lost its way back: %s", got)
 	}
 }
@@ -104,7 +104,7 @@ func TestLiveKeys_EnterIsNamedForWhatItDoesOnThisStep(t *testing.T) {
 		keysReview: "write the profile",
 		keysDone:   "start using it",
 	} {
-		if got := shortOf(liveSets[state]); !strings.Contains(got, want) {
+		if got := actsOf(liveSets[state]); !strings.Contains(got, want) {
 			t.Errorf("state %d does not say enter %q: %s", state, want, got)
 		}
 	}
@@ -122,8 +122,8 @@ func TestLiveKeys_CostNothingToAskFor(t *testing.T) {
 	}
 }
 
-func shortOf(set kernel.KeySet) string {
-	return strings.Join(labels(set.Short), " · ")
+func actsOf(set kernel.KeySet) string {
+	return strings.Join(labels(set.Acts), " · ")
 }
 
 func labels(bindings []kernel.Binding) []string {
@@ -139,7 +139,7 @@ func writeKeySet(b *strings.Builder, set kernel.KeySet) {
 		b.WriteString("  nothing of its own; the globals are all that answer\n")
 		return
 	}
-	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	fmt.Fprintf(b, "  acts   %s\n", actsOf(set))
 	for _, column := range set.Full {
 		fmt.Fprintf(b, "  full   [%s]\n", strings.Join(labels(column), ", "))
 	}

--- a/internal/ui/onboarding/testdata/keys.golden
+++ b/internal/ui/onboarding/testdata/keys.golden
@@ -1,23 +1,23 @@
 the first step
-  short  enter continue
+  acts   enter continue
   full   [enter continue]
 the first step, after it failed
-  short  ctrl+r try that again · enter continue
+  acts   ctrl+r try that again · enter continue
   full   [ctrl+r try that again, enter continue]
 a step with something to type
-  short  enter continue · shift+tab back a step
+  acts   enter continue · shift+tab back a step
   full   [enter continue, shift+tab back a step, ctrl+r try that again]
 a step with something to choose
-  short  ↑/↓ choose · enter continue · shift+tab back a step
+  acts   ↑/↓ choose · enter continue · shift+tab back a step
   full   [↑/↓ choose, enter continue, shift+tab back a step, ctrl+r try that again]
 the review
-  short  enter write the profile · shift+tab back a step
+  acts   enter write the profile · shift+tab back a step
   full   [enter write the profile, shift+tab back a step]
 the summary
-  short  enter start using it
+  acts   enter start using it
   full   [enter start using it]
 after a step failed
-  short  ctrl+r try that again · shift+tab back a step
+  acts   ctrl+r try that again · shift+tab back a step
   full   [ctrl+r try that again, shift+tab back a step, enter continue]
 waiting on the site
   nothing of its own; the globals are all that answer

--- a/internal/ui/palette/issues_test.go
+++ b/internal/ui/palette/issues_test.go
@@ -216,7 +216,7 @@ func TestPalette_EnterOverAnIssueIsAdvertisedAsOpeningIt(t *testing.T) {
 	if gen != int(keysIssue) {
 		t.Fatalf("the cursor is on an issue and the keys are in state %d", gen)
 	}
-	if labels := shortOf(set); !strings.Contains(labels, "open it") || strings.Contains(labels, "run it") {
+	if labels := actsOf(set); !strings.Contains(labels, "open it") || strings.Contains(labels, "run it") {
 		t.Errorf("the footer says %q over an issue", labels)
 	}
 }

--- a/internal/ui/palette/kernel_test.go
+++ b/internal/ui/palette/kernel_test.go
@@ -49,8 +49,8 @@ func TestSession_Frame(t *testing.T) {
 	golden(t, "session_120x30.golden", ansi.Strip(s.m.Frame()))
 
 	footer := lastLine(ansi.Strip(s.m.Frame()))
-	mustContain(t, footer, "run it", "close", "commands")
-	mustNotContain(t, footer, "quit", "help")
+	mustContain(t, footer, "run it", "close", "ctrl+k")
+	mustNotContain(t, footer, "? ctrl+k", "quit", "help")
 
 	s.press("esc")
 	mustNotContain(t, ansi.Strip(s.m.Frame()), "what do you want to do?")

--- a/internal/ui/palette/keys.go
+++ b/internal/ui/palette/keys.go
@@ -50,22 +50,22 @@ var liveSets = func() [keyStates]kernel.KeySet {
 	k := defaultKeys()
 	var sets [keyStates]kernel.KeySet
 	sets[keysOffering] = kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Run, k.Close},
+		Acts: []kernel.Binding{k.Run, k.Close},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.Run, k.Close},
 		},
 	}
 	sets[keysIssue] = kernel.KeySet{
-		Short: []kernel.Binding{k.Down, k.Up, k.Open, k.Close},
+		Acts: []kernel.Binding{k.Open, k.Close},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
 			{k.Open, k.Close},
 		},
 	}
 	sets[keysNothing] = kernel.KeySet{
-		Short: []kernel.Binding{k.Close},
-		Full:  [][]kernel.Binding{{k.Close}},
+		Acts: []kernel.Binding{k.Close},
+		Full: [][]kernel.Binding{{k.Close}},
 	}
 	return sets
 }()

--- a/internal/ui/palette/keys_test.go
+++ b/internal/ui/palette/keys_test.go
@@ -50,11 +50,11 @@ func TestLiveKeys_FollowWhetherThereIsAnythingToRun(t *testing.T) {
 	if emptyGen == gen {
 		t.Errorf("both states report generation %d, so the footer will not repaint between them", gen)
 	}
-	if shortOf(empty) == shortOf(set) {
-		t.Errorf("the same keys are advertised with and without a match: %s", shortOf(empty))
+	if actsOf(empty) == actsOf(set) {
+		t.Errorf("the same keys are advertised with and without a match: %s", actsOf(empty))
 	}
-	if !strings.Contains(shortOf(empty), "close") {
-		t.Errorf("nothing matching leaves no key advertised at all: %s", shortOf(empty))
+	if !strings.Contains(actsOf(empty), "close") {
+		t.Errorf("nothing matching leaves no key advertised at all: %s", actsOf(empty))
 	}
 }
 
@@ -89,7 +89,7 @@ func TestKeys_TheDispatcherAnswersExactlyWhatTheBindingsSay(t *testing.T) {
 }
 
 func writeKeySet(b *strings.Builder, set kernel.KeySet) {
-	fmt.Fprintf(b, "  short  %s\n", shortOf(set))
+	fmt.Fprintf(b, "  acts   %s\n", actsOf(set))
 	for _, column := range set.Full {
 		labels := make([]string, 0, len(column))
 		for _, binding := range column {

--- a/internal/ui/palette/palette_test.go
+++ b/internal/ui/palette/palette_test.go
@@ -174,7 +174,7 @@ func TestPalette_NothingMatchingSaysSoAndOffersNoKeysThatWouldDoAnything(t *test
 	if gen != int(keysNothing) {
 		t.Errorf("the keys are in state %d with nothing on offer", gen)
 	}
-	if labels := shortOf(set); strings.Contains(labels, "run it") {
+	if labels := actsOf(set); strings.Contains(labels, "run it") {
 		t.Errorf("the footer offers enter with nothing to run: %s", labels)
 	}
 }
@@ -410,9 +410,9 @@ func lineWith(t *testing.T, frame, want string) string {
 	return ""
 }
 
-func shortOf(set kernel.KeySet) string {
-	out := make([]string, 0, len(set.Short))
-	for _, b := range set.Short {
+func actsOf(set kernel.KeySet) string {
+	out := make([]string, 0, len(set.Acts))
+	for _, b := range set.Acts {
 		out = append(out, b.Help().Key+" "+b.Help().Desc)
 	}
 	return strings.Join(out, " · ")

--- a/internal/ui/palette/testdata/keys.golden
+++ b/internal/ui/palette/testdata/keys.golden
@@ -1,11 +1,11 @@
 something to run
-  short  ↓ down · ↑ up · enter run it · esc close
+  acts   enter run it · esc close
   full   [↓ down, ↑ up, pgdn page down, pgup page up]
   full   [enter run it, esc close]
 a cached issue under the cursor
-  short  ↓ down · ↑ up · enter open it · esc close
+  acts   enter open it · esc close
   full   [↓ down, ↑ up, pgdn page down, pgup page up]
   full   [enter open it, esc close]
 nothing matches
-  short  esc close
+  acts   esc close
   full   [esc close]

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -27,4 +27,4 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- g1 Issues                                                    ↓ down | ↑ up | enter run it | esc close | ctrl+k commands
+ Issues  enter run it  esc close                                                                                  ctrl+k

--- a/internal/ui/testdata/footer_100x28.golden
+++ b/internal/ui/testdata/footer_100x28.golden
@@ -1,0 +1,16 @@
+comment
+ Issues  a write  e edit  d delete                                                      ? ctrl+k esc
+form
+ Issues  enter use this issue type                                                      ? ctrl+k esc
+issue
+ Issues  e edit  t status  c comment                                                    ? ctrl+k esc
+issue.edit
+ Issues  enter change  del empty  ctrl+s save  X discard                                ? ctrl+k esc
+issue.move
+ Issues  enter choose                                                                   ? ctrl+k esc
+list
+ Issues  enter open  / filter  a all  e search  s save                                    ? ctrl+k q
+onboarding
+ Issues  enter continue                                                                       ctrl+k
+palette
+ Issues  enter run it  esc close                                                              ctrl+k

--- a/internal/ui/testdata/footer_120x38.golden
+++ b/internal/ui/testdata/footer_120x38.golden
@@ -1,0 +1,16 @@
+comment
+ Issues  a write  e edit  d delete                                                                          ? ctrl+k esc
+form
+ Issues  enter use this issue type                                                                          ? ctrl+k esc
+issue
+ Issues  e edit  t status  c comment                                                                        ? ctrl+k esc
+issue.edit
+ Issues  enter change  del empty  ctrl+s save  X discard                                                    ? ctrl+k esc
+issue.move
+ Issues  enter choose                                                                                       ? ctrl+k esc
+list
+ Issues  enter open  / filter  a all  e search  s save                                                        ? ctrl+k q
+onboarding
+ Issues  enter continue                                                                                           ctrl+k
+palette
+ Issues  enter run it  esc close                                                                                  ctrl+k

--- a/internal/ui/testdata/footer_80x20.golden
+++ b/internal/ui/testdata/footer_80x20.golden
@@ -1,0 +1,16 @@
+comment
+ Issues  a write  e edit  d delete                                  ? ctrl+k esc
+form
+ Issues  enter use this issue type                                  ? ctrl+k esc
+issue
+ Issues  e edit  t status  c comment                                ? ctrl+k esc
+issue.edit
+ Issues  enter change  del empty  ctrl+s save  X discard            ? ctrl+k esc
+issue.move
+ Issues  enter choose                                               ? ctrl+k esc
+list
+ Issues  enter open  / filter  a all  e search  s save                ? ctrl+k q
+onboarding
+ Issues  enter continue                                                   ctrl+k
+palette
+ Issues  enter run it  esc close                                          ctrl+k

--- a/internal/ui/testdata/overlay_120x38.golden
+++ b/internal/ui/testdata/overlay_120x38.golden
@@ -1,0 +1,42 @@
+comment
+a write a comment    ↓/j  down         ctrl+d half page down    1-9   saved query           ctrl+k commands
+e edit this one      ↑/k  up           ctrl+u half page up      g 1-9 switch view           ?      help
+d delete this one    pgdn page down    g g    oldest            esc   back                  q      quit
+                     pgup page up      G      newest            r     refresh
+                                                                R     refetch everything
+
+form
+enter use this issue type    ↓/j  down         1-9   saved query           ctrl+k commands
+                             ↑/k  up           g 1-9 switch view           ?      help
+                             home first row    esc   back                  q      quit
+                             end  last row     r     refresh
+                                               R     refetch everything
+
+issue
+e edit fields      ↓/j    down         d/ctrl+d half page down    1-9   saved query           ctrl+k commands
+t change status    ↑/k    up           u/ctrl+u half page up      g 1-9 switch view           ?      help
+c comment          f/pgdn page down    g g      top               esc   back                  q      quit
+                   b/pgup page up      G        bottom            r     refresh
+                                                                  R     refetch everything
+
+issue.edit
+enter  change this field    ↓/j down    ←/h previous value    1-9   saved query           ctrl+k commands
+del    empty this field     ↑/k up      →/l next value        g 1-9 switch view           ?      help
+ctrl+s save                                                   esc   back                  q      quit
+X      discard changes                                        r     refresh
+                                                              R     refetch everything
+
+issue.move
+enter choose    ↓/j down    1-9   saved query           ctrl+k commands
+                ↑/k up      g 1-9 switch view           ?      help
+                            esc   back                  q      quit
+                            r     refresh
+                            R     refetch everything
+
+list
+enter open                        ↓/j  down         ctrl+d half page down    1-9   saved query           ctrl+k commands
+/     filter                      ↑/k  up           ctrl+u half page up      g 1-9 switch view           ?      help
+a     all issues                  pgdn page down    g g    first row         esc   back                  q      quit
+e     edit this search            pgup page up      G      last row          r     refresh
+s     save this query to a key                                               R     refetch everything
+


### PR DESCRIPTION
## Why

The owner said the CLI "feels too many button clicks, or views to change and commands to select before
I can do something". The cause is not depth. **The bottom row was over capacity and gave up the wrong
end of itself.**

Verified before designing anything:

- The seven view slots `docs/UX.md` reserves cost **81 columns** — each entry is `len(label)+2` because
  `footer()` styles it `Padding(0,1)` — against the **80** the program documents as its minimum.
- `internal/ui/issue/testdata/session_issue_80x20.golden` ended mid-list: `? help`, `esc back` and, in
  the real binary where `internal/ui/views.go` imports the palette, `ctrl+k commands` were **all past
  the ellipsis**. Run at 80 columns against real Jira, the program never said `ctrl+k` existed.
- `internal/ui/issue/testdata/session_thread_100x28.golden` was **twelve bytes** — ` g1 Issues ` and
  nothing else. `bubbles/help` truncates loosely and overflows by a column; the kernel computed
  `gap = width - len(left) - len(hints)`, found it below 1, and threw the *whole line* away. At 80 it
  truncated, at 100 it vanished, at 120 it fit. A committed golden encoded that. (#96)
- The issue pane answers **sixteen strokes, thirteen of them motions**, so a row listing them in
  declaration order spent itself on scrolling.

## What this does

**One row, three cells. No second row at any width** — the constraint is width, not height, and
another row would be truncated the same way while costing a view one line in thirteen (at 80×20 the
body is 17 rows with a status line up, and the list has as few as 13 live rows).

| cell | content | drop order |
|---|---|---|
| root | the current **root** view's title | third |
| actions | `KeySet.Acts`, most-used first, terse; overflow → `+N` | second, from the right |
| globals | `? ctrl+k esc` (or `q` at the bottom of the stack) | **never** |

```
 Issues  e edit  t status  c comment                                ? ctrl+k esc
 Issues  enter open  / filter  a all  e search  s save                ? ctrl+k q
 Issues  a write  e edit  d delete                                  ? ctrl+k esc
```

The squeeze order is the whole point: actions fold into a `+N` from the right, then the root cell
goes, then the actions keep their keys and lose their descriptions. The globals are not on that
ladder. `oneLine`/`MaxWidth` already guaranteed one row; nothing wraps.

**`KeySet` gains `Acts`**, filled in all seven key scopes with the actions those views already had.
**No new keys — a pure re-partition.** Terse labels are load-bearing (`e edit fields` → `e edit`);
the sentence stays in `?`. A prompt state keeps its words, because two answers to one question always
fit and the wording is the point of asking.

**`?` now leads with the actions and lists every key exactly once.** The first cut put `Acts` in front
of a `Full` that still carried the same actions in full, which cost two columns and pushed the globals
off the right of a 120-column screen. `mergeKeys` instead builds the leading column from `Acts` in the
row's order, carrying the longest description any column gives that key, and draws the rest of `Full`
with the actions taken out. The result is in `internal/ui/testdata/overlay_120x38.golden`.

**Every entry is a zone** under the kernel's prefix, and a click is fed back through the kernel's own
key handling as the binding's **first stroke** — so key, palette entry and pointer are one
implementation. `kernel.Stroke` is the inverse of `tea.Key.String`, which is what `key.Matches`
compares against; it refuses a stroke it cannot spell rather than delivering a different key. `+N`
opens `?`; the root cell goes back to that root.

### Two claims the issue pane made, false in opposite directions

`m.key()` ends with `m.pager, _ = m.pager.Update(msg)` and never matched its own
`PageUp`/`PageDown`/`HalfUp`/`HalfDown`. So:

- **`ctrl+f` and `ctrl+b` were advertised and bound by nothing.** `viewport.DefaultKeyMap` binds
  neither. The footer's claim was correct only by coincidence for the rest.
- **the pager's bare `f`, `b`, `u` and `d` worked and were named nowhere** — not the registry, not `?`,
  not the row.

The keymap now spells what the widget answers to: `f/pgdn`, `b/pgup`, `u/ctrl+u`, `d/ctrl+d`.

### Landed for the packets that follow

`internal/ui/kernel/external.go`: `Copy`, `OpenURL`, `IssueURL`.

- **An OSC 52 write cannot be confirmed.** It is an escape sequence out to the terminal; a terminal or
  multiplexer that refuses it drops it silently, so there is no error and a copy that never happened
  looks exactly like one that did. `Copy` therefore names what it copied on the status line itself
  rather than trusting a caller to remember.
- **`Deps.Site` was documented "for display only" and nothing validates its shape past onboarding.**
  The comment is corrected, and `IssueURL` parses rather than concatenates: a scheme already on the
  front, a port, the context path a Data Center install is served under, a trailing slash. It refuses
  what is not a site — `javascript:alert(1)` does not become `https://javascript:alert(1)`.

## Honesty gates

- `internal/ui/livekeys_test.go` gains two passes. Every registered scope's resting set must name an
  action; every reporting view must name one in the state it opens in, or be listed in `actionFree`
  **with the reason** (three states are: a save in flight, a transition in flight, a step being checked
  against the site). And every advertised action must have a first stroke `kernel.Stroke` can turn back
  into a keypress, and a key label no sibling shares — the zone a click resolves to is minted from that
  label.
- `internal/ui/keys_test.go`'s label walk learns `Acts`, so a command's advertised key is still held
  against the row that shows it.

## Tests

- `internal/ui/testdata/footer_{80x20,100x28,120x38}.golden` — **every view at all three sizes**, drawn
  through the real kernel in the only package that registers the palette, so it is the only place
  `ctrl+k` is honestly on the row.
- `internal/ui/testdata/overlay_120x38.golden` — every non-capturing view's `?`.
- Width sweeps 80→132, twice: over a synthetic seven-action view in the kernel, and over every real
  view in `internal/ui`. Both assert the globals survive and the row never exceeds the width.
- `TestFooter_GivesThingsUpInOrder` — one case per rung of the ladder.
- `TestFooter_ClickingAnActionArrivesAtTheViewAsItsKey`, `…ClickingTheCountOpensTheOverlay…`,
  `TestMouse_ClickingTheRootCellGoesBackToTheRoot`.
- `TestStroke_IsTheInverseOfHowAKeyIsSpelt` over 45 strokes, plus the two refusals.
- `TestFooter_AnActionThatLeftTheRowStopsAnsweringToWhereItWas` — the zones are minted from a label and
  the click handler walks the whole inventory, so what stops an action that folded into a `+N` from
  still answering in the gap it used to occupy is bubblezone rebuilding its positions from each scanned
  frame. I went looking for a stale-zone bug here, built the machinery to carry the drawn set through
  `chromeCache`, then measured and found `Get` returns nothing for an id the current frame does not
  carry. The machinery is gone; the test that would have caught it stays.
- `TestFooter_ClickingCloseHelpClosesTheOverlay` — the row says `? close help` while `?` is up, so
  pointing at it closes the overlay. The other two cells are deliberately inert there: switching root
  view under an overlay would leave it covering a view nobody asked to see.
- `internal/ui/kernel/external_test.go` — nine site shapes that must work, six that must be refused,
  the clipboard note, and every desktop's handler. Nothing runs a browser or a clipboard: both are
  messages handed back to Bubble Tea.

### Goldens that changed, and why

Every frame golden containing the row: `internal/ui/kernel/{frame_*,chrome_*,help_*}`,
`internal/ui/list/list_*`, `internal/ui/issue/session_*`, `internal/ui/palette/session_120x30`, and the
seven `keys.golden`. Three kinds of change:

1. The row itself: ` g1 Board  g2 Backlog        enter open | / filter | ? help | q quit` becomes
   ` Board  enter open  / filter                                                 ? q`.
2. **`session_thread_100x28.golden` stops being twelve bytes** and carries a full row.
3. `keys.golden` records `acts` where it recorded `short`, and the overlay columns lose the actions
   they now list once.

## Performance

`main` vs this branch, eight runs each, medians (M2 Pro):

| | ns/op | allocs/op |
|---|---|---|
| `BenchmarkFrame` — main | 124,221 | **297** |
| `BenchmarkFrame` — branch | 123,309 | **297** |
| `BenchmarkKeyToFrame` — main | 123,800 | **310** |
| `BenchmarkKeyToFrame` — branch | 125,143 | **310** |

**Allocations are identical.** Nothing new allocates per frame: `chromeFor` still memoizes on a
comparable key, `LiveKeys` still hands back a stored value, and what makes the row change reaches
`chromeKey` as `keysGen` rather than as a `KeySet`. Times are within run-to-run noise (an early reading
showed +8% and did not reproduce). #103 still stands — nothing asserts these numbers, which is why
they were measured on both sides rather than assumed.

## Deviations from the packet's owned paths

Three test files outside the list had to change, because the design they were written against is the
one this replaces. Each keeps its property and states the new premise; none is weakened or skipped:

- `internal/ui/kernel/palette_test.go` — `TestSlotGesture_IsSpeltTheWayTheFooterSpellsIt` asserted
  `g3 Board` on the row. The row names one destination now, so the test became
  `TestSlotGesture_ReachesTheViewWhoseSlotItWasBuiltFrom`: the gesture is `g3`, it opens the view
  holding slot 3 and not slot 4, and `?` teaches the digits. And
  `TestFooter_StillOffersThePaletteToAViewThatIsTakingTyping` asserted the word "commands"; the globals
  are bare keys, so it asserts `ctrl+k` and the absence of `? ctrl+k` and a trailing `q`.
- `internal/ui/issue/comments_kernel_test.go` — three session tests asserted `"a write a comment"`,
  `"down"`, `"up"` and `"edit fields"` on the row. No reading of this design keeps them: the motions
  left the row and the labels are terse. `TestSession_TheSmallestTerminalStillTeachesThePanesKeys` is
  now stronger — it asserts every action *and* the way out survive at 80 columns and that nothing is
  ellipsised.
- `internal/ui/palette/{palette,issues,kernel}_test.go` and `internal/ui/list/empty_test.go` — a
  `shortOf` helper reading `KeySet.Short`, renamed and pointed at `Acts`.

One design decision differs from the packet's example labels. The thread's `a write a comment` became
**`a write`**, not `c comment`: the thread's write key matches both `a` and `c`, and relabelling it `c`
would collide with the issue pane's `c comment` and kill the property
`TestSession_TheFooterNamesTheKeyOnlyWhereItOpensTheThread` exists to hold — that the footer names `c`
where it *opens* the thread and not inside it.

The two target renderings in the packet show `y copy` and `o open` on the issue pane. Those keys do not
exist yet; `kernel.Copy`/`OpenURL`/`IssueURL` land here so the packets that bind them can. The goldens
show today's inventory.

## What P3.7–P3.11 code against

```go
type KeySet struct {
	Acts  []Binding   // the footer's middle cell: what can be done here, most-used first, terse
	Short []Binding   // the one-line bubbles/help form; the footer's fallback when Acts is empty
	Full  [][]Binding // the ? overlay, one inner slice per column
}

func (k KeySet) IsZero() bool

func Terse(b Binding, desc string) Binding
func Stroke(b Binding) (tea.KeyPressMsg, bool)

func Copy(text, what string) tea.Cmd
func OpenURL(link string) tea.Cmd
func IssueURL(site, key string) (string, error)
```

`kernel.RegisterKeys` and `kernel.KeyReporter` are unchanged. `internal/ui/kernel/registry.go` is
untouched: slot registration is P3.7's.

Closes #96. Part of #16.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
