### PR TITLE
feat(comments): read the thread and write into it in whatever box it is given

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -513,6 +513,29 @@ of headroom under the 15 MiB binary gate. So the display renderer is written her
   Deliberately not `jira.FieldsNavigable`: a wildcard returns a value per field per issue with
   nothing to label any of them by, and it reports itself as a read of everything, which is how a
   narrow cached row starts looking wide. `Issue.Requested` still names exactly what was asked for.
+- [x] **R3 — One thread and one composer, in whatever box it is given** · **owns**
+  `internal/ui/comment/**` including its `testdata/**`, this row
+  The owner asked for comments beside the issue rather than over it, and for writing one not to take
+  the screen away from what it answers. Both are the same requirement: one `*comment.Model`, embedded
+  as a child by a sidebar and pushed whole-screen by the same instance, so there is one fetch, one
+  draft, one cursor and one composer with the text still in it. `Thread` therefore returns `*Model`
+  rather than `kernel.View`, and `Init` reads nothing until an issue is named, because a pane builds
+  the thread before it knows which issue it is showing.
+  **One layout, not two.** The thread is on top and the composer under it, at
+  `clamp(1+rows, 3, max(3, boxH/2))` — a ceiling of half the box, so a comment is never written on a
+  screen that hides what it is replying to, at any size. The composer spends one row on chrome and
+  not two (which comment, and the keys that finish it, on one line that degrades through terser
+  forms) so that `1+rows` is the draft's own rows rather than one short of them. `rows` comes from
+  the widget's `DynamicHeight`, because a textarea soft-wraps on words and dividing cells by the
+  width is a row out at every width but one.
+  Bodies are drawn through R1 instead of `adf.MarkdownWith`, which is what put `**` and `## ` on
+  screen, and the delete confirmation quotes its opening words through `richtext.Summary`.
+  **A line wider than the box is cut where it says so, and panned to.** R1 leaves code and grid rows
+  at their own width by design — wrapping code corrupts what a reader is about to copy — so at 34
+  columns most code blocks are wider than the pane. The pane marks the cut and binds `←/h` and `→/l`
+  to reach the rest; only the over-wide lines slide, because sliding the rest would take the author
+  and the date of the comment being read off the left edge. Truncating silently is the one answer
+  that was not available.
 
 ## Batch 4 — Attachments · parallel ×3
 

--- a/internal/ui/comment/bench_test.go
+++ b/internal/ui/comment/bench_test.go
@@ -44,10 +44,36 @@ func thread(tb testing.TB, n, w, h int) *Model {
 	return m
 }
 
+// wideThread is a thread of comments whose code blocks are all wider than the
+// box, so that every line on screen is one the pane has to cut.
+func wideThread(tb testing.TB, w, h int) *Model {
+	tb.Helper()
+
+	m := thread(tb, 200, w, h)
+	code := "func total(rows []Row) Money { return sum(rows).Round(2) } // the rounding that lies"
+	for i := range m.comments {
+		m.comments[i].Body = adf.NewDoc(
+			adf.NewNode("paragraph", adf.NewText("comment number "+strconv.Itoa(i))),
+			adf.NewNode("codeBlock", adf.NewText(code)).WithAttrs(adf.Attrs{"language": "go"}),
+		)
+	}
+	m.blocks.reset()
+	_ = m.View()
+	return m
+}
+
 func scroll(b *testing.B, m *Model) {
 	b.Helper()
 
 	var down, up tea.Msg = keyPress("j"), keyPress("k")
+	// The first press of each key renders the two comments the selection moves
+	// between; every frame after that is the memo, which is the steady state this
+	// claims to measure.
+	for _, key := range []tea.Msg{down, up} {
+		next, _ := m.Update(key)
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := range b.N {
@@ -102,6 +128,55 @@ func BenchmarkThreadRedraw200x60(b *testing.B) {
 	}
 }
 
+// BenchmarkThreadRedrawSidebar34x24 is the sidebar: the same instance at a third
+// of the width, with every comment laid out for it.
+func BenchmarkThreadRedrawSidebar34x24(b *testing.B) {
+	m := thread(b, 10000, 34, 24)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = m.View()
+	}
+}
+
+// BenchmarkThreadCompose is a frame with the composer open, which is a second
+// layout over the same thread and must not cost a render of it.
+func BenchmarkThreadCompose(b *testing.B) {
+	m := thread(b, 10000, 34, 24)
+	next, _ := m.Update(WriteMsg{})
+	m, _ = next.(*Model)
+	for _, r := range "A reply long enough to wrap in a sidebar twice over." {
+		next, _ = m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m, _ = next.(*Model)
+	}
+	_ = m.View()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = m.View()
+	}
+}
+
+// BenchmarkThreadPan is the window cut out of the lines too wide for the box.
+// Panning re-cuts a screenful, so it is the one gesture that cannot be answered
+// out of the memo — but it is memoized per pan, so holding the key is not a cut
+// per frame.
+func BenchmarkThreadPan(b *testing.B) {
+	m := wideThread(b, 34, 24)
+	right, left := keyPress("l"), keyPress("h")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		key := right
+		if i%2 == 1 {
+			key = left
+		}
+		next, _ := m.Update(key)
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+}
+
 // BenchmarkThreadRenderBlock is the per-comment cost the memo protects.
 func BenchmarkThreadRenderBlock(b *testing.B) {
 	m := thread(b, 20, 120, 40)
@@ -113,9 +188,12 @@ func BenchmarkThreadRenderBlock(b *testing.B) {
 	}
 }
 
+// Deliberately not parallel. An allocation count comes from process-wide
+// MemStats, so a benchmark run beside sixty other tests is handed their
+// allocations divided by its own iteration count — and under -race it runs long
+// enough to be handed a lot of them. A sequential test is the only one that has
+// the counter to itself.
 func TestScrolling_CostsTheSameOnTenThousandCommentsAsOnTwenty(t *testing.T) {
-	t.Parallel()
-
 	big := testing.Benchmark(BenchmarkThreadSteadyScroll10k)
 	small := testing.Benchmark(BenchmarkThreadSteadyScroll20)
 
@@ -124,10 +202,53 @@ func TestScrolling_CostsTheSameOnTenThousandCommentsAsOnTwenty(t *testing.T) {
 		t.Errorf("a 10k-comment thread allocates %d per frame against %d for a 20-comment one; the render is not virtualized",
 			bigAllocs, smallAllocs)
 	}
-	// What is left is the frame string View has to return and the header joined
-	// onto it; every comment behind them is memoized.
+	// What is left is the frame string View has to return; every comment behind it
+	// is memoized.
 	if bigAllocs > 2 {
 		t.Errorf("a steady-state frame allocates %d times, want the memo to carry all but the frame itself", bigAllocs)
+	}
+}
+
+// The composer is a second thing in the box and not a second layout of it, so a
+// frame with it open costs no render of the thread above it. What a composing
+// frame does cost is one render of the editor widget, which is the library's own
+// and is not memoized here: its key would have to include the cursor, the scroll
+// offset and the placeholder, and a memo that misses one of those draws the
+// wrong text at the wrong width.
+func TestComposing_RendersNoCommentPerFrame(t *testing.T) {
+	t.Parallel()
+
+	m := thread(t, 200, 34, 24)
+	next, _ := m.Update(WriteMsg{})
+	m, _ = next.(*Model)
+	_ = m.View()
+
+	before := len(m.blocks.made)
+	for range 50 {
+		_ = m.View()
+	}
+	if got := len(m.blocks.made); got != before {
+		t.Errorf("fifty composing frames rendered %d comments", got-before)
+	}
+}
+
+// Panning cuts the lines again — it has to, the window into them moved — but it
+// never lays a comment out again: the cut is over lines the memo already holds.
+func TestPanning_CutsTheLinesAgainAndRendersNoComment(t *testing.T) {
+	t.Parallel()
+
+	m := wideThread(t, 34, 24)
+	before := len(m.blocks.made)
+	for range 10 {
+		next, _ := m.Update(keyPress("l"))
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+	if m.pan == 0 {
+		t.Fatal("nothing panned, so this measured the wrong thing")
+	}
+	if got := len(m.blocks.made); got != before {
+		t.Errorf("panning rendered %d comments again", got-before)
 	}
 }
 

--- a/internal/ui/comment/box_test.go
+++ b/internal/ui/comment/box_test.go
@@ -1,0 +1,445 @@
+package comment
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// boxes are the three boxes this view has to be the same code in: a sidebar
+// narrow enough that a comment body has thirty cells, the half-screen a divider
+// usually lands on, and a whole screen.
+var boxes = []struct {
+	name          string
+	width, height int
+}{
+	{name: "a sidebar", width: 34, height: 24},
+	{name: "half a screen", width: 60, height: 24},
+	{name: "a whole screen", width: 120, height: 24},
+}
+
+// richBody is a comment holding the things markdown would put on screen as
+// punctuation: a heading, a bold run, a link, and a code block wider than any of
+// the boxes.
+func richBody() adf.Doc {
+	return adf.NewDoc(
+		adf.NewNode("heading", adf.NewText("What the log said")).WithAttrs(adf.Attrs{"level": 2}),
+		adf.NewNode("paragraph",
+			adf.NewText("The total is ").WithMarks(adf.Mark{Type: "strong"}),
+			adf.NewText("wrong").WithMarks(adf.Mark{Type: "strong"}),
+			adf.NewText(" past the rounding step, see "),
+			adf.NewText("the note").WithMarks(adf.Mark{
+				Type:  "link",
+				Attrs: adf.Attrs{"href": "https://example.atlassian.net/wiki/x"},
+			}),
+			adf.NewText("."),
+		),
+		adf.NewNode("codeBlock", adf.NewText(
+			"func total(rows []Row) Money { return sum(rows).Round(2) } // the rounding that lies",
+		)).WithAttrs(adf.Attrs{"language": "go"}),
+	)
+}
+
+func withComment(t *testing.T, body adf.Doc) *jiratest.Fake {
+	t.Helper()
+
+	f := newFake(3)
+	if _, err := f.AddComment(t.Context(), "PROJ-1", body); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	return f
+}
+
+// One layout, at any box a sidebar or a screen can be: every frame is exactly as
+// tall as the box, no line is wider than it, and the thread is above whatever
+// answers it rather than replaced by it.
+func TestThread_TheSameModelLaysOutASidebarAndAWholeScreen(t *testing.T) {
+	t.Parallel()
+
+	for _, box := range boxes {
+		for _, state := range []struct {
+			name string
+			keys []string
+		}{
+			{name: "reading"},
+			{name: "composing", keys: []string{"a"}},
+			{name: "confirming a delete", keys: []string{"d"}},
+		} {
+			t.Run(box.name+", "+state.name, func(t *testing.T) {
+				t.Parallel()
+
+				f := newFake(3)
+				comment(t, f, "PROJ-1", "Reproduced on staging.")
+				dr := newDriver(t, testDeps(t, f), "PROJ-1", box.width, box.height)
+				dr.key(state.keys...)
+
+				lines := strings.Split(dr.view(), "\n")
+				if len(lines) != box.height {
+					t.Errorf("the frame is %d lines in a box %d tall", len(lines), box.height)
+				}
+				for i, line := range lines {
+					if got := ansi.StringWidth(line); got > box.width {
+						t.Errorf("line %d is %d cells wide in a box %d wide: %q",
+							i, got, box.width, line)
+					}
+				}
+				lay := dr.m.layout()
+				if lay.head+lay.thread+lay.prompt+lay.composer != box.height {
+					t.Errorf("%+v does not divide a box of %d", lay, box.height)
+				}
+				if !strings.Contains(lines[0], "PROJ-1") {
+					t.Errorf("the box does not open by saying which issue it is about: %q", lines[0])
+				}
+				if lay.thread == 0 {
+					t.Error("nothing of the thread is on screen, so a comment is being written blind")
+				}
+				if at := strings.Index(dr.view(), "Reproduced on staging."); at < 0 {
+					t.Error("the comment being answered is not on screen")
+				}
+			})
+		}
+	}
+}
+
+// The composer's height rule is what makes a sidebar and a screen the same
+// layout, so it is checked through the model rather than only on the arithmetic:
+// the draft that fits in a 120-cell row wraps three times in a 34-cell one, and
+// the composer grows by exactly that much.
+func TestThread_TheComposerGrowsWithTheDraftAtEveryWidth(t *testing.T) {
+	t.Parallel()
+
+	const draft = "A reply long enough that it wraps more than once in a narrow sidebar and keeps going."
+
+	for _, box := range boxes {
+		t.Run(box.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(3)
+			comment(t, f, "PROJ-1", "Reproduced on staging.")
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", box.width, box.height)
+			dr.key("a")
+			dr.typeText(draft)
+
+			lay := dr.m.layout()
+			if want := composerHeight(dr.m.composerLines, box.height); lay.composer != want {
+				t.Errorf("the composer is %d rows, want composerHeight(%d, %d) = %d",
+					lay.composer, dr.m.composerLines, box.height, want)
+			}
+			if lay.composer > max(box.height/2, 3) {
+				t.Errorf("the composer took %d of a box %d tall", lay.composer, box.height)
+			}
+			if lay.editor < dr.m.editor.Height() {
+				t.Errorf("the composer draws %d rows of a draft the widget lays out in %d, so the cursor can sit off screen",
+					lay.editor, dr.m.editor.Height())
+			}
+			// Whatever the row count, the whole draft is readable: the words at
+			// the start of it are on screen along with the words at the end.
+			mustContain(t, dr.view(), "A reply long enough", "keeps going.")
+		})
+	}
+}
+
+// A draft longer than the box stops at half of it and gives the rest back to the
+// thread, at every width, which is what stops a comment being written on a
+// screen that hides what it answers.
+func TestThread_ALongDraftStopsAtHalfTheBox(t *testing.T) {
+	t.Parallel()
+
+	for _, box := range boxes {
+		t.Run(box.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFake(3)
+			comment(t, f, "PROJ-1", "Reproduced on staging.")
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", box.width, box.height)
+			dr.key("a")
+			for i := range 40 {
+				dr.typeText("line " + strconv.Itoa(i))
+				dr.send(keyPress("enter"))
+			}
+
+			lay := dr.m.layout()
+			if want := max(box.height/2, 3); lay.composer != want {
+				t.Errorf("a forty-line draft took %d rows of a box %d tall, want %d",
+					lay.composer, box.height, want)
+			}
+			if lay.thread < box.height/2-2 {
+				t.Errorf("the thread was left %d rows of a box %d tall", lay.thread, box.height)
+			}
+			if got := len(strings.Split(dr.view(), "\n")); got != box.height {
+				t.Errorf("the frame is %d lines in a box %d tall", got, box.height)
+			}
+		})
+	}
+}
+
+// A body richtext lays out wider than the box — a code block is never wrapped,
+// because wrapping corrupts what a reader is about to copy — is cut at the box
+// and says so, and the pan keys reach the rest of it. Nothing is cut silently.
+func TestThread_AWideCodeBlockIsCutWhereItSaysSoAndPannedTo(t *testing.T) {
+	t.Parallel()
+
+	f := withComment(t, richBody())
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 34, 14)
+
+	ell := dr.m.deps.Theme.Glyphs.Ellipsis
+	first := dr.view()
+	if !strings.Contains(first, "func total(rows []Row)") {
+		t.Error("the code block does not start on screen")
+	}
+	if !strings.Contains(first, ell) {
+		t.Errorf("a line wider than the box was cut with no marker saying so:\n%s", first)
+	}
+	if b := dr.m.blockAt(0); b.wide <= b.width {
+		t.Errorf("the block reports a widest line of %d in a box %d wide, so nothing is pannable",
+			b.wide, b.width)
+	}
+
+	dr.key("l")
+	if dr.m.pan == 0 {
+		t.Fatal("the pan key moved nothing")
+	}
+	// Panning stops at the widest line in the window rather than running off
+	// into empty cells, so the whole of the code block is reachable and no more.
+	var panned string
+	for steps := 0; ; steps++ {
+		at := dr.m.pan
+		panned = dr.view()
+		dr.key("l")
+		if dr.m.pan == at {
+			break
+		}
+		if steps > 20 {
+			t.Fatal("panning right never stopped")
+		}
+	}
+	if !strings.Contains(panned, "the rounding that lies") {
+		t.Errorf("panning did not reach the end of the code block:\n%s", panned)
+	}
+	// The prose around it does not slide: it fits, and moving it would take the
+	// author and the date of the comment being read off the left edge.
+	mustContain(t, panned, "Sam Tester", "What the log said")
+
+	for steps := 0; dr.m.pan > 0; steps++ {
+		dr.key("h")
+		if steps > 20 {
+			t.Fatal("panning left never came home")
+		}
+	}
+	if got := dr.view(); got != first {
+		t.Errorf("panning out and back did not come home:\n--- was ---\n%s\n--- now ---\n%s", first, got)
+	}
+	for i, line := range strings.Split(panned, "\n") {
+		if got := ansi.StringWidth(line); got > 34 {
+			t.Errorf("panned line %d is %d cells wide in a 34 column box", i, got)
+		}
+	}
+}
+
+// A body written out as markdown puts ## and ** and [text](url) on screen as
+// punctuation. It is drawn as styled text instead, at every width.
+func TestThread_DrawsARichBodyAsStyledTextAndNotAsMarkdown(t *testing.T) {
+	t.Parallel()
+
+	for _, box := range boxes {
+		t.Run(box.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := withComment(t, richBody())
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", box.width, box.height)
+
+			got := dr.view()
+			mustContain(t, got, "What the log said", "wrong")
+			mustNotContain(t, got, "**", "## ", "](https://")
+			// The styling itself survives: in the no-colour theme emphasis is
+			// bold rather than a colour, and it is still there.
+			if !strings.Contains(dr.m.View(), "\x1b[1m") {
+				t.Error("nothing in the body is emphasised, so the marks were dropped rather than drawn")
+			}
+		})
+	}
+}
+
+// The confirmation quotes the comment back through the same renderer, so a
+// heading is not quoted with its hashes on.
+func TestThread_TheDeleteConfirmationQuotesWordsAndNotMarkdown(t *testing.T) {
+	t.Parallel()
+
+	for _, box := range boxes {
+		t.Run(box.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := withComment(t, richBody())
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", box.width, box.height)
+			dr.key("d")
+
+			if dr.m.mode != confirming {
+				t.Fatal("d did not ask")
+			}
+			prompt := strings.Join(dr.m.prompt, "\n")
+			mustContain(t, ansi.Strip(prompt), "delete")
+			mustNotContain(t, ansi.Strip(prompt), "**", "## ")
+			// The key that goes ahead is named wherever the box put it.
+			mustContain(t, ansi.Strip(prompt), "y")
+		})
+	}
+}
+
+// The box changes size when the divider moves, when the terminal resizes and
+// when this same instance goes from a sidebar to the whole screen. Every memo
+// keyed on width has to invalidate, and the text has to still be there.
+func TestThread_AResizeMidComposeKeepsTheTextAndRelaysTheBox(t *testing.T) {
+	t.Parallel()
+
+	const draft = "Half a thought that has to survive the divider moving."
+
+	f := withComment(t, richBody())
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 34, 24)
+	dr.key("a")
+	dr.typeText(draft)
+
+	narrow := dr.m.composerLines
+	if narrow < 2 {
+		t.Fatalf("the draft occupies %d rows in a 34 column box, expected it to wrap", narrow)
+	}
+
+	for _, box := range boxes {
+		dr.send(kernel.SizeMsg{Width: box.width, Height: box.height})
+
+		if got := dr.m.editor.Value(); got != draft {
+			t.Fatalf("in %s the composer holds %q", box.name, got)
+		}
+		if dr.m.mode != writing {
+			t.Fatalf("in %s the composer closed", box.name)
+		}
+		lines := strings.Split(dr.view(), "\n")
+		if len(lines) != box.height {
+			t.Errorf("in %s the frame is %d lines, want %d", box.name, len(lines), box.height)
+		}
+		for i, line := range lines {
+			if got := ansi.StringWidth(line); got > box.width {
+				t.Errorf("in %s line %d is %d cells wide: %q", box.name, i, got, line)
+			}
+		}
+		if want := composerHeight(dr.m.composerLines, box.height); dr.m.layout().composer != want {
+			t.Errorf("in %s the composer is %d rows, want %d", box.name, dr.m.layout().composer, want)
+		}
+		mustContain(t, dr.view(), "Half a thought")
+	}
+
+	// Widening it unwraps the draft, which is the memo that would have gone
+	// stale: the same text takes fewer rows in a wider box.
+	if wide := dr.m.composerLines; wide >= narrow {
+		t.Errorf("the draft takes %d rows at 120 columns and %d at 34; the width memo did not move",
+			wide, narrow)
+	}
+	// The body memo moved with it: the code block that had to be cut at 34
+	// columns fits a 120 column box whole.
+	if b := dr.m.blockAt(0); b.width != 120 {
+		t.Errorf("the comment is still laid out for a box %d wide", b.width)
+	}
+}
+
+// A comment is typed with the keys the kernel would otherwise spend on itself. A
+// view that does not claim the keyboard reports success over text with its
+// digits eaten.
+func TestThread_ACommentKeepsTheKeysTheKernelWouldHaveTaken(t *testing.T) {
+	t.Parallel()
+
+	const draft = "q quits, 1 and 2 pick views, and ? opens help — none of that belongs here."
+
+	f := newFake(3)
+	dr := newDriver(t, testDeps(t, f), "PROJ-1", 34, 24)
+	dr.key("a")
+	if !dr.m.WantsRawKeys() {
+		t.Fatal("the composer does not claim the keyboard while it has focus")
+	}
+	dr.typeText(draft)
+
+	if got := dr.m.editor.Value(); got != draft {
+		t.Errorf("the composer holds %q, want %q", got, draft)
+	}
+	dr.key("ctrl+s")
+
+	stored, err := jira.Collect(t.Context(), mustComments(t, f, "PROJ-1"), 0)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("the site holds %d comments, want 1", len(stored))
+	}
+	if got := adf.Markdown(stored[0].Body); got != draft {
+		t.Errorf("the site holds %q, want %q", got, draft)
+	}
+}
+
+// A thread built before an issue is known must not ask the site for one. A pane
+// that embeds this builds it first and names the issue after.
+func TestThread_InitAsksForNothingUntilThereIsAnIssue(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(3)
+	comment(t, f, "PROJ-1", "Reproduced on staging.")
+	m := Thread(testDeps(t, f), "")
+	if cmd := m.Init(); cmd != nil {
+		t.Error("a thread with no issue asked the site for one anyway")
+	}
+	if got := countCalls(f, "Comments"); got != 0 {
+		t.Errorf("the site was asked for comments %d times before an issue was named", got)
+	}
+
+	dr := &driver{t: t, m: m}
+	dr.send(kernel.SizeMsg{Width: 34, Height: 24})
+	dr.send(ThreadMsg{Key: "PROJ-1"})
+
+	if !dr.m.loaded {
+		t.Fatal("naming the issue did not read the thread")
+	}
+	mustContain(t, dr.view(), "Reproduced on staging.")
+
+	// Being named the same issue again does not throw the reader's place away.
+	before := countCalls(f, "Comments")
+	dr.send(ThreadMsg{Key: "PROJ-1"})
+	if got := countCalls(f, "Comments"); got != before {
+		t.Errorf("the thread was read again on being told the issue it already had (%d then %d)",
+			before, got)
+	}
+}
+
+func TestThread_GoldenAtEveryBox(t *testing.T) {
+	t.Parallel()
+
+	for _, box := range boxes {
+		for _, state := range []struct {
+			name string
+			keys []string
+		}{
+			{name: "reading"},
+			{name: "composing", keys: []string{"a"}},
+			{name: "confirming", keys: []string{"d"}},
+		} {
+			name := "box_" + state.name + "_" + strconv.Itoa(box.width) + "x" +
+				strconv.Itoa(box.height) + ".golden"
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				f := withComment(t, richBody())
+				comment(t, f, "PROJ-1", "Fix is behind a flag until the migration lands.")
+				dr := newDriver(t, testDeps(t, f), "PROJ-1", box.width, box.height)
+				dr.key(state.keys...)
+				if len(state.keys) > 0 && state.keys[0] == "a" {
+					dr.typeText("Rounding is done in the adapter, not here.")
+				}
+
+				golden(t, name, dr.view())
+			})
+		}
+	}
+}

--- a/internal/ui/comment/comment.go
+++ b/internal/ui/comment/comment.go
@@ -31,9 +31,9 @@ const lookahead = 5
 // overscan, in both selected and unselected forms, several relayouts deep.
 const blockCacheLimit = 256
 
-// editorLines is the maximum number of logical lines the editor accepts. It is
-// the widget's own ceiling; a comment longer than this is not something a
-// terminal editor is the right place for.
+// editorLines is the most rows of text the editor accepts. It is the widget's
+// own ceiling; a comment longer than this is not something a terminal editor is
+// the right place for.
 const editorLines = 10000
 
 // editorOptions is how a document is rendered for somebody to edit, and how the
@@ -119,17 +119,30 @@ type Model struct {
 	editing   string
 	original  adf.Doc
 	pending   jira.Comment
+	prompt    []string
 	sending   bool
 	pendingGo bool
+
+	// composerLines is how many lines the draft occupies at the width the
+	// composer has, which is what its height is derived from. It is recomputed
+	// when the text or the width moves rather than per frame.
+	composerLines int
+
+	// pan is how far right the thread is scrolled. It is only ever non-zero
+	// because a line is wider than the box: code is never wrapped and a grid is
+	// never cut, so panning is how the rest of one is reached.
+	pan int
 
 	// draft is the text last written to disk, so that a keystroke that changes
 	// nothing does not rewrite the file.
 	draft       string
 	draftFailed bool
 
-	lines  []string
-	head   string
-	headAt headKey
+	lines    []string
+	head     []string
+	headAt   headKey
+	chrome   string
+	chromeAt chromeKey
 
 	width, height int
 	gen           int
@@ -145,8 +158,15 @@ type Model struct {
 func New(d kernel.Deps) kernel.View { return build(d, "") }
 
 // Thread builds the thread for one issue, which is how a view holding an issue
-// opens it.
-func Thread(d kernel.Deps, key string) kernel.View { return build(d, key) }
+// opens it — pushed over that view, or held as a child model inside it.
+//
+// A pane that embeds one owes it four things: the kernel.SizeMsg for the box it
+// has been given, every message the pane is handed, a kernel.ThreadMsg when the
+// issue changes, and its own answers to WantsRawKeys, BlocksClose and LiveKeys.
+// Everything else — one fetch, one draft, one cursor, one composer with the text
+// still in it — follows from there being one of these however many boxes it is
+// drawn in.
+func Thread(d kernel.Deps, key string) *Model { return build(d, key) }
 
 // Push returns the command that opens the thread for one issue on top of
 // whatever is on screen.
@@ -178,7 +198,14 @@ func newEditor() textarea.Model {
 	ta.Prompt = ""
 	ta.ShowLineNumbers = false
 	ta.Placeholder = "Markdown. Tables, lists, quotes and code fences all survive the round trip."
-	ta.MaxHeight = editorLines
+	// The widget sizes itself to the rows the draft actually occupies, which is
+	// what the composer's height is derived from: it soft-wraps on words, so
+	// counting cells and dividing by the width is a line out at every width but
+	// one. MaxHeight is then the display ceiling and MaxContentHeight the
+	// document's, which is why the two are not the same number.
+	ta.DynamicHeight = true
+	ta.MinHeight = 1
+	ta.MaxContentHeight = editorLines
 	// The widget's own cursor blink is a timer this view would then own for as
 	// long as the editor is open; dropping it costs a blinking block and keeps
 	// every frame reproducible.
@@ -202,8 +229,15 @@ func (m *Model) BlocksClose() (string, bool) {
 	return "", false
 }
 
-// Init reads the thread.
-func (m *Model) Init() tea.Cmd { return m.load() }
+// Init reads the thread, and only when there is one to read. A pane that embeds
+// this builds it before an issue may be known, and asking again for a thread
+// already in hand would throw the reader's place away.
+func (m *Model) Init() tea.Cmd {
+	if m.issue == "" || m.loaded || m.loading {
+		return nil
+	}
+	return m.load()
+}
 
 // Update handles one message.
 func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
@@ -219,10 +253,12 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 		m.deps.Theme = msg.Theme
 		m.styles = newStyles(msg.Theme)
 		m.blocks.reset()
+		m.reprompt()
 
 	case kernel.CapabilitiesMsg:
 		m.deps.Caps = msg.Caps
 		m.blocks.reset()
+		m.reprompt()
 
 	case kernel.RefreshMsg:
 		cmd = m.load()
@@ -268,34 +304,49 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 
 func (m *Model) location() *time.Location { return m.deps.Caps.Location() }
 
+// resize takes the box the pane has been given. The width is what every memo is
+// keyed on, so a divider moving, a terminal resizing and this same thread going
+// from a sidebar to the whole screen all arrive here and all invalidate the same
+// things; the height only moves where the lines go.
 func (m *Model) resize(w, h int) tea.Cmd {
 	if w == m.width && h == m.height {
 		return nil
 	}
+	if w != m.width {
+		m.blocks.reset()
+	}
 	m.width, m.height = w, h
-	m.blocks.reset()
-	m.editor.SetWidth(max(w-indent, 8))
-	m.editor.SetHeight(max(m.editorHeight(), 1))
-	m.ensureVisible()
+	m.relayout()
+	m.reprompt()
 	return m.pageAheadIfNeeded()
 }
 
-// focus keeps the editor's cursor out of a pane nobody is looking at, and lets
-// go of a request nobody is waiting for.
+// focus keeps the cursor out of a composer nobody is typing into. It does not
+// let go of a request, because losing the keys is not being closed: a thread in
+// a sidebar loses them whenever the pane beside it takes them, and the kernel
+// blurs a view it is pushing over or switching away from as well as one it is
+// discarding. Each request cancels its own context when it finishes, so the one
+// case that is a discard costs a read that lands nowhere rather than a goroutine
+// that stays.
 func (m *Model) focus(on bool) {
-	switch {
-	case on && m.mode == writing:
+	if on && m.mode == writing {
 		_ = m.editor.Focus()
-	case !on:
+		return
+	}
+	if !on {
 		m.editor.Blur()
-		m.stop()
 	}
 }
 
 func (m *Model) retarget(key string) tea.Cmd {
 	key = strings.TrimSpace(key)
-	if key == "" || key == m.issue {
+	switch key {
+	case "":
 		return nil
+	case m.issue:
+		// A pane that embeds this names the issue it was built with, and a
+		// thread that has read nothing yet has to take that as the cue.
+		return m.Init()
 	}
 	m.issue = key
 	m.comments, m.page = nil, jira.Page[jira.Comment]{}
@@ -430,8 +481,7 @@ func (m *Model) openEditor(id string, c jira.Comment) tea.Cmd {
 	m.draft = text
 	m.editor.SetValue(text)
 	m.editor.MoveToEnd()
-	m.editor.SetWidth(max(m.width-indent, 8))
-	m.editor.SetHeight(max(m.editorHeight(), 1))
+	m.relayout()
 	_ = m.editor.Focus()
 
 	switch {
@@ -461,6 +511,7 @@ func (m *Model) closeEditor() tea.Cmd {
 	m.editor.Blur()
 	m.editor.Reset()
 	m.draft = ""
+	m.relayout()
 	return cmd
 }
 
@@ -541,6 +592,7 @@ func (m *Model) saved(msg savedMsg) tea.Cmd {
 	m.mode, m.editing = browsing, ""
 	m.editor.Blur()
 	m.editor.Reset()
+	m.relayout()
 
 	if msg.edited {
 		at := slices.IndexFunc(m.comments, func(c jira.Comment) bool { return c.ID == msg.comment.ID })
@@ -571,12 +623,14 @@ func (m *Model) askToDelete() tea.Cmd {
 		return kernel.Warn("there is no comment here to delete")
 	}
 	m.mode, m.pending = confirming, *c
+	m.prompt = m.buildPrompt()
+	m.ensureVisible()
 	return nil
 }
 
 func (m *Model) confirmDelete() tea.Cmd {
 	id := m.pending.ID
-	m.mode = browsing
+	m.mode, m.prompt = browsing, nil
 	if m.deps.Jira == nil || id == "" {
 		return nil
 	}
@@ -604,17 +658,98 @@ func (m *Model) deleted(msg deletedMsg) tea.Cmd {
 
 // --- moving -----------------------------------------------------------------
 
-func (m *Model) threadHeight() int {
-	h := m.height - 2
-	if m.mode == confirming {
-		h--
-	}
-	return max(h, 1)
+// layout is how the box's lines are divided. head, thread, prompt and composer
+// add up to exactly the height the pane was given, at every height, which is
+// what makes a 34-column sidebar and a whole screen the same code rather than
+// two. chrome and editor are how the composer divides its own share.
+type layout struct {
+	head     int
+	thread   int
+	prompt   int
+	composer int
+	chrome   int
+	editor   int
 }
 
-func (m *Model) editorHeight() int { return max(m.height-4, 1) }
+// layout divides the box. The thread is on top and the composer under it,
+// because a comment is not written on a screen that hides what it is replying
+// to: the composer takes 1+lines — the draft and the one row saying what it is
+// and how to send it — with a floor of three so there is somewhere to start
+// typing, and a ceiling of half the box so that the thread never goes away.
+func (m *Model) layout() layout {
+	lay := m.divide(min(2, m.height))
+	if lay.thread == 0 && lay.head > 1 {
+		// The rule under the identity line is the last thing worth a row: what
+		// is being replied to earns one before the line under its name does.
+		lay = m.divide(1)
+	}
+	return lay
+}
 
-func (m *Model) blockLines(at int) []string {
+func (m *Model) divide(head int) layout {
+	lay := layout{head: head}
+	rest := m.height - head
+	if m.mode == confirming {
+		lay.prompt = min(len(m.prompt), rest)
+		rest -= lay.prompt
+	}
+	if m.mode == writing {
+		lay.composer = min(composerHeight(m.composerLines, m.height), rest)
+		// One line of the thread is worth more than the composer's chrome row;
+		// below that there is nothing left to give.
+		if rest-lay.composer == 0 && rest >= 2 {
+			lay.composer = rest - 1
+		}
+		rest -= lay.composer
+		if lay.composer >= 2 {
+			lay.chrome = 1
+		}
+		lay.editor = lay.composer - lay.chrome
+	}
+	lay.thread = max(rest, 0)
+	return lay
+}
+
+func composerHeight(lines, boxH int) int {
+	return min(max(1+lines, 3), max(3, boxH/2))
+}
+
+// composerRows is the most rows the draft itself may take in a box this tall:
+// the composer's ceiling, less the row of chrome above it.
+func composerRows(boxH int) int { return max(composerHeight(editorLines, boxH)-1, 1) }
+
+func (m *Model) threadHeight() int { return max(m.layout().thread, 1) }
+
+// relayout re-derives everything a change of box or of draft moves: how many
+// rows the draft occupies at this width, how far the thread may be panned, and
+// where its window sits.
+func (m *Model) relayout() {
+	m.editor.MaxHeight = composerRows(m.height)
+	m.editor.SetWidth(max(m.width, minBody))
+	m.composerLines = m.editor.Height()
+	// A box too short for the composer's own ceiling gives it fewer rows than
+	// the draft asked for. The widget is held to what will actually be drawn, or
+	// the cursor sits on a row nothing puts on screen.
+	if rows := m.layout().editor; rows >= 1 && rows < m.editor.Height() {
+		m.editor.SetHeight(rows)
+		m.composerLines = m.editor.Height()
+	}
+	m.clampPan()
+	m.ensureVisible()
+}
+
+// reprompt rebuilds the delete confirmation, which is laid out for the box it is
+// drawn in rather than cut to fit it.
+func (m *Model) reprompt() {
+	if m.mode != confirming || m.width <= 0 {
+		return
+	}
+	m.prompt = m.buildPrompt()
+}
+
+// blockAt lays one comment out at the width in hand, memoized on everything its
+// lines depend on.
+func (m *Model) blockAt(at int) *block {
 	if at < 0 || at >= len(m.comments) {
 		return nil
 	}
@@ -623,14 +758,33 @@ func (m *Model) blockLines(at int) []string {
 		id: c.ID, updated: c.Updated.UnixNano(), width: m.width,
 		gen: m.styles.gen, selected: at == m.cursor,
 	}
-	if lines, ok := m.blocks.get(k); ok {
-		return lines
+	if made, ok := m.blocks.get(k); ok {
+		return made
 	}
-	lines := renderBlock(c, m.width, at == m.cursor, m.styles, m.deps.Theme, m.location())
-	lines = m.zones.MarkLines(zoneComment+c.ID, lines)
-	lines = append(lines, "")
-	m.blocks.put(k, lines)
-	return lines
+	made := renderBlock(c, m.width, at == m.cursor, m.styles, m.deps.Theme, m.location())
+	m.blocks.put(k, made)
+	return made
+}
+
+// blockHeight is how many lines a comment takes, which is all the scrolling
+// needs to know. Asking for the lines themselves would mark a mouse zone around
+// a block nothing is about to draw.
+func (m *Model) blockHeight(at int) int {
+	b := m.blockAt(at)
+	if b == nil {
+		return 0
+	}
+	// The blank line between one comment and the next is drawn outside the
+	// block, so that it falls outside the zone.
+	return len(b.lines) + 1
+}
+
+func (m *Model) blockLines(at int) []string {
+	b := m.blockAt(at)
+	if b == nil {
+		return nil
+	}
+	return b.window(m.pan, m.deps.Theme.Glyphs.Ellipsis, m.zones, zoneComment+m.comments[at].ID)
 }
 
 func (m *Model) moveTo(at int) tea.Cmd {
@@ -670,7 +824,7 @@ func (m *Model) scrollToBottom() {
 	h := m.threadHeight()
 	used, at := 0, len(m.comments)-1
 	for at >= 0 {
-		n := len(m.blockLines(at))
+		n := m.blockHeight(at)
 		if used+n > h {
 			break
 		}
@@ -686,7 +840,7 @@ func (m *Model) scrollToBottom() {
 		m.top, m.skip = at, 0
 	default:
 		m.top = at
-		m.skip = max(len(m.blockLines(at))-(h-used), 0)
+		m.skip = max(m.blockHeight(at)-(h-used), 0)
 	}
 }
 
@@ -701,7 +855,7 @@ func (m *Model) ensureVisible() {
 	for m.top < m.cursor {
 		used := 0
 		for i := m.top; i <= m.cursor; i++ {
-			n := len(m.blockLines(i))
+			n := m.blockHeight(i)
 			if i == m.top {
 				n -= m.skip
 			}
@@ -713,7 +867,7 @@ func (m *Model) ensureVisible() {
 		m.top++
 		m.skip = 0
 	}
-	m.skip = min(m.skip, max(len(m.blockLines(m.top))-1, 0))
+	m.skip = min(m.skip, max(m.blockHeight(m.top)-1, 0))
 }
 
 // pageStep is how far a page key moves: as many comments as the window holds,
@@ -725,7 +879,7 @@ func (m *Model) pageStep(dir int) int {
 		if next < 0 || next >= len(m.comments) {
 			return at
 		}
-		used += len(m.blockLines(next))
+		used += m.blockHeight(next)
 		if used > h && next != m.cursor+dir {
 			return at
 		}
@@ -740,7 +894,7 @@ func (m *Model) pageStep(dir int) int {
 // a wheel does everywhere else.
 func (m *Model) scroll(delta int) {
 	for ; delta > 0; delta-- {
-		if m.skip+1 < len(m.blockLines(m.top)) {
+		if m.skip+1 < m.blockHeight(m.top) {
 			m.skip++
 			continue
 		}
@@ -758,8 +912,41 @@ func (m *Model) scroll(delta int) {
 			return
 		}
 		m.top--
-		m.skip = max(len(m.blockLines(m.top))-1, 0)
+		m.skip = max(m.blockHeight(m.top)-1, 0)
 	}
+}
+
+// panBy moves the window sideways. Half the box at a time, so that the step is
+// the same gesture whatever the box is: a 34-column sidebar and a 120-column
+// screen both take two presses to move a screenful.
+func (m *Model) panBy(dir int) {
+	m.pan = max(m.pan+dir*max(m.width/2, 1), 0)
+	m.clampPan()
+}
+
+// clampPan holds the pan against the widest line the window is actually showing,
+// so that scrolling off the code block that was being read brings the thread
+// back to its left edge rather than leaving the prose shifted out of the box.
+func (m *Model) clampPan() {
+	if m.pan == 0 {
+		return
+	}
+	m.pan = min(m.pan, max(m.widestVisible()-m.width, 0))
+}
+
+// widestVisible is the widest line in the window, which is as far as the pane
+// can usefully be panned.
+func (m *Model) widestVisible() int {
+	h, used, wide := m.threadHeight(), -m.skip, m.width
+	for i := m.top; i < len(m.comments) && used < h; i++ {
+		b := m.blockAt(i)
+		if b == nil {
+			break
+		}
+		wide = max(wide, b.wide)
+		used += len(b.lines) + 1
+	}
+	return wide
 }
 
 // --- input ------------------------------------------------------------------
@@ -798,6 +985,10 @@ func (m *Model) browseKey(stroke string) tea.Cmd {
 		m.scroll(m.threadHeight() / 2)
 	case actHalfUp:
 		m.scroll(-m.threadHeight() / 2)
+	case actPanRight:
+		m.panBy(1)
+	case actPanLeft:
+		m.panBy(-1)
 	case actTop:
 		return m.jumpTo(0)
 	case actBottom:
@@ -827,6 +1018,9 @@ func (m *Model) editorKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 	var cmd tea.Cmd
 	m.editor, cmd = m.editor.Update(msg)
+	// The composer grows with the draft, and the thread above it gives up the
+	// lines: the layout is re-derived on the keystroke rather than per frame.
+	m.relayout()
 	return tea.Batch(cmd, m.keepDraft(m.editor.Value()))
 }
 
@@ -837,7 +1031,7 @@ func (m *Model) confirmKey(stroke string) tea.Cmd {
 	if m.confirm[stroke] == actConfirm {
 		return m.confirmDelete()
 	}
-	m.mode = browsing
+	m.mode, m.prompt = browsing, nil
 	return nil
 }
 
@@ -887,8 +1081,11 @@ func (m *Model) click(msg tea.MouseClickMsg) tea.Cmd {
 	return nil
 }
 
+// wheel scrolls the thread, including while a comment is being written: the
+// thread is on screen then, and re-reading what is being replied to is the
+// reason it is.
 func (m *Model) wheel(msg tea.MouseWheelMsg) tea.Cmd {
-	if m.mode != browsing {
+	if m.mode == confirming {
 		return nil
 	}
 	switch msg.Button {
@@ -905,42 +1102,77 @@ func (m *Model) wheel(msg tea.MouseWheelMsg) tea.Cmd {
 
 func (m *Model) mark(name, s string) string { return m.zones.Mark(name, s) }
 
-// View draws the window and nothing else: a thread of a thousand comments and a
-// thread of ten do the same work here.
+// View draws the box it was given, in exactly as many lines as it was given:
+// the thread, then whatever the thread is answering — a composer, or the
+// sentence naming a comment about to go. It draws the window and nothing else,
+// so a thread of a thousand comments and a thread of ten do the same work here,
+// and the same instance draws a sidebar and a whole screen with no second
+// layout.
 func (m *Model) View() string {
 	if m.width <= 0 || m.height <= 0 {
 		return ""
 	}
-	if m.mode == writing {
-		return m.header() + "\n" + m.editorCaption() + "\n" + m.editor.View() + "\n" + m.editorHint()
-	}
+	m.clampPan()
+	lay := m.layout()
 	lines := m.lines[:0]
-	h := m.threadHeight()
-	if len(m.comments) == 0 {
-		lines = m.appendEmpty(lines, h)
-	} else {
-		for i := m.top; i < len(m.comments) && len(lines) < h; i++ {
-			block := m.blockLines(i)
-			from := 0
-			if i == m.top {
-				from = min(m.skip, len(block))
-			}
-			for _, line := range block[from:] {
-				if len(lines) >= h {
-					break
-				}
-				lines = append(lines, line)
-			}
-		}
-		for len(lines) < h {
-			lines = append(lines, "")
-		}
-	}
-	if m.mode == confirming {
-		lines = append(lines, m.deletePrompt())
-	}
+	lines = append(lines, m.headLines(lay.head)...)
+	lines = m.appendThread(lines, lay.thread)
+	lines = append(lines, m.prompt[:lay.prompt]...)
+	lines = m.appendComposer(lines, lay)
 	m.lines = lines
-	return m.header() + "\n" + strings.Join(lines, "\n")
+	return strings.Join(lines, "\n")
+}
+
+func (m *Model) appendThread(lines []string, h int) []string {
+	if h <= 0 {
+		return lines
+	}
+	if len(m.comments) == 0 {
+		return m.appendEmpty(lines, h)
+	}
+	at := len(lines)
+	for i := m.top; i < len(m.comments) && len(lines)-at < h; i++ {
+		block := m.blockLines(i)
+		from := 0
+		if i == m.top {
+			from = min(m.skip, len(block))
+		}
+		for _, line := range block[from:] {
+			if len(lines)-at >= h {
+				break
+			}
+			lines = append(lines, line)
+		}
+	}
+	for len(lines)-at < h {
+		lines = append(lines, "")
+	}
+	return lines
+}
+
+// appendComposer draws the composer under the thread: one row saying which
+// comment this is and how to finish it, then the draft. The chrome row is what
+// a box too short for both gives up, because what is left is the text being
+// typed.
+func (m *Model) appendComposer(lines []string, lay layout) []string {
+	if lay.composer <= 0 {
+		return lines
+	}
+	if lay.chrome > 0 {
+		lines = append(lines, m.composerChrome())
+	}
+	drawn := 0
+	for _, line := range strings.Split(m.editor.View(), "\n") {
+		if drawn >= lay.editor {
+			break
+		}
+		lines = append(lines, line)
+		drawn++
+	}
+	for ; drawn < lay.editor; drawn++ {
+		lines = append(lines, "")
+	}
+	return lines
 }
 
 func (m *Model) appendEmpty(lines []string, h int) []string {

--- a/internal/ui/comment/comment_test.go
+++ b/internal/ui/comment/comment_test.go
@@ -468,17 +468,47 @@ func TestThread_EveryRequestReportsWhatWentWrongInItsOwnWords(t *testing.T) {
 func TestThread_ReadingAThreadThatFailsSaysSoRatherThanShowingAnEmptyOne(t *testing.T) {
 	t.Parallel()
 
-	f := newFake(3)
-	comment(t, f, "PROJ-1", "unreachable")
-	f.FailNext(&jira.RateLimitError{RetryAfter: 12 * time.Second})
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "a refusal",
+			err:  &jira.CapabilityError{Reason: "you need Browse Projects to read this issue"},
+			want: "Browse Projects",
+		},
+		{
+			name: "a rate limit",
+			err:  &jira.RateLimitError{RetryAfter: 12 * time.Second},
+			want: "retry in 12s",
+		},
+		{
+			name: "a transport failure",
+			err:  &jira.TransportError{Op: "GET /comment", Err: errors.New("connection reset")},
+			want: "connection reset",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+			f := newFake(3)
+			comment(t, f, "PROJ-1", "unreachable")
+			f.FailNext(tc.err)
 
-	if got := dr.lastStatus(); got.Level != kernel.LevelError || !strings.Contains(got.Text, "retry in 12s") {
-		t.Errorf("reading a rate-limited thread reported %+v", got)
-	}
-	if dr.m.loaded {
-		t.Error("a thread that never arrived is marked as loaded")
+			dr := newDriver(t, testDeps(t, f), "PROJ-1", 100, 24)
+
+			if got := dr.lastStatus(); got.Level != kernel.LevelError ||
+				!strings.Contains(got.Text, tc.want) {
+				t.Errorf("reading the thread reported %+v, want it to carry %q", got, tc.want)
+			}
+			if dr.m.loaded {
+				t.Error("a thread that never arrived is marked as loaded")
+			}
+			// The box still draws, and says it is still reading rather than
+			// claiming the issue has no comments.
+			mustContain(t, dr.view(), "reading the thread")
+		})
 	}
 }
 
@@ -628,10 +658,7 @@ func TestThread_RendersTheEditorAndTheConfirmation(t *testing.T) {
 func TestThread_DrawsNothingBeforeItHasBeenGivenASize(t *testing.T) {
 	t.Parallel()
 
-	view, ok := Thread(testDeps(t, newFake(3)), "PROJ-1").(*Model)
-	if !ok {
-		t.Fatal("Thread did not return a *Model")
-	}
+	view := Thread(testDeps(t, newFake(3)), "PROJ-1")
 	if got := view.View(); got != "" {
 		t.Errorf("a view with no size drew %q", got)
 	}

--- a/internal/ui/comment/harness_test.go
+++ b/internal/ui/comment/harness_test.go
@@ -102,11 +102,7 @@ type driver struct {
 func newDriver(t *testing.T, d kernel.Deps, key string, w, h int) *driver {
 	t.Helper()
 
-	view, ok := Thread(d, key).(*Model)
-	if !ok {
-		t.Fatal("Thread did not return a *Model")
-	}
-	dr := &driver{t: t, m: view}
+	dr := &driver{t: t, m: Thread(d, key)}
 	dr.send(kernel.SizeMsg{Width: w, Height: h})
 	dr.run(dr.m.Init())
 	dr.send(kernel.FocusMsg{Focused: true})

--- a/internal/ui/comment/keys.go
+++ b/internal/ui/comment/keys.go
@@ -11,6 +11,11 @@ type keyMap struct {
 	PageDown kernel.Binding
 	HalfUp   kernel.Binding
 	HalfDown kernel.Binding
+	// PanLeft and PanRight move the thread sideways. Code is never wrapped and a
+	// grid is never cut, so a comment holding either can be wider than the box —
+	// in a narrow sidebar, most of them are — and this is how the rest is read.
+	PanLeft  kernel.Binding
+	PanRight kernel.Binding
 	Go       kernel.Binding
 	Top      kernel.Binding
 	Bottom   kernel.Binding
@@ -34,6 +39,8 @@ func defaultKeys() keyMap {
 		PageDown: kernel.Bind([]string{"pgdown", "ctrl+f", "space"}, "pgdn", "page down"),
 		HalfUp:   kernel.Bind([]string{"ctrl+u"}, "ctrl+u", "half page up"),
 		HalfDown: kernel.Bind([]string{"ctrl+d"}, "ctrl+d", "half page down"),
+		PanLeft:  kernel.Bind([]string{"h", "left"}, "←/h", "pan left"),
+		PanRight: kernel.Bind([]string{"l", "right"}, "→/l", "pan right"),
 		Go:       kernel.Bind([]string{"g"}, "g", "go to"),
 		Top:      kernel.Bind([]string{"home"}, "g g", "oldest"),
 		Bottom:   kernel.Bind([]string{"G", "end"}, "G", "newest"),
@@ -59,7 +66,7 @@ func (k keyMap) keySet() kernel.KeySet {
 		},
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp},
-			{k.HalfDown, k.HalfUp, k.Top, k.Bottom},
+			{k.HalfDown, k.HalfUp, k.Top, k.Bottom, k.PanLeft, k.PanRight},
 			{k.Write, k.Edit, k.Delete},
 		},
 	}
@@ -99,6 +106,8 @@ const (
 	actPageUp
 	actHalfDown
 	actHalfUp
+	actPanLeft
+	actPanRight
 	actGo
 	actTop
 	actBottom
@@ -118,6 +127,7 @@ func (k keyMap) tables() (browse, confirm map[string]action) {
 		binding{k.Down, actDown}, binding{k.Up, actUp},
 		binding{k.PageDown, actPageDown}, binding{k.PageUp, actPageUp},
 		binding{k.HalfDown, actHalfDown}, binding{k.HalfUp, actHalfUp},
+		binding{k.PanLeft, actPanLeft}, binding{k.PanRight, actPanRight},
 		binding{k.Go, actGo}, binding{k.Top, actTop}, binding{k.Bottom, actBottom},
 		binding{k.Write, actWrite}, binding{k.Edit, actEdit}, binding{k.Delete, actDelete},
 	)

--- a/internal/ui/comment/render.go
+++ b/internal/ui/comment/render.go
@@ -9,6 +9,8 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/richtext"
+	"github.com/varijkapil13/saral/internal/ui/widget"
 	"github.com/varijkapil13/saral/pkg/adf"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
@@ -18,6 +20,12 @@ const (
 	marker = 2
 	// indent is how far a comment's own words sit in from the gutter.
 	indent = 4
+	// minBody is the narrowest column a comment's own words are laid out in. A
+	// sidebar can be dragged narrower than this; the body then goes past the box
+	// and is panned like any other line too wide for it.
+	minBody = 8
+	// promptWords is how much of a comment the delete confirmation quotes back.
+	promptWords = 40
 )
 
 // styles are this view's styles, built once per theme generation because
@@ -32,9 +40,19 @@ type styles struct {
 	warning  lipgloss.Style
 	action   lipgloss.Style
 	rule     lipgloss.Style
+
+	// body and marks are what a comment's words are drawn with. They are built
+	// with the rest of the styles because NewStyles walks the whole palette, and
+	// nothing may do that inside a render.
+	body  richtext.Styles
+	marks richtext.Markers
 }
 
 func newStyles(t *kernel.Theme) *styles {
+	marks := richtext.UnicodeMarkers()
+	if asciiMode(t) {
+		marks = richtext.ASCIIMarkers()
+	}
 	return &styles{
 		gen:      t.Gen,
 		author:   t.Accent,
@@ -45,13 +63,28 @@ func newStyles(t *kernel.Theme) *styles {
 		warning:  t.Warning,
 		action:   t.HintKey,
 		rule:     t.Muted,
+		body: richtext.NewStyles(richtext.Palette{
+			Base:    t.Base,
+			Muted:   t.Muted,
+			Title:   t.Title,
+			Accent:  t.Accent,
+			Danger:  t.Danger,
+			Warning: t.Warning,
+			Success: t.Success,
+			// The theme pads a badge and the renderer measures the run rather
+			// than the cells a token adds around it, so a padded one would lay
+			// out a cell wider than it reports.
+			Badge: t.Badge.UnsetPadding(),
+			Color: t.Color,
+		}),
+		marks: marks,
 	}
 }
 
 // asciiMode reports whether the theme's glyph set is the ASCII fallback, which
-// is what pkg/adf needs in order to pick its own markers. The theme carries the
-// glyphs rather than the name of the set they came from, so the set is
-// identified by one of its members.
+// is what pkg/adf and the display renderer need in order to pick their own
+// markers. The theme carries the glyphs rather than the name of the set they
+// came from, so the set is identified by one of its members.
 func asciiMode(t *kernel.Theme) bool {
 	return t.Glyphs.Ellipsis == kernel.ASCIIGlyphs().Ellipsis
 }
@@ -70,60 +103,148 @@ type blockKey struct {
 // rather than evicted one at a time: a scroll invalidates a screenful at once
 // anyway, and clearing keeps the map's capacity.
 type blocks struct {
-	made  map[blockKey][]string
+	made  map[blockKey]*block
 	limit int
 }
 
 func newBlocks(limit int) *blocks {
-	return &blocks{made: make(map[blockKey][]string, limit), limit: limit}
+	return &blocks{made: make(map[blockKey]*block, limit), limit: limit}
 }
 
-func (b *blocks) get(k blockKey) ([]string, bool) {
-	lines, ok := b.made[k]
-	return lines, ok
+func (b *blocks) get(k blockKey) (*block, bool) {
+	made, ok := b.made[k]
+	return made, ok
 }
 
-func (b *blocks) put(k blockKey, lines []string) {
+func (b *blocks) put(k blockKey, made *block) {
 	if len(b.made) >= b.limit {
 		clear(b.made)
 	}
-	b.made[k] = lines
+	b.made[k] = made
 }
 
 func (b *blocks) reset() { clear(b.made) }
 
-// renderBlock draws one comment: who wrote it and when, whatever restricts it,
-// and its body wrapped to the width it has been given. Every line is padded to
-// the full width so that the mouse zone around the block is the rectangle the
-// block occupies rather than the shape of its last line. The blank line that
-// separates one comment from the next is added outside, so that it falls
-// outside the zone.
-func renderBlock(c *jira.Comment, width int, selected bool, st *styles, t *kernel.Theme, loc *time.Location) []string {
-	body := adf.MarkdownWith(c.Body, adf.Options{
-		TableWidth: max(width-indent, 8),
-		ASCII:      asciiMode(t),
-		Location:   loc,
-	})
-	lines := make([]string, 0, 8)
+// block is one comment laid out at one width: its lines, how wide each of them
+// is, and the window last cut out of them.
+//
+// The widths are kept because the display renderer reports them while it builds
+// each line, and a line wider than the box is the one thing the pane cannot draw
+// as it stands. Re-measuring them per frame is what docs/PERFORMANCE.md names as
+// the third cost in a program of this shape.
+type block struct {
+	lines  []string
+	widths []int
+	width  int
+	wide   int
 
-	head := metaLine(c, st, t, loc)
-	if selected {
-		head = st.selected.Render(pad(t.Glyphs.Collapsed+" "+head, width))
-	} else {
-		head = pad(strings.Repeat(" ", marker)+head, width)
+	// shown is lines with the mouse zone marked and every over-wide line cut to
+	// the box, at the pan in panAt. Marking allocates, so it is done once per
+	// pan rather than once per frame.
+	shown []string
+	panAt int
+}
+
+// pan is how far this block is actually panned. A block whose every line fits
+// does not move when the pane is panned: the lines too wide for the box are the
+// only reason to pan, and sliding the rest out of view would take the author and
+// the date of the comment being read with them.
+func (b *block) pan(want int) int {
+	if b.wide <= b.width {
+		return 0
 	}
-	lines = append(lines, head)
+	return want
+}
 
-	room := max(width-indent, 8)
-	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
-		for _, wrapped := range strings.Split(ansi.Wrap(line, room, "-"), "\n") {
-			lines = append(lines, pad(strings.Repeat(" ", indent)+wrapped, width))
+// window is the block as the box shows it, with the blank line that separates
+// one comment from the next on the end of it — outside the zone, so that a click
+// between two comments belongs to neither.
+func (b *block) window(want int, ell string, z widget.Zoner, name string) []string {
+	at := b.pan(want)
+	if b.shown != nil && b.panAt == at {
+		return b.shown
+	}
+	lines := b.lines
+	if b.wide > b.width {
+		cut := make([]string, len(b.lines))
+		for i, line := range b.lines {
+			if b.widths[i] <= b.width {
+				cut[i] = line
+				continue
+			}
+			cut[i] = window(line, at, b.width, ell)
 		}
+		lines = cut
 	}
-	if len(lines) == 1 {
-		lines = append(lines, pad(strings.Repeat(" ", indent)+st.muted.Render("(empty)"), width))
+	marked := z.MarkLines(name, lines)
+	shown := make([]string, 0, len(marked)+1)
+	shown = append(shown, marked...)
+	shown = append(shown, "")
+	b.shown, b.panAt = shown, at
+	return b.shown
+}
+
+// window is the part of one line the box shows, with a marker wherever something
+// has been cut off. Nothing is cut silently: the display renderer leaves a code
+// line and a grid row at their own width by design — wrapping code corrupts what
+// a reader is about to copy — so the pane says where a line continues and the
+// pan keys reach it.
+func window(line string, from, width int, ell string) string {
+	if from > 0 {
+		line = ell + ansi.TruncateLeft(line, from+ansi.StringWidth(ell), "")
 	}
-	return lines
+	return pad(ansi.Truncate(line, width, ell), width)
+}
+
+// renderBlock lays one comment out: who wrote it and when, whatever restricts
+// it, and its body drawn through the display renderer rather than written out as
+// markdown, which is a serialisation for editing and puts ## and ** on screen.
+//
+// Every line that fits is padded to the full width so that the mouse zone around
+// the block is the rectangle the block occupies rather than the shape of its last
+// line. The blank line that separates one comment from the next is added
+// outside, so that it falls outside the zone.
+func renderBlock(c *jira.Comment, width int, selected bool, st *styles, t *kernel.Theme, loc *time.Location) *block {
+	body := richtext.Render(c.Body, richtext.Options{
+		Width:    max(width-indent, minBody),
+		Location: loc,
+		Styles:   st.body,
+		Markers:  st.marks,
+	})
+	b := &block{
+		lines:  make([]string, 0, len(body.Lines)+1),
+		widths: make([]int, 0, len(body.Lines)+1),
+		width:  width,
+		wide:   width,
+		panAt:  -1,
+	}
+
+	meta := metaLine(c, st, t, loc)
+	head := strings.Repeat(" ", marker) + meta
+	if selected {
+		head = t.Glyphs.Collapsed + " " + meta
+	}
+	headW := ansi.StringWidth(head)
+	head = pad(head, width)
+	if selected {
+		head = st.selected.Render(head)
+	}
+	b.add(head, headW)
+
+	gutter := strings.Repeat(" ", indent)
+	for i, line := range body.Lines {
+		b.add(pad(gutter+line, width), indent+body.Widths[i])
+	}
+	if len(b.lines) == 1 {
+		b.add(pad(gutter+st.muted.Render("(empty)"), width), width)
+	}
+	return b
+}
+
+func (b *block) add(line string, width int) {
+	b.lines = append(b.lines, line)
+	b.widths = append(b.widths, width)
+	b.wide = max(b.wide, width)
 }
 
 // metaLine names the author, when the comment was written, whether it has been
@@ -194,46 +315,64 @@ type headKey struct {
 	issue      string
 	width, gen int
 	comments   int
+	rule       bool
 	loaded     bool
 	more       bool
 	selected   bool
 }
 
-func (m *Model) headKey() headKey {
+func (m *Model) headKey(rows int) headKey {
 	return headKey{
 		issue: m.issue, width: m.width, gen: m.styles.gen,
-		comments: len(m.comments), loaded: m.loaded,
+		comments: len(m.comments), rule: rows > 1, loaded: m.loaded,
 		more: m.page.HasMore(), selected: m.selected() != nil,
 	}
 }
 
-// header is the identity line above the thread and the rule under it. The
-// actions on the right are mouse zones, because docs/UX.md asks that nothing be
-// keyboard-only.
-func (m *Model) header() string {
-	key := m.headKey()
-	if m.head != "" && key == m.headAt {
+// headLines is the identity line above the thread and, where the box has a row
+// to spare for it, the rule under it. The actions on the right are mouse zones,
+// because docs/UX.md asks that nothing be keyboard-only.
+func (m *Model) headLines(rows int) []string {
+	key := m.headKey(rows)
+	if m.head != nil && key == m.headAt {
 		return m.head
 	}
-	m.head, m.headAt = m.buildHeader(), key
+	m.head, m.headAt = m.buildHead(rows), key
 	return m.head
 }
 
-func (m *Model) buildHeader() string {
+func (m *Model) buildHead(rows int) []string {
+	if rows <= 0 {
+		return nil
+	}
 	t := m.deps.Theme
-	actions := m.actionBar()
-	room := max(m.width-ansi.StringWidth(actions)-2, 8)
-
 	label := m.issue
 	if label == "" {
 		label = "Comments"
 	} else {
 		label += " " + t.Glyphs.Separator + " " + m.countLabel()
 	}
+
+	actions := m.actionBar()
+	actionsW := ansi.StringWidth(actions)
+	// A box too narrow for both keeps the identity and drops the actions rather
+	// than cutting the issue key out of the line: the footer advertises the same
+	// three, and its row is clickable too.
+	if m.width < ansi.StringWidth(label)+actionsW+2 {
+		actions, actionsW = "", 0
+	}
+	room := m.width
+	if actionsW > 0 {
+		room = max(m.width-actionsW-2, minBody)
+	}
 	left := m.styles.title.Render(ansi.Truncate(label, room, t.Glyphs.Ellipsis))
-	gap := max(m.width-ansi.StringWidth(left)-ansi.StringWidth(actions), 1)
-	rule := m.styles.rule.Render(strings.Repeat(t.Glyphs.HLine, max(m.width, 1)))
-	return left + strings.Repeat(" ", gap) + actions + "\n" + rule
+	gap := max(m.width-ansi.StringWidth(left)-actionsW, 0)
+	head := make([]string, 0, 2)
+	head = append(head, left+strings.Repeat(" ", gap)+actions)
+	if rows < 2 {
+		return head
+	}
+	return append(head, m.styles.rule.Render(strings.Repeat(t.Glyphs.HLine, max(m.width, 1))))
 }
 
 func (m *Model) countLabel() string {
@@ -271,65 +410,176 @@ func (m *Model) actionBar() string {
 	return strings.Join(parts, "  ")
 }
 
-// deletePrompt is the confirmation docs/UX.md principle 4 asks for: it names
-// the comment that is about to go, in words, and says what answers it. Nothing
-// deletes a comment except the key this line names.
-func (m *Model) deletePrompt() string {
+// hint is a pair of labels and the zones they answer to. Each form says the same
+// thing in fewer cells than the one before it, so that a 34-column sidebar keeps
+// the keys rather than losing the second half of the sentence naming them.
+type hint struct{ left, right string }
+
+// pick is the fullest form that fits the room, or the tersest one when none of
+// them does. Measuring happens before marking: a zone marker is a private escape
+// sequence, so it changes the bytes and not the cells.
+func pick(room int, sep string, forms ...hint) hint {
+	sepW := ansi.StringWidth(sep)
+	for _, f := range forms {
+		if ansi.StringWidth(f.left)+sepW+ansi.StringWidth(f.right) <= room {
+			return f
+		}
+	}
+	return forms[len(forms)-1]
+}
+
+// shortest is the first form that fits the room, or the last one. The forms are
+// written longest first and each says the same thing in fewer cells, so a narrow
+// box loses a detail rather than the end of a sentence.
+func shortest(room int, forms ...string) string {
+	for _, f := range forms {
+		if ansi.StringWidth(f) <= room {
+			return f
+		}
+	}
+	return forms[len(forms)-1]
+}
+
+// fit picks the fullest pair that fits and marks each half as its own click
+// target.
+func (m *Model) fit(width int, sep, leftZone, rightZone string, forms ...hint) string {
+	f := pick(max(width-2, 0), sep, forms...)
+	line := "  " + m.mark(leftZone, f.left) + sep + m.mark(rightZone, f.right)
+	return ansi.Truncate(line, max(width, 1), m.deps.Theme.Glyphs.Ellipsis)
+}
+
+// buildPrompt is the confirmation docs/UX.md principle 4 asks for: it names the
+// comment that is about to go, in words, and says what answers it. Nothing
+// deletes a comment except the key it names.
+//
+// It is the one thing here that may take a second line. Everything else in the
+// box gives way to the width it has been given; a sentence saying what is about
+// to be destroyed may not be cut short of saying it, so a box too narrow to hold
+// the sentence and the keys side by side puts them one above the other, and only
+// then starts giving up the parts of the sentence from the end.
+func (m *Model) buildPrompt() []string {
 	t := m.deps.Theme
 	c := m.pending
+	keys := m.fit(m.width, ", ", zoneConfirm, zoneRefuse,
+		hint{"y deletes it", "any other key keeps it"},
+		hint{"y deletes", "any key keeps"},
+		hint{"y", "any"})
+	keysW := ansi.StringWidth(keys)
+
 	label := "delete " + authorName(&c) + "'s comment"
+	parts := m.promptParts(&c)
+	whole := label + strings.Join(parts, "") + "?"
+	if room := m.width - keysW; ansi.StringWidth(whole) <= room {
+		return []string{pad(m.styles.danger.Render(whole), room) + m.styles.muted.Render(keys)}
+	}
+	for _, part := range parts {
+		if ansi.StringWidth(label+part)+1 <= m.width {
+			label += part
+		}
+	}
+	sentence := ansi.Truncate(label+"?", max(m.width, 1), t.Glyphs.Ellipsis)
+	return []string{m.styles.danger.Render(sentence), m.styles.muted.Render(keys)}
+}
+
+// promptParts are what the confirmation adds to whose comment it is, in the
+// order they earn their cells. The opening words come from the display
+// renderer's summary rather than from markdown, so a heading is not quoted back
+// with its hashes on.
+func (m *Model) promptParts(c *jira.Comment) []string {
+	parts := make([]string, 0, 3)
 	if when := formatWhen(c.Created, m.location()); when != "" {
-		label += " from " + when
+		parts = append(parts, " from "+when)
 	}
 	if restricted := visibilityLabel(c.Visibility); restricted != "" {
-		label += ", " + restricted
+		parts = append(parts, ", "+restricted)
 	}
-	if first := firstWords(c.Body, 40); first != "" {
-		label += ", " + strconv.Quote(first)
+	if opening := richtext.Summary(c.Body, promptWords); opening != "" {
+		parts = append(parts, ", "+strconv.Quote(opening))
 	}
-	label += "?"
-	hint := "  " + m.mark(zoneConfirm, "y deletes it") + ", " + m.mark(zoneRefuse, "any other key keeps it")
-	room := max(m.width-ansi.StringWidth(hint), 8)
-	return m.styles.danger.Render(ansi.Truncate(label, room, t.Glyphs.Ellipsis)) + m.styles.muted.Render(hint)
+	return parts
 }
 
-// firstWords is the opening of a comment, on one line, so that a confirmation
-// names the comment the way the person who wrote it would recognise it.
-func firstWords(d adf.Doc, width int) string {
-	text := strings.TrimSpace(adf.Markdown(d))
-	if text == "" {
-		return ""
-	}
-	if at := strings.IndexByte(text, '\n'); at >= 0 {
-		text = text[:at]
-	}
-	return ansi.Truncate(strings.TrimSpace(text), width, "…")
+// composerChrome is the composer's one row: which comment is being written on
+// the left, and the keys that finish it on the right.
+//
+// One row and not two, because the row it saves is a row of the draft — which is
+// what makes composerHeight's 1+lines the draft's own lines rather than one short
+// of them. The keys are the half that must survive a narrow box, so they are
+// measured first and the caption takes what they leave.
+// chromeKey is everything the composer's chrome row is built from, so the row is
+// rebuilt when one of them moves rather than once per keystroke.
+type chromeKey struct {
+	issue      string
+	editing    string
+	width, gen int
+	sending    bool
 }
 
-// editorCaption says which comment the editor is on, so that an edit and a new
-// comment are never the same screen.
-func (m *Model) editorCaption() string {
+func (m *Model) chromeKey() chromeKey {
+	return chromeKey{
+		issue: m.issue, editing: m.editing, width: m.width,
+		gen: m.styles.gen, sending: m.sending,
+	}
+}
+
+func (m *Model) composerChrome() string {
+	key := m.chromeKey()
+	if m.chrome != "" && key == m.chromeAt {
+		return m.chrome
+	}
+	m.chrome, m.chromeAt = m.buildChrome(), key
+	return m.chrome
+}
+
+func (m *Model) buildChrome() string {
+	keys := m.composerKeys()
+	keysW := ansi.StringWidth(keys)
+	room := max(m.width-keysW-1, 0)
+	caption := ansi.Truncate(m.composerCaption(room), room, m.deps.Theme.Glyphs.Ellipsis)
+	gap := max(m.width-ansi.StringWidth(caption)-keysW, 0)
+	return m.styles.title.Render(caption) + strings.Repeat(" ", gap) + m.styles.muted.Render(keys)
+}
+
+// composerCaption says which comment the composer is on, so that an edit and a
+// new comment are never the same pane, in the fullest form the room allows.
+//
+// A restriction is never one of the details dropped: it is the one property of a
+// comment that decides who else can read what is being written about them, so it
+// outlives whose comment it is and when they wrote it.
+func (m *Model) composerCaption(room int) string {
 	if m.editing == "" {
-		return m.styles.title.Render("A new comment on " + m.issue)
+		return shortest(room, "A new comment on "+m.issue, "New on "+m.issue, m.issue)
 	}
-	label := "Editing " + authorName(&m.pending) + "'s comment"
+	who := "Editing " + authorName(&m.pending) + "'s comment"
+	dated := who
 	if when := formatWhen(m.pending.Created, m.location()); when != "" {
-		label += " from " + when
+		dated = who + " from " + when
 	}
-	if restricted := visibilityLabel(m.pending.Visibility); restricted != "" {
-		label += " " + m.deps.Theme.Glyphs.Separator + " " + restricted + ", and it stays that way"
+	restricted := visibilityLabel(m.pending.Visibility)
+	if restricted == "" {
+		return shortest(room, dated, who, "Editing")
 	}
-	return m.styles.title.Render(ansi.Truncate(label, max(m.width, 8), m.deps.Theme.Glyphs.Ellipsis))
+	sep := " " + m.deps.Theme.Glyphs.Separator + " "
+	stays := ", and it stays that way"
+	return shortest(room,
+		dated+sep+restricted+stays,
+		who+sep+restricted+stays,
+		who+sep+restricted,
+		"Editing"+sep+restricted,
+		restricted)
 }
 
-// editorHint is the line under the editor. It names the keys that finish, since
-// the footer cannot: the registry holds one key set per view, not one per mode.
-func (m *Model) editorHint() string {
+// composerKeys name what finishes the comment. The footer says the same two
+// while this mode is live, and this row is where they are clickable.
+func (m *Model) composerKeys() string {
 	if m.sending {
-		return m.styles.muted.Render("  sending" + m.deps.Theme.Glyphs.Ellipsis)
+		return "sending" + m.deps.Theme.Glyphs.Ellipsis
 	}
-	return m.styles.muted.Render("  " + m.mark(zoneSend, "ctrl+s sends") + "  " +
-		m.mark(zoneCancel, "esc keeps it as a draft"))
+	f := pick(max(m.width/2, 1), "  ",
+		hint{"ctrl+s sends", "esc keeps it as a draft"},
+		hint{"ctrl+s sends", "esc keeps it"},
+		hint{"ctrl+s", "esc"})
+	return m.mark(zoneSend, f.left) + "  " + m.mark(zoneCancel, f.right)
 }
 
 // alwaysPresent are the entries in pkg/adf's list that name prose details

--- a/internal/ui/comment/render_test.go
+++ b/internal/ui/comment/render_test.go
@@ -1,7 +1,10 @@
 package comment
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/varijkapil13/saral/pkg/adf"
 	"github.com/varijkapil13/saral/pkg/jira"
@@ -83,21 +86,94 @@ func TestList_ReadsAsASentence(t *testing.T) {
 	}
 }
 
-func TestFirstWords_TakesTheOpeningLineAndNoMore(t *testing.T) {
+// The confirmation quotes the comment back so that the person who wrote it
+// recognises it. The words come from the display renderer, so a heading is not
+// quoted with its hashes on, and they arrive on one line however many the
+// comment has.
+func TestPromptParts_QuoteTheOpeningWordsOnOneLineWithNoMarkdownInThem(t *testing.T) {
 	t.Parallel()
 
+	m := build(testDeps(t, nil), "PROJ-1")
+	m.width = 120
 	body := adf.NewDoc(
-		adf.NewNode("paragraph", adf.NewText("The first line of it.")),
+		adf.NewNode("heading", adf.NewText("The first line of it")).WithAttrs(adf.Attrs{"level": 2}),
 		adf.NewNode("paragraph", adf.NewText("The second, which nobody needs in a confirmation.")),
 	)
-	if got := firstWords(body, 40); got != "The first line of it." {
-		t.Errorf("got %q", got)
+	parts := m.promptParts(&jira.Comment{Body: body})
+	if len(parts) == 0 {
+		t.Fatal("the confirmation quotes nothing back")
 	}
-	if got := firstWords(body, 10); got != "The first…" {
-		t.Errorf("a narrow confirmation got %q", got)
+	quote := parts[len(parts)-1]
+	if !strings.Contains(quote, "The first line of it") {
+		t.Errorf("the confirmation quotes %q, want it to open with the comment", quote)
 	}
-	if got := firstWords(adf.Doc{}, 40); got != "" {
-		t.Errorf("an empty document got %q", got)
+	for _, unwanted := range []string{"#", "\n"} {
+		if strings.Contains(quote, unwanted) {
+			t.Errorf("the confirmation quotes %q, which carries %q", quote, unwanted)
+		}
+	}
+	if got := ansi.StringWidth(quote); got > promptWords+4 {
+		t.Errorf("the confirmation quotes %d cells, want no more than %d and its punctuation",
+			got, promptWords)
+	}
+	if got := m.promptParts(&jira.Comment{}); len(got) != 0 {
+		t.Errorf("a comment with nothing in it and no dates contributed %v", got)
+	}
+}
+
+// The composer's height is the one layout rule, and it holds at every box a
+// sidebar or a screen can be.
+func TestComposerHeight_GrowsWithTheDraftAndNeverPastHalfTheBox(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		lines, boxH int
+		want        int
+	}{
+		{name: "an empty draft in a tall box keeps its floor", lines: 1, boxH: 40, want: 3},
+		{name: "two lines still fit the floor", lines: 2, boxH: 40, want: 3},
+		{name: "a draft past the floor takes the lines it needs", lines: 6, boxH: 40, want: 7},
+		{name: "a long draft stops at half the box", lines: 40, boxH: 40, want: 20},
+		{name: "half of a short box is still half of it", lines: 40, boxH: 8, want: 4},
+		{name: "a box too short for half of it keeps the floor", lines: 1, boxH: 4, want: 3},
+		{name: "a box of one line cannot go below the floor here", lines: 1, boxH: 1, want: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := composerHeight(tc.lines, tc.boxH); got != tc.want {
+				t.Errorf("composerHeight(%d, %d) = %d, want %d", tc.lines, tc.boxH, got, tc.want)
+			}
+		})
+	}
+}
+
+// A line wider than the box is cut, and never silently: the marker is what says
+// the line goes on, and the pan is what reaches the rest of it.
+func TestWindow_SaysWhereALineWasCut(t *testing.T) {
+	t.Parallel()
+
+	line := "0123456789abcdefghij"
+	for _, tc := range []struct {
+		name string
+		from int
+		want string
+	}{
+		{name: "the left edge", from: 0, want: "012345678~"},
+		{name: "panned past the start", from: 5, want: "~6789abcd~"},
+		{name: "panned to the end", from: 10, want: "~bcdefghij"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := window(line, tc.from, 10, "~"); got != tc.want {
+				t.Errorf("window(%q, %d, 10) = %q, want %q", line, tc.from, got, tc.want)
+			}
+		})
+	}
+	if got := window("short", 0, 10, "~"); got != "short     " {
+		t.Errorf("a line that fits came back as %q, want it padded to the box", got)
 	}
 }
 

--- a/internal/ui/comment/testdata/box_composing_120x24.golden
+++ b/internal/ui/comment/testdata/box_composing_120x24.golden
@@ -1,0 +1,23 @@
+PROJ-1 | 2 comments                                                                                  write  edit  delete
+------------------------------------------------------------------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                                                                                        
+    What the log said                                                                                                   
+                                                                                                                        
+    The total is wrong past the rounding step, see the note (https://example.atlassian.net/wiki/x).                     
+                                                                                                                        
+    | go                                                                                                                
+    | func total(rows []Row) Money { return sum(rows).Round(2) } // the rounding that lies                              
+
+> Sam Tester | 02 Mar 2026 09:00                                                                                        
+    Fix is behind a flag until the migration lands.                                                                     
+
+
+
+
+
+
+
+
+
+A new comment on PROJ-1                                                            ctrl+s sends  esc keeps it as a draft
+Rounding is done in the adapter, not here.                                                                              

--- a/internal/ui/comment/testdata/box_composing_34x24.golden
+++ b/internal/ui/comment/testdata/box_composing_34x24.golden
@@ -1,0 +1,24 @@
+PROJ-1 | 2 comments               
+----------------------------------
+  Sam Tester | 02 Mar 2026 09:00  
+    What the log said             
+                                  
+    The total is wrong past the   
+    rounding step, see the note   
+    (https://example.atlassian.net
+    \ /wiki/x).                   
+                                  
+    | go                          
+    | func total(rows []Row) Mo...
+
+> Sam Tester | 02 Mar 2026 09:00  
+    Fix is behind a flag until the
+    migration lands.              
+
+
+
+
+
+New on PROJ-1          ctrl+s  esc
+Rounding is done in the adapter,  
+not here.                         

--- a/internal/ui/comment/testdata/box_composing_60x24.golden
+++ b/internal/ui/comment/testdata/box_composing_60x24.golden
@@ -1,0 +1,23 @@
+PROJ-1 | 2 comments                      write  edit  delete
+------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                            
+    What the log said                                       
+                                                            
+    The total is wrong past the rounding step, see the note 
+    (https://example.atlassian.net/wiki/x).                 
+                                                            
+    | go                                                    
+    | func total(rows []Row) Money { return sum(rows).Rou...
+
+> Sam Tester | 02 Mar 2026 09:00                            
+    Fix is behind a flag until the migration lands.         
+
+
+
+
+
+
+
+
+A new comment on PROJ-1           ctrl+s sends  esc keeps it
+Rounding is done in the adapter, not here.                  

--- a/internal/ui/comment/testdata/box_confirming_120x24.golden
+++ b/internal/ui/comment/testdata/box_confirming_120x24.golden
@@ -1,0 +1,24 @@
+PROJ-1 | 2 comments                                                                                  write  edit  delete
+------------------------------------------------------------------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                                                                                        
+    What the log said                                                                                                   
+                                                                                                                        
+    The total is wrong past the rounding step, see the note (https://example.atlassian.net/wiki/x).                     
+                                                                                                                        
+    | go                                                                                                                
+    | func total(rows []Row) Money { return sum(rows).Round(2) } // the rounding that lies                              
+
+> Sam Tester | 02 Mar 2026 09:00                                                                                        
+    Fix is behind a flag until the migration lands.                                                                     
+
+
+
+
+
+
+
+
+
+
+delete Sam Tester's comment from 02 Mar 2026 09:00, "Fix is behind a flag until the migratio…"?
+  y deletes it, any other key keeps it

--- a/internal/ui/comment/testdata/box_confirming_34x24.golden
+++ b/internal/ui/comment/testdata/box_confirming_34x24.golden
@@ -1,0 +1,24 @@
+PROJ-1 | 2 comments               
+----------------------------------
+  Sam Tester | 02 Mar 2026 09:00  
+    What the log said             
+                                  
+    The total is wrong past the   
+    rounding step, see the note   
+    (https://example.atlassian.net
+    \ /wiki/x).                   
+                                  
+    | go                          
+    | func total(rows []Row) Mo...
+
+> Sam Tester | 02 Mar 2026 09:00  
+    Fix is behind a flag until the
+    migration lands.              
+
+
+
+
+
+
+delete Sam Tester's comment?
+  y deletes, any key keeps

--- a/internal/ui/comment/testdata/box_confirming_60x24.golden
+++ b/internal/ui/comment/testdata/box_confirming_60x24.golden
@@ -1,0 +1,24 @@
+PROJ-1 | 2 comments                      write  edit  delete
+------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                            
+    What the log said                                       
+                                                            
+    The total is wrong past the rounding step, see the note 
+    (https://example.atlassian.net/wiki/x).                 
+                                                            
+    | go                                                    
+    | func total(rows []Row) Money { return sum(rows).Rou...
+
+> Sam Tester | 02 Mar 2026 09:00                            
+    Fix is behind a flag until the migration lands.         
+
+
+
+
+
+
+
+
+
+delete Sam Tester's comment from 02 Mar 2026 09:00?
+  y deletes it, any other key keeps it

--- a/internal/ui/comment/testdata/box_reading_120x24.golden
+++ b/internal/ui/comment/testdata/box_reading_120x24.golden
@@ -1,0 +1,23 @@
+PROJ-1 | 2 comments                                                                                  write  edit  delete
+------------------------------------------------------------------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                                                                                        
+    What the log said                                                                                                   
+                                                                                                                        
+    The total is wrong past the rounding step, see the note (https://example.atlassian.net/wiki/x).                     
+                                                                                                                        
+    | go                                                                                                                
+    | func total(rows []Row) Money { return sum(rows).Round(2) } // the rounding that lies                              
+
+> Sam Tester | 02 Mar 2026 09:00                                                                                        
+    Fix is behind a flag until the migration lands.                                                                     
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/comment/testdata/box_reading_34x24.golden
+++ b/internal/ui/comment/testdata/box_reading_34x24.golden
@@ -1,0 +1,23 @@
+PROJ-1 | 2 comments               
+----------------------------------
+  Sam Tester | 02 Mar 2026 09:00  
+    What the log said             
+                                  
+    The total is wrong past the   
+    rounding step, see the note   
+    (https://example.atlassian.net
+    \ /wiki/x).                   
+                                  
+    | go                          
+    | func total(rows []Row) Mo...
+
+> Sam Tester | 02 Mar 2026 09:00  
+    Fix is behind a flag until the
+    migration lands.              
+
+
+
+
+
+
+

--- a/internal/ui/comment/testdata/box_reading_60x24.golden
+++ b/internal/ui/comment/testdata/box_reading_60x24.golden
@@ -1,0 +1,23 @@
+PROJ-1 | 2 comments                      write  edit  delete
+------------------------------------------------------------
+  Sam Tester | 02 Mar 2026 09:00                            
+    What the log said                                       
+                                                            
+    The total is wrong past the rounding step, see the note 
+    (https://example.atlassian.net/wiki/x).                 
+                                                            
+    | go                                                    
+    | func total(rows []Row) Money { return sum(rows).Rou...
+
+> Sam Tester | 02 Mar 2026 09:00                            
+    Fix is behind a flag until the migration lands.         
+
+
+
+
+
+
+
+
+
+

--- a/internal/ui/comment/testdata/confirm_100x24.golden
+++ b/internal/ui/comment/testdata/confirm_100x24.golden
@@ -20,5 +20,5 @@ PROJ-1 | 1 comment                                                              
 
 
 
-
-delete Sam Tester's comment from 02 Mar 2026 09:00, "Reprod...  y deletes it, any other key keeps it
+delete Sam Tester's comment from 02 Mar 2026 09:00, "Reproduced on staging."?
+  y deletes it, any other key keeps it

--- a/internal/ui/comment/testdata/editor_100x24.golden
+++ b/internal/ui/comment/testdata/editor_100x24.golden
@@ -1,24 +1,23 @@
 PROJ-1 | 1 comment                                                               write  edit  delete
 ----------------------------------------------------------------------------------------------------
-A new comment on PROJ-1
-Markdown. Tables, lists, quotes and code fences all survive the round trip.                     
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-                                                                                                
-  ctrl+s sends  esc keeps it as a draft
+> Sam Tester | 02 Mar 2026 09:00                                                                    
+    Reproduced on staging.                                                                          
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+A new comment on PROJ-1                                        ctrl+s sends  esc keeps it as a draft
+Markdown. Tables, lists, quotes and code fences all survive the round trip.                         

--- a/internal/ui/comment/testdata/keys.golden
+++ b/internal/ui/comment/testdata/keys.golden
@@ -1,7 +1,7 @@
 reading the thread
   acts   a write · e edit · d delete
   full   [↓/j down, ↑/k up, pgdn page down, pgup page up]
-  full   [ctrl+d half page down, ctrl+u half page up, g g oldest, G newest]
+  full   [ctrl+d half page down, ctrl+u half page up, g g oldest, G newest, ←/h pan left, →/l pan right]
   full   [a write a comment, e edit this one, d delete this one]
 writing a comment
   acts   ctrl+s send · esc put it aside

--- a/internal/ui/testdata/overlay_120x38.golden
+++ b/internal/ui/testdata/overlay_120x38.golden
@@ -3,7 +3,8 @@ a write a comment    ↓/j  down         ctrl+d half page down    1-9   saved qu
 e edit this one      ↑/k  up           ctrl+u half page up      g 1-9 switch view           ?      help
 d delete this one    pgdn page down    g g    oldest            esc   back                  q      quit
                      pgup page up      G      newest            r     refresh
-                                                                R     refetch everything
+                                       ←/h    pan left          R     refetch everything
+                                       →/l    pan right
 
 form
 enter use this issue type    ↓/j  down         1-9   saved query           ctrl+k commands


### PR DESCRIPTION
## What this does

`internal/ui/comment` now works at any box size, so a sidebar and a full screen are the same
code rather than two layouts. `Thread` returns `*Model` so a pane can embed it as a child model
and push the same instance whole-screen: one fetch, one draft, one cursor, one composer with the
text still in it.

**One layout.** Thread on top, composer under it, `composerH = clamp(1+rows, 3, max(3, boxH/2))`.
The frame is now exactly as many lines as the box at every height — it was one line too tall at
heights 1 and 2, because the header was joined onto the body instead of counted with it.

**The composer spends one chrome row, not two.** Caption on the left, the keys that finish on the
right. Two rows made `1+rows` one short of the draft's own rows, so a three-line draft was always
drawn in two. One row also degrades better: at 34 columns the caption falls from
`A new comment on PROJ-1` to `New on PROJ-1` and the keys from `ctrl+s sends  esc keeps it as a
draft` to `ctrl+s  esc`, rather than truncating the issue key out of the line. When a restricted
comment is being edited, the restriction is the last detail dropped — the date and the author name
go first, because the restriction is what says who else can read what is being written.

**`rows` comes from the widget.** `textarea.DynamicHeight` measures the real soft wrap; counting
cells and dividing by the width is a row out at every width but one, because the widget wraps on
words. `MaxHeight` is now the display ceiling and `MaxContentHeight` the document's, which is why
they are different numbers.

**Bodies go through `richtext`.** No more `**` or `## ` on screen; the delete confirmation quotes
its opening words through `richtext.Summary`, so a heading is not quoted with its hashes on.

**`Init` reads nothing until an issue is named**, and being named the issue it already has does not
re-read and throw the reader's place away.

## A narrow box and a wide code block

`richtext` leaves code lines and grid rows at their own width by design — wrapping code corrupts
what a reader is about to copy — so at 34 columns most code blocks are wider than the pane. The
pane cuts them **and says so** with the theme's ellipsis, and binds `←/h` / `→/l` to reach the
rest. Only the over-wide lines slide: sliding the prose too would take the author and the date of
the comment being read off the left edge. Panning clamps to the widest line actually in the window,
so scrolling off a code block brings the thread home rather than leaving it shifted.

Truncating silently was the one answer not available.

## Resize

`resize` clears the block memo on a width change only, then re-derives the composer's rows, the
pan clamp and the window. `TestThread_AResizeMidComposeKeepsTheTextAndRelaysTheBox` drives one
instance through 34 → 60 → 120 mid-compose and asserts the text survives, the frame stays exactly
the box, the composer's rows shrink as the draft unwraps, and the body memo re-laid out for the new
width.

## Outside my owned paths

- `internal/ui/testdata/overlay_120x38.golden` — registering `←/h` / `→/l` changes the `?` overlay,
  which is what that sweep exists to surface. First attempt put them in their own `Full` row, which
  added a column and pushed `ctrl+k commands` / `? help` / `q quit` past the right edge at 120
  columns — [#96](https://github.com/varijkapil13/saral/issues/96) exactly. They are folded into the
  existing motions column instead; the overlay grows by one row and the globals keep their place.
- `docs/ROADMAP.md` — the R3 row, as the packet allows.

## Performance, measured on an M2 Pro

`BenchmarkFrame` and `BenchmarkKeyToFrame` in `internal/ui/kernel`, unchanged as expected (this
packet does not touch the kernel):

| | main | this branch |
|---|---|---|
| `BenchmarkFrame` | 132,419 ns/op · 297 allocs/op | 132,583 ns/op · 297 allocs/op |
| `BenchmarkKeyToFrame` | 120,555 ns/op · 310 allocs/op | 123,308 ns/op · 310 allocs/op |

`internal/ui/comment`:

| | main | this branch |
|---|---|---|
| `SteadyScroll10k` | 4,173 ns · 2 allocs | 3,666 ns · **1 alloc** |
| `SteadyScroll20` | 3,200 ns · 2 allocs | 2,654 ns · **1 alloc** |
| `Redraw200x60` | 2,248 ns · 2 allocs | 2,054 ns · **1 alloc** |
| `RenderBlock` | 4,014 ns · 33 allocs | 12,848 ns · 60 allocs |
| `RedrawSidebar34x24` | — | 593 ns · 1 alloc |
| `Pan` | — | 8,430 ns · 42 allocs |
| `Compose` | — | 65,190 ns · 471 allocs |

A frame is down to the one string `View` returns. `RenderBlock` costs 3× more because it is a
styled render rather than a markdown serialisation — but it is memoized per `(id, updated, width,
theme gen, selected)`, so it is not a per-frame cost, and both new frame paths are pinned by tests:
`TestComposing_RendersNoCommentPerFrame` and `TestPanning_CutsTheLinesAgainAndRendersNoComment`.

`Compose`'s 471 allocations are one `textarea.View` per frame — the widget's own. It is deliberately
not memoized: the key would have to include the cursor, the scroll offset and the placeholder, and a
memo that misses one of those draws the wrong text at the wrong width, which is the exact failure
this packet is about. At 65 µs it is 250× under the 16 ms keystroke budget, and it happens once per
keystroke.

## An unsound assertion fixed, not tagged away

`TestScrolling_CostsTheSameOnTenThousandCommentsAsOnTwenty` started failing under `-race` — 44
allocs/op against a real 1. `testing.Benchmark` reads **process-wide** `MemStats`, so run under
`t.Parallel()` it is handed sixty other tests' allocations divided by its own iteration count, and
`-race` widens the window enough to catch a lot of them. Direct `ReadMemStats` measurement around
the frame loop says 1 alloc/frame with and without `-race`.

It is now sequential, with the reason written down, rather than given a `//go:build !race` tag —
this is the [#112](https://github.com/varijkapil13/saral/issues/112) class of problem, and a
sequential test is the only one that has the counter to itself.

## Consumers

`Thread`'s return type changed from `kernel.View` to `*Model`.

- `internal/ui/issue/comments.go:43` calls `comment.Push`, not `Thread` — unaffected, still
  compiles and its test passes.
- `internal/ui/comment/harness_test.go` and `comment_test.go` dropped their
  `.(*Model)` assertions.
- The sibling packet embedding this in the issue sidebar is the intended consumer; `Thread`'s doc
  comment names the four things a pane owes it (`kernel.SizeMsg`, every message, a `ThreadMsg` on
  issue change, and its own `WantsRawKeys` / `BlocksClose` / `LiveKeys`).

## Behaviour change worth a second look

`focus(false)` no longer cancels the in-flight read. Losing the keys is not being closed: the kernel
blurs a view it is pushing over and one it is switching root away from (and keeps that one alive in
`m.live`) as well as one it is discarding, so cancelling there threw away reads nobody had
abandoned — opening the palette over a loading thread cancelled it. Every request cancels its own
context in `withCancel`, so the one case that really is a discard costs a read that lands nowhere
rather than a goroutine that stays. Cancelling exactly on close needs a kernel close hook, which is
not this packet's to add.

## Tests

Full suite run **six times with `-race`: six green.** `go vet`, `golangci-lint run` (0 issues),
`go mod tidy` clean, stripped binary 11 MiB (under the 15 MiB gate), `scripts/checkleak.py` clean.

New, all at 34 / 60 / 120 columns: the same model laying out a sidebar and a screen (frame height
exact, no line over width, the layout summing to the box, a line of thread always on screen); the
composer growing with the draft and stopping at half the box; rich bodies styled with no `**`,
`## ` or `](https://` and emphasis surviving as bold in the no-colour theme; the confirmation
quoting words and not markdown. Plus a wide code block cut and panned to at 34, a resize
mid-compose, a comment typed with `q`, digits and `?` in it surviving the kernel's globals, `Init`
asking for nothing until an issue is named, and 403 / 429 / transport on the load.

Nine new goldens (reading / composing / confirming × 34 / 60 / 120). The three changed goldens are
UI changes: `editor_100x24` now shows the thread above the composer, `confirm_100x24` puts the
confirmation on two lines rather than truncating the quoted words, and `keys.golden` gains the pan
keys in the `?` set only — the footer's `Acts` row is untouched, since motions stay off it.
