### PR TITLE
feat(issue): fetch the custom fields an issue really has, labelled the way the site spells them

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -502,6 +502,17 @@ of headroom under the 15 MiB binary gate. So the display renderer is written her
   Lines are not padded to `Width` — padding belongs to the pane — and `Widths` is reported so a pane
   can clamp panning without measuring. Code is neither wrapped nor cut and a grid wraps inside its
   columns, so the two constructs allowed past the width are the only ones that go past it.
+- [x] **R2 — The custom fields the detail read never asked for** · **owns** `internal/app/search.go`,
+  `internal/app/search_test.go`, this row
+  `app.DetailProjection()` asked for twenty platform fields and none of the site's own, so story
+  points, the sprint, the epic link and the acceptance criteria were missing from the answer before
+  any view had the chance to draw them. `Projection.Custom` expands into every `Field.Custom` ID in
+  the catalogue `Search` already fetches and caches, and the answer carries `app.FieldLabels` — field
+  ID to the name this site displays — because `customfield_13401` is not a name a person can read and
+  the label is translated, so it has to be resolved at runtime rather than written down.
+  Deliberately not `jira.FieldsNavigable`: a wildcard returns a value per field per issue with
+  nothing to label any of them by, and it reports itself as a read of everything, which is how a
+  narrow cached row starts looking wide. `Issue.Requested` still names exactly what was asked for.
 
 ## Batch 4 — Attachments · parallel ×3
 

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -40,9 +40,9 @@ type SearchClient interface {
 
 // Projection is the narrow set of fields one view needs.
 //
-// It is split in two because only half of it can be written down. IDs are the
-// platform's own field identifiers, which are the same on every site; Names are
-// display names resolved against the site's field catalogue at runtime, which
+// It is in three parts because only one of them can be written down. IDs are
+// the platform's own field identifiers, which are the same on every site; Names
+// and Custom are resolved against the site's field catalogue at runtime, which
 // is the only way to ask for a custom field without writing a customfield_NNNNN
 // into the source. A name the site has no field for is reported, never guessed.
 type Projection struct {
@@ -50,6 +50,16 @@ type Projection struct {
 	Name  string
 	IDs   []string
 	Names []string
+	// Custom asks for every custom field this site defines, by taking their IDs
+	// from the catalogue Search already holds. It is how story points, the
+	// sprint, the epic link and the acceptance criteria — most of what an issue
+	// is on a configured site — arrive without a customfield_NNNNN anywhere in
+	// the source and without a name having to be written down first.
+	//
+	// It belongs on a read of one issue. A site with two hundred custom fields
+	// turns a page of fifty rows into ten thousand values nothing renders, so a
+	// list projection leaves it off.
+	Custom bool
 }
 
 // With returns a copy of the projection asking for more field IDs, which is how
@@ -66,6 +76,13 @@ func (p Projection) WithNames(names ...string) Projection {
 	return p
 }
 
+// WithCustom returns a copy of the projection asking for this site's custom
+// fields as well.
+func (p Projection) WithCustom() Projection {
+	p.Custom = true
+	return p
+}
+
 // ListProjection is what a row in a list needs and nothing else. Six fields,
 // not sixty: a bare issue read returns every field on the site, and on a site
 // with ninety custom fields that is ninety nulls per row.
@@ -76,11 +93,14 @@ func ListProjection() Projection {
 	}
 }
 
-// DetailProjection is what one open issue needs. It is wider than a list row
-// and still narrower than everything.
+// DetailProjection is what one open issue needs: the platform fields an issue
+// screen draws, plus whatever custom fields this site defines. It is wider than
+// a list row and still narrower than a wildcard, whose values arrive with
+// nothing to label them by.
 func DetailProjection() Projection {
 	return Projection{
-		Name: "issue detail",
+		Name:   "issue detail",
+		Custom: true,
 		IDs: []string{
 			"summary", "status", "assignee", "priority", "updated", "issuetype",
 			"description", "project", "reporter", "labels", "components",
@@ -96,7 +116,72 @@ type Resolved struct {
 	// Missing names the fields this site has none of, so that a view can say so
 	// instead of rendering an empty column.
 	Missing []string
+	// Labels is what this site calls the fields that were asked for. It is
+	// filled whenever resolving needed the catalogue and empty otherwise, so
+	// that a list of six platform IDs still resolves without a fetch.
+	Labels FieldLabels
 }
+
+// FieldLabels is what a site calls the fields one read asked for, keyed by
+// field ID.
+//
+// The two halves are not interchangeable. An ID identifies a field: it is what
+// a value arrives under, what the cache is keyed by and what a write names. A
+// name only displays one, and customfield_13401 is not a name anyone can read.
+// A name is also translated, is not the spelling the same field answers to in
+// JQL, and has been seen changing between two reads in one session — so it
+// travels beside the answer it was read with and is never written down as
+// though it identified anything.
+//
+// It is immutable for the reason jira.FieldSet is: it travels by value out of a
+// search that several callers may be sharing.
+type FieldLabels struct {
+	refs map[string]jira.FieldRef
+}
+
+// NewFieldLabels labels the field IDs a read asked for, taking each name from
+// the catalogue as this site spells it now. An ID the catalogue has no field
+// for is left unlabelled rather than handed its own ID as a name: whether to
+// show a raw ID is the caller's decision.
+func NewFieldLabels(catalogue []jira.Field, ids []string) FieldLabels {
+	if len(catalogue) == 0 || len(ids) == 0 {
+		return FieldLabels{}
+	}
+	refs := make(map[string]jira.FieldRef, len(ids))
+	for i := range catalogue {
+		if slices.Contains(ids, catalogue[i].ID) {
+			refs[catalogue[i].ID] = catalogue[i].Ref()
+		}
+	}
+	if len(refs) == 0 {
+		return FieldLabels{}
+	}
+	return FieldLabels{refs: refs}
+}
+
+// Name returns what this site calls a field, or the empty string when the read
+// carried no label for it.
+func (l FieldLabels) Name(id string) string { return l.refs[id].Name }
+
+// Field returns the reference for a field ID: the name to put on screen and the
+// schema that says what its value is.
+func (l FieldLabels) Field(id string) (jira.FieldRef, bool) {
+	ref, ok := l.refs[id]
+	return ref, ok
+}
+
+// IDs returns the labelled field IDs, sorted, so that iteration is stable.
+func (l FieldLabels) IDs() []string {
+	out := make([]string, 0, len(l.refs))
+	for id := range l.refs {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// Len reports how many fields are labelled.
+func (l FieldLabels) Len() int { return len(l.refs) }
 
 // Request is one search to run.
 type Request struct {
@@ -114,6 +199,10 @@ type Request struct {
 type Result struct {
 	Page    jira.Page[jira.Issue]
 	Missing []string
+	// Labels names the fields the page's issues carry values for, for the
+	// reason Resolved carries them: a value keyed by customfield_13401 cannot
+	// be rendered on its own.
+	Labels FieldLabels
 }
 
 // Search is the use case behind every issue list.
@@ -156,10 +245,23 @@ func NewSearch(client SearchClient, opts ...Option) *Search {
 var errNoClient = errors.New("app: this search has no Jira client to run against")
 
 // Fields returns the site's field catalogue, fetched once and kept until
-// Invalidate drops it. Resolving a field name is the only reason anything above
-// the adapter needs it, and it changes about as often as the site's
-// configuration does.
+// Invalidate drops it. Resolving a field is the only reason anything above the
+// adapter needs it — a name into the ID to ask for, an ID into the name to show
+// — and it changes about as often as the site's configuration does.
 func (s *Search) Fields(ctx context.Context) ([]jira.Field, error) {
+	fields, err := s.fields(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cloneFields(fields), nil
+}
+
+// fields is the catalogue itself rather than a copy of it, for the readers
+// inside this package that only read. It stays unexported because a caller that
+// wrote to what it returns would be writing into the cache — and copying a
+// hundred field definitions to resolve one projection is a cost every issue a
+// user opens would pay.
+func (s *Search) fields(ctx context.Context) ([]jira.Field, error) {
 	if s.client == nil {
 		return nil, errNoClient
 	}
@@ -179,7 +281,7 @@ func (s *Search) Fields(ctx context.Context) ([]jira.Field, error) {
 	s.mu.Lock()
 	s.catalogue, s.loaded = fields, true
 	s.mu.Unlock()
-	return cloneFields(fields), nil
+	return fields, nil
 }
 
 // Invalidate drops the cached field catalogue, which is what a refresh that
@@ -196,24 +298,30 @@ func (s *Search) cached() ([]jira.Field, bool) {
 	if !s.loaded {
 		return nil, false
 	}
-	return cloneFields(s.catalogue), true
+	return s.catalogue, true
 }
 
-// Resolve turns a projection into the field IDs to ask for.
+// Resolve turns a projection into the field IDs to ask for, and into what this
+// site calls each of them.
 //
-// The catalogue is fetched only when the projection names a field, so the list
-// view — six platform field IDs and no names — resolves without touching the
-// network at all.
+// The catalogue is fetched only when the projection names a field or asks for
+// the custom ones, so the list view — six platform field IDs and no names —
+// resolves without touching the network at all.
+//
+// Custom fields are taken from the catalogue by ID rather than asked for with
+// jira.FieldsNavigable. The wildcard is both wider and less useful: it returns
+// a value per field per issue, and it returns them keyed by IDs the answer
+// carries no names for, which is a screen of customfield_13401.
 func (s *Search) Resolve(ctx context.Context, p Projection) (Resolved, error) {
 	out := Resolved{IDs: make([]string, 0, len(p.IDs)+len(p.Names))}
 	for _, id := range p.IDs {
 		out.IDs = appendUnique(out.IDs, id)
 	}
 	names := trimmed(p.Names)
-	if len(names) == 0 {
+	if len(names) == 0 && !p.Custom {
 		return out, nil
 	}
-	catalogue, err := s.Fields(ctx)
+	catalogue, err := s.fields(ctx)
 	if err != nil {
 		return Resolved{}, err
 	}
@@ -225,6 +333,14 @@ func (s *Search) Resolve(ctx context.Context, p Projection) (Resolved, error) {
 		}
 		out.IDs = appendUnique(out.IDs, field.ID)
 	}
+	if p.Custom {
+		for i := range catalogue {
+			if catalogue[i].Custom {
+				out.IDs = appendUnique(out.IDs, catalogue[i].ID)
+			}
+		}
+	}
+	out.Labels = NewFieldLabels(catalogue, out.IDs)
 	return out, nil
 }
 
@@ -254,7 +370,7 @@ func (s *Search) Run(ctx context.Context, r Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	return Result{Page: page, Missing: resolved.Missing}, nil
+	return Result{Page: page, Missing: resolved.Missing, Labels: resolved.Labels}, nil
 }
 
 // Count reports roughly how many issues a query matches, and whether this
@@ -410,7 +526,7 @@ type SavedQuery struct {
 }
 
 func (q SavedQuery) projection() Projection {
-	if len(q.Projection.IDs) == 0 && len(q.Projection.Names) == 0 {
+	if len(q.Projection.IDs) == 0 && len(q.Projection.Names) == 0 && !q.Projection.Custom {
 		return ListProjection()
 	}
 	return q.Projection

--- a/internal/app/search_test.go
+++ b/internal/app/search_test.go
@@ -3,8 +3,10 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"slices"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -613,5 +615,588 @@ func TestSearch_WithNoClientSaysSoRatherThanPanicking(t *testing.T) {
 	}
 	if _, err := s.Fields(t.Context()); err == nil {
 		t.Error("a catalogue read with no client to read from succeeded")
+	}
+}
+
+const oneIssue = `key = "PROJ-1"`
+
+// translatedFields is a catalogue the way a site that is not in English sends
+// one: no untranslated name on a system field, a display name per custom field
+// in the site's own language that its untranslated spelling does not match, and
+// one custom field no JQL clause can name.
+func translatedFields() []jira.Field {
+	return []jira.Field{
+		{
+			ID: "summary", Key: "summary", Name: "Zusammenfassung",
+			Navigable: true, Searchable: true, Orderable: true,
+			ClauseNames: []string{"summary"},
+			Schema:      jira.FieldSchema{Type: "string", System: "summary"},
+		},
+		{
+			ID: "status", Key: "status", Name: "Bearbeitungsstand",
+			Navigable: true, Searchable: true, Orderable: true,
+			ClauseNames: []string{"status"},
+			Schema:      jira.FieldSchema{Type: "status", System: "status"},
+		},
+		{
+			ID: "customfield_20001", Key: "customfield_20001",
+			Name: "Aufwandspunkte", UntranslatedName: "EffortPoints", Custom: true,
+			Navigable: true, Searchable: true, Orderable: true,
+			ClauseNames: []string{"cf[20001]", "EffortPoints"},
+			Schema: jira.FieldSchema{
+				Type:     "number",
+				Custom:   "com.atlassian.jira.plugin.system.customfieldtypes:float",
+				CustomID: 20001,
+			},
+		},
+		{
+			ID: "customfield_20002", Key: "customfield_20002",
+			Name: "Abnahmekriterien", UntranslatedName: "AcceptanceCriteria", Custom: true,
+			Navigable: true,
+			Schema: jira.FieldSchema{
+				Type:     "string",
+				Custom:   "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
+				CustomID: 20002,
+			},
+		},
+	}
+}
+
+func systemFieldsOnly() []jira.Field {
+	all := translatedFields()
+	out := make([]jira.Field, 0, len(all))
+	for i := range all {
+		if !all[i].Custom {
+			out = append(out, all[i])
+		}
+	}
+	return out
+}
+
+// translatedSite is one issue on a site whose fields are the ones above, with a
+// value under each of the two custom field IDs.
+func translatedSite(fields []jira.Field) *jiratest.Fake {
+	return jiratest.New(
+		jiratest.WithFields(fields),
+		jiratest.WithIssues([]jira.Issue{{
+			ID:      "30001",
+			Key:     "PROJ-1",
+			Project: jira.ProjectRef{ID: "10001", Key: "PROJ", Name: "Bestellwesen"},
+			Summary: "Der Export läuft zweimal",
+			Fields: jira.NewFieldSet(map[string]jira.FieldValue{
+				"customfield_20001": {Kind: jira.KindNumber, Number: 5},
+				"customfield_20002": {Kind: jira.KindText, Text: "Zwei Läufe, eine Datei"},
+			}),
+		}}),
+	)
+}
+
+// fieldNamed is the ID this site holds a field under, which is the only way to
+// get at one from a test without writing a customfield_NNNNN down.
+func fieldNamed(t *testing.T, f *jiratest.Fake, name string) jira.Field {
+	t.Helper()
+
+	catalogue, err := f.Fields(t.Context())
+	if err != nil {
+		t.Fatalf("reading the catalogue: %v", err)
+	}
+	field, err := jira.ResolveField(catalogue, name)
+	if err != nil {
+		t.Fatalf("resolving %q on this site: %v", name, err)
+	}
+	return field
+}
+
+func TestDetailProjection_AsksForTheCustomFieldsAndTheListOneDoesNot(t *testing.T) {
+	t.Parallel()
+
+	if !DetailProjection().Custom {
+		t.Error("an open issue does not ask for this site's custom fields, which are most of what an issue is")
+	}
+	if ListProjection().Custom {
+		t.Error("a list row asks for every custom field, which is a hundred values per row nothing renders")
+	}
+}
+
+func TestProjection_WithCustomLeavesTheOneItWasBuiltFromAlone(t *testing.T) {
+	t.Parallel()
+
+	base := ListProjection()
+	wider := base.WithCustom()
+
+	if base.Custom {
+		t.Error("widening a field set to the custom fields changed the one it was built from")
+	}
+	if !wider.Custom {
+		t.Error("the widened field set does not ask for the custom fields")
+	}
+	if !slices.Equal(base.IDs, wider.IDs) {
+		t.Errorf("asking for the custom fields changed the platform IDs: %v against %v", wider.IDs, base.IDs)
+	}
+}
+
+func TestRun_ADetailReadBringsBackTheCustomValuesAndWhatTheSiteCallsThem(t *testing.T) {
+	t.Parallel()
+
+	f := testFake(9)
+	points := fieldNamed(t, f, "Story Points")
+
+	got, err := NewSearch(f).Run(t.Context(), Request{
+		JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1,
+	})
+	if err != nil {
+		t.Fatalf("reading one issue: %v", err)
+	}
+	if len(got.Page.Items) != 1 {
+		t.Fatalf("the read came back with %d issues, want 1", len(got.Page.Items))
+	}
+	if len(got.Missing) != 0 {
+		t.Errorf("the read reported %v missing; nothing was asked for by name", got.Missing)
+	}
+
+	issue := got.Page.Items[0]
+	if issue.Fields.Len() == 0 {
+		t.Fatal("the issue carries no custom field values, which is most of what an issue is on a configured site")
+	}
+	ref, ok := got.Labels.Field(points.ID)
+	if !ok {
+		t.Fatalf("%s came back with no label, so a view can only render its ID", points.ID)
+	}
+	if ref.Name != points.Name {
+		t.Errorf("%s is labelled %q, want %q: the name is the one this site displays", points.ID, ref.Name, points.Name)
+	}
+	if value, ok := issue.Fields.Number(ref); !ok || value == 0 {
+		t.Errorf("reading %s through its own label gave %v (%t)", points.ID, value, ok)
+	}
+	for _, id := range issue.Fields.IDs() {
+		if got.Labels.Name(id) == "" {
+			t.Errorf("the issue carries a value for %s that nothing can name", id)
+		}
+	}
+}
+
+func TestResolve_TakesEveryCustomFieldIDFromTheCatalogueRatherThanAWildcard(t *testing.T) {
+	t.Parallel()
+
+	f := testFake(0)
+	catalogue, err := f.Fields(t.Context())
+	if err != nil {
+		t.Fatalf("reading the catalogue: %v", err)
+	}
+
+	got, err := NewSearch(f).Resolve(t.Context(), DetailProjection())
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	custom := 0
+	for i := range catalogue {
+		if !catalogue[i].Custom {
+			continue
+		}
+		custom++
+		if !slices.Contains(got.IDs, catalogue[i].ID) {
+			t.Errorf("%s is a custom field on this site and was not asked for", catalogue[i].ID)
+		}
+		if got.Labels.Name(catalogue[i].ID) != catalogue[i].Name {
+			t.Errorf("%s resolved without the name to render it by", catalogue[i].ID)
+		}
+	}
+	if custom == 0 {
+		t.Fatal("this site has no custom fields, so the test proves nothing")
+	}
+	for _, wildcard := range []string{jira.FieldsAll, jira.FieldsNavigable} {
+		if slices.Contains(got.IDs, wildcard) {
+			t.Errorf("the read asks for %s, which returns a value per field per issue and no name for any of them", wildcard)
+		}
+	}
+	if jira.NewFieldMask(got.IDs).Wide() {
+		t.Error("a field set taken from the catalogue reports itself as a read of everything, which would let a narrow cached row look wide")
+	}
+}
+
+func TestResolve_LabelsACustomFieldWithTheNameThisSiteShowsNotItsUntranslatedOne(t *testing.T) {
+	t.Parallel()
+
+	f := translatedSite(translatedFields())
+	got, err := NewSearch(f).Resolve(t.Context(), DetailProjection())
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	if name := got.Labels.Name("customfield_20001"); name != "Aufwandspunkte" {
+		t.Errorf("the field is labelled %q, want the name this site displays", name)
+	}
+	if name := got.Labels.Name("summary"); name != "Zusammenfassung" {
+		t.Errorf("the summary is labelled %q; a system field is translated too", name)
+	}
+	if len(got.Missing) != 0 {
+		t.Errorf("the read reported %v missing: a custom field taken by ID never had to be named", got.Missing)
+	}
+}
+
+func TestResolve_AsksForACustomFieldNoJQLClauseCanName(t *testing.T) {
+	t.Parallel()
+
+	f := translatedSite(translatedFields())
+	criteria := fieldNamed(t, f, "AcceptanceCriteria")
+	if len(criteria.ClauseNames) != 0 {
+		t.Fatalf("%s has clause names %v, so the test is not about the field it means to be", criteria.ID, criteria.ClauseNames)
+	}
+
+	s := NewSearch(f)
+	resolved, err := s.Resolve(t.Context(), DetailProjection())
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if !slices.Contains(resolved.IDs, criteria.ID) {
+		t.Errorf("%s was not asked for; a field that cannot be named in JQL is still readable by ID", criteria.ID)
+	}
+	if name := resolved.Labels.Name(criteria.ID); name != criteria.Name {
+		t.Errorf("%s is labelled %q, want %q", criteria.ID, name, criteria.Name)
+	}
+
+	got, err := s.Run(t.Context(), Request{JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1})
+	if err != nil {
+		t.Fatalf("reading one issue: %v", err)
+	}
+	ref, ok := got.Labels.Field(criteria.ID)
+	if !ok {
+		t.Fatalf("%s came back unlabelled", criteria.ID)
+	}
+	if text, ok := got.Page.Items[0].Fields.Text(ref); !ok || text == "" {
+		t.Errorf("%s came back with %q (%t)", criteria.ID, text, ok)
+	}
+}
+
+func TestRun_ADetailReadOnASiteWithNoCustomFieldsAsksForTheSameFieldsAsBefore(t *testing.T) {
+	t.Parallel()
+
+	f := translatedSite(systemFieldsOnly())
+	got, err := NewSearch(f).Run(t.Context(), Request{
+		JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1,
+	})
+	if err != nil {
+		t.Fatalf("reading one issue on a site with no custom fields: %v", err)
+	}
+	if len(got.Page.Items) != 1 {
+		t.Fatalf("the read came back with %d issues, want 1", len(got.Page.Items))
+	}
+
+	issue := got.Page.Items[0]
+	if issue.Summary == "" {
+		t.Error("the issue came back without its summary")
+	}
+	if issue.Fields.Len() != 0 {
+		t.Errorf("the issue carries %d custom values on a site that defines none", issue.Fields.Len())
+	}
+	want := slices.Sorted(slices.Values(DetailProjection().IDs))
+	if got := issue.Requested.IDs(); !slices.Equal(got, want) {
+		t.Errorf("the read asked for %v, want the platform fields alone %v", got, want)
+	}
+	if got.Labels.Len() != len(systemFieldsOnly()) {
+		t.Errorf("%d fields came back labelled, want the %d this site defines", got.Labels.Len(), len(systemFieldsOnly()))
+	}
+}
+
+func TestRun_TheIssuesMaskNamesExactlyWhatTheProjectionAskedFor(t *testing.T) {
+	t.Parallel()
+
+	f := testFake(9)
+	s := NewSearch(f)
+	resolved, err := s.Resolve(t.Context(), DetailProjection())
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	got, err := s.Run(t.Context(), Request{JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1})
+	if err != nil {
+		t.Fatalf("reading one issue: %v", err)
+	}
+
+	issue := got.Page.Items[0]
+	if issue.Requested.Wide() {
+		t.Error("the issue reports a read of every field the site has, which is not what was asked for")
+	}
+	want := slices.Sorted(slices.Values(resolved.IDs))
+	if got := issue.Requested.IDs(); !slices.Equal(got, want) {
+		t.Errorf("the issue reports %v as asked for, want %v", got, want)
+	}
+	for _, id := range issue.Fields.IDs() {
+		if !issue.Requested.Has(id) {
+			t.Errorf("the issue carries a value for %s, which its own mask says nothing asked for", id)
+		}
+	}
+}
+
+func TestMergeIssue_ADetailReadWidensACachedRowWithoutMakingItLookWide(t *testing.T) {
+	t.Parallel()
+
+	f := testFake(9)
+	points := fieldNamed(t, f, "Story Points")
+	s := NewSearch(f)
+
+	rows, err := s.Run(t.Context(), Request{JQL: testJQL, Projection: ListProjection()})
+	if err != nil {
+		t.Fatalf("reading the list: %v", err)
+	}
+	row := rows.Page.Items[0]
+	detail, err := s.Run(t.Context(), Request{JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1})
+	if err != nil {
+		t.Fatalf("reading one issue: %v", err)
+	}
+	if row.Key != detail.Page.Items[0].Key {
+		t.Fatalf("the list row is %s and the detail read is %s", row.Key, detail.Page.Items[0].Key)
+	}
+
+	merged := MergeIssue(row, detail.Page.Items[0])
+	if merged.Requested.Wide() {
+		t.Error("merging a detail read over a cached row claims every field the site has")
+	}
+	if !merged.Requested.Has(points.ID) {
+		t.Errorf("the merged issue does not report %s as read, so a write would treat its value as nothing anybody asked about", points.ID)
+	}
+	if _, ok := merged.Fields.ByID(points.ID); !ok {
+		t.Errorf("the merged issue lost the %s value the detail read brought back", points.ID)
+	}
+
+	back := MergeIssue(merged, row)
+	if back.Requested.Wide() {
+		t.Error("a narrow list refresh over the merged issue made it look wide")
+	}
+	if _, ok := back.Fields.ByID(points.ID); !ok {
+		t.Errorf("a list refresh dropped %s, which it never asked about", points.ID)
+	}
+	if !back.Requested.Has(points.ID) {
+		t.Errorf("a list refresh stopped reporting %s as read while still carrying its value", points.ID)
+	}
+}
+
+func TestRun_AListReadIsUnchangedByTheWiderDetailRead(t *testing.T) {
+	t.Parallel()
+
+	f := testFake(9)
+	got, err := NewSearch(f).Run(t.Context(), Request{JQL: testJQL, Projection: ListProjection()})
+	if err != nil {
+		t.Fatalf("reading the list: %v", err)
+	}
+	if n := callsTo(f, "Fields"); n != 0 {
+		t.Errorf("a list read fetched the catalogue %d times, which is a request in front of the first paint", n)
+	}
+	if got.Labels.Len() != 0 {
+		t.Errorf("a list read came back with %d labels, which it could only have from a catalogue fetch", got.Labels.Len())
+	}
+
+	issue := got.Page.Items[0]
+	if issue.Fields.Len() != 0 {
+		t.Errorf("a list row carries %d custom values", issue.Fields.Len())
+	}
+	want := slices.Sorted(slices.Values(ListProjection().IDs))
+	if got := issue.Requested.IDs(); !slices.Equal(got, want) {
+		t.Errorf("a list row reports %v as asked for, want the six %v", got, want)
+	}
+}
+
+func TestRun_FetchesTheCatalogueOnceAcrossTwoDetailReads(t *testing.T) {
+	t.Parallel()
+
+	f := testFake(9)
+	s := NewSearch(f)
+	for range 2 {
+		if _, err := s.Run(t.Context(), Request{JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1}); err != nil {
+			t.Fatalf("reading one issue: %v", err)
+		}
+	}
+	if n := callsTo(f, "Fields"); n != 1 {
+		t.Errorf("the catalogue was fetched %d times for two reads, want 1: it changes with the site's configuration, not with the issue", n)
+	}
+	if n := callsTo(f, "Search"); n != 2 {
+		t.Errorf("the adapter ran %d searches, want 2", n)
+	}
+}
+
+func TestRun_ADetailReadSaysWhyTheCatalogueCouldNotBeRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		fail error
+		want func(error) bool
+	}{
+		{
+			name: "the site rate limiting the catalogue",
+			fail: &jira.RateLimitError{RetryAfter: 30 * time.Second},
+			want: func(err error) bool {
+				var limited *jira.RateLimitError
+				return errors.As(err, &limited) && limited.RetryAfter == 30*time.Second
+			},
+		},
+		{
+			name: "a token that cannot read the catalogue",
+			fail: &jira.CapabilityError{Reason: "you need Browse Projects"},
+			want: func(err error) bool {
+				var missing *jira.CapabilityError
+				return errors.As(err, &missing)
+			},
+		},
+		{
+			name: "the site being unreachable",
+			fail: &jira.TransportError{Op: "GET /rest/api/3/field", Err: errors.New("no route to host")},
+			want: func(err error) bool {
+				var broken *jira.TransportError
+				return errors.As(err, &broken)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := testFake(9)
+			f.FailNext(tt.fail)
+
+			_, err := NewSearch(f).Run(t.Context(), Request{
+				JQL: oneIssue, Projection: DetailProjection(), MaxResults: 1,
+			})
+			if !tt.want(err) {
+				t.Fatalf("got %v, want the adapter's own typed failure", err)
+			}
+			if callsTo(f, "Search") != 0 {
+				t.Error("the search went out anyway, so the issue would have opened missing every custom field and said nothing about it")
+			}
+		})
+	}
+}
+
+func TestFieldLabels_LabelOnlyWhatWasAskedForAndCannotBeWrittenThrough(t *testing.T) {
+	t.Parallel()
+
+	catalogue := translatedFields()
+	labels := NewFieldLabels(catalogue, []string{"customfield_20001", "customfield_99999"})
+
+	if got := labels.IDs(); !slices.Equal(got, []string{"customfield_20001"}) {
+		t.Errorf("the labels cover %v, want only the field the catalogue has", got)
+	}
+	if labels.Len() != 1 {
+		t.Errorf("the labels count %d, want 1", labels.Len())
+	}
+	if _, ok := labels.Field("customfield_99999"); ok {
+		t.Error("a field this site does not have came back labelled")
+	}
+	if name := labels.Name("customfield_99999"); name != "" {
+		t.Errorf("an unlabelled field is named %q, want nothing: whether to show a raw ID is the caller's decision", name)
+	}
+
+	for i := range catalogue {
+		catalogue[i].Name = "rewritten"
+	}
+	if name := labels.Name("customfield_20001"); name == "rewritten" {
+		t.Error("writing to the catalogue afterwards changed the labels taken from it")
+	}
+
+	var unread FieldLabels
+	if unread.Len() != 0 || len(unread.IDs()) != 0 || unread.Name("summary") != "" {
+		t.Error("a read that carried no labels answers as though it had some")
+	}
+	if _, ok := unread.Field("summary"); ok {
+		t.Error("a read that carried no labels resolved one")
+	}
+}
+
+func TestSavedQuery_AFieldSetOfNothingButCustomFieldsIsNotTheListDefault(t *testing.T) {
+	t.Parallel()
+
+	q := SavedQuery{Name: "Estimates", JQL: testJQL, Projection: Projection{Name: "estimates", Custom: true}}
+	got := q.projection()
+	if !got.Custom {
+		t.Error("a saved query asking only for the custom fields fell back to the list field set, which asks for none of them")
+	}
+	if len(got.IDs) != 0 {
+		t.Errorf("the field set grew to %v", got.IDs)
+	}
+
+	empty := SavedQuery{Name: "Anything", JQL: testJQL}.projection()
+	if len(empty.IDs) != len(ListProjection().IDs) || empty.Custom {
+		t.Errorf("a saved query with no field set of its own resolved to %+v, want the list one", empty)
+	}
+}
+
+// configuredSite is a catalogue the size of one a real site answered with: 101
+// fields, 57 of them custom. It is what the detail read's cost has to be
+// measured against, because a site with six custom fields cannot show it.
+func configuredSite() []jira.Field {
+	detail := DetailProjection().IDs
+	out := make([]jira.Field, 0, 101)
+	for i, id := range detail {
+		out = append(out, jira.Field{
+			ID: id, Key: id, Name: "Field " + strconv.Itoa(i),
+			Navigable: true, Searchable: true, Orderable: true,
+			ClauseNames: []string{id},
+			Schema:      jira.FieldSchema{Type: "string", System: id},
+		})
+	}
+	for i := len(detail); i < 44; i++ {
+		id := "system_" + strconv.Itoa(i)
+		out = append(out, jira.Field{
+			ID: id, Key: id, Name: "Field " + strconv.Itoa(i),
+			Navigable: true, Searchable: true, Orderable: true,
+			ClauseNames: []string{id},
+			Schema:      jira.FieldSchema{Type: "string", System: id},
+		})
+	}
+	for i := range 57 {
+		id := fmt.Sprintf("customfield_%d", 21000+i)
+		out = append(out, jira.Field{
+			ID: id, Key: id,
+			Name: "Custom " + strconv.Itoa(i), UntranslatedName: "Custom" + strconv.Itoa(i),
+			Custom: true, Navigable: true, Searchable: true, Orderable: true,
+			ClauseNames: []string{id},
+			Schema: jira.FieldSchema{
+				Type:     "string",
+				Custom:   "com.atlassian.jira.plugin.system.customfieldtypes:textfield",
+				CustomID: 21000 + i,
+			},
+		})
+	}
+	return out
+}
+
+func resolverOn(tb testing.TB, fields []jira.Field) *Search {
+	tb.Helper()
+
+	s := NewSearch(jiratest.New(jiratest.WithFields(fields)))
+	if _, err := s.Fields(tb.Context()); err != nil {
+		tb.Fatalf("warming the catalogue: %v", err)
+	}
+	return s
+}
+
+// BenchmarkResolveList is the resolve a keystroke pays for: six platform IDs,
+// no catalogue.
+func BenchmarkResolveList(b *testing.B) {
+	s := resolverOn(b, configuredSite())
+	ctx := b.Context()
+	p := ListProjection()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := s.Resolve(ctx, p); err != nil {
+			b.Fatalf("Resolve: %v", err)
+		}
+	}
+}
+
+// BenchmarkResolveDetail is what opening an issue costs on a site with 57 custom
+// fields, once the catalogue is held.
+func BenchmarkResolveDetail(b *testing.B) {
+	s := resolverOn(b, configuredSite())
+	ctx := b.Context()
+	p := DetailProjection()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := s.Resolve(ctx, p); err != nil {
+			b.Fatalf("Resolve: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## R2 — the custom fields the detail read never asked for

The owner's report was that *"there are so many things that belong to an issue that are not shown on
the issue screen."* The largest single gap is that they were never fetched: `app.DetailProjection()`
asked for twenty platform fields and none of the site's own, so story points, the sprint, the epic
link, severity and acceptance criteria were absent from the answer before any view had the chance to
draw them. `jira.Issue.Fields` — the whole custom-field set — arrived empty on every read.

This packet makes them **arrive, and arrive labelled**. Rendering them is a later packet's job.

### What changed

- **`Projection.Custom bool`**, expanded by `Search.Resolve` into every `Field.Custom` ID in the
  catalogue the search **already fetches and caches**. `DetailProjection()` sets it; `ListProjection()`
  does not and must not — a site with two hundred custom fields would turn a page of fifty rows into
  ten thousand values nothing renders.
- **Labels travel with the answer.** `app.FieldLabels` maps a field ID to the `jira.FieldRef` the
  catalogue holds for it, and hangs off both `Resolved` and `Result`. The catalogue is needed anyway
  to put a field on screen, so taking the IDs from it costs nothing extra and answers the labelling
  question in the same pass.
- `Search.Resolve` reads the cached catalogue without copying it. `Search.Fields` still hands out a
  copy — that contract and its test are unchanged.
- `SavedQuery.projection()` no longer treats a field set that asks only for the custom fields as one
  that asks for nothing.

### Why not `*navigable`

`jira.FieldsNavigable` exists and this deliberately does not use it:

1. **A wildcard's values arrive with nothing to label them by.** The answer is keyed by
   `customfield_13401` and carries no name for it, so the view would need the catalogue anyway — at
   which point taking the IDs from the catalogue is strictly narrower for the same information.
2. **It fetches per issue, not per field.** On a site with two hundred fields, `*navigable` is two
   hundred values for every issue in the result set. The ID list is one request body, and only the
   fields the issue actually has come back with values.
3. **It lies about what was read.** `jira.NewFieldMask` makes either wildcard `Wide()`, and PC.1's
   whole point is that a mask is honest. A wide mask makes `app.MergeIssue` replace a cached issue
   wholesale, so a `*navigable` read — which is not every field — would make a narrow cached row look
   like a read of everything. There is a test asserting the resolved ID list is not wide.

The one thing `*navigable` would have given us is fields no catalogue entry covers, and there are
none: `/field` is where the IDs come from in the first place.

### The API two later packets code against

```go
// internal/app
type Projection struct {
    Name   string
    IDs    []string
    Names  []string
    Custom bool   // new: every custom field this site defines
}
func (p Projection) WithCustom() Projection      // new; With/WithNames unchanged
func DetailProjection() Projection               // now Custom: true
func ListProjection() Projection                 // unchanged, Custom stays false

type Resolved struct {
    IDs     []string
    Missing []string
    Labels  FieldLabels   // new
}

type Result struct {
    Page    jira.Page[jira.Issue]
    Missing []string
    Labels  FieldLabels   // new
}

// FieldLabels is immutable and safe to share; the zero value answers for a read
// that carried no labels.
type FieldLabels struct{ /* unexported */ }
func NewFieldLabels(catalogue []jira.Field, ids []string) FieldLabels
func (l FieldLabels) Name(id string) string               // "" when unlabelled
func (l FieldLabels) Field(id string) (jira.FieldRef, bool)
func (l FieldLabels) IDs() []string                       // sorted
func (l FieldLabels) Len() int
```

How a renderer is expected to use it — `Field` returns a `jira.FieldRef`, so the same lookup gives
both the name to draw and the schema that says what the value is:

```go
for _, id := range issue.Fields.IDs() {
    ref, ok := res.Labels.Field(id)
    if !ok {
        continue // or draw the raw ID; that decision is the caller's, not this type's
    }
    if n, ok := issue.Fields.Number(ref); ok { draw(ref.Name, n) }
}
```

`Labels` is filled only when resolving needed the catalogue. A list read of six platform IDs still
resolves with **no** catalogue fetch, so it comes back with no labels — deliberately, because
labelling it would put a request in front of the first paint.

### Consumers

| Consumer | Status |
|---|---|
| `internal/ui/issue/cmds.go` — `load()` runs `DetailProjection()` | Now receives the custom values and `Result.Labels`. **Renders neither yet**: `internal/ui/issue/**` is another packet's path in this wave, and drawing them is that packet's job. Nothing regressed — the view ignores field IDs it does not know, and its golden tests are untouched. |
| `internal/ui/list/cmds.go` — `listRequest()` runs `ListProjection()` | Unaffected by construction, and asserted: no catalogue fetch, no labels, no custom values, mask still exactly the six. |
| `internal/ui/issue/edit.go` — `editProjection()` | Its own nine-ID projection, `Custom` false. The write path is exactly as narrow as it was, and `covered()` comparing against `Issue.Requested` only becomes *more* often true, correctly, because those fields really were read. |
| `internal/app/cache.go` — `MergeIssue`, `encodeIssue` | Not touched. `Issue.Requested` still names exactly the IDs that were asked for, and the cache already round-trips a `FieldSet` and a mask. It stores **IDs**, never labels, which is what makes a site changing language harmless. |

### Measurements

Per-frame allocation is budgeted and nothing asserts it ([#103](https://github.com/varijkapil13/saral/issues/103)), so these are measured, not assumed. M2 Pro, no `-race`.

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| `BenchmarkResolveList` — six platform IDs, no catalogue | 63 | 96 | **1** |
| `BenchmarkResolveDetail` — 20 platform IDs + 57 custom, catalogue held | 13,100 | 18,904 | **7** |

Both run against a catalogue the size of the one a real site answered with: 101 fields, 57 of them
custom.

- **The search path a keystroke pays for is unchanged**: a list resolve is the same single
  allocation — the ID slice it returns — because it still returns before touching the catalogue.
- **Opening an issue costs 13 µs and 7 allocations** in `Resolve`, against a 16 ms frame budget, and
  it is paid once per issue opened on a fetch goroutine, not per frame. The 18.9 KB is the label map.
- Reading the cached catalogue without copying it is why that is 7 allocations and not 109: through
  `Search.Fields` it measured **16,200 ns / 38,952 B / 109 allocs**, the extra 102 being one clone of
  101 field definitions and their `ClauseNames` slices per resolve.
- `BenchmarkFrame` **297 allocs/op** and `BenchmarkKeyToFrame` **310 allocs/op**, unchanged — this
  packet is not on a render path.
- The `//go:build !race` budget assertions in `internal/app` (which CI never runs, per #103) pass
  locally: `go test ./internal/app` green.

### Notes from the field that this had to survive

- **Three spellings, and `clauseNames` can be empty.** Nothing here resolves a custom field by name,
  which is the point: the IDs come from the catalogue. A field with `clauseNames: []` — 9 of 101 on a
  real site — cannot be named in JQL by any spelling, and is still perfectly readable by ID. There is
  a test for exactly that field.
- **A localised site names the field differently.** `FieldLabels` carries `Field.Name`, the name the
  site displays, not `UntranslatedName` and not a name reconstructed from one. Tested on a catalogue
  whose display names and untranslated names disagree.
- The adapter already sends `expand=schema` when a query names a non-system field, so these values
  arrive typed rather than shape-guessed — no adapter change was needed.
- `POST /search/jql` takes the field list in the body, so a long ID list is not a URL-length problem.

### A detail read now depends on the catalogue

It did not before, because it named no fields. If the catalogue cannot be read the read fails with
the site's own error rather than quietly dropping every custom field — an issue silently missing half
its content looks exactly like an issue that has none, which is the confusion PC.1's mask exists to
prevent. It costs one request per session: the fetch is cached and coalesced, and there is a test
that two detail reads fetch it once. 403, 429 and a transport failure on that fetch are each tested,
including that no search goes out afterwards.

### Verification

- `go mod tidy` clean; **no `go.mod` change** — `git diff --exit-code go.mod go.sum` clean.
- `go vet ./...`, `golangci-lint run`: 0 issues.
- `go test -race -count=1 ./...`: all 18 packages green. No existing test weakened, skipped or
  deleted; nine of the new tests were checked to fail with `Projection.Custom` forced off.
- Stripped binary: **10.43 MiB against the 15 MiB gate** (4.57 MiB headroom, unchanged).
- `scripts/checkleak.py` clean. The German field and issue names in the test are invented; no capture
  was run in this tree.

Owned paths only: `internal/app/search.go`, `internal/app/search_test.go`, and one row in
`docs/ROADMAP.md`.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
