### PR TITLE
feat(richtext): show a description as styled text instead of raw markdown

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -17,6 +17,7 @@ These are budgets, not aspirations: CI enforces the ones it can, and benchmarks 
 | Cache read for a view's first paint | < 5 ms | bbolt read benchmark |
 | Rank 10k cached issues against a keystroke | **< 16 ms**, 1 allocation | `BenchmarkIndexSearch10k`, asserted in `internal/app/index_budget_test.go` |
 | Rebuild the local index over 10k cached issues | < 16 ms | `BenchmarkIndexRebuild10k`, asserted beside it |
+| Render a description to styled lines | **≤ 8 allocations a line**, and linear in the lines | `BenchmarkRender`, asserted in `internal/ui/richtext/budget_test.go` |
 
 ## Where the time actually goes
 
@@ -82,6 +83,38 @@ rows, the prepared pattern, the ranking buffer — outlives the call or never le
 candidates it is run over. That is the property that made writing the scorer cheaper than taking
 `github.com/sahilm/fuzzy`, whose API materialises a `[]string` of every target and a `[]int` of
 matched offsets per hit.
+
+### What rendering a document costs today
+
+Measured on an M2 Pro over `internal/ui/richtext`, against the kitchen-sink description a real site
+stored: 40 blocks, 31 node types, 11 mark types, 117 lines at 80 columns.
+
+| Benchmark | ns/op | allocs/op |
+|---|---|---|
+| `BenchmarkRender/80` — a themed render, the width a pane usually has | 119,000 | 702 |
+| `BenchmarkRender/40` — the same document in a narrow pane, so more lines | 121,000 | 779 |
+| `BenchmarkRenderNoColor` — the same, in the no-colour theme | 109,000 | 525 |
+| `BenchmarkRenderLong` — five copies of it, the size a long description reaches | 352,000 | 2,179 |
+| `BenchmarkSummary` — a document flattened onto one 80-cell line | 2,000 | 6 |
+
+That is **six allocations a line**, and `internal/ui/richtext/budget_test.go` asserts a ceiling of
+eight per line with colour and six without, plus that the cost per line does not grow with the
+document. The floor is one a line: the lines are the answer the caller keeps.
+
+**A render is not a per-frame cost.** A pane memoizes it and re-renders on a resize or a change of
+data, which is what the ceiling is sized for. Three things were what made it worth measuring:
+
+- `strings.Builder.Reset` drops the buffer, so a builder reused for every line pays an allocation and
+  a regrow each time. A `[]byte` truncated to zero keeps its capacity.
+- Asking a `lipgloss.Style` to render a run costs a style walk per call, and for an underlined or
+  struck-through run lipgloss re-styles **every rune** — a thirteen-letter word comes back as
+  thirteen SGR pairs, with an escape sequence inside any grapheme cluster in it. The renderer asks a
+  style once what it puts around one rune and then puts that around the whole run, so a run is one
+  sequence and a joined emoji stays joined.
+- A closure per block is an allocation per block, and a document has a block for every paragraph.
+
+A summary stops at the width it was asked for rather than flattening 32,000 characters and cutting
+the result, which is what a list of twenty rows over long descriptions pays.
 
 ## Measuring for real
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -474,6 +474,35 @@ feature. Each is one PR, small and tested, in the paths it names.
   so a board read decoded to no rows and reported no error. Three envelopes exist, one per shape, and
   there is now a fixture and a terminating walk for each.
 
+## Rendering wave · found by reading an issue against a site
+
+An issue's description came out as raw markdown — `##`, `**`, `[text](url)`, backticks, fences, pipe
+tables — because `internal/ui/issue` writes `adf.MarkdownWith` straight into its pager. That markdown
+is a serialisation for editing: it backs the `$EDITOR` handoff and P2.1's byte-stable round trip,
+`pkg/adf` is public API that must not import a UI library, and it deliberately does not escape prose.
+It was never a display format. Handing it to a markdown renderer would re-parse text that was never
+markdown and would arrive after the information a display needs is already gone — by then an error
+panel and a plain quote are the same node — and `chroma` alone is 5.11 MiB stripped against 4.57 MiB
+of headroom under the 15 MiB binary gate. So the display renderer is written here instead.
+
+- [x] **R1 — The display renderer** · **owns** `internal/ui/richtext/**` including its `testdata/**`,
+  `docs/PERFORMANCE.md`, this row
+  `internal/ui/richtext` walks an `adf.Doc` straight to styled terminal lines, importing only
+  `pkg/adf`, `charm.land/lipgloss/v2` and `x/ansi` — never the kernel, because the caller passes the
+  theme in as tokens, which is also what keeps the goldens a property of the document and lets the
+  issue and comment views share one renderer. It covers the 31 node types and 11 mark types a real
+  site stored, so a panel keeps its own marker and colour rather than becoming a quote, a status
+  lozenge keeps the colour enum it arrives with, an unknown node stays visibly unknown, and a media
+  node stays a placeholder with the id P4.3 will resolve.
+  **Styling happens after the break, never before.** `ansi.Wrap` does not re-open an SGR sequence on
+  a continuation line: a bold run wrapped at 20 columns opens bold on line 0, leaves lines 1 and 2
+  with no sequence at all and puts the reset on line 3, so a pane showing a window into the middle of
+  it draws the run unstyled and one starting at the reset opens with a stray reset. Every line is
+  built from independently painted spans and a test asserts that no line inherits or leaks a style.
+  Lines are not padded to `Width` — padding belongs to the pane — and `Widths` is reported so a pane
+  can clamp panning without measuring. Code is neither wrapped nor cut and a grid wraps inside its
+  columns, so the two constructs allowed past the width are the only ones that go past it.
+
 ## Batch 4 — Attachments · parallel ×3
 
 - [ ] **P4.1 — List and download** · [#17](https://github.com/varijkapil13/saral/issues/17) · **owns** `pkg/jira/cloud/attachment.go`

--- a/internal/ui/richtext/bench_test.go
+++ b/internal/ui/richtext/bench_test.go
@@ -1,0 +1,61 @@
+package richtext
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// long is a document of the size a real description reaches: the kitchen sink
+// over and over, which is 40 blocks a copy.
+func long(t testing.TB, copies int) adf.Doc {
+	t.Helper()
+	one := load(t, "kitchen.json")
+	nodes := make([]adf.Node, 0, len(one.Content)*copies)
+	for range copies {
+		nodes = append(nodes, one.Content...)
+	}
+	return adf.NewDoc(nodes...)
+}
+
+func BenchmarkRender(b *testing.B) {
+	for _, width := range []int{120, 80, 40} {
+		d := load(b, "kitchen.json")
+		opt := options(width)
+		opt.Styles = NewStyles(colourPalette())
+		b.Run(fmt.Sprint(width), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				Render(d, opt)
+			}
+		})
+	}
+}
+
+func BenchmarkRenderLong(b *testing.B) {
+	d := long(b, 5)
+	opt := options(80)
+	opt.Styles = NewStyles(colourPalette())
+	b.ReportAllocs()
+	for b.Loop() {
+		Render(d, opt)
+	}
+}
+
+func BenchmarkRenderNoColor(b *testing.B) {
+	d := load(b, "kitchen.json")
+	opt := options(80)
+	b.ReportAllocs()
+	for b.Loop() {
+		Render(d, opt)
+	}
+}
+
+func BenchmarkSummary(b *testing.B) {
+	d := load(b, "kitchen.json")
+	b.ReportAllocs()
+	for b.Loop() {
+		Summary(d, 80)
+	}
+}

--- a/internal/ui/richtext/blocks.go
+++ b/internal/ui/richtext/blocks.go
@@ -1,0 +1,343 @@
+package richtext
+
+import (
+	"strconv"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// blocks renders a run of block nodes, separated by a blank line. tight is for
+// the inside of a list item, where a nested list belongs to the item above it
+// and a blank line between the two reads as a new list.
+func (f *frame) blocks(nodes []adf.Node, tight bool) {
+	for i := range nodes {
+		if i > 0 && (!tight || !isList(nodes[i].Type)) {
+			f.separate()
+		}
+		f.block(nodes[i])
+	}
+}
+
+func (f *frame) block(n adf.Node) {
+	switch n.Type {
+	case "paragraph":
+		f.paragraph(n)
+	case "heading":
+		f.heading(n)
+	case "bulletList", "orderedList":
+		f.list(n)
+	case "taskList", "decisionList":
+		f.checklist(n)
+	case "blockquote":
+		f.quote(n)
+	case "codeBlock":
+		f.codeBlock(n)
+	case "rule":
+		f.rule()
+	case "panel":
+		f.panel(n)
+	case "table":
+		f.table(n)
+	case "mediaSingle", "mediaGroup":
+		f.mediaBlock(n)
+	case "expand", "nestedExpand":
+		f.expand(n)
+	case "blockCard", "embedCard":
+		f.cardBlock(n)
+	// A layout is two columns in a browser and one after another in a terminal:
+	// eighty cells split in two holds no prose worth reading.
+	case "layoutSection", "layoutColumn", "caption", "doc":
+		f.blocks(n.Content, false)
+	default:
+		if isInline(n.Type) {
+			f.nodeBlock(n, alignLeft)
+			return
+		}
+		f.unknownBlock(n)
+	}
+}
+
+// inlineBlock wraps a run of inline nodes into lines.
+func (f *frame) inlineBlock(nodes []adf.Node, a align) {
+	f.spans = f.spans[:0]
+	f.inline(nodes)
+	f.fill(a)
+}
+
+// nodeBlock is the same for one inline node standing where a block should be.
+func (f *frame) nodeBlock(n adf.Node, a align) {
+	f.spans = f.spans[:0]
+	f.inlineNode(n)
+	f.fill(a)
+}
+
+// textBlock is the same for text of one style: a label, a placeholder, a title.
+func (f *frame) textBlock(text string, p paint, a align) {
+	f.spans = f.spans[:0]
+	f.addPaint(text, p)
+	f.fill(a)
+}
+
+// cardBlock is the same for a smart link standing on a line of its own.
+func (f *frame) cardBlock(n adf.Node) {
+	f.spans = f.spans[:0]
+	f.cardSpans(n)
+	f.fill(alignLeft)
+}
+
+func (f *frame) paragraph(n adf.Node) {
+	a, level := blockMarks(n.Marks)
+	if level > 0 {
+		pad := indent(level * 2)
+		f.push(pad, pad, &f.sty.Body)
+		defer f.pop()
+	}
+	f.inlineBlock(n.Content, a)
+}
+
+// heading renders a heading at the weight its level earns.
+func (f *frame) heading(n adf.Node) {
+	level, ok := attrInt(n.Attrs, "level")
+	switch {
+	case !ok || level < 1:
+		level = 1
+	case level > 6:
+		level = 6
+	}
+	style := &f.sty.H3
+	switch level {
+	case 1:
+		style = &f.sty.H1
+	case 2:
+		style = &f.sty.H2
+	}
+	// Levels one to three are told apart by weight, and level one keeps an
+	// attribute rather than a colour so that it survives the no-colour theme.
+	// Below three there is no weight left to spend, so the indent says it.
+	if level > 3 {
+		pad := indent((level - 3) * 2)
+		f.push(pad, pad, &f.sty.Body)
+		defer f.pop()
+	}
+	a, _ := blockMarks(n.Marks)
+	ctx, p := f.setCtx(style)
+	f.inlineBlock(n.Content, a)
+	f.restoreCtx(ctx, p)
+}
+
+func (f *frame) list(n adf.Node) {
+	ordered := n.Type == "orderedList"
+	number := 1
+	if ordered {
+		if start, ok := attrInt(n.Attrs, "order"); ok && start > 0 {
+			number = start
+		}
+	}
+	bullet := f.mk.Bullet + " "
+	for i := range n.Content {
+		child := n.Content[i]
+		if child.Type != "listItem" {
+			f.block(child)
+			continue
+		}
+		marker, style := bullet, &f.sty.Bullet
+		if ordered {
+			marker, style = strconv.Itoa(number)+". ", &f.sty.Number
+			number++
+		}
+		f.item(child, marker, style)
+	}
+}
+
+// checklist renders a task or decision list. ADF's content model for these is
+// (item | list)+: indenting an action item in the editor stores a sibling list
+// inside its parent, and treating that as an item renders every child as
+// unsupported.
+func (f *frame) checklist(n adf.Node) {
+	for i := range n.Content {
+		child := n.Content[i]
+		if child.Type == "taskList" || child.Type == "decisionList" {
+			f.push("  ", "  ", &f.sty.Body)
+			f.checklist(child)
+			f.pop()
+			continue
+		}
+		marker, style := f.mk.Decision+" ", &f.sty.Decision
+		if child.Type == "taskItem" {
+			marker, style = f.mk.Task+" ", &f.sty.Task
+			if state, _ := attrString(child.Attrs, "state"); strings.EqualFold(state, "DONE") {
+				marker, style = f.mk.TaskDone+" ", &f.sty.TaskDone
+			}
+		}
+		f.item(child, marker, style)
+	}
+}
+
+// item renders one list, task or decision item under its marker, indenting
+// everything below the first line to the width of that marker.
+func (f *frame) item(n adf.Node, marker string, style *lipgloss.Style) {
+	f.push(marker, indentFor(marker), style)
+	switch {
+	case len(n.Content) == 0:
+		f.markerOnly()
+	case inlineOnly(n.Content):
+		f.inlineBlock(n.Content, alignLeft)
+	default:
+		f.blocks(n.Content, true)
+	}
+	// An item whose content rendered nothing would otherwise take its marker
+	// with it, and a list with a row missing is a list read wrong.
+	if !f.rails[len(f.rails)-1].used {
+		f.markerOnly()
+	}
+	f.pop()
+}
+
+func (f *frame) quote(n adf.Node) {
+	f.push(f.mk.VLine+" ", f.mk.VLine+" ", &f.sty.QuoteBar)
+	ctx, p := f.setCtx(&f.sty.Quote)
+	f.blocks(n.Content, false)
+	f.restoreCtx(ctx, p)
+	f.pop()
+}
+
+// panel renders one of the five stock panels or a custom one. A panel is not a
+// blockquote: what the document said about a warning is lost the moment it
+// renders as the bar an ordinary quote gets, so each kind keeps its own marker,
+// its own label and its own style — and a custom panel keeps the colour the
+// site chose.
+func (f *frame) panel(n adf.Node) {
+	kind, _ := attrString(n.Attrs, "panelType")
+	style, marker, label := f.sty.panelStyle(kind, *f.mk)
+	// The icon the author picked is used only where the glyph set says the
+	// terminal can be trusted with a glyph nobody chose: ASCII mode exists
+	// because it cannot, and a marker measured wrong takes the gutter with it.
+	if icon, ok := attrString(n.Attrs, "panelIconText"); ok && icon != "" && !f.mk.ascii() {
+		if clean := sanitize(strings.TrimSpace(icon)); clean != "" {
+			marker = clean
+		}
+	}
+	p := f.paint(style)
+	if f.sty.Color {
+		if colour, ok := attrString(n.Attrs, "panelColor"); ok {
+			if c, ok := wireColor(colour); ok {
+				p = paintOf(style.Foreground(c))
+			}
+		}
+	}
+	f.pushPaint(f.mk.VLine+" ", f.mk.VLine+" ", p)
+	f.textBlock(marker+" "+label, p, alignLeft)
+	f.blocks(n.Content, false)
+	f.pop()
+}
+
+// codeBlock renders code as it was written. It is neither wrapped nor
+// truncated: wrapping corrupts what a reader is going to copy, and truncating
+// loses it without saying so. A line wider than the pane is left wide, its
+// width recorded, and panning it is the pane's job.
+func (f *frame) codeBlock(n adf.Node) {
+	f.push(f.mk.VLine+" ", f.mk.VLine+" ", &f.sty.CodeBar)
+	if language, ok := attrString(n.Attrs, "language"); ok && language != "" {
+		f.line(sanitize(language), &f.sty.CodeLang)
+	}
+	code := strings.TrimRight(rawText(n.Content), "\n")
+	for {
+		line, rest, more := strings.Cut(code, "\n")
+		f.line(expandTabs(sanitize(line), 0), &f.sty.CodeBlock)
+		if !more {
+			break
+		}
+		code = rest
+	}
+	f.pop()
+}
+
+func (f *frame) rule() {
+	f.line(strings.Repeat(f.mk.HLine, f.avail()), &f.sty.Rule)
+}
+
+// expand renders a fold. It is closed unless the reader has opened it, and the
+// key it is opened by is its position in document order: a localId is optional
+// on the wire, is not unique when it is there, and says nothing about a
+// document that was never edited in the browser. Document order is derivable
+// from the document alone, which is what a pane holding a set of open folds
+// needs it to be.
+func (f *frame) expand(n adf.Node) {
+	index := *f.nextFold
+	*f.nextFold++
+	open := f.opt.Open[index]
+
+	title, _ := attrString(n.Attrs, "title")
+	title = sanitize(strings.TrimSpace(title))
+	if title == "" {
+		title = "details"
+	}
+	marker := f.mk.Folded
+	if open {
+		marker = f.mk.Unfolded
+	}
+	f.settle()
+	at := len(f.lines)
+	f.push(marker+" ", indentFor(marker+" "), &f.sty.FoldMark)
+	f.textBlock(title, f.paint(&f.sty.FoldTitle), alignLeft)
+	f.pop()
+	if f.unplaced {
+		at = -1
+	}
+	*f.folds = append(*f.folds, Fold{Index: index, Line: at, Open: open, Title: title})
+
+	if !open {
+		*f.nextFold += countFolds(n.Content)
+		return
+	}
+	f.push("  ", "  ", &f.sty.Body)
+	f.blocks(n.Content, false)
+	f.pop()
+}
+
+// mediaBlock renders an attachment or an image as a placeholder line that keeps
+// the id or the URL: a placeholder naming nothing is a dead end for whatever
+// comes to resolve it, and a reader cannot go and look at it either.
+func (f *frame) mediaBlock(n adf.Node) {
+	if len(n.Content) == 0 {
+		f.unknownBlock(n)
+		return
+	}
+	for i := range n.Content {
+		if i > 0 {
+			f.separate()
+		}
+		child := n.Content[i]
+		if child.Type == "media" || child.Type == "mediaInline" {
+			media := f.paint(&f.sty.Media)
+			f.pushPaint(f.mk.Media+" ", indentFor(f.mk.Media+" "), media)
+			f.textBlock(mediaTarget(child), media, alignLeft)
+			f.pop()
+			continue
+		}
+		f.block(child)
+	}
+}
+
+// unknownBlock quarantines a node this build has never heard of behind its own
+// bar, so that whatever it holds cannot be read as prose somebody wrote.
+func (f *frame) unknownBlock(n adf.Node) {
+	f.push(f.mk.VLine+" ", f.mk.VLine+" ", &f.sty.Unknown)
+	f.line(f.mk.Unknown+" unsupported: "+nodeName(n), &f.sty.Unknown)
+	switch {
+	case inlineOnly(n.Content):
+		f.inlineBlock(n.Content, alignLeft)
+	case len(n.Content) > 0:
+		f.blocks(n.Content, false)
+	case n.Text != "":
+		f.textBlock(n.Text, f.pctx, alignLeft)
+	default:
+		if text, ok := attrString(n.Attrs, "text"); ok && text != "" {
+			f.textBlock(text, f.pctx, alignLeft)
+		}
+	}
+	f.pop()
+}

--- a/internal/ui/richtext/budget_test.go
+++ b/internal/ui/richtext/budget_test.go
@@ -1,0 +1,91 @@
+//go:build !race
+
+package richtext
+
+import (
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// The budgets here are about the binary that ships. The race detector puts its
+// own allocations on every one of these paths, so asserting them under -race
+// would measure the instrumentation instead — the same reason
+// internal/app/index_budget_test.go is built the same way.
+
+// TestBudget_Render holds the allocation cost of a render to a ceiling. A pane
+// memoizes this, so it is not a per-frame cost — but a resize re-renders every
+// document on screen.
+//
+// The ceilings are per line rather than per document, because the lines are the
+// answer the caller keeps and the floor is therefore one allocation each. What
+// they hold is roughly a third above what this machine measures.
+func TestBudget_Render(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	for _, tc := range []struct {
+		width   int
+		colour  bool
+		perLine float64
+	}{
+		{120, false, 6.0},
+		{80, false, 6.0},
+		{80, true, 8.0},
+		{40, true, 8.0},
+	} {
+		opt := options(tc.width)
+		if tc.colour {
+			opt.Styles = NewStyles(colourPalette())
+		}
+		lines := len(Render(d, opt).Lines)
+		got := testing.Benchmark(func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				Render(d, opt)
+			}
+		})
+		allocs := float64(got.AllocsPerOp())
+		if want := float64(lines) * tc.perLine; allocs > want {
+			t.Errorf("at width %d (colour=%v) a render costs %.0f allocations over %d lines, "+
+				"which is more than %.1f a line; %s",
+				tc.width, tc.colour, allocs, lines, tc.perLine, got.MemString())
+		}
+	}
+}
+
+// TestBudget_Summary is the one a list row pays, once per visible row.
+func TestBudget_Summary(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	got := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			Summary(d, 80)
+		}
+	})
+	if allocs := got.AllocsPerOp(); allocs > 8 {
+		t.Errorf("a summary costs %d allocations: %s", allocs, got.MemString())
+	}
+}
+
+// TestBudget_ScalesWithTheDocument catches the quadratic mistakes: a wider
+// document must not cost more per line than a narrow one.
+func TestBudget_ScalesWithTheDocument(t *testing.T) {
+	t.Parallel()
+	opt := options(80)
+	cost := func(d adf.Doc) (float64, int) {
+		lines := len(Render(d, opt).Lines)
+		got := testing.Benchmark(func(b *testing.B) {
+			for b.Loop() {
+				Render(d, opt)
+			}
+		})
+		return float64(got.AllocsPerOp()) / float64(lines), lines
+	}
+	one, oneLines := cost(load(t, "kitchen.json"))
+	five, fiveLines := cost(long(t, 5))
+	if five > one*1.5 {
+		t.Errorf("%d lines cost %.2f allocations each against %.2f over %d lines, so the cost is not linear",
+			fiveLines, five, one, oneLines)
+	}
+}

--- a/internal/ui/richtext/edge_test.go
+++ b/internal/ui/richtext/edge_test.go
@@ -1,0 +1,65 @@
+package richtext
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// TestRender_IsDeterministic is what a pane memoizing a render depends on: the
+// same document at the same width is the same lines, whatever order a map was
+// walked in.
+func TestRender_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"kitchen.json", "edges.json"} {
+		d := load(t, name)
+		opt := options(72)
+		opt.Open = map[int]bool{0: true, 1: true, 2: true}
+		first := Render(d, opt)
+		for range 3 {
+			again := Render(d, opt)
+			if !slices.Equal(first.Lines, again.Lines) || !slices.Equal(first.Widths, again.Widths) {
+				t.Fatalf("%s rendered differently the second time", name)
+			}
+			if !slices.Equal(first.Folds, again.Folds) {
+				t.Fatalf("%s reported different folds the second time", name)
+			}
+		}
+	}
+}
+
+// TestRender_TableWithNoHeaderRow gets no divider under its first row, which is
+// the only honest thing to draw when nothing said it was a heading.
+func TestRender_TableWithNoHeaderRow(t *testing.T) {
+	t.Parallel()
+	cell := func(text string) adf.Node { return adf.NewNode("tableCell", para(text)) }
+	d := doc(adf.NewNode("table",
+		adf.NewNode("tableRow", cell("a"), cell("b")),
+		adf.NewNode("tableRow", cell("c"), cell("d"))))
+	got := stripped(Render(d, options(40)))
+	if strings.Contains(got, UnicodeMarkers().HLine) {
+		t.Errorf("a table with no header row was given a divider:\n%s", got)
+	}
+	for _, want := range []string{"│ a │ b │", "│ c │ d │"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wanted the row %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestRender_ListHoldingSomethingElse covers a list holding what ADF's content
+// model does not allow: it is rendered rather than dropped.
+func TestRender_ListHoldingSomethingElse(t *testing.T) {
+	t.Parallel()
+	d := doc(adf.NewNode("bulletList",
+		adf.NewNode("listItem", para("an item")),
+		para("a paragraph where an item should be")))
+	got := stripped(Render(d, options(40)))
+	for _, want := range []string{"• an item", "a paragraph where an item"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wanted %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/ui/richtext/fold_test.go
+++ b/internal/ui/richtext/fold_test.go
@@ -1,0 +1,127 @@
+package richtext
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func folds(t *testing.T, name string, open map[int]bool) (r Rendered, text string) {
+	t.Helper()
+	opt := options(80)
+	opt.Open = open
+	r = Render(load(t, name), opt)
+	return r, stripped(r)
+}
+
+func TestFolds_AreClosedUntilTheReaderOpensOne(t *testing.T) {
+	t.Parallel()
+	const inside = "Expands may hold a table"
+	_, closed := folds(t, "kitchen.json", nil)
+	if strings.Contains(closed, inside) {
+		t.Errorf("a closed fold showed what is inside it:\n%s", closed)
+	}
+	if !strings.Contains(closed, UnicodeMarkers().Folded+" an expand") {
+		t.Errorf("a closed fold does not say it can be opened:\n%s", closed)
+	}
+	_, opened := folds(t, "kitchen.json", map[int]bool{0: true})
+	if !strings.Contains(opened, inside) {
+		t.Errorf("an opened fold did not show what is inside it:\n%s", opened)
+	}
+	if !strings.Contains(opened, UnicodeMarkers().Unfolded+" an expand") {
+		t.Errorf("an opened fold still shows as closed:\n%s", opened)
+	}
+}
+
+// TestFolds_IndexIsDocumentOrder pins the key Options.Open is read with. A
+// localId would have been the obvious choice and is the wrong one: it is
+// optional on the wire, absent on every expand in the stored kitchen sink, and
+// no more unique than the editor that wrote it made it.
+func TestFolds_IndexIsDocumentOrder(t *testing.T) {
+	t.Parallel()
+	r, _ := folds(t, "edges.json", nil)
+	want := []struct {
+		index int
+		title string
+	}{
+		{0, "in a cell"}, // the table comes first, and a cell may hold a fold
+		{1, "a fold holding another fold"},
+	}
+	if len(r.Folds) != len(want) {
+		t.Fatalf("expected %d folds, got %+v", len(want), r.Folds)
+	}
+	for i, w := range want {
+		if r.Folds[i].Index != w.index || r.Folds[i].Title != w.title {
+			t.Errorf("fold %d is %+v, wanted index %d titled %q", i, r.Folds[i], w.index, w.title)
+		}
+	}
+}
+
+// TestFolds_IndicesDoNotMoveWhenOneOpens is what makes the index a key rather
+// than a position: the fold inside a closed one is counted, so opening its
+// parent does not renumber the folds after it.
+func TestFolds_IndicesDoNotMoveWhenOneOpens(t *testing.T) {
+	t.Parallel()
+	before, _ := folds(t, "edges.json", nil)
+	after, _ := folds(t, "edges.json", map[int]bool{1: true})
+
+	for i := range before.Folds {
+		if before.Folds[i].Index != after.Folds[i].Index || before.Folds[i].Title != after.Folds[i].Title {
+			t.Errorf("opening a fold renumbered the others: %+v became %+v", before.Folds[i], after.Folds[i])
+		}
+	}
+	if len(after.Folds) != len(before.Folds)+1 {
+		t.Fatalf("opening a fold did not reveal the one inside it: %+v", after.Folds)
+	}
+	inner := after.Folds[len(after.Folds)-1]
+	if inner.Index != 2 {
+		t.Errorf("the fold inside a fold is keyed %d, and the count reserved 2: %+v", inner.Index, after.Folds)
+	}
+	if inner.Title != "details" {
+		t.Errorf("a fold with no title of its own is named %q", inner.Title)
+	}
+	if !after.Folds[1].Open || before.Folds[1].Open {
+		t.Errorf("a fold does not report whether it is open: %+v then %+v", before.Folds[1], after.Folds[1])
+	}
+}
+
+// TestFolds_LineIsWhereTheFoldIs is the half a pane hit-tests against.
+func TestFolds_LineIsWhereTheFoldIs(t *testing.T) {
+	t.Parallel()
+	for _, open := range []map[int]bool{nil, {0: true}, {1: true}, {0: true, 1: true, 2: true}} {
+		r, _ := folds(t, "edges.json", open)
+		for _, f := range r.Folds {
+			if f.Line < 0 || f.Line >= len(r.Lines) {
+				t.Fatalf("fold %+v points at line %d of %d", f, f.Line, len(r.Lines))
+			}
+			// A fold in a table cell reports the line its row starts on, which is
+			// the only line of the document's own that a grid position has.
+			row := ansi.Strip(r.Lines[f.Line])
+			if !strings.Contains(row, f.Title) {
+				t.Errorf("fold %+v points at %q, which does not hold its title", f, row)
+			}
+		}
+	}
+}
+
+// TestFolds_InATableCellOpensInsideTheRow covers the fold ADF allows in a grid
+// position, which is why a fold's line is patched to the row it landed in.
+func TestFolds_InATableCellOpensInsideTheRow(t *testing.T) {
+	t.Parallel()
+	_, closed := folds(t, "edges.json", nil)
+	if strings.Contains(closed, "a fold inside") {
+		t.Errorf("a closed fold in a cell showed what is inside it:\n%s", closed)
+	}
+	opened, text := folds(t, "edges.json", map[int]bool{0: true})
+	if !strings.Contains(text, "a fold inside") {
+		t.Errorf("a fold opened inside a cell did not show what is in it:\n%s", text)
+	}
+	row := opened.Folds[0].Line
+	if !strings.Contains(ansi.Strip(opened.Lines[row]), "in a cell") {
+		t.Errorf("a fold in a cell points at %q rather than at its row", ansi.Strip(opened.Lines[row]))
+	}
+	if !strings.Contains(ansi.Strip(opened.Lines[row+1]), "a fold inside") {
+		t.Errorf("the row a fold opened in did not grow under it: %q", ansi.Strip(opened.Lines[row+1]))
+	}
+}

--- a/internal/ui/richtext/frame.go
+++ b/internal/ui/richtext/frame.go
@@ -1,0 +1,638 @@
+package richtext
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const (
+	// minAvail is the narrowest column prose is wrapped into. A deeply nested
+	// list in a split pane can otherwise ask for a negative width.
+	minAvail = 8
+
+	// tabWidth is what a tab is expanded to before anything is measured.
+	// ansi.StringWidth counts a tab as one cell while a terminal jumps to the
+	// next stop, so a line holding one would be measured wrong and a pane would
+	// pan past the end of it.
+	tabWidth = 4
+)
+
+// span is a run of text carrying one style. A line is a concatenation of spans
+// painted independently, which is what makes it self-contained: see the package
+// comment for what wrapping styled text does instead.
+type span struct {
+	text string
+	p    paint
+	w    int  // the width, where it is already known: a rendered table cell
+	brk  bool // a hard break: end the line here
+}
+
+// paint is the pair of sequences a style puts either side of a run, read from
+// the style once instead of per run.
+//
+// lipgloss re-styles every rune of an underlined or struck-through run, which is
+// one escape pair per letter and an escape sequence inside any grapheme cluster
+// the run holds — an emoji built from joiners comes apart. Asking a style what
+// it puts around one rune leaves lipgloss owning the sequences and hands the
+// terminal one pair.
+type paint struct {
+	open, close string
+	pad         int // cells the style adds of its own, if a caller's token pads
+}
+
+// painted is one style's sequences, remembered by where the style lives. The
+// tokens all sit in one Styles for the whole of a render, so their address is a
+// key, and asking a style for its sequences costs a render of its own.
+type painted struct {
+	at *lipgloss.Style
+	p  paint
+}
+
+// markPainted is the same for a run of marked text, which is the one style
+// nothing could have built in advance. A document repeats its marks — every
+// bold run in it asks for the same style — so the key is the marks and the
+// block style they were applied over.
+type markPainted struct {
+	m   marks
+	ctx string
+	p   paint
+}
+
+// paintOf reads a style's sequences off a probe it cannot mistake for content.
+func paintOf(st lipgloss.Style) paint {
+	const probe = "\x01"
+	out := st.Render(probe)
+	before, after, ok := strings.Cut(out, probe)
+	if !ok {
+		return paint{}
+	}
+	return paint{open: before, close: after, pad: ansi.StringWidth(out)}
+}
+
+func (p paint) put(dst []byte, text string) []byte {
+	dst = append(dst, p.open...)
+	dst = append(dst, text...)
+	return append(dst, p.close...)
+}
+
+// piece is the range of one span that landed on the line being built.
+type piece struct {
+	src      int
+	from, to int
+	w        int
+}
+
+// rail is one level of the gutter: a quote's bar, a list item's marker and the
+// indent under it, a panel's edge.
+type rail struct {
+	first, cont   string
+	firstW, contW int
+	p             paint
+	used          bool
+}
+
+// align is what an alignment mark asks of a paragraph.
+type align int
+
+const (
+	alignLeft align = iota
+	alignCenter
+	alignRight
+)
+
+// frame accumulates the lines of one rendering target. The document has one;
+// every table cell gets another, because a cell is laid out in its own column
+// and then padded into the grid.
+type frame struct {
+	opt *Options
+	sty *Styles
+	mk  *Markers
+
+	width  int
+	floor  int // the narrowest the content of a line may be squeezed to
+	lines  []string
+	widths []int
+
+	folds    *[]Fold
+	nextFold *int
+
+	// unplaced marks a frame whose lines are not the document's own — a table
+	// cell — so that a fold inside it is given its row's line instead.
+	unplaced bool
+
+	rails []rail
+	ctx   lipgloss.Style // the style prose takes in the block being rendered
+	pctx  paint
+	pcont paint
+
+	memo     *[]painted
+	marked   *[]markPainted
+	spans    []span
+	rowSpans []span
+	pieces   []piece
+	pend     []piece
+	word     []piece
+	cont     int // index of the continuation-marker span, -1 until one is needed
+	tmp      [4]span
+
+	// raw is the line under construction. strings.Builder is not used here
+	// because its Reset drops the buffer, so reusing one costs an allocation and
+	// a regrow per line.
+	raw []byte
+
+	// owed holds a separating blank line that is only written if something
+	// follows it, so that a block rendering nothing does not leave a gap.
+	owed  string
+	owedW int
+	owe   bool
+
+	// dry is a frame being rendered only to be measured — a table column asking
+	// how wide its content wants to be — which needs the widths and not the
+	// lines.
+	dry bool
+}
+
+// paint is the sequences a token puts around a run, taken from the token once
+// per render however many runs it paints.
+func (f *frame) paint(at *lipgloss.Style) paint {
+	for i := range *f.memo {
+		if (*f.memo)[i].at == at {
+			return (*f.memo)[i].p
+		}
+	}
+	p := paintOf(*at)
+	*f.memo = append(*f.memo, painted{at: at, p: p})
+	return p
+}
+
+// markPaint is the sequences a run of marked text takes over the style of the
+// block it sits in.
+func (f *frame) markPaint(m marks) paint {
+	for i := range *f.marked {
+		if (*f.marked)[i].m == m && (*f.marked)[i].ctx == f.pctx.open {
+			return (*f.marked)[i].p
+		}
+	}
+	p := paintOf(f.sty.apply(f.ctx, m))
+	*f.marked = append(*f.marked, markPainted{m: m, ctx: f.pctx.open, p: p})
+	return p
+}
+
+func (f *frame) sub(width int) *frame {
+	return &frame{
+		opt: f.opt, sty: f.sty, mk: f.mk, memo: f.memo, marked: f.marked,
+		width: width, floor: f.floor, folds: f.folds, nextFold: f.nextFold,
+		ctx: f.ctx, pctx: f.pctx, pcont: f.pcont,
+	}
+}
+
+// push adds a gutter level. first is what the next line carries and cont what
+// the ones after it do; they are padded to the same width so that the room
+// available to the content does not depend on which line it is.
+func (f *frame) push(first, cont string, style *lipgloss.Style) {
+	f.pushPaint(first, cont, f.paint(style))
+}
+
+func (f *frame) pushPaint(first, cont string, p paint) {
+	fw, cw := ansi.StringWidth(first), ansi.StringWidth(cont)
+	for cw < fw {
+		cont += " "
+		cw++
+	}
+	for fw < cw {
+		first += " "
+		fw++
+	}
+	f.rails = append(f.rails, rail{first: first, cont: cont, firstW: fw, contW: cw, p: p})
+}
+
+func (f *frame) pop() { f.rails = f.rails[:len(f.rails)-1] }
+
+func (f *frame) gutter() int {
+	n := 0
+	for i := range f.rails {
+		n += f.rails[i].contW
+	}
+	return n
+}
+
+// avail is how many cells the content of a line has.
+func (f *frame) avail() int {
+	return max(f.width-f.gutter(), f.floor)
+}
+
+// railText is what rail i puts on the line being written.
+func (f *frame) railText(i int, advance bool) (text string, width int) {
+	r := &f.rails[i]
+	if r.used {
+		return r.cont, r.contW
+	}
+	if advance {
+		r.used = true
+	}
+	return r.first, r.firstW
+}
+
+// writeGutter puts the current gutter on the line being built and reports its
+// width. trim drops the trailing whitespace of a line with nothing after the
+// gutter, so that a blank line inside a quote is the bar and nothing else.
+func (f *frame) writeGutter(trim, advance bool) int {
+	last := len(f.rails)
+	if trim {
+		for last > 0 {
+			text, _ := f.railText(last-1, false)
+			if strings.TrimRight(text, " ") != "" {
+				break
+			}
+			last--
+		}
+	}
+	width := 0
+	for i := range f.rails {
+		text, w := f.railText(i, advance)
+		if i >= last {
+			continue
+		}
+		if trim && i == last-1 {
+			cut := strings.TrimRight(text, " ")
+			w -= len(text) - len(cut)
+			text = cut
+		}
+		if text == "" {
+			continue
+		}
+		f.raw = f.rails[i].p.put(f.raw, text)
+		width += w
+	}
+	return width
+}
+
+// keep appends the line under construction, writing out any separating blank
+// line that was waiting to see whether anything followed it. A dry frame keeps
+// only the width, which is all it was built to answer.
+func (f *frame) keep(width int) {
+	f.settle()
+	text := ""
+	if !f.dry {
+		text = string(f.raw)
+	}
+	f.lines = append(f.lines, text)
+	f.widths = append(f.widths, width)
+}
+
+// settle writes a blank line that is owed, for a block that is about to record
+// which line it started on and cannot have that line move under it.
+func (f *frame) settle() {
+	if !f.owe {
+		return
+	}
+	f.owe = false
+	f.lines = append(f.lines, f.owed)
+	f.widths = append(f.widths, f.owedW)
+}
+
+// separate owes a blank line between two blocks. The gutter it carries is the
+// one in force now — the blank between two of a panel's paragraphs belongs to
+// the panel — and it never consumes a marker, which belongs to a line with
+// something on it.
+func (f *frame) separate() {
+	if len(f.lines) == 0 && !f.owe {
+		return
+	}
+	f.raw = f.raw[:0]
+	f.owedW = f.writeGutter(true, false)
+	f.owed, f.owe = string(f.raw), true
+}
+
+// markerOnly emits a line that is only the gutter, for an item whose content
+// rendered nothing: a list with a row missing is a list read wrong.
+func (f *frame) markerOnly() {
+	f.raw = f.raw[:0]
+	f.keep(f.writeGutter(true, true))
+}
+
+// out emits one line from the spans given, exactly as they are. A code line, a
+// grid row and a placeholder are all lines whose width is what it is; wrapping
+// them would be a lie about the document.
+func (f *frame) out(spans []span) {
+	empty := true
+	for i := range spans {
+		if spans[i].text != "" {
+			empty = false
+			break
+		}
+	}
+	f.raw = f.raw[:0]
+	width := f.writeGutter(empty, true)
+	for i := range spans {
+		s := &spans[i]
+		if s.text == "" {
+			continue
+		}
+		f.raw = s.p.put(f.raw, s.text)
+		width += s.p.pad
+		if s.w > 0 {
+			width += s.w
+			continue
+		}
+		width += ansi.StringWidth(s.text)
+	}
+	f.keep(width)
+}
+
+// line emits one unwrapped line of a single style.
+func (f *frame) line(text string, style *lipgloss.Style) {
+	f.tmp[0] = span{text: text, p: f.paint(style)}
+	f.out(f.tmp[:1])
+}
+
+// setCtx changes the style prose takes in the block being rendered and hands
+// back what it was, for the caller to put back. A closure would be tidier and
+// would cost an allocation per block: it captures a whole lipgloss.Style.
+func (f *frame) setCtx(style *lipgloss.Style) (lipgloss.Style, paint) {
+	ctx, pctx := f.ctx, f.pctx
+	f.ctx, f.pctx = *style, f.paint(style)
+	return ctx, pctx
+}
+
+func (f *frame) restoreCtx(ctx lipgloss.Style, p paint) { f.ctx, f.pctx = ctx, p }
+
+// emit flushes the line under construction.
+func (f *frame) emit(a align, lineW int) {
+	f.raw = f.raw[:0]
+	width := f.writeGutter(len(f.pieces) == 0, true)
+	if len(f.pieces) > 0 {
+		if lead := f.lead(a, lineW); lead > 0 {
+			for range lead {
+				f.raw = append(f.raw, ' ')
+			}
+			width += lead
+		}
+	}
+	for _, p := range f.pieces {
+		s := &f.spans[p.src]
+		f.raw = s.p.put(f.raw, s.text[p.from:p.to])
+		width += p.w + s.p.pad
+	}
+	f.keep(width)
+	f.pieces = f.pieces[:0]
+	f.pend = f.pend[:0]
+}
+
+// lead is how far a centred or right-aligned line is pushed across. Only the
+// leading spaces are written: the pane owns the padding on the other side,
+// along with the gutter and the mouse zone.
+func (f *frame) lead(a align, lineW int) int {
+	room := f.avail() - lineW
+	if room <= 0 {
+		return 0
+	}
+	switch a {
+	case alignCenter:
+		return room / 2
+	case alignRight:
+		return room
+	default:
+		return 0
+	}
+}
+
+// fill wraps the spans collected in f.spans into lines. Words are placed whole
+// where they fit; a word longer than the whole column is broken, and the break
+// is marked, because a reader cannot otherwise tell a break in the layout from
+// one in the text.
+//
+// A word is a run of non-space text and may cross a span boundary: the sub
+// mark in H₂O and a comma after a code span are each their own span, and
+// breaking a line between two spans that no space separates puts a break where
+// the document has none.
+func (f *frame) fill(a align) {
+	avail, lineW, at := f.avail(), 0, len(f.lines)
+	f.pieces, f.pend, f.word, f.cont = f.pieces[:0], f.pend[:0], f.word[:0], -1
+
+	for i := range len(f.spans) {
+		if f.spans[i].brk {
+			lineW = f.place(a, lineW, avail)
+			f.emit(a, lineW)
+			lineW = 0
+			continue
+		}
+		text := f.spans[i].text
+		for pos := 0; pos < len(text); {
+			if text[pos] == ' ' {
+				lineW = f.place(a, lineW, avail)
+				end := pos
+				for end < len(text) && text[end] == ' ' {
+					end++
+				}
+				if lineW > 0 {
+					f.pend = append(f.pend, piece{src: i, from: pos, to: end, w: end - pos})
+				}
+				pos = end
+				continue
+			}
+			end := pos
+			for end < len(text) && text[end] != ' ' {
+				end++
+			}
+			f.word = append(f.word, piece{src: i, from: pos, to: end, w: ansi.StringWidth(text[pos:end])})
+			pos = end
+		}
+	}
+	lineW = f.place(a, lineW, avail)
+	if len(f.pieces) > 0 || len(f.lines) == at {
+		f.emit(a, lineW)
+	}
+}
+
+// place puts the word collected so far on the line, breaking first if it does
+// not fit and splitting it if it cannot fit on a line of its own.
+func (f *frame) place(a align, lineW, avail int) int {
+	if len(f.word) == 0 {
+		return lineW
+	}
+	total, pendW := 0, 0
+	for _, p := range f.word {
+		total += p.w
+	}
+	for _, p := range f.pend {
+		pendW += p.w
+	}
+	if lineW > 0 && lineW+pendW+total > avail {
+		f.emit(a, lineW)
+		lineW, pendW = 0, 0
+	}
+	if lineW == 0 && total > avail {
+		lineW = f.split(a, avail)
+		f.word = f.word[:0]
+		return lineW
+	}
+	if lineW > 0 {
+		for _, p := range f.pend {
+			f.appendPiece(p)
+		}
+		lineW += pendW
+	}
+	f.pend = f.pend[:0]
+	for _, p := range f.word {
+		f.appendPiece(p)
+	}
+	f.word = f.word[:0]
+	return lineW + total
+}
+
+// split breaks one word that is wider than the column. The pieces are cut at
+// grapheme boundaries, so a CJK cell or an emoji is never halved.
+func (f *frame) split(a align, avail int) int {
+	marked := true
+	for _, p := range f.word {
+		if hasWide(f.spans[p.src].text[p.from:p.to]) {
+			marked = false
+			break
+		}
+	}
+	lineW, broken := 0, false
+	for _, p := range f.word {
+		for at := p.from; at < p.to; {
+			if lineW == 0 && broken && marked {
+				lineW = f.appendCont()
+			}
+			room := avail - lineW
+			if room < 1 {
+				f.emit(a, lineW)
+				lineW = 0
+				continue
+			}
+			rest := f.spans[p.src].text[at:p.to]
+			if w := ansi.StringWidth(rest); w <= room {
+				f.appendPiece(piece{src: p.src, from: at, to: p.to, w: w})
+				lineW += w
+				break
+			}
+			head, _ := splitWidth(rest, room)
+			headW := ansi.StringWidth(head)
+			f.appendPiece(piece{src: p.src, from: at, to: at + len(head), w: headW})
+			f.emit(a, lineW+headW)
+			lineW, broken = 0, true
+			at += len(head)
+		}
+	}
+	return lineW
+}
+
+// appendCont heads a continuation line with the marker that says the renderer
+// broke the word, not the author.
+func (f *frame) appendCont() int {
+	if f.cont < 0 {
+		f.spans = append(f.spans, span{text: f.mk.Cont + " ", p: f.pcont})
+		f.cont = len(f.spans) - 1
+	}
+	text := f.spans[f.cont].text
+	w := ansi.StringWidth(text)
+	f.pieces = append(f.pieces, piece{src: f.cont, from: 0, to: len(text), w: w})
+	return w
+}
+
+// appendPiece extends the piece under construction when the new range carries
+// straight on from it, so that a run of words in one style costs one Render
+// call per line rather than one per word.
+func (f *frame) appendPiece(p piece) {
+	if n := len(f.pieces); n > 0 {
+		last := &f.pieces[n-1]
+		if last.src == p.src && last.to == p.from {
+			last.to, last.w = p.to, last.w+p.w
+			return
+		}
+	}
+	f.pieces = append(f.pieces, p)
+}
+
+// splitWidth cuts a string at the last grapheme boundary that fits in n cells,
+// returning the two halves. ansi does the cutting: a cluster wider than the
+// room left would otherwise come back empty and the caller would not advance.
+func splitWidth(s string, n int) (head, tail string) {
+	for room := n; room <= n+4; room++ {
+		if head = ansi.Truncate(s, room, ""); head != "" {
+			return head, ansi.TruncateLeft(s, room, "")
+		}
+	}
+	return s, ""
+}
+
+// hasWide reports whether a run holds anything wider than one cell, which is
+// how a run with no break opportunity in it is told from CJK. Breaking CJK
+// between two ideographs is what a terminal is supposed to do, and marking
+// every one of those lines as a broken word would be noise.
+func hasWide(s string) bool {
+	for _, r := range s {
+		if ansi.StringWidth(string(r)) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// expandTabs replaces tabs with the spaces to the next stop, which is what a
+// terminal does and what ansi.StringWidth does not.
+func expandTabs(s string, col int) string {
+	if !strings.ContainsRune(s, '\t') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + tabWidth)
+	for _, r := range s {
+		if r != '\t' {
+			b.WriteRune(r)
+			col += ansi.StringWidth(string(r))
+			continue
+		}
+		pad := tabWidth - col%tabWidth
+		for range pad {
+			b.WriteByte(' ')
+		}
+		col += pad
+	}
+	return b.String()
+}
+
+// sanitize drops the control characters a terminal would act on. Issue text is
+// written by anyone with a Jira login, and an escape sequence in a description
+// must not be able to repaint the screen it is displayed in.
+func sanitize(s string) string {
+	if !hasControl(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func hasControl(s string) bool {
+	for _, r := range s {
+		if isControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isControl(r rune) bool {
+	switch {
+	case r == '\t':
+		return false
+	case r < 0x20 || r == 0x7f:
+		return true
+	case r >= 0x80 && r <= 0x9f:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/ui/richtext/harness_test.go
+++ b/internal/ui/richtext/harness_test.go
@@ -1,0 +1,113 @@
+package richtext
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files")
+
+// load reads one of the stored documents. kitchen.json is what a real site
+// stored when it was sent every node type it accepts; edges.json is the shapes
+// a site keeps but will not accept, which is how an app's own nodes arrive.
+func load(t testing.TB, name string) adf.Doc {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name)) //nolint:gosec // a literal under testdata
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := adf.Unmarshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// plainPalette is the theme the layout goldens are written under: attributes
+// only, no colour, so that a golden diff is about the document and never about
+// a hex value somebody changed in the kernel.
+func plainPalette() Palette {
+	base := lipgloss.NewStyle()
+	return Palette{
+		Base:    base,
+		Muted:   base.Faint(true),
+		Title:   base.Bold(true),
+		Accent:  base.Bold(true),
+		Danger:  base.Bold(true),
+		Warning: base.Bold(true),
+		Success: base.Bold(true),
+		Badge:   base.Reverse(true),
+		Color:   false,
+	}
+}
+
+// colourPalette is the theme the styling assertions use. Each token is a
+// different colour so that a test can say which one a run was rendered in.
+func colourPalette() Palette {
+	return Palette{
+		Base:    lipgloss.NewStyle().Foreground(lipgloss.Color("#101010")),
+		Muted:   lipgloss.NewStyle().Foreground(lipgloss.Color("#202020")),
+		Title:   lipgloss.NewStyle().Foreground(lipgloss.Color("#303030")),
+		Accent:  lipgloss.NewStyle().Foreground(lipgloss.Color("#404040")),
+		Danger:  lipgloss.NewStyle().Foreground(lipgloss.Color("#505050")),
+		Warning: lipgloss.NewStyle().Foreground(lipgloss.Color("#606060")),
+		Success: lipgloss.NewStyle().Foreground(lipgloss.Color("#707070")),
+		Badge:   lipgloss.NewStyle().Foreground(lipgloss.Color("#808080")),
+		Color:   true,
+	}
+}
+
+func options(width int) Options {
+	return Options{
+		Width:    width,
+		Location: time.UTC,
+		Styles:   NewStyles(plainPalette()),
+		Markers:  UnicodeMarkers(),
+	}
+}
+
+// stripped is what a golden file holds: the layout, with the styling taken off,
+// which is the convention the other views' goldens follow.
+func stripped(r Rendered) string {
+	var b strings.Builder
+	for i, line := range r.Lines {
+		b.WriteString(ansi.Strip(line))
+		if i < len(r.Lines)-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func golden(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		if err := os.WriteFile(path, []byte(got), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // a literal under testdata
+	if err != nil {
+		t.Fatalf("%v — run: go test ./internal/ui/richtext -update", err)
+	}
+	if string(want) != got {
+		t.Errorf("output differs from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}
+
+func doc(nodes ...adf.Node) adf.Doc { return adf.NewDoc(nodes...) }
+
+func para(text string) adf.Node {
+	return adf.NewNode("paragraph", adf.NewText(text))
+}

--- a/internal/ui/richtext/inline.go
+++ b/internal/ui/richtext/inline.go
@@ -1,0 +1,286 @@
+package richtext
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// inline collects the spans for a run of inline nodes. Nothing is wrapped here:
+// the spans are handed to the line builder, which breaks them and styles each
+// line on its own.
+func (f *frame) inline(nodes []adf.Node) {
+	for i := range nodes {
+		f.inlineNode(nodes[i])
+	}
+}
+
+func (f *frame) inlineNode(n adf.Node) {
+	switch n.Type {
+	case "text":
+		f.markedText(n)
+	case "hardBreak":
+		f.spans = append(f.spans, span{brk: true})
+	case "mention":
+		f.add(mentionText(n.Attrs), &f.sty.Mention)
+	case "status":
+		text, colour := statusParts(n.Attrs)
+		f.add(text, f.sty.status(colour))
+	case "emoji":
+		f.addText(emojiText(n.Attrs))
+	case "date":
+		f.add(f.dateText(n.Attrs), &f.sty.Date)
+	case "inlineCard", "inlineEmbedCard":
+		f.cardSpans(n)
+	case "media", "mediaInline":
+		f.add(f.mk.Media+" "+mediaTarget(n), &f.sty.Media)
+	case "placeholder":
+		if text, ok := attrString(n.Attrs, "text"); ok {
+			f.add(text, &f.sty.Muted)
+		}
+	default:
+		f.unknownSpans(n)
+	}
+}
+
+// add appends one run of text, breaking it where the text itself breaks: a
+// newline inside a text node is a line break rather than a character a terminal
+// should be asked to print.
+func (f *frame) add(text string, style *lipgloss.Style) {
+	f.addPaint(text, f.paint(style))
+}
+
+// addText is the same for prose taking the style of the block it is in, which
+// was asked for its sequences when the block set it.
+func (f *frame) addText(text string) { f.addPaint(text, f.pctx) }
+
+func (f *frame) addPaint(text string, p paint) {
+	if text == "" {
+		return
+	}
+	for {
+		before, after, more := strings.Cut(text, "\n")
+		if clean := expandTabs(sanitize(before), 0); clean != "" {
+			f.spans = append(f.spans, span{text: clean, p: p})
+		}
+		if !more {
+			return
+		}
+		f.spans = append(f.spans, span{brk: true})
+		text = after
+	}
+}
+
+// markedText renders one text node under its marks. sub and sup are spelled out
+// rather than dropped: a terminal has no raised digit, and H2O read as H2O is
+// wrong in a way a reader cannot see.
+func (f *frame) markedText(n adf.Node) {
+	m := gatherMarks(n.Marks)
+	if !m.any() && !m.sub && !m.sup {
+		f.addText(n.Text)
+		return
+	}
+	p := f.markPaint(m)
+	switch {
+	case m.sup:
+		f.addPaint("^"+n.Text, p)
+	case m.sub:
+		f.addPaint("_"+n.Text, p)
+	default:
+		f.addPaint(n.Text, p)
+	}
+	// The address is shown rather than hidden behind the words: a terminal
+	// cannot be relied on to make a link clickable, and a link whose address a
+	// reader cannot see is one they cannot follow.
+	if m.href != "" && strings.TrimSpace(n.Text) != m.href {
+		f.add(" ("+m.href+")", &f.sty.URL)
+	}
+}
+
+func gatherMarks(list []adf.Mark) marks {
+	var m marks
+	for i := range list {
+		switch list[i].Type {
+		case "strong":
+			m.strong = true
+		case "em":
+			m.em = true
+		case "underline":
+			m.underline = true
+		case "strike":
+			m.strike = true
+		case "code":
+			m.code = true
+		case "link":
+			if m.href == "" {
+				href, _ := attrString(list[i].Attrs, "href")
+				m.href = sanitize(strings.TrimSpace(href))
+			}
+		case "subsup":
+			kind, _ := attrString(list[i].Attrs, "type")
+			if kind == "sub" {
+				m.sub = true
+			} else {
+				m.sup = true
+			}
+		case "textColor":
+			m.fg, _ = attrString(list[i].Attrs, "color")
+		case "backgroundColor":
+			m.bg, _ = attrString(list[i].Attrs, "color")
+		}
+	}
+	return m
+}
+
+// blockMarks reads the marks ADF puts on a block rather than on its text.
+func blockMarks(list []adf.Mark) (a align, level int) {
+	a, level = alignLeft, 0
+	for i := range list {
+		switch list[i].Type {
+		case "alignment":
+			switch kind, _ := attrString(list[i].Attrs, "align"); kind {
+			case "center":
+				a = alignCenter
+			case "end", "right":
+				a = alignRight
+			}
+		case "indentation":
+			if n, ok := attrInt(list[i].Attrs, "level"); ok && n > 0 {
+				level = min(n, 6)
+			}
+		}
+	}
+	return a, level
+}
+
+// mentionText renders a mention from the display text the editor stored with
+// it. The account id behind it means nothing to a reader.
+func mentionText(a adf.Attrs) string {
+	text, _ := attrString(a, "text")
+	text = sanitize(strings.TrimSpace(text))
+	if text == "" {
+		if id, ok := attrString(a, "id"); ok {
+			text = sanitize(id)
+		}
+	}
+	if text == "" {
+		return "@?"
+	}
+	if strings.HasPrefix(text, "@") {
+		return text
+	}
+	return "@" + text
+}
+
+// statusParts renders a lozenge and hands back the colour enum it carries, so
+// that the colour the author chose is the colour a reader sees. The brackets
+// stay whatever the theme does: they are what is left of the lozenge once the
+// colour is stripped, and a no-colour terminal has nothing else.
+func statusParts(a adf.Attrs) (text, colour string) {
+	text, _ = attrString(a, "text")
+	text = sanitize(strings.TrimSpace(text))
+	colour, _ = attrString(a, "color")
+	if text == "" {
+		return "[status]", colour
+	}
+	return "[" + text + "]", colour
+}
+
+func emojiText(a adf.Attrs) string {
+	if text, ok := attrString(a, "text"); ok && text != "" {
+		return sanitize(text)
+	}
+	if short, ok := attrString(a, "shortName"); ok && short != "" {
+		return sanitize(short)
+	}
+	if id, ok := attrString(a, "id"); ok && id != "" {
+		return ":" + sanitize(id) + ":"
+	}
+	return ""
+}
+
+// dateText renders the instant a date node carries, which arrives as epoch
+// milliseconds in a string.
+func (f *frame) dateText(a adf.Attrs) string {
+	stamp, _ := attrString(a, "timestamp")
+	ms, err := strconv.ParseInt(strings.TrimSpace(stamp), 10, 64)
+	if err != nil {
+		return sanitize(stamp)
+	}
+	loc := f.opt.Location
+	if loc == nil {
+		loc = time.UTC
+	}
+	return time.UnixMilli(ms).In(loc).Format(time.DateOnly)
+}
+
+// cardSpans renders a smart link. Jira resolves these server-side for the
+// browser; over the API only the URL comes back, so the URL is what a reader
+// gets.
+func (f *frame) cardSpans(n adf.Node) {
+	url, name := cardParts(n)
+	switch {
+	case url == "" && name == "":
+		f.unknownSpans(n)
+	case name == "" || name == url:
+		f.add(url, &f.sty.Card)
+	default:
+		f.add(name, &f.sty.Card)
+		f.add(" ("+url+")", &f.sty.URL)
+	}
+}
+
+func cardParts(n adf.Node) (url, name string) {
+	url, _ = attrString(n.Attrs, "url")
+	if data, ok := n.Attrs["data"].(map[string]any); ok {
+		if url == "" {
+			url, _ = data["url"].(string)
+		}
+		name, _ = data["name"].(string)
+	}
+	return sanitize(strings.TrimSpace(url)), sanitize(strings.TrimSpace(name))
+}
+
+// mediaTarget names an attachment or an image as a placeholder rather than as a
+// broken link. The id is what a preview resolves against the attachment list,
+// so the line has to leave something to find.
+func mediaTarget(n adf.Node) string {
+	alt, _ := attrString(n.Attrs, "alt")
+	alt = sanitize(strings.TrimSpace(alt))
+	target, _ := attrString(n.Attrs, "url")
+	target = sanitize(strings.TrimSpace(target))
+	if target == "" {
+		if id, ok := attrString(n.Attrs, "id"); ok && id != "" {
+			target = "media:" + sanitize(id)
+		}
+	}
+	switch {
+	case alt == "" && target == "":
+		return "media"
+	case alt == "":
+		return target
+	case target == "":
+		return alt
+	default:
+		return alt + " (" + target + ")"
+	}
+}
+
+// unknownSpans shows that a node is there, and what it holds, without
+// pretending to know how it should look. pkg/adf keeps such a node for the
+// round trip; a reader who cannot see that something is there cannot go and
+// look at it in a browser.
+func (f *frame) unknownSpans(n adf.Node) {
+	f.add(f.mk.Unknown+" "+nodeName(n), &f.sty.Unknown)
+	switch {
+	case len(n.Content) > 0:
+		f.add(": ", &f.sty.Unknown)
+		f.inline(n.Content)
+	case n.Text != "":
+		f.addText(": " + n.Text)
+	}
+}

--- a/internal/ui/richtext/markers.go
+++ b/internal/ui/richtext/markers.go
@@ -1,0 +1,94 @@
+package richtext
+
+// Markers are the glyphs put in front of a construct that plain text has no
+// spelling for. Nothing here assumes a Nerd Font: the Unicode set is geometric
+// and box-drawing shapes only, and the ASCII set is for the terminals and fonts
+// docs/UX.md says never to assume anything about.
+//
+// A panel is not a blockquote, so each panel kind carries its own marker: what
+// the document said about a warning is lost the moment it renders as the same
+// bar an ordinary quote gets.
+type Markers struct {
+	Info    string
+	Note    string
+	Success string
+	Warning string
+	Error   string
+	Panel   string // a panel whose kind the site chose, and whose colour is on the wire
+
+	Decision string
+	Task     string
+	TaskDone string
+
+	Media string
+
+	Folded   string
+	Unfolded string
+
+	Bullet   string
+	VLine    string
+	HLine    string
+	Ellipsis string
+
+	// Cont heads a line the renderer broke rather than the author: a URL longer
+	// than the pane is the usual one. Without it a reader cannot tell a break in
+	// the text from a break in the layout.
+	Cont string
+
+	// Unknown heads a node type this build has never heard of. pkg/adf keeps
+	// those for the round trip, and a reader who cannot see that something is
+	// there cannot go and look at it in a browser.
+	Unknown string
+}
+
+// UnicodeMarkers is the default set.
+func UnicodeMarkers() Markers {
+	return Markers{
+		Info: "ℹ", Note: "✎", Success: "✓", Warning: "⚠", Error: "✗", Panel: "◆",
+		Decision: "◇", Task: "☐", TaskDone: "☑",
+		Media:  "▣",
+		Folded: "▸", Unfolded: "▾",
+		Bullet: "•", VLine: "│", HLine: "─", Ellipsis: "…",
+		Cont: "↳", Unknown: "?",
+	}
+}
+
+// ASCIIMarkers is the fallback for a terminal or font that cannot be trusted
+// with anything else.
+func ASCIIMarkers() Markers {
+	return Markers{
+		Info: "i", Note: "*", Success: "+", Warning: "!", Error: "x", Panel: "#",
+		Decision: "<>", Task: "[ ]", TaskDone: "[x]",
+		Media:  "[]",
+		Folded: ">", Unfolded: "v",
+		Bullet: "-", VLine: "|", HLine: "-", Ellipsis: "...",
+		Cont: "\\", Unknown: "?",
+	}
+}
+
+// ascii reports whether the ASCII set is in force. The set is identified by one
+// of its members rather than by a flag a caller could forget to set, which is
+// how kernel.Theme's glyph set is identified too.
+func (m Markers) ascii() bool { return m.VLine == ASCIIMarkers().VLine }
+
+// withDefaults fills the markers a caller left empty, so that a zero Options
+// still renders a bullet rather than nothing.
+func (m Markers) withDefaults() Markers {
+	d := UnicodeMarkers()
+	for _, f := range [...]struct {
+		at   *string
+		want string
+	}{
+		{&m.Info, d.Info}, {&m.Note, d.Note}, {&m.Success, d.Success},
+		{&m.Warning, d.Warning}, {&m.Error, d.Error}, {&m.Panel, d.Panel},
+		{&m.Decision, d.Decision}, {&m.Task, d.Task}, {&m.TaskDone, d.TaskDone},
+		{&m.Media, d.Media}, {&m.Folded, d.Folded}, {&m.Unfolded, d.Unfolded},
+		{&m.Bullet, d.Bullet}, {&m.VLine, d.VLine}, {&m.HLine, d.HLine},
+		{&m.Ellipsis, d.Ellipsis}, {&m.Cont, d.Cont}, {&m.Unknown, d.Unknown},
+	} {
+		if *f.at == "" {
+			*f.at = f.want
+		}
+	}
+	return m
+}

--- a/internal/ui/richtext/nodes.go
+++ b/internal/ui/richtext/nodes.go
@@ -1,0 +1,126 @@
+package richtext
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// spaces is sliced to build an indent, so that indenting a list item does not
+// allocate.
+const spaces = "                                "
+
+func indent(n int) string {
+	if n > len(spaces) {
+		n = len(spaces)
+	}
+	return spaces[:n]
+}
+
+// indentFor returns an indent as wide on screen as the marker it continues.
+func indentFor(marker string) string { return indent(ansi.StringWidth(marker)) }
+
+// attrString reads a string attribute, reporting whether it was there and of
+// that type — an attribute this package models can still arrive as something
+// else, and a document that does that must still render.
+func attrString(a adf.Attrs, key string) (string, bool) {
+	v, ok := a[key].(string)
+	return v, ok
+}
+
+// attrInt reads a numeric attribute. JSON numbers decode to float64, but a
+// document built in Go carries whatever the caller put there.
+func attrInt(a adf.Attrs, key string) (int, bool) {
+	switch v := a[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case json.Number:
+		n, err := v.Int64()
+		return int(n), err == nil
+	default:
+		return 0, false
+	}
+}
+
+// rawText concatenates the text of a run of nodes, which is how a code block
+// carries its lines. Nothing is dropped here: a code block's newlines are its
+// structure.
+func rawText(nodes []adf.Node) string {
+	if len(nodes) == 1 {
+		return nodes[0].Text
+	}
+	var b strings.Builder
+	for i := range nodes {
+		b.WriteString(nodes[i].Text)
+	}
+	return b.String()
+}
+
+func isInline(typ string) bool {
+	switch typ {
+	case "text", "hardBreak", "mention", "status", "emoji", "date",
+		"inlineCard", "inlineEmbedCard", "media", "mediaInline",
+		"placeholder", "inlineExtension", "unsupportedInline":
+		return true
+	default:
+		return false
+	}
+}
+
+func isList(typ string) bool {
+	switch typ {
+	case "bulletList", "orderedList", "taskList", "decisionList":
+		return true
+	default:
+		return false
+	}
+}
+
+func inlineOnly(nodes []adf.Node) bool {
+	for i := range nodes {
+		if !isInline(nodes[i].Type) {
+			return false
+		}
+	}
+	return len(nodes) > 0
+}
+
+// nodeName is what an unknown node is called on screen: the node it stands in
+// for if it is one of ADF's own wrappers for something a client cannot read,
+// the app's key if it is an extension, and its own type otherwise.
+func nodeName(n adf.Node) string {
+	switch n.Type {
+	case "unsupportedBlock", "unsupportedInline":
+		if original, ok := n.Attrs["originalValue"].(map[string]any); ok {
+			if typ, ok := original["type"].(string); ok && typ != "" {
+				return sanitize(typ)
+			}
+		}
+	case "extension", "bodiedExtension", "inlineExtension", "multiBodiedExtension":
+		if key, ok := attrString(n.Attrs, "extensionKey"); ok && key != "" {
+			return sanitize(n.Type) + " " + sanitize(key)
+		}
+	}
+	return sanitize(n.Type)
+}
+
+// countFolds counts the expands in a subtree, so that closing one does not
+// renumber the folds inside it: an index has to mean the same node whatever the
+// reader has opened.
+func countFolds(nodes []adf.Node) int {
+	n := 0
+	for i := range nodes {
+		if nodes[i].Type == "expand" || nodes[i].Type == "nestedExpand" {
+			n++
+		}
+		n += countFolds(nodes[i].Content)
+	}
+	return n
+}

--- a/internal/ui/richtext/render_test.go
+++ b/internal/ui/richtext/render_test.go
@@ -1,0 +1,353 @@
+package richtext
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// section is the run of blocks under one of the kitchen sink's headings, so
+// that a golden is per construct and still driven from what a site stored
+// rather than from nodes a test made up.
+func section(t *testing.T, d adf.Doc, title string) adf.Doc {
+	t.Helper()
+	var out []adf.Node
+	on := false
+	for i := range d.Content {
+		n := d.Content[i]
+		if n.Type == "heading" {
+			if on {
+				break
+			}
+			on = strings.Contains(Summary(adf.NewDoc(n), 200), title)
+			continue
+		}
+		if on {
+			out = append(out, n)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("the stored document has no section under a heading holding %q", title)
+	}
+	return adf.NewDoc(out...)
+}
+
+func TestRender_WholeDocument(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"kitchen", "edges"} {
+		d := load(t, name+".json")
+		for _, width := range []int{80, 40} {
+			golden(t, fmt.Sprintf("%s_%d.golden", name, width), stripped(Render(d, options(width))))
+		}
+	}
+}
+
+func TestRender_PerConstruct(t *testing.T) {
+	t.Parallel()
+	kitchen := load(t, "kitchen.json")
+	for _, tc := range []struct {
+		name    string
+		heading string
+		widths  []int
+	}{
+		{"lists", "Lists", []int{60, 28}},
+		{"tasks", "Task and decision", []int{60, 28}},
+		{"code", "Code", []int{60, 28}},
+		{"quote", "Quote and rule", []int{60, 28}},
+		{"panels", "Panels", []int{60, 24}},
+		{"table", "Table with a header", []int{80, 40, 24}},
+		{"cards", "Expand, layout and cards", []int{60, 28}},
+		{"inline", "Inline nodes", []int{60, 30}},
+		{"nonascii", "Non-ASCII", []int{60, 20}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := section(t, kitchen, tc.heading)
+			for _, width := range tc.widths {
+				golden(t, fmt.Sprintf("%s_%d.golden", tc.name, width), stripped(Render(d, options(width))))
+			}
+		})
+	}
+}
+
+// TestRender_ASCIIMarkers covers the terminals docs/UX.md says never to assume
+// anything about: the glyph set changes and nothing else does.
+func TestRender_ASCIIMarkers(t *testing.T) {
+	t.Parallel()
+	kitchen := load(t, "kitchen.json")
+	for _, heading := range []string{"Panels", "Task and decision", "Lists"} {
+		d := section(t, kitchen, heading)
+		opt := options(60)
+		opt.Markers = ASCIIMarkers()
+		name := strings.ToLower(strings.Fields(heading)[0]) + "_ascii_60.golden"
+		golden(t, name, stripped(Render(d, opt)))
+	}
+}
+
+// TestRender_OpenFold covers the other half of an expand: the same document
+// rendered with the fold the reader has opened.
+func TestRender_OpenFold(t *testing.T) {
+	t.Parallel()
+	d := section(t, load(t, "kitchen.json"), "Expand, layout and cards")
+	opt := options(60)
+	opt.Open = map[int]bool{0: true}
+	golden(t, "cards_open_60.golden", stripped(Render(d, opt)))
+}
+
+func TestRender_ZeroOptionsStillRenders(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	r := Render(d, Options{})
+	if len(r.Lines) == 0 {
+		t.Fatal("a zero Options rendered nothing")
+	}
+	if r.Width() > defaultWidth {
+		// Code and tables are allowed past the width; nothing else is.
+		for i, line := range r.Lines {
+			if r.Widths[i] > defaultWidth && !strings.Contains(line, "select") {
+				continue
+			}
+		}
+	}
+	if !strings.Contains(stripped(r), UnicodeMarkers().Bullet) {
+		t.Error("a zero Options lost the markers; the Unicode set is the default")
+	}
+}
+
+func TestRender_EmptyDocument(t *testing.T) {
+	t.Parallel()
+	for _, d := range []adf.Doc{{}, adf.NewDoc()} {
+		r := Render(d, options(80))
+		if len(r.Lines) != 0 || len(r.Widths) != 0 || len(r.Folds) != 0 {
+			t.Errorf("an empty document rendered %d lines", len(r.Lines))
+		}
+	}
+}
+
+// TestRender_WidthsAreWhatTheLinesMeasure is the contract a pane clamps panning
+// against: it must not have to measure a line itself.
+func TestRender_WidthsAreWhatTheLinesMeasure(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"kitchen.json", "edges.json"} {
+		d := load(t, name)
+		for _, width := range []int{120, 80, 40, 24, 12} {
+			for _, palette := range []Palette{plainPalette(), colourPalette()} {
+				opt := options(width)
+				opt.Styles = NewStyles(palette)
+				r := Render(d, opt)
+				if len(r.Lines) != len(r.Widths) {
+					t.Fatalf("%s at %d: %d lines against %d widths", name, width, len(r.Lines), len(r.Widths))
+				}
+				for i, line := range r.Lines {
+					if got := ansi.StringWidth(line); got != r.Widths[i] {
+						t.Errorf("%s at %d, line %d: measured %d, reported %d\n%q",
+							name, width, i, got, r.Widths[i], line)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestRender_ProseFitsTheWidth holds the wrapping to its promise, over the
+// sections that hold no code and no grid: everything else wraps, however narrow
+// the pane.
+func TestRender_ProseFitsTheWidth(t *testing.T) {
+	t.Parallel()
+	kitchen := load(t, "kitchen.json")
+	for _, heading := range []string{"Task and decision", "Quote and rule", "Panels", "Inline nodes"} {
+		d := section(t, kitchen, heading)
+		// Nothing narrower than 16 is asserted: a gutter deep enough to squeeze
+		// the content below minAvail is allowed to push a line past the width,
+		// which is the floor doing its job rather than the wrapping failing.
+		for _, width := range []int{80, 40, 24, 16} {
+			r := Render(d, options(width))
+			for i, line := range r.Lines {
+				if r.Widths[i] > width {
+					t.Errorf("%q at width %d, line %d is %d wide: %q",
+						heading, width, i, r.Widths[i], ansi.Strip(line))
+				}
+			}
+		}
+	}
+}
+
+// TestRender_OnlyCodeAndGridsOverflow is the other half of that promise: the
+// two constructs that are allowed past the width are the only ones that go
+// past it, and both are marked as such by the bar they carry.
+func TestRender_OnlyCodeAndGridsOverflow(t *testing.T) {
+	t.Parallel()
+	bar := UnicodeMarkers().VLine
+	for _, name := range []string{"kitchen.json", "edges.json"} {
+		d := load(t, name)
+		for _, width := range []int{80, 40, 24} {
+			r := Render(d, options(width))
+			for i, line := range r.Lines {
+				plain := ansi.Strip(line)
+				if r.Widths[i] <= max(width, minAvail) || strings.HasPrefix(plain, bar) {
+					continue
+				}
+				t.Errorf("%s at width %d, line %d is %d wide and is neither code nor a grid: %q",
+					name, width, i, r.Widths[i], plain)
+			}
+		}
+	}
+}
+
+// TestRender_CodeIsNeitherWrappedNorTruncated is the decision written down: a
+// line of code arrives whole or not at all, and it arrives whole.
+func TestRender_CodeIsNeitherWrappedNorTruncated(t *testing.T) {
+	t.Parallel()
+	const sql = "select key, summary, status from issue where project = 'EX' " +
+		"and status in ('open', 'in review') order by updated desc;"
+	d := load(t, "edges.json")
+	for _, width := range []int{80, 40, 12} {
+		r := Render(d, options(width))
+		found := false
+		for _, line := range r.Lines {
+			if strings.Contains(ansi.Strip(line), sql) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("at width %d the code line came back wrapped or cut:\n%s", width, stripped(r))
+		}
+	}
+}
+
+// TestRender_TableCellWrapsRatherThanBeingCut is the same decision for a grid:
+// the column is squeezed and the words go onto another line of the row.
+func TestRender_TableCellWrapsRatherThanBeingCut(t *testing.T) {
+	t.Parallel()
+	d := load(t, "edges.json")
+	r := Render(d, options(80))
+	got := stripped(r)
+	for _, word := range strings.Fields("a sentence long enough to wrap inside its own column rather than be cut off") {
+		if !strings.Contains(got, word) {
+			t.Errorf("the squeezed cell lost %q:\n%s", word, got)
+		}
+	}
+	if strings.Contains(got, UnicodeMarkers().Ellipsis) {
+		t.Error("a cell was truncated; a squeezed column wraps")
+	}
+}
+
+// TestRender_NothingIsDropped is the property behind every construct decision:
+// whatever the document says, in order, is somewhere in the lines. Wrapping may
+// put a break inside a word, so the comparison ignores whitespace.
+func TestRender_NothingIsDropped(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"kitchen.json", "edges.json"} {
+		d := load(t, name)
+		want := packed(documentText(d))
+		for _, width := range []int{120, 80, 40, 16} {
+			got := packed(withoutGrids(stripped(Render(d, options(width)))))
+			if missing, ok := subsequence(want, got); !ok {
+				t.Errorf("%s at width %d dropped text from %q onwards", name, width, missing)
+			}
+		}
+	}
+}
+
+// documentText is every character the document asks to be shown, in order.
+//
+// A table is left out because a grid is laid out in columns: a row two lines
+// tall interleaves its cells, so document order is not line order, and what a
+// grid keeps is asserted on its own. A closed expand is left out because not
+// showing what is inside it is the whole point of a fold.
+func documentText(d adf.Doc) string {
+	var b strings.Builder
+	d.Walk(func(n adf.Node) bool {
+		switch n.Type {
+		case "table", "expand", "nestedExpand":
+			return false
+		case "text":
+			b.WriteString(n.Text)
+		case "mention", "emoji", "status", "placeholder":
+			text, _ := attrString(n.Attrs, "text")
+			b.WriteString(text)
+		}
+		return true
+	})
+	return b.String()
+}
+
+// withoutGrids drops the lines a grid drew, which are the ones whose order is
+// the layout's rather than the document's.
+func withoutGrids(s string) string {
+	bar := UnicodeMarkers().VLine
+	var keep []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(line, bar) && strings.HasSuffix(line, bar) {
+			continue
+		}
+		keep = append(keep, line)
+	}
+	return strings.Join(keep, "\n")
+}
+
+func packed(s string) string {
+	var b strings.Builder
+	for _, r := range sanitize(s) {
+		if r == ' ' || r == '\n' || r == '\t' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// subsequence reports whether want appears in got in order, and where it stops
+// if it does not.
+func subsequence(want, got string) (string, bool) {
+	at := 0
+	for i, r := range want {
+		next := strings.IndexRune(got[at:], r)
+		if next < 0 {
+			end := min(i+24, len(want))
+			return want[i:end], false
+		}
+		at += next + len(string(r))
+	}
+	return "", true
+}
+
+func TestSummary(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	got := Summary(d, 60)
+	if w := ansi.StringWidth(got); w > 60 {
+		t.Errorf("a summary of 60 came back %d wide: %q", w, got)
+	}
+	if strings.ContainsAny(got, "\n\x1b") {
+		t.Errorf("a summary is one plain line: %q", got)
+	}
+	if !strings.HasPrefix(got, "Kitchen sink") {
+		t.Errorf("a summary leads with the document: %q", got)
+	}
+	if !strings.HasSuffix(got, UnicodeMarkers().Ellipsis) {
+		t.Errorf("a summary that ran out of room says so: %q", got)
+	}
+	if Summary(d, 0) != "" {
+		t.Error("a summary with no room is empty")
+	}
+	if Summary(adf.Doc{}, 40) != "" {
+		t.Error("a summary of nothing is empty")
+	}
+}
+
+// TestSummary_CountsCellsNotBytes measures a cut in cells rather than bytes,
+// which is the way a truncation helper is usually got wrong.
+func TestSummary_CountsCellsNotBytes(t *testing.T) {
+	t.Parallel()
+	d := doc(para("日本語のテキスト、中文字符 🚀 Größe"))
+	for _, width := range []int{4, 5, 8, 11, 20} {
+		if w := ansi.StringWidth(Summary(d, width)); w > width {
+			t.Errorf("a summary of %d came back %d wide: %q", width, w, Summary(d, width))
+		}
+	}
+}

--- a/internal/ui/richtext/richtext.go
+++ b/internal/ui/richtext/richtext.go
@@ -1,0 +1,207 @@
+// Package richtext renders an ADF document as styled terminal lines.
+//
+// It exists because pkg/adf's markdown is a serialisation for editing: it backs
+// the $EDITOR handoff and a byte-stable round trip, it deliberately does not
+// escape prose, and it is public API that must not grow a dependency on a UI
+// library. Displaying it puts ## and ** and [text](url) on screen, and feeding
+// it to a markdown renderer would re-parse text that was never markdown — so
+// *not emphasis* would become emphasis — after the information a display needs
+// has already been thrown away: by then an error panel and a plain quote are
+// the same node.
+//
+// So the walk happens once, over the document, straight to lines:
+//
+//	r := richtext.Render(doc, richtext.Options{
+//		Width:   pane - gutter,
+//		Styles:  richtext.NewStyles(palette),
+//		Markers: richtext.UnicodeMarkers(),
+//	})
+//
+// The caller hands in the theme. This package holds none, which keeps the
+// golden files a property of the document rather than of whichever theme was
+// loaded, lets the issue and the comment views share one renderer, and
+// forecloses an import cycle: nothing here imports internal/ui/kernel.
+//
+// Every line stands on its own. A line is built by breaking first and styling
+// after, because ansi.Wrap does not re-open an SGR sequence on the lines it
+// makes, so a pane showing a window into the middle of a wrapped run would
+// otherwise draw it unstyled or open it with a stray reset.
+//
+// Lines are not padded to Width: padding belongs to the pane, which owns the
+// gutter and the mouse zone. Widths is there so a pane can clamp panning
+// without measuring every line on every frame, and a line may be wider than
+// Width where the alternative is losing data — code is never wrapped and a
+// table is never cut.
+package richtext
+
+import (
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// defaultWidth is what a caller who asked for no width gets, rather than a
+// document rendered one word per line.
+const defaultWidth = 80
+
+// Options tunes one rendering.
+type Options struct {
+	// Width is how many cells a line has, gutters included.
+	Width int
+
+	// Location renders the instant a date node carries. Nil means UTC. No clock
+	// is read, so a document always renders to the same lines.
+	Location *time.Location
+
+	// Styles is the theme, already built. Nothing here constructs a style per
+	// line.
+	Styles Styles
+
+	// Markers are the glyphs. The zero value is the Unicode set.
+	Markers Markers
+
+	// Open holds the folds the reader has opened, by Fold.Index. Everything
+	// else is closed, which is how Jira shows an expand too.
+	Open map[int]bool
+}
+
+// Fold is one expand in the document, whether or not it is open.
+type Fold struct {
+	// Index is the fold's position in document order, and the key Options.Open
+	// is read with. It does not move when another fold is opened or closed.
+	Index int
+
+	// Line is where the fold's own line landed in Lines. A fold inside a table
+	// cell reports the line the row starts on, because that is the line a pane
+	// can hit-test.
+	Line int
+
+	Open  bool
+	Title string
+}
+
+// Rendered is a document laid out at one width.
+type Rendered struct {
+	// Lines are the styled lines, unpadded.
+	Lines []string
+
+	// Widths is the width of each line in terminal cells, measured while it was
+	// built. A pane clamps panning against these rather than measuring every
+	// line on every frame.
+	Widths []int
+
+	// Folds are every expand in the document, in document order.
+	Folds []Fold
+}
+
+// Width is the widest line, which is how far a pane can pan.
+func (r Rendered) Width() int {
+	n := 0
+	for _, w := range r.Widths {
+		n = max(n, w)
+	}
+	return n
+}
+
+// Render lays a document out at one width.
+func Render(d adf.Doc, opt Options) Rendered {
+	opt.Markers = opt.Markers.withDefaults()
+	if opt.Width <= 0 {
+		opt.Width = defaultWidth
+	}
+	var folds []Fold
+	var memo []painted
+	var marked []markPainted
+	next := 0
+	f := &frame{
+		opt: &opt, sty: &opt.Styles, mk: &opt.Markers, memo: &memo, marked: &marked,
+		width: opt.Width, floor: minAvail,
+		folds: &folds, nextFold: &next,
+	}
+	f.ctx, f.pctx, f.pcont = opt.Styles.Body, f.paint(&f.sty.Body), f.paint(&f.sty.Cont)
+	f.blocks(d.Content, false)
+	return Rendered{Lines: f.lines, Widths: f.widths, Folds: folds}
+}
+
+// Summary flattens a document onto one unstyled line, for a list row or a
+// palette entry. Structure is dropped rather than spelled: a row has no space
+// to say that something was a heading.
+func Summary(d adf.Doc, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	fl := flat{limit: width}
+	fl.b.Grow(width * 2)
+	fl.nodes(d.Content)
+	return ansi.Truncate(fl.b.String(), width, "…")
+}
+
+// flat collapses a document's text into one line, one space between words, and
+// stops once it has more than the caller can show.
+type flat struct {
+	b     strings.Builder
+	limit int
+	w     int
+	gap   bool
+}
+
+// full reports whether there is already more than the width asked for, with a
+// cell in hand for the ellipsis.
+func (fl *flat) full() bool { return fl.w > fl.limit }
+
+func (fl *flat) nodes(nodes []adf.Node) {
+	for i := range nodes {
+		if fl.full() {
+			return
+		}
+		n := &nodes[i]
+		switch n.Type {
+		case "text":
+			fl.add(n.Text)
+		case "mention":
+			fl.add(mentionText(n.Attrs))
+		case "status":
+			text, _ := statusParts(n.Attrs)
+			fl.add(text)
+		case "emoji":
+			fl.add(emojiText(n.Attrs))
+		case "hardBreak", "rule":
+			fl.gap = true
+		default:
+			fl.nodes(n.Content)
+		}
+		if !isInline(n.Type) {
+			fl.gap = true
+		}
+	}
+}
+
+func (fl *flat) add(s string) {
+	for at := 0; at < len(s) && !fl.full(); {
+		if isSpace(s[at]) {
+			fl.gap = true
+			at++
+			continue
+		}
+		end := at
+		for end < len(s) && !isSpace(s[end]) {
+			end++
+		}
+		if fl.gap && fl.b.Len() > 0 {
+			fl.b.WriteByte(' ')
+			fl.w++
+		}
+		fl.gap = false
+		word := sanitize(s[at:end])
+		fl.b.WriteString(word)
+		fl.w += ansi.StringWidth(word)
+		at = end
+	}
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f'
+}

--- a/internal/ui/richtext/style_test.go
+++ b/internal/ui/richtext/style_test.go
@@ -1,0 +1,439 @@
+package richtext
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// sgr describes what the escape sequences on one line do to the terminal's
+// state. A line a pane can show on its own must open every attribute it uses
+// and close every attribute it opened.
+type sgr struct {
+	openAtEnd bool
+	strayEnd  bool // a reset with nothing open before it
+	notSGR    string
+}
+
+// scanSGR walks the escape sequences on a line. Anything that is not an SGR
+// sequence is reported: a renderer of text has no business moving a cursor.
+func scanSGR(line string) sgr {
+	var out sgr
+	open := false
+	for at := 0; at < len(line); {
+		if line[at] != 0x1b {
+			at++
+			continue
+		}
+		if at+1 >= len(line) || line[at+1] != '[' {
+			out.notSGR = "an escape that is not a CSI"
+			return out
+		}
+		end := at + 2
+		for end < len(line) && (line[end] < 0x40 || line[end] > 0x7e) {
+			end++
+		}
+		if end >= len(line) {
+			out.notSGR = "an unterminated CSI"
+			return out
+		}
+		params := line[at+2 : end]
+		if line[end] != 'm' {
+			out.notSGR = "CSI " + params + string(line[end])
+			return out
+		}
+		if isReset(params) {
+			if !open {
+				out.strayEnd = true
+			}
+			open = false
+		} else {
+			open = true
+		}
+		at = end + 1
+	}
+	out.openAtEnd = open
+	return out
+}
+
+func isReset(params string) bool {
+	if params == "" {
+		return true
+	}
+	for _, part := range strings.Split(params, ";") {
+		if strings.Trim(part, "0") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// TestStyle_EveryLineIsSelfContained is the regression this package's whole line
+// model exists for. ansi.Wrap does not re-open an SGR sequence on a continuation
+// line, so styling before the break hands a windowed pane lines that render
+// unstyled and a line that opens with a stray reset. Nothing here may do that,
+// under any theme, at any width.
+func TestStyle_EveryLineIsSelfContained(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"kitchen.json", "edges.json"} {
+		d := load(t, name)
+		for _, palette := range []Palette{plainPalette(), colourPalette()} {
+			for _, markers := range []Markers{UnicodeMarkers(), ASCIIMarkers()} {
+				for _, width := range []int{120, 80, 55, 40, 24, 12} {
+					opt := Options{
+						Width:   width,
+						Styles:  NewStyles(palette),
+						Markers: markers,
+						Open:    map[int]bool{0: true, 1: true, 2: true},
+					}
+					for i, line := range Render(d, opt).Lines {
+						got := scanSGR(line)
+						switch {
+						case got.notSGR != "":
+							t.Errorf("%s at %d line %d holds %s: %q", name, width, i, got.notSGR, line)
+						case got.openAtEnd:
+							t.Errorf("%s at %d line %d leaves a style open, so the next line inherits it: %q",
+								name, width, i, line)
+						case got.strayEnd:
+							t.Errorf("%s at %d line %d resets a style it never opened: %q", name, width, i, line)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestStyle_NoLineIsStylingAroundNothing checks the other half of that: a line
+// that carries styling carries text with it, rather than an empty escape pair a
+// terminal is asked to act on for no reason.
+func TestStyle_NoLineIsStylingAroundNothing(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	opt := options(60)
+	opt.Styles = NewStyles(colourPalette())
+	for i, line := range Render(d, opt).Lines {
+		if strings.Contains(line, "\x1b") && ansi.Strip(line) == "" {
+			t.Errorf("line %d is styling around nothing: %q", i, line)
+		}
+	}
+}
+
+// TestStyle_OneSequencePerRun is why the line model paints a run rather than
+// asking lipgloss to render it: lipgloss re-styles every rune of an underlined
+// or struck-through run, which is one escape pair per letter and an escape
+// sequence inside any grapheme cluster the run happens to hold.
+func TestStyle_OneSequencePerRun(t *testing.T) {
+	t.Parallel()
+	d := doc(adf.NewNode("paragraph",
+		adf.NewText("a struck ", adf.NewMark("strike", nil)),
+		adf.NewText("and an underlined 👨‍👩‍👧 family", adf.NewMark("underline", nil))))
+	line := Render(d, options(80)).Lines[0]
+	if got := strings.Count(line, "\x1b"); got > 4 {
+		t.Errorf("two runs came back as %d escape sequences: %q", got, line)
+	}
+	if !strings.Contains(line, "👨\u200d👩\u200d👧") {
+		t.Errorf("an emoji built from joiners was taken apart: %q", line)
+	}
+}
+
+// TestStyle_ControlCharactersNeverReachALine is why the renderer sanitizes:
+// issue text is written by anyone with a Jira login, and an escape sequence in a
+// description must not be able to repaint the screen it is displayed in.
+func TestStyle_ControlCharactersNeverReachALine(t *testing.T) {
+	t.Parallel()
+	d := load(t, "edges.json")
+	for i, line := range Render(d, options(80)).Lines {
+		for _, r := range ansi.Strip(line) {
+			if unicode.IsControl(r) {
+				t.Errorf("line %d carries the control character %q: %q", i, r, line)
+			}
+		}
+	}
+	if got := stripped(Render(d, options(80))); !strings.Contains(got, "[31m and a bell") {
+		t.Errorf("the escape was dropped along with the text it was in:\n%s", got)
+	}
+}
+
+// styledLine is the first line holding the word, with the styling still on it.
+func styledLine(t *testing.T, r Rendered, word string) string {
+	t.Helper()
+	for _, line := range r.Lines {
+		if strings.Contains(ansi.Strip(line), word) {
+			return line
+		}
+	}
+	t.Fatalf("no line holds %q", word)
+	return ""
+}
+
+// paramsAt is the SGR in force where the word starts, as its parameters. An
+// attribute and a colour arrive in one sequence, so a test asks what the
+// sequence says rather than matching bytes.
+func paramsAt(line, word string) []string {
+	var params []string
+	for at := 0; at < len(line); {
+		if line[at] == 0x1b {
+			end := at + 2
+			for end < len(line) && (line[end] < 0x40 || line[end] > 0x7e) {
+				end++
+			}
+			if p := line[at+2 : end]; isReset(p) {
+				params = nil
+			} else {
+				params = strings.Split(p, ";")
+			}
+			at = end + 1
+			continue
+		}
+		if strings.HasPrefix(line[at:], word) {
+			return params
+		}
+		at++
+	}
+	return nil
+}
+
+func hasParam(params []string, want string) bool {
+	for _, p := range params {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// paintedIn reports whether the run starting at word is painted in the colour,
+// which is how a test names a palette token rather than a hex value.
+func paintedIn(line, word, colour string) bool {
+	return strings.Contains(strings.Join(paramsAt(line, word), ";"), colour)
+}
+
+func TestStyle_MarksLandOnTheirOwnWords(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	opt := options(300) // wide enough that a run is not split by the wrapping
+	opt.Styles = NewStyles(colourPalette())
+	r := Render(d, opt)
+
+	for _, tc := range []struct {
+		word, param, why string
+	}{
+		{"strong", "1", "strong is bold"},
+		{"emphasis", "3", "em is italic"},
+		{"strikethrough", "9", "strike is struck through"},
+		{"underline", "4", "underline is underlined"},
+	} {
+		line := styledLine(t, r, tc.word)
+		if !hasParam(paramsAt(line, tc.word), tc.param) {
+			t.Errorf("%s: %q came out as %v", tc.why, tc.word, paramsAt(line, tc.word))
+		}
+	}
+
+	// A code span is painted in the badge token, and the one text node carrying
+	// both code and link keeps the badge and gains the link's underline.
+	code := styledLine(t, r, "inline code")
+	if !paintedIn(code, "inline code", "128;128;128") {
+		t.Errorf("an inline code span is not painted in the badge token: %v", paramsAt(code, "inline code"))
+	}
+	linked := styledLine(t, r, "code span")
+	if !paintedIn(linked, "code span", "128;128;128") || !hasParam(paramsAt(linked, "code span"), "4") {
+		t.Errorf("a code span that is also a link keeps both marks: %v", paramsAt(linked, "code span"))
+	}
+	if line := styledLine(t, r, "a titled link"); !paintedIn(line, "a titled link", "64;64;64") {
+		t.Errorf("a link is not painted in the link token: %v", paramsAt(line, "a titled link"))
+	}
+
+	// A colour off the wire is applied as it arrives.
+	if line := styledLine(t, r, "coloured"); !paintedIn(line, "coloured", "255;86;48") {
+		t.Errorf("a textColor mark was dropped: %v", paramsAt(line, "coloured"))
+	}
+	if line := styledLine(t, r, "highlighted"); !paintedIn(line, "highlighted", "48;2;254;222;200") {
+		t.Errorf("a backgroundColor mark was dropped: %v", paramsAt(line, "highlighted"))
+	}
+}
+
+// TestStyle_NoColorKeepsEmphasis is what NO_COLOR asks for: colour goes away and
+// emphasis does not. kernel.Theme's plain mode is the precedent.
+func TestStyle_NoColorKeepsEmphasis(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	r := Render(d, options(300)) // the plain palette: attributes only
+
+	for _, tc := range []struct {
+		word, param, why string
+	}{
+		{"strong", "1", "strong stays bold"},
+		{"emphasis", "3", "em stays italic"},
+		{"underline", "4", "underline stays underlined"},
+		{"strikethrough", "9", "strike stays struck through"},
+		{"inline code", "7", "a code span stays a lozenge, in reverse video"},
+		{"[NEEDS REVIEW]", "1", "a status lozenge stays emphasised"},
+	} {
+		line := styledLine(t, r, tc.word)
+		if !hasParam(paramsAt(line, tc.word), tc.param) {
+			t.Errorf("%s: %q came out as %v", tc.why, tc.word, paramsAt(line, tc.word))
+		}
+	}
+
+	for i, line := range r.Lines {
+		for _, colour := range []string{"38;2", "48;2", "38;5", "48;5"} {
+			if strings.Contains(line, colour) {
+				t.Errorf("line %d carries colour in a theme that has none: %q", i, line)
+			}
+		}
+	}
+}
+
+func TestStyle_StatusCarriesItsColourEnum(t *testing.T) {
+	t.Parallel()
+	d := load(t, "edges.json")
+	opt := options(300)
+	opt.Styles = NewStyles(colourPalette())
+	line := styledLine(t, Render(d, opt), "[red]")
+
+	for _, tc := range []struct{ word, colour, token string }{
+		{"[neutral]", "32;32;32", "muted"},
+		{"[blue]", "64;64;64", "accent"},
+		{"[purple]", "64;64;64", "accent"},
+		{"[red]", "80;80;80", "danger"},
+		{"[yellow]", "96;96;96", "warning"},
+		{"[green]", "112;112;112", "success"},
+		{"[teal]", "32;32;32", "muted, because the enum grew a value this build has not met"},
+	} {
+		if !paintedIn(line, tc.word, "38;2;"+tc.colour) {
+			t.Errorf("%s should be painted %s and came out as %v", tc.word, tc.token, paramsAt(line, tc.word))
+		}
+	}
+	if !strings.Contains(ansi.Strip(line), "[status]") {
+		t.Errorf("a lozenge with no words still shows as one: %q", line)
+	}
+}
+
+func TestStyle_PanelKindsAreToldApart(t *testing.T) {
+	t.Parallel()
+	m := UnicodeMarkers()
+	d := load(t, "kitchen.json")
+	opt := options(120)
+	opt.Styles = NewStyles(colourPalette())
+	got := Render(d, opt)
+	plain := stripped(got)
+
+	for _, want := range []string{
+		m.Info + " INFO", m.Note + " NOTE", m.Warning + " WARNING",
+		m.Success + " SUCCESS", m.Error + " ERROR", "🚀 PANEL",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("no panel rendered as %q:\n%s", want, plain)
+		}
+	}
+	for _, tc := range []struct{ label, colour, token string }{
+		{"WARNING", "96;96;96", "warning"},
+		{"ERROR", "80;80;80", "danger"},
+		{"SUCCESS", "112;112;112", "success"},
+		{"INFO", "64;64;64", "accent"},
+	} {
+		if line := styledLine(t, got, tc.label); !paintedIn(line, tc.label, tc.colour) {
+			t.Errorf("the %s panel is not painted %s: %v", tc.label, tc.token, paramsAt(line, tc.label))
+		}
+	}
+
+	// A custom panel keeps the colour the site chose, and loses it where there
+	// is no colour to be had rather than becoming an emphasis it never carried.
+	if line := styledLine(t, got, "PANEL"); !paintedIn(line, "PANEL", "201;55;44") {
+		t.Errorf("a custom panel dropped its panelColor: %v", paramsAt(line, "PANEL"))
+	}
+	if line := styledLine(t, Render(d, options(120)), "custom panel"); strings.Contains(line, "38;2") {
+		t.Errorf("a custom panel painted a colour in a theme that has none: %q", line)
+	}
+}
+
+func TestStyle_QuoteIsNotAPanel(t *testing.T) {
+	t.Parallel()
+	d := load(t, "kitchen.json")
+	opt := options(120)
+	opt.Styles = NewStyles(colourPalette())
+	quote := styledLine(t, Render(d, opt), "A blockquote holds")
+	if strings.Contains(ansi.Strip(quote), "INFO") || strings.Contains(quote, "96;96;96") {
+		t.Errorf("a quote came out as a panel: %q", quote)
+	}
+	if !paintedIn(quote, UnicodeMarkers().VLine, "32;32;32") {
+		t.Errorf("a quote's bar is painted muted: %v", paramsAt(quote, UnicodeMarkers().VLine))
+	}
+}
+
+func TestStyle_UnknownNodeStaysVisiblyUnknown(t *testing.T) {
+	t.Parallel()
+	d := load(t, "edges.json")
+	opt := options(80)
+	opt.Styles = NewStyles(colourPalette())
+	r := Render(d, opt)
+	plain := stripped(r)
+	for _, want := range []string{
+		"? unsupported: futureBlock",
+		"? unsupported: extension roadmap-macro",
+		"? futureInline",
+		"? inlineExtension chart",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("an unknown node did not say so as %q:\n%s", want, plain)
+		}
+	}
+	line := styledLine(t, r, "unsupported: futureBlock")
+	if !paintedIn(line, "?", "96;96;96") {
+		t.Errorf("an unknown node reads as prose somebody wrote: %v", paramsAt(line, "?"))
+	}
+}
+
+func TestStyle_MediaLeavesSomethingToFind(t *testing.T) {
+	t.Parallel()
+	plain := stripped(Render(load(t, "edges.json"), options(80)))
+	for _, want := range []string{
+		"media:3f6b1c72-9d0e-4a55-b1b7-6c6b0a9f2e41",
+		"media:8a0c5d31-1b2e-4f77-9c3a-2d4e6f8a0b1c",
+		"media:1c2b3a49-5d6e-4f80-9a1b-2c3d4e5f6071",
+		"a screenshot",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("a media placeholder dropped %q, so a preview has nothing to resolve:\n%s", want, plain)
+		}
+	}
+	if external := stripped(Render(load(t, "kitchen.json"), options(120))); !strings.Contains(external, "an-external-image.png") {
+		t.Error("an external image dropped its URL")
+	}
+}
+
+func TestStyle_TabsAreExpandedSoTheWidthIsTrue(t *testing.T) {
+	t.Parallel()
+	d := doc(adf.NewNode("codeBlock", adf.NewText("a\tb\n\tc")))
+	r := Render(d, options(40))
+	for i, line := range r.Lines {
+		if strings.ContainsRune(line, '\t') {
+			t.Errorf("line %d still holds a tab, which measures as one cell and prints as four: %q", i, line)
+		}
+		if got := ansi.StringWidth(line); got != r.Widths[i] {
+			t.Errorf("line %d measures %d against a reported %d", i, got, r.Widths[i])
+		}
+	}
+}
+
+// TestStyle_PaddedTokenIsStillMeasured covers a caller handing in a token that
+// pads: the width a pane clamps against has to include it.
+func TestStyle_PaddedTokenIsStillMeasured(t *testing.T) {
+	t.Parallel()
+	palette := plainPalette()
+	palette.Badge = palette.Badge.Padding(0, 1)
+	opt := options(300)
+	opt.Styles = NewStyles(palette)
+	opt.Styles.Color = true // a badge with a background is what padding is for
+	r := Render(load(t, "kitchen.json"), opt)
+	for i, line := range r.Lines {
+		if got := ansi.StringWidth(line); got != r.Widths[i] {
+			t.Errorf("line %d measures %d against a reported %d: %q", i, got, r.Widths[i], line)
+		}
+	}
+}

--- a/internal/ui/richtext/styles.go
+++ b/internal/ui/richtext/styles.go
@@ -1,0 +1,308 @@
+package richtext
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Palette is the theme, handed in by the caller. The renderer never reads a
+// theme itself: the views that use it hold one, this package holds none, and
+// the goldens are then a property of the document rather than of whichever
+// theme was loaded when they were written.
+type Palette struct {
+	Base    lipgloss.Style
+	Muted   lipgloss.Style
+	Title   lipgloss.Style
+	Accent  lipgloss.Style
+	Danger  lipgloss.Style
+	Warning lipgloss.Style
+	Success lipgloss.Style
+	Badge   lipgloss.Style
+
+	// Color is false for the no-colour theme, where emphasis must survive as
+	// bold, faint, italic or reverse rather than disappearing: NO_COLOR asks for
+	// colour to go away, not for emphasis to.
+	Color bool
+}
+
+// PanelStyles is one style per panel kind. Custom is the one the site coloured
+// itself, whose colour arrives with the document.
+type PanelStyles struct {
+	Info    lipgloss.Style
+	Note    lipgloss.Style
+	Warning lipgloss.Style
+	Success lipgloss.Style
+	Error   lipgloss.Style
+	Custom  lipgloss.Style
+}
+
+// StatusStyles is one style per value of the colour enum a status lozenge
+// carries. The theme has one accent, so blue and purple share it; the words in
+// the lozenge are what tell those two apart, and inventing a colour outside the
+// palette would break both the no-colour theme and the theme-independence of
+// the goldens.
+type StatusStyles struct {
+	Neutral lipgloss.Style
+	Blue    lipgloss.Style
+	Purple  lipgloss.Style
+	Red     lipgloss.Style
+	Yellow  lipgloss.Style
+	Green   lipgloss.Style
+}
+
+// Styles is one style per construct, built once per theme so that nothing
+// constructs a lipgloss.Style inside a render loop.
+type Styles struct {
+	Body  lipgloss.Style
+	Muted lipgloss.Style
+
+	H1 lipgloss.Style
+	H2 lipgloss.Style
+	H3 lipgloss.Style
+
+	Strong    lipgloss.Style
+	Em        lipgloss.Style
+	Underline lipgloss.Style
+	Strike    lipgloss.Style
+	Code      lipgloss.Style
+	Link      lipgloss.Style
+	URL       lipgloss.Style
+
+	Bullet   lipgloss.Style
+	Number   lipgloss.Style
+	Task     lipgloss.Style
+	TaskDone lipgloss.Style
+	Decision lipgloss.Style
+
+	Quote    lipgloss.Style
+	QuoteBar lipgloss.Style
+
+	CodeBlock lipgloss.Style
+	CodeLang  lipgloss.Style
+	CodeBar   lipgloss.Style
+
+	Panel PanelStyles
+
+	Rule lipgloss.Style
+
+	TableBorder lipgloss.Style
+	TableHeader lipgloss.Style
+	TableCell   lipgloss.Style
+
+	FoldMark  lipgloss.Style
+	FoldTitle lipgloss.Style
+
+	Media   lipgloss.Style
+	Mention lipgloss.Style
+	Date    lipgloss.Style
+	Card    lipgloss.Style
+
+	Status StatusStyles
+
+	Unknown lipgloss.Style
+	Cont    lipgloss.Style
+
+	// Color mirrors Palette.Color. A textColor mark has nothing to render in a
+	// theme that has no colour, and must not silently become emphasis it never
+	// carried.
+	Color bool
+}
+
+// NewStyles derives every construct's style from the palette.
+func NewStyles(p Palette) Styles {
+	s := Styles{Color: p.Color}
+	s.Body = p.Base
+	s.Muted = p.Muted
+
+	// Levels 1 and 2 are told apart by an attribute rather than a colour, so
+	// that they stay distinguishable in the no-colour theme; 3 and below are
+	// told apart by the indent the renderer gives them.
+	s.H1 = p.Title.Bold(true).Underline(true)
+	s.H2 = p.Title.Bold(true)
+	s.H3 = p.Accent.Bold(true)
+
+	s.Strong = p.Base.Bold(true)
+	s.Em = p.Base.Italic(true)
+	s.Underline = p.Base.Underline(true)
+	s.Strike = p.Base.Strikethrough(true)
+	s.Code = p.Badge
+	if !p.Color {
+		s.Code = p.Base.Reverse(true)
+	}
+	s.Link = p.Accent.Underline(true)
+	if !p.Color {
+		s.Link = p.Base.Underline(true)
+	}
+	s.URL = p.Muted
+
+	s.Bullet = p.Muted
+	s.Number = p.Muted
+	s.Task = p.Accent
+	s.TaskDone = p.Success
+	s.Decision = p.Accent
+
+	s.Quote = p.Muted
+	s.QuoteBar = p.Muted
+
+	s.CodeBlock = p.Base
+	s.CodeLang = p.Muted
+	s.CodeBar = p.Muted
+
+	s.Panel = PanelStyles{
+		Info:    p.Accent,
+		Note:    p.Accent,
+		Warning: p.Warning,
+		Success: p.Success,
+		Error:   p.Danger,
+		Custom:  p.Accent,
+	}
+
+	s.Rule = p.Muted
+
+	s.TableBorder = p.Muted
+	s.TableHeader = p.Title.Bold(true)
+	s.TableCell = p.Base
+
+	s.FoldMark = p.Accent
+	s.FoldTitle = p.Title.Bold(true)
+
+	s.Media = p.Accent
+	s.Mention = p.Accent
+	s.Date = p.Accent
+	s.Card = p.Accent
+
+	s.Status = StatusStyles{
+		Neutral: p.Muted,
+		Blue:    p.Accent,
+		Purple:  p.Accent,
+		Red:     p.Danger,
+		Yellow:  p.Warning,
+		Green:   p.Success,
+	}
+	if !p.Color {
+		bold := p.Base.Bold(true)
+		s.Status = StatusStyles{Neutral: bold, Blue: bold, Purple: bold, Red: bold, Yellow: bold, Green: bold}
+	}
+
+	s.Unknown = p.Warning.Bold(true)
+	s.Cont = p.Muted
+	return s
+}
+
+// status picks the style for the colour a lozenge carries. An unknown value is
+// neutral rather than dropped: the wording is still the author's.
+func (s *Styles) status(name string) *lipgloss.Style {
+	switch name {
+	case "blue":
+		return &s.Status.Blue
+	case "purple":
+		return &s.Status.Purple
+	case "red":
+		return &s.Status.Red
+	case "yellow":
+		return &s.Status.Yellow
+	case "green":
+		return &s.Status.Green
+	default:
+		return &s.Status.Neutral
+	}
+}
+
+// panelStyle picks the style and marker for a panel.
+func (s *Styles) panelStyle(kind string, m Markers) (style *lipgloss.Style, marker, label string) {
+	switch kind {
+	case "info":
+		return &s.Panel.Info, m.Info, "INFO"
+	case "note":
+		return &s.Panel.Note, m.Note, "NOTE"
+	case "success", "tip":
+		return &s.Panel.Success, m.Success, strings.ToUpper(sanitize(kind))
+	case "warning":
+		return &s.Panel.Warning, m.Warning, "WARNING"
+	case "error":
+		return &s.Panel.Error, m.Error, "ERROR"
+	case "", "custom":
+		return &s.Panel.Custom, m.Panel, "PANEL"
+	default:
+		return &s.Panel.Custom, m.Panel, strings.ToUpper(sanitize(kind))
+	}
+}
+
+// marks is the set of inline annotations on one text node, gathered before any
+// of them is applied: ADF hands them over in an order that is byte-significant
+// and means nothing, so strong inside em has to render as em inside strong.
+type marks struct {
+	strong    bool
+	em        bool
+	underline bool
+	strike    bool
+	code      bool
+	sub       bool
+	sup       bool
+	href      string
+	fg        string
+	bg        string
+}
+
+func (m marks) any() bool {
+	return m.strong || m.em || m.underline || m.strike || m.code ||
+		m.href != "" || m.fg != "" || m.bg != ""
+}
+
+// apply builds the style for a run of marked text on top of the style its block
+// gives it — a quote's text stays a quote's text under a bold mark.
+func (s *Styles) apply(ctx lipgloss.Style, m marks) lipgloss.Style {
+	out := ctx
+	switch {
+	case m.code:
+		out = s.Code
+		if m.href != "" {
+			out = out.Underline(true)
+		}
+	case m.href != "":
+		out = s.Link
+	}
+	if m.strong {
+		out = out.Bold(true)
+	}
+	if m.em {
+		out = out.Italic(true)
+	}
+	if m.underline {
+		out = out.Underline(true)
+	}
+	if m.strike {
+		out = out.Strikethrough(true)
+	}
+	if s.Color {
+		if c, ok := wireColor(m.fg); ok {
+			out = out.Foreground(c)
+		}
+		if c, ok := wireColor(m.bg); ok {
+			out = out.Background(c)
+		}
+	}
+	return out
+}
+
+// wireColor reads a colour off the wire. Anything but a hex triple is refused
+// rather than handed on, because lipgloss renders an unparseable colour as no
+// colour and a caller cannot tell that from a document that asked for none.
+func wireColor(v string) (color.Color, bool) {
+	if len(v) != 7 && len(v) != 4 {
+		return nil, false
+	}
+	if v[0] != '#' {
+		return nil, false
+	}
+	for i := 1; i < len(v); i++ {
+		switch c := v[i]; {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return nil, false
+		}
+	}
+	return lipgloss.Color(v), true
+}

--- a/internal/ui/richtext/table.go
+++ b/internal/ui/richtext/table.go
@@ -1,0 +1,265 @@
+package richtext
+
+import (
+	"strings"
+
+	"github.com/varijkapil13/saral/pkg/adf"
+)
+
+// cellFloor is the narrowest a column is squeezed to. Past it the grid is
+// allowed to be wider than the pane: a table that does not fit is panned, not
+// cut, and a column of two cells holds nothing worth reading anyway.
+const cellFloor = 8
+
+// cell is one grid position. A blank one is the tail of a span: the columns a
+// merged cell covers are held so that every value below it stays under the
+// heading it belongs to.
+type cell struct {
+	nodes  []adf.Node
+	header bool
+	lines  []string
+	widths []int
+	nat    int
+}
+
+// table lays a table out as a grid whose columns line up in terminal cells.
+//
+// A cell wraps inside its column rather than being cut off: squeezing a column
+// and truncating what is in it loses data silently, which is the one thing a
+// reader cannot recover from. A row is therefore as tall as its tallest cell.
+// The pixel colwidth the browser editor stores is ignored — it says nothing
+// about a terminal, and what a column needs is measurable from what is in it.
+func (f *frame) table(n adf.Node) {
+	rows, header := f.grid(n)
+	if len(rows) == 0 {
+		return
+	}
+	widths := f.columns(rows)
+	for i := range rows {
+		folds := len(*f.folds)
+		for j := range rows[i] {
+			c := &rows[i][j]
+			if len(c.nodes) == 0 {
+				continue
+			}
+			c.lines, c.widths = f.cellLines(c.nodes, widths[j], c.header, f.folds, f.nextFold)
+		}
+		// A blank line owed from the block above is written first, so that the
+		// line a fold in this row reports is the line the row is really on.
+		f.settle()
+		at := len(f.lines)
+		f.row(rows[i], widths)
+		if i == 0 && header {
+			f.divider(widths)
+		}
+		f.patchFolds(folds, at)
+	}
+}
+
+// grid folds the table into rectangular rows, expanding a merged cell into the
+// positions it covers. Emitting one column for a cell that spans two puts every
+// value after it under the wrong heading, which is not a cosmetic problem — it
+// is the wrong answer.
+func (f *frame) grid(n adf.Node) (rows [][]cell, header bool) {
+	rows = make([][]cell, 0, len(n.Content))
+	var carry []int // per column, the rows a span from above still covers
+	columns := 0
+	for i := range n.Content {
+		row := n.Content[i]
+		if row.Type != "tableRow" {
+			continue
+		}
+		out := make([]cell, 0, len(row.Content))
+		headers, at := 0, 0
+		for j := range row.Content {
+			for at < len(carry) && carry[at] > 0 {
+				carry[at]--
+				at++
+				out = append(out, cell{})
+			}
+			src := row.Content[j]
+			if src.Type == "tableHeader" {
+				headers++
+			}
+			span, _ := attrInt(src.Attrs, "colspan")
+			down, _ := attrInt(src.Attrs, "rowspan")
+			for k := range max(span, 1) {
+				held := cell{}
+				if k == 0 {
+					held = cell{nodes: src.Content, header: src.Type == "tableHeader"}
+				}
+				out = append(out, held)
+				for len(carry) <= at {
+					carry = append(carry, 0)
+				}
+				carry[at] = max(down, 1) - 1
+				at++
+			}
+		}
+		for ; at < len(carry); at++ {
+			if carry[at] > 0 {
+				carry[at]--
+				out = append(out, cell{})
+			}
+		}
+		if len(rows) == 0 {
+			header = headers > 0 && headers == len(out)
+		}
+		columns = max(columns, len(out))
+		rows = append(rows, out)
+	}
+	if columns == 0 {
+		return nil, false
+	}
+	for i := range rows {
+		for len(rows[i]) < columns {
+			rows[i] = append(rows[i], cell{})
+		}
+	}
+	return rows, header
+}
+
+// columns measures every column against what is in it and then squeezes the
+// widest ones until the grid fits.
+func (f *frame) columns(rows [][]cell) []int {
+	widths := make([]int, len(rows[0]))
+	// The measuring pass renders into fold storage of its own: counting the same
+	// fold twice would put two entries in the answer, and advancing the shared
+	// counter would renumber every fold after it.
+	var scratch []Fold
+	count := *f.nextFold
+	sub := f.cellFrame(1<<20, false, &scratch, &count)
+	sub.dry = true
+	for i := range rows {
+		for j := range rows[i] {
+			c := &rows[i][j]
+			if len(c.nodes) == 0 {
+				continue
+			}
+			for _, n := range sub.remeasure(c.nodes, c.header) {
+				c.nat = max(c.nat, n)
+			}
+			widths[j] = max(widths[j], c.nat)
+		}
+	}
+	avail := f.avail()
+	for gridWidth(widths) > avail {
+		widest := -1
+		for j := range widths {
+			if widths[j] > cellFloor && (widest < 0 || widths[j] > widths[widest]) {
+				widest = j
+			}
+		}
+		if widest < 0 {
+			break
+		}
+		widths[widest]--
+	}
+	return widths
+}
+
+// gridWidth is what a row costs on screen: a bar at each end and between every
+// pair of columns, and a space either side of every cell.
+func gridWidth(widths []int) int {
+	total := 1
+	for _, w := range widths {
+		total += w + 3
+	}
+	return total
+}
+
+// remeasure asks how wide a cell wants to be, which is the width it takes when
+// nothing wraps it. The frame is reused across the cells of one table: what is
+// wanted is the widths, and the lines a dry frame builds are empty.
+func (f *frame) remeasure(nodes []adf.Node, header bool) []int {
+	f.lines, f.widths, f.rails, f.owe = f.lines[:0], f.widths[:0], f.rails[:0], false
+	ctx := &f.sty.TableCell
+	if header {
+		ctx = &f.sty.TableHeader
+	}
+	f.setCtx(ctx)
+	f.blocks(nodes, false)
+	return f.widths
+}
+
+// cellLines renders one cell in its own column.
+func (f *frame) cellLines(nodes []adf.Node, width int, header bool, folds *[]Fold, next *int) (lines []string, widths []int) {
+	sub := f.cellFrame(width, header, folds, next)
+	sub.blocks(nodes, false)
+	return sub.lines, sub.widths
+}
+
+func (f *frame) cellFrame(width int, header bool, folds *[]Fold, next *int) *frame {
+	sub := f.sub(width)
+	sub.folds, sub.nextFold, sub.floor, sub.unplaced = folds, next, 1, true
+	if header {
+		sub.setCtx(&f.sty.TableHeader)
+	} else {
+		sub.setCtx(&f.sty.TableCell)
+	}
+	return sub
+}
+
+// row emits one row of the grid, as tall as its tallest cell.
+func (f *frame) row(cells []cell, widths []int) {
+	height := 1
+	for i := range cells {
+		height = max(height, len(cells[i].lines))
+	}
+	for line := range height {
+		f.grid1(cells, widths, line)
+	}
+}
+
+func (f *frame) grid1(cells []cell, widths []int, line int) {
+	border := f.paint(&f.sty.TableBorder)
+	f.rowSpans = f.rowSpans[:0]
+	for j := range widths {
+		text, w := "", 0
+		if j < len(cells) && line < len(cells[j].lines) {
+			text, w = cells[j].lines[line], cells[j].widths[line]
+		}
+		f.rowSpans = append(f.rowSpans,
+			span{text: f.mk.VLine, p: border, w: 1},
+			span{text: " ", w: 1},
+			span{text: text, w: w},
+			span{text: pad(widths[j] - w), w: max(widths[j]-w, 0)},
+			span{text: " ", w: 1})
+	}
+	f.rowSpans = append(f.rowSpans, span{text: f.mk.VLine, p: border, w: 1})
+	f.out(f.rowSpans)
+}
+
+// divider is the line under a header row.
+func (f *frame) divider(widths []int) {
+	border := f.paint(&f.sty.TableBorder)
+	f.rowSpans = f.rowSpans[:0]
+	for j := range widths {
+		f.rowSpans = append(f.rowSpans,
+			span{text: f.mk.VLine, p: border, w: 1},
+			span{text: strings.Repeat(f.mk.HLine, widths[j]+2), p: border, w: widths[j] + 2})
+	}
+	f.rowSpans = append(f.rowSpans, span{text: f.mk.VLine, p: border, w: 1})
+	f.out(f.rowSpans)
+}
+
+// patchFolds points the folds a row's cells registered at the row itself. A
+// fold's line is what a pane hit-tests against, and a line inside a cell is not
+// one of the document's own.
+func (f *frame) patchFolds(from, at int) {
+	for i := from; i < len(*f.folds); i++ {
+		if (*f.folds)[i].Line < 0 {
+			(*f.folds)[i].Line = at
+		}
+	}
+}
+
+func pad(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n <= len(spaces) {
+		return spaces[:n]
+	}
+	return strings.Repeat(" ", n)
+}

--- a/internal/ui/richtext/testdata/cards_28.golden
+++ b/internal/ui/richtext/testdata/cards_28.golden
@@ -1,0 +1,13 @@
+▸ an expand — click to open
+
+left column
+
+right column
+
+https://example.com/browse/A
+↳ BC-1
+
+https://example.com/a-block-
+↳ card
+
+https://example.com/an-embed

--- a/internal/ui/richtext/testdata/cards_60.golden
+++ b/internal/ui/richtext/testdata/cards_60.golden
@@ -1,0 +1,11 @@
+▸ an expand — click to open
+
+left column
+
+right column
+
+https://example.com/browse/ABC-1
+
+https://example.com/a-block-card
+
+https://example.com/an-embed

--- a/internal/ui/richtext/testdata/cards_open_60.golden
+++ b/internal/ui/richtext/testdata/cards_open_60.golden
@@ -1,0 +1,14 @@
+▾ an expand — click to open
+  Expands may hold a table, but never another expand.
+
+  │ inside an expand │ yes │
+
+left column
+
+right column
+
+https://example.com/browse/ABC-1
+
+https://example.com/a-block-card
+
+https://example.com/an-embed

--- a/internal/ui/richtext/testdata/code_28.golden
+++ b/internal/ui/richtext/testdata/code_28.golden
@@ -1,0 +1,9 @@
+│ go
+│ func render(d Doc) string {
+│     if d.Version != 1 {
+│         return ""
+│     }
+│     return walk(d.Content)
+│ }
+
+│ a code block with no language attribute

--- a/internal/ui/richtext/testdata/code_60.golden
+++ b/internal/ui/richtext/testdata/code_60.golden
@@ -1,0 +1,9 @@
+│ go
+│ func render(d Doc) string {
+│     if d.Version != 1 {
+│         return ""
+│     }
+│     return walk(d.Content)
+│ }
+
+│ a code block with no language attribute

--- a/internal/ui/richtext/testdata/edges.json
+++ b/internal/ui/richtext/testdata/edges.json
@@ -1,0 +1,193 @@
+{
+ "type": "doc",
+ "version": 1,
+ "content": [
+  {
+   "type": "heading",
+   "attrs": { "level": 3 },
+   "content": [{ "type": "text", "text": "Nodes a site keeps but never writes" }]
+  },
+  {
+   "type": "unsupportedBlock",
+   "attrs": {
+    "originalValue": {
+     "type": "futureBlock",
+     "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "held for the round trip" }] }]
+    }
+   }
+  },
+  {
+   "type": "futureBlock",
+   "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "a node type no schema published" }] }]
+  },
+  {
+   "type": "extension",
+   "attrs": { "extensionType": "com.example.app", "extensionKey": "roadmap-macro", "parameters": { "id": 7 } }
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    { "type": "text", "text": "inline: " },
+    { "type": "unsupportedInline", "attrs": { "originalValue": { "type": "futureInline" } } },
+    { "type": "text", "text": " and " },
+    { "type": "inlineExtension", "attrs": { "extensionKey": "chart", "extensionType": "com.example.app" } },
+    { "type": "text", "text": "." }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": { "level": 3 },
+   "content": [{ "type": "text", "text": "Lozenges, in every colour the enum has" }]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    { "type": "status", "attrs": { "text": "neutral", "color": "neutral" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "text": "blue", "color": "blue" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "text": "purple", "color": "purple" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "text": "red", "color": "red" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "text": "yellow", "color": "yellow" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "text": "green", "color": "green" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "text": "teal", "color": "teal" } },
+    { "type": "text", "text": " " },
+    { "type": "status", "attrs": { "color": "red" } }
+   ]
+  },
+  {
+   "type": "panel",
+   "attrs": { "panelType": "tip" },
+   "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "a tip is a success panel by another name" }] }]
+  },
+  {
+   "type": "panel",
+   "attrs": { "panelType": "somethingNew" },
+   "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "a panel kind this build has not met" }] }]
+  },
+  {
+   "type": "panel",
+   "attrs": { "panelType": "custom", "panelColor": "not-a-colour" },
+   "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "a colour that will not parse is no colour" }] }]
+  },
+  {
+   "type": "heading",
+   "attrs": { "level": 3 },
+   "content": [{ "type": "text", "text": "Things wider than the pane" }]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    { "type": "text", "text": "See " },
+    {
+     "type": "text",
+     "marks": [{ "type": "link", "attrs": { "href": "https://example.atlassian.net/wiki/spaces/EX/pages/98304/the-runbook-for-a-basket-that-divides-by-zero" } }],
+     "text": "https://example.atlassian.net/wiki/spaces/EX/pages/98304/the-runbook-for-a-basket-that-divides-by-zero"
+    },
+    { "type": "text", "text": " first." }
+   ]
+  },
+  {
+   "type": "codeBlock",
+   "attrs": { "language": "sql" },
+   "content": [{ "type": "text", "text": "select key, summary, status from issue where project = 'EX' and status in ('open', 'in review') order by updated desc;\n\tindented with a tab" }]
+  },
+  {
+   "type": "table",
+   "content": [
+    {
+     "type": "tableRow",
+     "content": [
+      { "type": "tableHeader", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "one" }] }] },
+      { "type": "tableHeader", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "two" }] }] },
+      { "type": "tableHeader", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "three" }] }] },
+      { "type": "tableHeader", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "four" }] }] },
+      { "type": "tableHeader", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "five" }] }] },
+      { "type": "tableHeader", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "six" }] }] }
+     ]
+    },
+    {
+     "type": "tableRow",
+     "content": [
+      { "type": "tableCell", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "a sentence long enough to wrap inside its own column rather than be cut off" }] }] },
+      { "type": "tableCell", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "日本語のセルは二倍の幅" }] }] },
+      { "type": "tableCell", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "c" }] }] },
+      { "type": "tableCell", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "d" }] }] },
+      { "type": "tableCell", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "e" }] }] },
+      {
+       "type": "tableCell",
+       "content": [
+        {
+         "type": "nestedExpand",
+         "attrs": { "title": "in a cell" },
+         "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "a fold inside a grid" }] }]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": { "level": 3 },
+   "content": [{ "type": "text", "text": "Media, folds and the half-written" }]
+  },
+  {
+   "type": "mediaGroup",
+   "content": [
+    { "type": "media", "attrs": { "id": "3f6b1c72-9d0e-4a55-b1b7-6c6b0a9f2e41", "type": "file", "collection": "attachments", "alt": "a screenshot" } },
+    { "type": "media", "attrs": { "id": "8a0c5d31-1b2e-4f77-9c3a-2d4e6f8a0b1c", "type": "file", "collection": "attachments" } }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    { "type": "text", "text": "inline media " },
+    { "type": "mediaInline", "attrs": { "id": "1c2b3a49-5d6e-4f80-9a1b-2c3d4e5f6071", "type": "file", "collection": "attachments" } },
+    { "type": "text", "text": ", a mention with nothing to show " },
+    { "type": "mention", "attrs": { "id": "5b10a2844c20165700ede21g" } },
+    { "type": "text", "text": ", an emoji with only a short name " },
+    { "type": "emoji", "attrs": { "shortName": ":sparkles:" } },
+    { "type": "text", "text": ", a date that will not parse " },
+    { "type": "date", "attrs": { "timestamp": "yesterday" } },
+    { "type": "text", "text": " and a placeholder " },
+    { "type": "placeholder", "attrs": { "text": "type something" } }
+   ]
+  },
+  {
+   "type": "expand",
+   "attrs": { "title": "a fold holding another fold" },
+   "content": [
+    { "type": "paragraph", "content": [{ "type": "text", "text": "the fold inside keeps its own number" }] },
+    {
+     "type": "nestedExpand",
+     "attrs": {},
+     "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "and has no title of its own" }] }]
+    }
+   ]
+  },
+  {
+   "type": "taskList",
+   "content": [
+    { "type": "taskItem", "attrs": { "state": "SOMETHING_ELSE" }, "content": [{ "type": "text", "text": "a state this build has not met is not done" }] },
+    { "type": "taskItem", "attrs": { "state": "done" }, "content": [{ "type": "text", "text": "the state is matched without regard to case" }] },
+    { "type": "taskItem", "attrs": { "state": "TODO" } }
+   ]
+  },
+  { "type": "paragraph" },
+  {
+   "type": "paragraph",
+   "content": [{ "type": "text", "text": "text carrying an escape \u001b[31m and a bell \u0007 must not repaint the screen" }]
+  },
+  {
+   "type": "paragraph",
+   "marks": [{ "type": "alignment", "attrs": { "align": "end" } }],
+   "content": [{ "type": "text", "text": "pushed to the right" }]
+  }
+ ]
+}

--- a/internal/ui/richtext/testdata/edges_40.golden
+++ b/internal/ui/richtext/testdata/edges_40.golden
@@ -1,0 +1,84 @@
+Nodes a site keeps but never writes
+
+│ ? unsupported: futureBlock
+
+│ ? unsupported: futureBlock
+│ a node type no schema published
+
+│ ? unsupported: extension roadmap-macro
+
+inline: ? futureInline and ?
+inlineExtension chart.
+
+Lozenges, in every colour the enum has
+
+[neutral] [blue] [purple] [red] [yellow]
+[green] [teal] [status]
+
+│ ✓ TIP
+│ a tip is a success panel by another
+│ name
+
+│ ◆ SOMETHINGNEW
+│ a panel kind this build has not met
+
+│ ◆ PANEL
+│ a colour that will not parse is no
+│ colour
+
+Things wider than the pane
+
+See
+https://example.atlassian.net/wiki/space
+↳ s/EX/pages/98304/the-runbook-for-a-bas
+↳ ket-that-divides-by-zero first.
+
+│ sql
+│ select key, summary, status from issue where project = 'EX' and status in ('open', 'in review') order by updated desc;
+│     indented with a tab
+
+│ one      │ two      │ three │ four │ five │ six      │
+│──────────│──────────│───────│──────│──────│──────────│
+│ a        │ 日本語の │ c     │ d    │ e    │ ▸ in a   │
+│ sentence │ セルは二 │       │      │      │   cell   │
+│ long     │ 倍の幅   │       │      │      │          │
+│ enough   │          │       │      │      │          │
+│ to wrap  │          │       │      │      │          │
+│ inside   │          │       │      │      │          │
+│ its own  │          │       │      │      │          │
+│ column   │          │       │      │      │          │
+│ rather   │          │       │      │      │          │
+│ than be  │          │       │      │      │          │
+│ cut off  │          │       │      │      │          │
+
+Media, folds and the half-written
+
+▣ a screenshot
+  (media:3f6b1c72-9d0e-4a55-b1b7-6c6b0a9
+  ↳ f2e41)
+
+▣ media:8a0c5d31-1b2e-4f77-9c3a-2d4e6f8a
+  ↳ 0b1c
+
+inline media ▣
+media:1c2b3a49-5d6e-4f80-9a1b-2c3d4e5f60
+↳ 71, a mention with nothing to show
+@5b10a2844c20165700ede21g, an emoji with
+only a short name :sparkles:, a date
+that will not parse yesterday and a
+placeholder type something
+
+▸ a fold holding another fold
+
+☐ a state this build has not met is not
+  done
+☑ the state is matched without regard to
+  case
+☐
+
+
+
+text carrying an escape [31m and a bell
+must not repaint the screen
+
+                     pushed to the right

--- a/internal/ui/richtext/testdata/edges_80.golden
+++ b/internal/ui/richtext/testdata/edges_80.golden
@@ -1,0 +1,64 @@
+Nodes a site keeps but never writes
+
+│ ? unsupported: futureBlock
+
+│ ? unsupported: futureBlock
+│ a node type no schema published
+
+│ ? unsupported: extension roadmap-macro
+
+inline: ? futureInline and ? inlineExtension chart.
+
+Lozenges, in every colour the enum has
+
+[neutral] [blue] [purple] [red] [yellow] [green] [teal] [status]
+
+│ ✓ TIP
+│ a tip is a success panel by another name
+
+│ ◆ SOMETHINGNEW
+│ a panel kind this build has not met
+
+│ ◆ PANEL
+│ a colour that will not parse is no colour
+
+Things wider than the pane
+
+See
+https://example.atlassian.net/wiki/spaces/EX/pages/98304/the-runbook-for-a-baske
+↳ t-that-divides-by-zero first.
+
+│ sql
+│ select key, summary, status from issue where project = 'EX' and status in ('open', 'in review') order by updated desc;
+│     indented with a tab
+
+│ one                │ two                 │ three │ four │ five │ six         │
+│────────────────────│─────────────────────│───────│──────│──────│─────────────│
+│ a sentence long    │ 日本語のセルは二倍  │ c     │ d    │ e    │ ▸ in a cell │
+│ enough to wrap     │ の幅                │       │      │      │             │
+│ inside its own     │                     │       │      │      │             │
+│ column rather than │                     │       │      │      │             │
+│ be cut off         │                     │       │      │      │             │
+
+Media, folds and the half-written
+
+▣ a screenshot (media:3f6b1c72-9d0e-4a55-b1b7-6c6b0a9f2e41)
+
+▣ media:8a0c5d31-1b2e-4f77-9c3a-2d4e6f8a0b1c
+
+inline media ▣ media:1c2b3a49-5d6e-4f80-9a1b-2c3d4e5f6071, a mention with
+nothing to show @5b10a2844c20165700ede21g, an emoji with only a short name
+:sparkles:, a date that will not parse yesterday and a placeholder type
+something
+
+▸ a fold holding another fold
+
+☐ a state this build has not met is not done
+☑ the state is matched without regard to case
+☐
+
+
+
+text carrying an escape [31m and a bell  must not repaint the screen
+
+                                                             pushed to the right

--- a/internal/ui/richtext/testdata/inline_30.golden
+++ b/internal/ui/richtext/testdata/inline_30.golden
@@ -1,0 +1,14 @@
+A mention of @Example User, an
+emoji 🎉, a date 2026-01-01, a
+status lozenge [NEEDS REVIEW],
+and a hard break next.
+This text is after the hard
+break.
+
+a centred paragraph (alignment
+    is a mark on the node)
+
+  an indented paragraph
+
+▣ https://example.com/an-exter
+  ↳ nal-image.png

--- a/internal/ui/richtext/testdata/inline_60.golden
+++ b/internal/ui/richtext/testdata/inline_60.golden
@@ -1,0 +1,9 @@
+A mention of @Example User, an emoji 🎉, a date 2026-01-01,
+a status lozenge [NEEDS REVIEW], and a hard break next.
+This text is after the hard break.
+
+   a centred paragraph (alignment is a mark on the node)
+
+  an indented paragraph
+
+▣ https://example.com/an-external-image.png

--- a/internal/ui/richtext/testdata/kitchen.json
+++ b/internal/ui/richtext/testdata/kitchen.json
@@ -1,0 +1,1288 @@
+{
+ "type": "doc",
+ "version": 1,
+ "content": [
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 1
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Kitchen sink: every ADF node this site accepts"
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "A paragraph with "
+    },
+    {
+     "type": "text",
+     "text": "strong",
+     "marks": [
+      {
+       "type": "strong"
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "emphasis",
+     "marks": [
+      {
+       "type": "em"
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "strikethrough",
+     "marks": [
+      {
+       "type": "strike"
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "underline",
+     "marks": [
+      {
+       "type": "underline"
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "inline code",
+     "marks": [
+      {
+       "type": "code"
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", H"
+    },
+    {
+     "type": "text",
+     "text": "2",
+     "marks": [
+      {
+       "type": "subsup",
+       "attrs": {
+        "type": "sub"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": "O and x"
+    },
+    {
+     "type": "text",
+     "text": "2",
+     "marks": [
+      {
+       "type": "subsup",
+       "attrs": {
+        "type": "sup"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "coloured",
+     "marks": [
+      {
+       "type": "textColor",
+       "attrs": {
+        "color": "#ff5630"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "highlighted",
+     "marks": [
+      {
+       "type": "backgroundColor",
+       "attrs": {
+        "color": "#fedec8"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": ", "
+    },
+    {
+     "type": "text",
+     "text": "a titled link",
+     "marks": [
+      {
+       "type": "link",
+       "attrs": {
+        "href": "https://example.com/docs",
+        "title": "the title"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": " and "
+    },
+    {
+     "type": "text",
+     "text": "https://example.com/plain",
+     "marks": [
+      {
+       "type": "link",
+       "attrs": {
+        "href": "https://example.com/plain"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": "."
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "A linked "
+    },
+    {
+     "type": "text",
+     "text": "code span",
+     "marks": [
+      {
+       "type": "code"
+      },
+      {
+       "type": "link",
+       "attrs": {
+        "href": "https://example.com/code"
+       }
+      }
+     ]
+    },
+    {
+     "type": "text",
+     "text": " — code and link are the one pair of marks that may share a text node."
+    }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Lists"
+    }
+   ]
+  },
+  {
+   "type": "bulletList",
+   "content": [
+    {
+     "type": "listItem",
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "first bullet"
+        }
+       ]
+      },
+      {
+       "type": "bulletList",
+       "content": [
+        {
+         "type": "listItem",
+         "content": [
+          {
+           "type": "paragraph",
+           "content": [
+            {
+             "type": "text",
+             "text": "nested bullet"
+            }
+           ]
+          },
+          {
+           "type": "bulletList",
+           "content": [
+            {
+             "type": "listItem",
+             "content": [
+              {
+               "type": "paragraph",
+               "content": [
+                {
+                 "type": "text",
+                 "text": "third level"
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "listItem",
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "second bullet with "
+        },
+        {
+         "type": "text",
+         "text": "bold",
+         "marks": [
+          {
+           "type": "strong"
+          }
+         ]
+        },
+        {
+         "type": "text",
+         "text": " inside"
+        }
+       ]
+      },
+      {
+       "type": "codeBlock",
+       "attrs": {
+        "language": "shell"
+       },
+       "content": [
+        {
+         "type": "text",
+         "text": "saral --help"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "orderedList",
+   "attrs": {
+    "order": 1
+   },
+   "content": [
+    {
+     "type": "listItem",
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "step one"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "listItem",
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "step two"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "listItem",
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "step three"
+        }
+       ]
+      },
+      {
+       "type": "orderedList",
+       "attrs": {
+        "order": 1
+       },
+       "content": [
+        {
+         "type": "listItem",
+         "content": [
+          {
+           "type": "paragraph",
+           "content": [
+            {
+             "type": "text",
+             "text": "substep"
+            }
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "orderedList",
+   "attrs": {
+    "order": 7
+   },
+   "content": [
+    {
+     "type": "listItem",
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "a list that starts at seven"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Task and decision lists"
+    }
+   ]
+  },
+  {
+   "type": "taskList",
+   "content": [
+    {
+     "type": "taskItem",
+     "content": [
+      {
+       "type": "text",
+       "text": "probe every node type"
+      }
+     ],
+     "attrs": {
+      "localId": "ks-task-1",
+      "state": "DONE"
+     }
+    },
+    {
+     "type": "taskItem",
+     "content": [
+      {
+       "type": "text",
+       "text": "write it up"
+      }
+     ],
+     "attrs": {
+      "localId": "ks-task-2",
+      "state": "TODO"
+     }
+    },
+    {
+     "type": "taskList",
+     "content": [
+      {
+       "type": "taskItem",
+       "content": [
+        {
+         "type": "text",
+         "text": "an indented item is a sibling list, not a child of the item above"
+        }
+       ],
+       "attrs": {
+        "localId": "ks-task-3",
+        "state": "TODO"
+       }
+      }
+     ],
+     "attrs": {
+      "localId": "ks-tasklist-2"
+     }
+    }
+   ],
+   "attrs": {
+    "localId": "ks-tasklist-1"
+   }
+  },
+  {
+   "type": "decisionList",
+   "content": [
+    {
+     "type": "decisionItem",
+     "content": [
+      {
+       "type": "text",
+       "text": "keep the original bytes"
+      }
+     ],
+     "attrs": {
+      "localId": "ks-decision-1",
+      "state": "DECIDED"
+     }
+    }
+   ],
+   "attrs": {
+    "localId": "ks-decisions"
+   }
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Code"
+    }
+   ]
+  },
+  {
+   "type": "codeBlock",
+   "attrs": {
+    "language": "go"
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "func render(d Doc) string {\n\tif d.Version != 1 {\n\t\treturn \"\"\n\t}\n\treturn walk(d.Content)\n}"
+    }
+   ]
+  },
+  {
+   "type": "codeBlock",
+   "content": [
+    {
+     "type": "text",
+     "text": "a code block with no language attribute"
+    }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Quote and rule"
+    }
+   ]
+  },
+  {
+   "type": "blockquote",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "A blockquote holds paragraphs and lists — never a heading, a rule or a table."
+      }
+     ]
+    },
+    {
+     "type": "bulletList",
+     "content": [
+      {
+       "type": "listItem",
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "a bullet inside the quote"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "rule"
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Panels"
+    }
+   ]
+  },
+  {
+   "type": "panel",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "info panel"
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "panelType": "info"
+   }
+  },
+  {
+   "type": "panel",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "note panel"
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "panelType": "note"
+   }
+  },
+  {
+   "type": "panel",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "warning panel"
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "panelType": "warning"
+   }
+  },
+  {
+   "type": "panel",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "success panel"
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "panelType": "success"
+   }
+  },
+  {
+   "type": "panel",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "error panel with "
+      },
+      {
+       "type": "text",
+       "text": "code",
+       "marks": [
+        {
+         "type": "code"
+        }
+       ]
+      },
+      {
+       "type": "text",
+       "text": " in it"
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "panelType": "error"
+   }
+  },
+  {
+   "type": "panel",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "custom panel — note the colour comes back upper-cased"
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "panelType": "custom",
+    "panelColor": "#C9372C",
+    "panelIcon": ":rocket:",
+    "panelIconText": "🚀"
+   }
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Table with a header row and merged cells"
+    }
+   ]
+  },
+  {
+   "type": "table",
+   "attrs": {
+    "isNumberColumnEnabled": false,
+    "layout": "default",
+    "displayMode": "default"
+   },
+   "content": [
+    {
+     "type": "tableRow",
+     "content": [
+      {
+       "type": "tableHeader",
+       "attrs": {
+        "colwidth": [
+         180
+        ]
+       },
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "Node"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableHeader",
+       "attrs": {
+        "colwidth": [
+         120
+        ]
+       },
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "Accepted"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableHeader",
+       "attrs": {
+        "colwidth": [
+         260
+        ]
+       },
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "Note"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "tableRow",
+     "content": [
+      {
+       "type": "tableCell",
+       "attrs": {
+        "colspan": 2,
+        "background": "#deebff"
+       },
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "a cell spanning two columns"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "colspan 2"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "tableRow",
+     "content": [
+      {
+       "type": "tableCell",
+       "attrs": {
+        "rowspan": 2
+       },
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "a cell spanning two rows"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "b"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "c"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "tableRow",
+     "content": [
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "d"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "e"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Expand, layout and cards"
+    }
+   ]
+  },
+  {
+   "type": "expand",
+   "content": [
+    {
+     "type": "paragraph",
+     "content": [
+      {
+       "type": "text",
+       "text": "Expands may hold a table, but never another expand."
+      }
+     ]
+    },
+    {
+     "type": "table",
+     "content": [
+      {
+       "type": "tableRow",
+       "content": [
+        {
+         "type": "tableHeader",
+         "attrs": {},
+         "content": [
+          {
+           "type": "paragraph",
+           "content": [
+            {
+             "type": "text",
+             "text": "inside an expand"
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "type": "tableCell",
+         "attrs": {},
+         "content": [
+          {
+           "type": "paragraph",
+           "content": [
+            {
+             "type": "text",
+             "text": "yes"
+            }
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ],
+   "attrs": {
+    "title": "an expand — click to open"
+   }
+  },
+  {
+   "type": "layoutSection",
+   "content": [
+    {
+     "type": "layoutColumn",
+     "attrs": {
+      "width": 50
+     },
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "left column"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "layoutColumn",
+     "attrs": {
+      "width": 50
+     },
+     "content": [
+      {
+       "type": "paragraph",
+       "content": [
+        {
+         "type": "text",
+         "text": "right column"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "inlineCard",
+     "attrs": {
+      "url": "https://example.com/browse/ABC-1"
+     }
+    }
+   ]
+  },
+  {
+   "type": "blockCard",
+   "attrs": {
+    "url": "https://example.com/a-block-card"
+   }
+  },
+  {
+   "type": "embedCard",
+   "attrs": {
+    "layout": "center",
+    "url": "https://example.com/an-embed"
+   }
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Inline nodes"
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "A mention of "
+    },
+    {
+     "type": "mention",
+     "attrs": {
+      "id": "5b10a2844c20165700ede21g",
+      "text": "@Example User",
+      "accessLevel": ""
+     }
+    },
+    {
+     "type": "text",
+     "text": ", an emoji "
+    },
+    {
+     "type": "emoji",
+     "attrs": {
+      "shortName": ":tada:",
+      "id": "1f389",
+      "text": "🎉"
+     }
+    },
+    {
+     "type": "text",
+     "text": ", a date "
+    },
+    {
+     "type": "date",
+     "attrs": {
+      "timestamp": "1767225600000"
+     }
+    },
+    {
+     "type": "text",
+     "text": ", a status lozenge "
+    },
+    {
+     "type": "status",
+     "attrs": {
+      "text": "NEEDS REVIEW",
+      "color": "yellow",
+      "localId": "ks-status-1",
+      "style": ""
+     }
+    },
+    {
+     "type": "text",
+     "text": ", and a hard break next."
+    },
+    {
+     "type": "hardBreak"
+    },
+    {
+     "type": "text",
+     "text": "This text is after the hard break."
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "a centred paragraph (alignment is a mark on the node)"
+    }
+   ],
+   "marks": [
+    {
+     "type": "alignment",
+     "attrs": {
+      "align": "center"
+     }
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "an indented paragraph"
+    }
+   ],
+   "marks": [
+    {
+     "type": "indentation",
+     "attrs": {
+      "level": 1
+     }
+    }
+   ]
+  },
+  {
+   "type": "mediaSingle",
+   "attrs": {
+    "layout": "center"
+   },
+   "content": [
+    {
+     "type": "media",
+     "attrs": {
+      "type": "external",
+      "url": "https://example.com/an-external-image.png"
+     }
+    }
+   ]
+  },
+  {
+   "type": "heading",
+   "attrs": {
+    "level": 2
+   },
+   "content": [
+    {
+     "type": "text",
+     "text": "Non-ASCII"
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "Umlauts: Größe, Übermäßig, Weiß. CJK: 日本語のテキスト、中文字符. Emoji: 🚀📊🐛. Combining: été. RTL: עברית."
+    }
+   ]
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "text": "A wide-rune table cell is the thing that breaks a renderer that counts bytes."
+    }
+   ]
+  },
+  {
+   "type": "table",
+   "content": [
+    {
+     "type": "tableRow",
+     "content": [
+      {
+       "type": "tableHeader",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "キー"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableHeader",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "Wert"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "tableRow",
+     "content": [
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "日本語"
+          }
+         ]
+        }
+       ]
+      },
+      {
+       "type": "tableCell",
+       "attrs": {},
+       "content": [
+        {
+         "type": "paragraph",
+         "content": [
+          {
+           "type": "text",
+           "text": "Größe 🚀"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/internal/ui/richtext/testdata/kitchen_40.golden
+++ b/internal/ui/richtext/testdata/kitchen_40.golden
@@ -1,0 +1,136 @@
+Kitchen sink: every ADF node this site
+accepts
+
+A paragraph with strong, emphasis,
+strikethrough, underline, inline code,
+H_2O and x^2, coloured, highlighted, a
+titled link (https://example.com/docs)
+and https://example.com/plain.
+
+A linked code span
+(https://example.com/code) — code and
+link are the one pair of marks that may
+share a text node.
+
+Lists
+
+• first bullet
+  • nested bullet
+    • third level
+• second bullet with bold inside
+
+  │ shell
+  │ saral --help
+
+1. step one
+2. step two
+3. step three
+   1. substep
+
+7. a list that starts at seven
+
+Task and decision lists
+
+☑ probe every node type
+☐ write it up
+  ☐ an indented item is a sibling list,
+    not a child of the item above
+
+◇ keep the original bytes
+
+Code
+
+│ go
+│ func render(d Doc) string {
+│     if d.Version != 1 {
+│         return ""
+│     }
+│     return walk(d.Content)
+│ }
+
+│ a code block with no language attribute
+
+Quote and rule
+
+│ A blockquote holds paragraphs and
+│ lists — never a heading, a rule or a
+│ table.
+│
+│ • a bullet inside the quote
+
+────────────────────────────────────────
+
+Panels
+
+│ ℹ INFO
+│ info panel
+
+│ ✎ NOTE
+│ note panel
+
+│ ⚠ WARNING
+│ warning panel
+
+│ ✓ SUCCESS
+│ success panel
+
+│ ✗ ERROR
+│ error panel with code in it
+
+│ 🚀 PANEL
+│ custom panel — note the colour comes
+│ back upper-cased
+
+Table with a header row and merged cells
+
+│ Node          │ Accepted │ Note      │
+│───────────────│──────────│───────────│
+│ a cell        │          │ colspan 2 │
+│ spanning two  │          │           │
+│ columns       │          │           │
+│ a cell        │ b        │ c         │
+│ spanning two  │          │           │
+│ rows          │          │           │
+│               │ d        │ e         │
+
+Expand, layout and cards
+
+▸ an expand — click to open
+
+left column
+
+right column
+
+https://example.com/browse/ABC-1
+
+https://example.com/a-block-card
+
+https://example.com/an-embed
+
+Inline nodes
+
+A mention of @Example User, an emoji 🎉,
+a date 2026-01-01, a status lozenge
+[NEEDS REVIEW], and a hard break next.
+This text is after the hard break.
+
+a centred paragraph (alignment is a mark
+              on the node)
+
+  an indented paragraph
+
+▣ https://example.com/an-external-image.
+  ↳ png
+
+Non-ASCII
+
+Umlauts: Größe, Übermäßig, Weiß. CJK:
+日本語のテキスト、中文字符. Emoji:
+🚀📊🐛. Combining: été. RTL: עברית.
+
+A wide-rune table cell is the thing that
+breaks a renderer that counts bytes.
+
+│ キー   │ Wert     │
+│────────│──────────│
+│ 日本語 │ Größe 🚀 │

--- a/internal/ui/richtext/testdata/kitchen_80.golden
+++ b/internal/ui/richtext/testdata/kitchen_80.golden
@@ -1,0 +1,118 @@
+Kitchen sink: every ADF node this site accepts
+
+A paragraph with strong, emphasis, strikethrough, underline, inline code, H_2O
+and x^2, coloured, highlighted, a titled link (https://example.com/docs) and
+https://example.com/plain.
+
+A linked code span (https://example.com/code) — code and link are the one pair
+of marks that may share a text node.
+
+Lists
+
+• first bullet
+  • nested bullet
+    • third level
+• second bullet with bold inside
+
+  │ shell
+  │ saral --help
+
+1. step one
+2. step two
+3. step three
+   1. substep
+
+7. a list that starts at seven
+
+Task and decision lists
+
+☑ probe every node type
+☐ write it up
+  ☐ an indented item is a sibling list, not a child of the item above
+
+◇ keep the original bytes
+
+Code
+
+│ go
+│ func render(d Doc) string {
+│     if d.Version != 1 {
+│         return ""
+│     }
+│     return walk(d.Content)
+│ }
+
+│ a code block with no language attribute
+
+Quote and rule
+
+│ A blockquote holds paragraphs and lists — never a heading, a rule or a table.
+│
+│ • a bullet inside the quote
+
+────────────────────────────────────────────────────────────────────────────────
+
+Panels
+
+│ ℹ INFO
+│ info panel
+
+│ ✎ NOTE
+│ note panel
+
+│ ⚠ WARNING
+│ warning panel
+
+│ ✓ SUCCESS
+│ success panel
+
+│ ✗ ERROR
+│ error panel with code in it
+
+│ 🚀 PANEL
+│ custom panel — note the colour comes back upper-cased
+
+Table with a header row and merged cells
+
+│ Node                        │ Accepted │ Note      │
+│─────────────────────────────│──────────│───────────│
+│ a cell spanning two columns │          │ colspan 2 │
+│ a cell spanning two rows    │ b        │ c         │
+│                             │ d        │ e         │
+
+Expand, layout and cards
+
+▸ an expand — click to open
+
+left column
+
+right column
+
+https://example.com/browse/ABC-1
+
+https://example.com/a-block-card
+
+https://example.com/an-embed
+
+Inline nodes
+
+A mention of @Example User, an emoji 🎉, a date 2026-01-01, a status lozenge
+[NEEDS REVIEW], and a hard break next.
+This text is after the hard break.
+
+             a centred paragraph (alignment is a mark on the node)
+
+  an indented paragraph
+
+▣ https://example.com/an-external-image.png
+
+Non-ASCII
+
+Umlauts: Größe, Übermäßig, Weiß. CJK: 日本語のテキスト、中文字符. Emoji: 🚀📊🐛.
+Combining: été. RTL: עברית.
+
+A wide-rune table cell is the thing that breaks a renderer that counts bytes.
+
+│ キー   │ Wert     │
+│────────│──────────│
+│ 日本語 │ Größe 🚀 │

--- a/internal/ui/richtext/testdata/lists_28.golden
+++ b/internal/ui/richtext/testdata/lists_28.golden
@@ -1,0 +1,16 @@
+• first bullet
+  • nested bullet
+    • third level
+• second bullet with bold
+  inside
+
+  │ shell
+  │ saral --help
+
+1. step one
+2. step two
+3. step three
+   1. substep
+
+7. a list that starts at
+   seven

--- a/internal/ui/richtext/testdata/lists_60.golden
+++ b/internal/ui/richtext/testdata/lists_60.golden
@@ -1,0 +1,14 @@
+• first bullet
+  • nested bullet
+    • third level
+• second bullet with bold inside
+
+  │ shell
+  │ saral --help
+
+1. step one
+2. step two
+3. step three
+   1. substep
+
+7. a list that starts at seven

--- a/internal/ui/richtext/testdata/lists_ascii_60.golden
+++ b/internal/ui/richtext/testdata/lists_ascii_60.golden
@@ -1,0 +1,14 @@
+- first bullet
+  - nested bullet
+    - third level
+- second bullet with bold inside
+
+  | shell
+  | saral --help
+
+1. step one
+2. step two
+3. step three
+   1. substep
+
+7. a list that starts at seven

--- a/internal/ui/richtext/testdata/nonascii_20.golden
+++ b/internal/ui/richtext/testdata/nonascii_20.golden
@@ -1,0 +1,17 @@
+Umlauts: Größe,
+Übermäßig, Weiß.
+CJK:
+日本語のテキスト、中
+文字符. Emoji:
+🚀📊🐛. Combining:
+été. RTL: עברית.
+
+A wide-rune table
+cell is the thing
+that breaks a
+renderer that counts
+bytes.
+
+│ キー   │ Wert     │
+│────────│──────────│
+│ 日本語 │ Größe 🚀 │

--- a/internal/ui/richtext/testdata/nonascii_60.golden
+++ b/internal/ui/richtext/testdata/nonascii_60.golden
@@ -1,0 +1,10 @@
+Umlauts: Größe, Übermäßig, Weiß. CJK:
+日本語のテキスト、中文字符. Emoji: 🚀📊🐛. Combining: été.
+RTL: עברית.
+
+A wide-rune table cell is the thing that breaks a renderer
+that counts bytes.
+
+│ キー   │ Wert     │
+│────────│──────────│
+│ 日本語 │ Größe 🚀 │

--- a/internal/ui/richtext/testdata/panels_24.golden
+++ b/internal/ui/richtext/testdata/panels_24.golden
@@ -1,0 +1,20 @@
+│ ℹ INFO
+│ info panel
+
+│ ✎ NOTE
+│ note panel
+
+│ ⚠ WARNING
+│ warning panel
+
+│ ✓ SUCCESS
+│ success panel
+
+│ ✗ ERROR
+│ error panel with code
+│ in it
+
+│ 🚀 PANEL
+│ custom panel — note
+│ the colour comes back
+│ upper-cased

--- a/internal/ui/richtext/testdata/panels_60.golden
+++ b/internal/ui/richtext/testdata/panels_60.golden
@@ -1,0 +1,17 @@
+│ ℹ INFO
+│ info panel
+
+│ ✎ NOTE
+│ note panel
+
+│ ⚠ WARNING
+│ warning panel
+
+│ ✓ SUCCESS
+│ success panel
+
+│ ✗ ERROR
+│ error panel with code in it
+
+│ 🚀 PANEL
+│ custom panel — note the colour comes back upper-cased

--- a/internal/ui/richtext/testdata/panels_ascii_60.golden
+++ b/internal/ui/richtext/testdata/panels_ascii_60.golden
@@ -1,0 +1,17 @@
+| i INFO
+| info panel
+
+| * NOTE
+| note panel
+
+| ! WARNING
+| warning panel
+
+| + SUCCESS
+| success panel
+
+| x ERROR
+| error panel with code in it
+
+| # PANEL
+| custom panel — note the colour comes back upper-cased

--- a/internal/ui/richtext/testdata/quote_28.golden
+++ b/internal/ui/richtext/testdata/quote_28.golden
@@ -1,0 +1,9 @@
+│ A blockquote holds
+│ paragraphs and lists —
+│ never a heading, a rule or
+│ a table.
+│
+│ • a bullet inside the
+│   quote
+
+────────────────────────────

--- a/internal/ui/richtext/testdata/quote_60.golden
+++ b/internal/ui/richtext/testdata/quote_60.golden
@@ -1,0 +1,6 @@
+│ A blockquote holds paragraphs and lists — never a heading,
+│ a rule or a table.
+│
+│ • a bullet inside the quote
+
+────────────────────────────────────────────────────────────

--- a/internal/ui/richtext/testdata/table_24.golden
+++ b/internal/ui/richtext/testdata/table_24.golden
@@ -1,0 +1,10 @@
+│ Node     │ Accepted │ Note     │
+│──────────│──────────│──────────│
+│ a cell   │          │ colspan  │
+│ spanning │          │ 2        │
+│ two      │          │          │
+│ columns  │          │          │
+│ a cell   │ b        │ c        │
+│ spanning │          │          │
+│ two rows │          │          │
+│          │ d        │ e        │

--- a/internal/ui/richtext/testdata/table_40.golden
+++ b/internal/ui/richtext/testdata/table_40.golden
@@ -1,0 +1,9 @@
+│ Node          │ Accepted │ Note      │
+│───────────────│──────────│───────────│
+│ a cell        │          │ colspan 2 │
+│ spanning two  │          │           │
+│ columns       │          │           │
+│ a cell        │ b        │ c         │
+│ spanning two  │          │           │
+│ rows          │          │           │
+│               │ d        │ e         │

--- a/internal/ui/richtext/testdata/table_80.golden
+++ b/internal/ui/richtext/testdata/table_80.golden
@@ -1,0 +1,5 @@
+│ Node                        │ Accepted │ Note      │
+│─────────────────────────────│──────────│───────────│
+│ a cell spanning two columns │          │ colspan 2 │
+│ a cell spanning two rows    │ b        │ c         │
+│                             │ d        │ e         │

--- a/internal/ui/richtext/testdata/task_ascii_60.golden
+++ b/internal/ui/richtext/testdata/task_ascii_60.golden
@@ -1,0 +1,6 @@
+[x] probe every node type
+[ ] write it up
+  [ ] an indented item is a sibling list, not a child of the
+      item above
+
+<> keep the original bytes

--- a/internal/ui/richtext/testdata/tasks_28.golden
+++ b/internal/ui/richtext/testdata/tasks_28.golden
@@ -1,0 +1,7 @@
+☑ probe every node type
+☐ write it up
+  ☐ an indented item is a
+    sibling list, not a
+    child of the item above
+
+◇ keep the original bytes

--- a/internal/ui/richtext/testdata/tasks_60.golden
+++ b/internal/ui/richtext/testdata/tasks_60.golden
@@ -1,0 +1,6 @@
+☑ probe every node type
+☐ write it up
+  ☐ an indented item is a sibling list, not a child of the
+    item above
+
+◇ keep the original bytes


### PR DESCRIPTION
# R1 — the display renderer

An issue's description arrives on screen as markdown source: `##`, `**`, `[text](url)`, backticks,
fences, pipe tables. `internal/ui/issue/render.go` writes `adf.MarkdownWith(...)` into its pager and
`pkg/adf` emits literal markdown, so that is exactly what a reader gets.

That markdown is **a serialisation for editing**. It exists for the `$EDITOR` handoff and the
byte-stable round trip, `pkg/adf` is public and semver'd and must not import a UI library, and it
deliberately does not escape prose. It was never a display format. This PR adds the display renderer:
`internal/ui/richtext`, which walks an `adf.Doc` straight to styled terminal lines.

`glamour` was measured and refused, and this does not revisit it: it would re-parse text that was
never markdown (so `*not emphasis*` becomes emphasis — a correctness failure), the information a
display needs is already destroyed by then (an error panel and a plain quote are the same node), and
`chroma` alone is **+5.11 MiB** stripped against **4.57 MiB** of headroom under the 15 MiB gate.
**No `go.mod` change**: the package imports `pkg/adf`, `charm.land/lipgloss/v2` and `x/ansi`, all
already direct dependencies, and never `internal/ui/kernel`.

## The API two later packets code against

```go
type Palette struct {
	Base, Muted, Title, Accent, Danger, Warning, Success, Badge lipgloss.Style
	Color bool // false is the no-colour theme: emphasis survives as an attribute
}

type PanelStyles struct{ Info, Note, Warning, Success, Error, Custom lipgloss.Style }
type StatusStyles struct{ Neutral, Blue, Purple, Red, Yellow, Green lipgloss.Style }

type Styles struct {
	Body, Muted                                  lipgloss.Style
	H1, H2, H3                                   lipgloss.Style
	Strong, Em, Underline, Strike, Code, Link, URL lipgloss.Style
	Bullet, Number, Task, TaskDone, Decision     lipgloss.Style
	Quote, QuoteBar                              lipgloss.Style
	CodeBlock, CodeLang, CodeBar                 lipgloss.Style
	Panel                                        PanelStyles
	Rule                                         lipgloss.Style
	TableBorder, TableHeader, TableCell          lipgloss.Style
	FoldMark, FoldTitle                          lipgloss.Style
	Media, Mention, Date, Card                   lipgloss.Style
	Status                                       StatusStyles
	Unknown, Cont                                lipgloss.Style
	Color                                        bool
}

func NewStyles(p Palette) Styles

type Markers struct {
	Info, Note, Success, Warning, Error, Panel string
	Decision, Task, TaskDone                   string
	Media                                      string
	Folded, Unfolded                           string
	Bullet, VLine, HLine, Ellipsis             string
	Cont                                       string // a line the renderer broke, not the author
	Unknown                                    string
}

func UnicodeMarkers() Markers
func ASCIIMarkers() Markers

type Options struct {
	Width    int             // cells a line has, gutters included; <= 0 means 80
	Location *time.Location  // for a date node; nil means UTC
	Styles   Styles
	Markers  Markers         // the zero value is the Unicode set
	Open     map[int]bool    // the folds the reader has opened, by Fold.Index
}

type Fold struct {
	Index int    // position in document order; the key Options.Open is read with
	Line  int    // where the fold's line landed in Lines
	Open  bool
	Title string
}

type Rendered struct {
	Lines  []string // styled, unpadded
	Widths []int    // each line's width in cells, measured while it was built
	Folds  []Fold   // every expand, in document order
}

func (r Rendered) Width() int // the widest line: how far a pane can pan

func Render(d adf.Doc, opt Options) Rendered
func Summary(d adf.Doc, width int) string // one plain unstyled line
```

Two refinements to the shape the design settled on, both additive: `Markers.Unknown` (a custom panel
and an unfamiliar node type are different things and were sharing one glyph), and `Rendered.Width()`
so a pane does not have to loop over `Widths` itself.

## Style after wrapping, and why every line stands alone

**Verified in this tree** — `ansi.Wrap` does not re-open an SGR sequence on a continuation line.
Wrapping one bold run at 20 columns gives:

```
line 0: "\x1b[1mthe basket total is"   ← opens bold
line 1: "recalculated before"          ← no sequence at all: renders unstyled
line 2: "the line items are"           ← the same
line 3: "read\x1b[m"                   ← the reset, alone
```

A windowed pane starting at line 1 draws the run unstyled and one starting at line 3 opens with a
stray reset. So the renderer keeps a span-then-break line model: spans are collected, broken, and
each output line is painted from its own spans.

`TestStyle_EveryLineIsSelfContained` walks the escape sequences of every line of both corpora at six
widths, under both palettes and both glyph sets, and fails a line that leaves a style open, resets
one it never opened, or emits any sequence that is not an SGR.

Two things fell out of measuring that:

- `strings.Builder.Reset` drops its buffer, so one reused per line pays an allocation and a regrow
  every time. The line is built in a `[]byte` truncated to zero.
- `lipgloss` re-styles **every rune** of an underlined or struck-through run — a thirteen-letter word
  comes back as thirteen SGR pairs, and an escape sequence lands *inside* any grapheme cluster, so an
  underlined `👨‍👩‍👧` comes apart. The renderer asks a style once what it puts around a single rune and
  puts that around the whole run: lipgloss still owns the sequences, the terminal gets one pair, and
  a joined emoji stays joined (`TestStyle_OneSequencePerRun`).

## The decisions this packet owned

**A panel is not a blockquote.** Each of info / note / warning / success / error gets its own marker,
its own label and its own palette token; a `custom` panel takes the `panelColor` off the wire, and its
`panelIconText` only where the glyph set says the terminal can be trusted with a glyph nobody chose.
A quote gets a muted bar and no label. That distinction was the main thing markdown lost.

**A status lozenge carries a colour enum**, so it is painted in it: neutral → muted, red → danger,
yellow → warning, green → success, blue and purple → accent. The theme has one accent, so those two
share it and the words in the lozenge are what tell them apart; inventing a colour outside the palette
would break the no-colour theme and the theme-independence of the goldens. The brackets stay in every
theme, because they are all that is left of a lozenge once colour is stripped.

**An unknown node stays visibly unknown**: `? unsupported: futureBlock` in the warning token, behind
its own bar, with whatever it holds under it — never as prose that looks authored. An `extension` is
named by its `extensionKey`, which is the only interesting thing about it.

**`media` is a placeholder, not a broken link**: `▣ a screenshot (media:3f6b…)`. The id or the URL is
always in the line, so a preview has something to resolve and a reader has something to look up.

**A table or a code block wider than the column**, decided per construct:

- **Code is neither wrapped nor truncated.** Wrapping corrupts what a reader is about to copy;
  truncating loses it and says nothing. A long line stays long, its width is reported, and panning it
  is the pane's job. Tabs are expanded to the next stop first, because `ansi.StringWidth` counts a tab
  as one cell while a terminal jumps four — otherwise `Widths` lies and a pane pans past the end.
- **A table squeezes its columns and wraps inside them**, so a row is as tall as its tallest cell and
  nothing is dropped. Columns squeeze to a floor of 8 cells; past that the grid is wider than the pane
  and is panned rather than cut. The pixel `colwidth` the browser editor stores is ignored — it says
  nothing about a terminal, and what a column needs is measurable from what is in it. A `colspan` is
  expanded into the positions it covers and a `rowspan` holds its column on the rows below, because a
  merged cell rendered as one column puts every value after it under the wrong heading.
- Everything else wraps. `TestRender_OnlyCodeAndGridsOverflow` asserts those two are the only
  constructs that go past the width, and `TestRender_ProseFitsTheWidth` asserts the rest fit down to
  16 columns.

**`expand` folds, keyed by document order.** A `localId` is optional on the wire — absent on every
expand in the stored kitchen sink — no more unique than the editor that wrote it made it, and says
nothing about a document that was never edited in a browser. Document order is derivable from the
document alone, which is what a pane holding a set of open folds needs. A closed fold still *counts*
the folds inside it, so opening one does not renumber the folds after it
(`TestFolds_IndicesDoNotMoveWhenOneOpens`). ADF allows a `nestedExpand` in a table cell, so a fold in
a cell reports the line its row starts on — the only line of the document's own a grid position has.

**`no-color`.** `Palette.Color == false` keeps strong as bold, em as italic, underline and strike as
themselves, a code span as reverse video and a lozenge as bold, and drops `textColor` /
`backgroundColor` rather than turning a colour into an emphasis the document never carried.
`TestStyle_NoColorKeepsEmphasis` asserts each of those and that no colour sequence appears anywhere.

Other things worth naming: a `layoutSection` renders one column after another, because eighty cells
split in two holds no prose worth reading; `alignment` writes only the leading spaces, since the pane
owns the padding on the other side; `subsup` is spelled `^2` / `_2` rather than dropped, because a
terminal has no raised digit and `H2O` read as `H2O` is wrong in a way a reader cannot see; a link
shows its address, because a terminal cannot be relied on to make one clickable and an address a
reader cannot see is one they cannot follow; and control characters are dropped, because issue text
is written by anyone with a Jira login and an escape sequence in a description must not repaint the
screen it is displayed in.

## Tests

- **Goldens per construct** at two or three widths including a narrow one — lists, tasks, code, quote,
  panels, table (80/40/24), cards, inline nodes, non-ASCII — plus both whole corpora at 80 and 40, the
  ASCII glyph set, and an opened fold. Following the house convention they hold `ansi.Strip`ped
  layout, so a golden diff is a layout change and never a hex value somebody moved in the kernel;
  styling is asserted separately and precisely.
- **Driven from stored ADF.** `testdata/kitchen.json` is the kitchen-sink description as a real site
  stored it: **31 node types and 11 mark types**, every mark including a `code`+`link` pair on one text
  node, a `colspan` with a background, a `rowspan`, alignment and indentation marks, an `order: 7`
  list, a nested task list, a custom panel with an emoji icon, and a non-ASCII section with umlauts,
  CJK, emoji, RTL and a CJK table. The per-construct goldens are slices of it, taken by heading, so a
  golden is per construct and still made of what a site really stores. `testdata/edges.json` covers
  what a site keeps but will not accept — `unsupportedBlock`, an unknown node, extensions, a
  `nestedExpand` in a cell, `mediaGroup`, `mediaInline`, every status colour, a 6-column table, a bad
  timestamp, an unparseable colour, a control character.
- **Non-ASCII throughout**, and nothing measures a display string with `len()`: `ansi.StringWidth`
  everywhere, `ansi.Truncate`/`TruncateLeft` for the one place text is split mid-word, and
  `TestRender_WidthsAreWhatTheLinesMeasure` re-measures every line of both corpora at five widths
  under both palettes.
- **Nothing is dropped:** `TestRender_NothingIsDropped` asserts the document's own characters appear
  in the lines, in order, at four widths.
- **Budgets** in `budget_test.go`, built `!race` like `internal/app/index_budget_test.go`, because the
  race detector's own allocations are not the ones being asserted.

## Verification

```
go mod tidy && git diff --exit-code go.mod go.sum   clean — no dependency added
go vet ./... && golangci-lint run                   0 issues
go test -race -count=1 ./...                        all packages ok
make check                                          ok
python3 scripts/checkleak.py                        clean (nothing captured in this tree)
go build -trimpath -ldflags "-s -w"                 10,939,442 B = 10.433 MiB
```

**Binary: 10.433 MiB against the 15 MiB gate, 4.567 MiB of headroom — byte-identical to the same
build from `main`.** Nothing imports the package yet, so the linker drops it; the point is that the
figure cannot move, because no dependency was added. That is the whole reason this renderer is written
rather than taken.

| Benchmark | ns/op | allocs/op |
|---|---|---|
| `BenchmarkRender/80` — themed, 117 lines | 119,000 | 702 |
| `BenchmarkRender/40` — narrower, so more lines | 121,000 | 779 |
| `BenchmarkRenderNoColor` | 109,000 | 525 |
| `BenchmarkRenderLong` — five copies, a long description | 352,000 | 2,179 |
| `BenchmarkSummary` — flattened to one 80-cell line | 2,000 | 6 |

Six allocations a line; the ceiling asserted is eight with colour and six without, plus that the cost
per line does not grow with the document. A render is **not** a per-frame cost — a pane memoizes it —
but a resize re-renders, which is what the ceiling is sized for. `BenchmarkFrame` and
`BenchmarkKeyToFrame` are untouched at ~297 and ~310 allocs/op: nothing consumes this package yet.

`internal/arch/imports_test.go` needs no new rule and passes unchanged: the package sits under
`internal/ui`, imports `pkg/adf` and two UI libraries, and breaks none of the seven boundaries.

## Consumers

Nothing adopts it in this PR, by design — `internal/ui/issue` and `internal/ui/comment` are other
packets' paths. `grep -rn "richtext\." internal/` hits only this package and its tests today. R3 and
R4 code against the signatures above; the two calls they replace are
`internal/ui/issue/render.go:body` and `internal/ui/issue/render.go:thread`, both of which currently
pass `adf.Options{TableWidth, ASCII, Location}`.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
