### PR TITLE
feat(issue): drag the boundary between the panes, or move it with a key

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -506,8 +506,12 @@ view that minted the ids is the only thing that knows what they mean, so the hit
   click count and no timestamp, so a view cannot recognise one without a clock.
 - **`widget.Window`** — the slice of rendered lines a scrolled pane draws, with the one line that has
   to stay visible. It slices rather than copies, so a scrolled pane costs no allocation per frame.
-- **`widget.Drag`** — press, move, release, bound to nothing yet
-  ([#75](https://github.com/varijkapil13/saral/issues/75)).
+- **`widget.Drag`** — press, move, release. `internal/ui/issue` binds it to the boundary between its
+  description and its sidebar: the press decides what is being dragged and nothing after it can, so a
+  release outside the column still lands on that divider, and a resize, a key, a view switch or a
+  press elsewhere cancels a gesture rather than applying it. The column is marked as a zone the way
+  the regions are — the marker at the top of it and again at the bottom — so a one-column rectangle is
+  what a press resolves through.
 
 **Zone ids are never freed.** `Mark` fills a permanent id map in the manager, and nothing evicts from
 it. Every id in this tree is minted from a per-instance prefix and a stable name, so redrawing an
@@ -557,6 +561,32 @@ key  = 2                                 # the number key that runs it; omit for
 The queries are held by `app.SavedQueries` and validated by its rules rather than a second copy of
 them, so a file and a keypress cannot disagree about what a saved query is. The file refuses the two
 things a keyboard cannot express: two queries under one name, and two on one key.
+
+### What is not in the profile
+
+`config.UIState` is how a view remembers the way it was arranged, in `ui.toml` under the **cache**
+directory rather than beside `config.toml`:
+
+```toml
+# ~/.cache/saral/ui.toml
+[splits]
+issue = 433                              # the sidebar's share of the pane, out of config.SplitScale
+```
+
+Three reasons it is there and not in a `Profile`. A pane width belongs to the terminal it was chosen
+in and not to a Jira account, so two profiles on one machine want one answer and a `config.toml`
+copied to a laptop should not carry a desktop's proportions. `config.toml` is a file people hand-edit
+and hand to each other, which a number a drag rewrites several times a gesture is not. And onboarding
+rebuilds the profile it writes from a zero value and the four fields it collects, so anything else
+kept there is dropped the next time somebody re-runs setup to re-check a token
+([#63](https://github.com/varijkapil13/saral/issues/63)) — a bug this neither fixes nor feeds.
+
+A **share** rather than a column count, so the choice survives a window of another size. `SaveSplit`
+re-reads before it writes and holds a mutex over the pair, so one view's entry cannot lose another's;
+`LoadUIState` answers with nothing at all where it cannot read — a first run, an unwritable cache, a
+file edited into something TOML will not parse — because this is the program's own record of how a
+pane was left rather than anything a person wrote. Writing is a `tea.Cmd` like every other piece of
+IO, and a failure is reported once on the status line rather than undoing a split that already works.
 
 ## Decisions recorded separately
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -559,6 +559,38 @@ of headroom under the 15 MiB binary gate. So the display renderer is written her
   what a hue cannot. And because the renderer never wraps code, `h` and `l` pan: a realistic Go
   signature is 79 cells and the widest description box at 120 columns is 78, so a code block is cut at
   every width the sidebar leaves and something had to reach the rest of it.
+- [x] **R5 — Let the reader choose the split** · **owns** `internal/ui/issue/{layout,split}.go`,
+  `internal/ui/issue/**_test.go`, `internal/ui/issue/testdata/**`, `internal/config/**`, this row
+  R4's split was computed and could not be changed — `clamp(bodyW/3, 35, 45)` — so a reader who
+  wanted more prose, or a wider sidebar for one long custom field, had no way to ask.
+  **`widget.Drag` finally has something to drag.** P3.3 shipped the press-move-release machine bound
+  to nothing because no view had two panes; the column between the description and the sidebar is
+  marked as a zone and is now what it was waiting for. The press decides what is being held, so a
+  release outside the column still lands on the divider, and a resize, a key, a view switch or a
+  press elsewhere cancels the gesture rather than applying a delta measured against a pane that has
+  gone. That last one is not theoretical: the help overlay swallows every mouse message while it is
+  up, so a release really can go missing.
+  `<`, `>` and `=` are the keyboard route and three palette commands are the third, because a drag is
+  mouse-only and principle 3 asks for all three. They are on the `?` overlay and not the footer row:
+  the row names what can be done to the *issue*, and below 90 columns there is no boundary for them
+  to move — where they say so rather than doing nothing, as they do at 90 itself, where the two
+  floors meet and leave exactly one legal split.
+  **The floors are measured, not chosen**: 53 cells of prose, below which the same paragraph loses
+  about two words a line, and 34 for the sidebar, below which a label and its value stop fitting side
+  by side. `layout_test.go` measures both rather than trusting them.
+  **The ratio is per machine, in `ui.toml` under the cache directory, and deliberately not in the
+  profile.** A pane width belongs to the terminal it was chosen in rather than to a Jira account,
+  `config.toml` is a file people hand each other, and onboarding rebuilds a profile from a zero value
+  and drops what it did not collect ([#63](https://github.com/varijkapil13/saral/issues/63)) — so a
+  field added there would be lost the next time anybody re-checked a token. That bug is neither fixed
+  nor made worse; the split is simply not in its way, which `internal/config` asserts by running that
+  same overwrite over a profile and finding the split still there.
+  **A drag is a motion stream, so it was measured.** A frame drawn while the boundary is held costs
+  what a frame at rest costs — two allocations at 120×40, unchanged. A motion that moves the boundary
+  nowhere costs no render. A motion that does move it is a resize of two regions and costs slightly
+  less than one: 767 allocations against 807, because the panes have a width they have never been
+  rendered at and lines are what a width means. Closes
+  [#75](https://github.com/varijkapil13/saral/issues/75).
 
 ## Batch 4 — Attachments · parallel ×3
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -221,6 +221,32 @@ view rather than to the kernel, because what a pane is differs per view — and 
 action row rather than among the motions, because in the narrow mode it is the only way to reach two
 of the three regions at all.
 
+**And `<`, `>` and `=` move the boundary between them**, in the same view. The split used to be
+computed — a third of the pane, held between 35 and 45 cells — so a reader who wanted more prose, or a
+wider sidebar for a long custom field, had no way to ask. Now the boundary can be dragged and the
+three strokes move it four cells at a time, `=` gives it back to the width, and the choice is kept as
+a **share of the pane rather than a column count**, so it means the same thing in a window of another
+size. Two floors hold it: 53 cells of prose, below which the same paragraph loses about two words a
+line, and 34 for the sidebar, below which a label and its value stop fitting side by side. At 90
+columns those two meet, so there is exactly one legal split there and the gesture says so rather than
+pretending to move — as it does below 90, where the regions take the screen in turn and there is no
+boundary on it at all.
+
+The three strokes are on the `?` overlay and not on the footer's action row. The row names what can
+be done to the issue in front of you, the split is a property of the window rather than of the issue,
+and below the breakpoint the keys have nothing to move — a row naming them there would name keys that
+answer with a refusal, which is the failure principle 2 describes rather than a smaller version of it.
+
+**The ratio is kept per machine, not per profile.** It goes in `ui.toml` under the cache directory,
+beside where a comment draft goes and where the palette's own frecency table is to go, for the
+reasons that directory already holds them: a pane width belongs to the terminal it was chosen in and not to a Jira
+account, so two profiles on one machine want one answer and a `config.toml` handed to somebody else
+should not carry your proportions. It is also what onboarding would have eaten — setup rebuilds
+a profile from a zero value and drops everything it did not collect
+([#63](https://github.com/varijkapil13/saral/issues/63)), so a number kept there would go the next
+time anybody re-checked a token. That bug is neither fixed nor made worse here; the split is simply
+not in its way.
+
 The one thing this table still does not promise is jumping to an issue by key — typing `PROJ-142`, or
 pasting a Jira URL. That is not built; it is
 [#62](https://github.com/varijkapil13/saral/issues/62).
@@ -236,6 +262,7 @@ arithmetic (see `docs/ARCHITECTURE.md`). This table is what the program does.
 | double-click a row | open it, same as `enter` — and only when both clicks are one gesture |
 | click a status, type or assignee cell | show only the rows with that value; click it again to show them all |
 | wheel | scroll the pane under the pointer, not the focused one |
+| drag the column between two panes | move the boundary; the panes follow the pointer and the ratio is kept |
 | click the line that names the search | show its JQL and offer to change it, the same as `e` |
 | click the footer's root cell | go back to that root, the same as `esc` from a pushed view |
 | click a footer action | do it — the view is handed the first stroke of the key that entry names |
@@ -264,13 +291,15 @@ the line under the rows too, `ctrl+g` clears it — the stroke `esc` already ans
 prompt is open, which is why it is not a new key to learn — and the palette carries *clear the filter
 on these rows*. The footer offers `ctrl+g` only while there is a filter to clear.
 
-Two gestures this table used to promise are not built, and are not being built here:
+**The divider is a column of blank, and it is deliberate that it stays blank.** The boundary between
+the issue pane's description and its sidebar is one column wide and carries no rule, because the
+sidebar's own gutter is the column next to it and two vertical lines side by side say less than one
+does. What tells a reader the boundary moves is `?`, the palette and the row in the table above, not
+a glyph.
+Everything a pointer can do to it, `<`, `>` and `=` do without one.
 
-- **Drag a divider to resize panes** — [#75](https://github.com/varijkapil13/saral/issues/75). The
-  issue detail pane has three regions now, but no divider to grab: its split is computed from the
-  width, clamped between 35 and 45 cells, rather than chosen. `widget.Drag` is the press-move-release
-  machine, tested and bound to nothing; whichever packet makes a split draggable binds it, along with
-  persisting the ratio.
+One gesture this table used to promise is not built, and is not being built here:
+
 - **Right-click for a context menu of the actions valid for a row** —
   [#76](https://github.com/varijkapil13/saral/issues/76). `kernel.Command` has no notion of what a
   command applies to, so "the actions valid for this row" has no data source, and the menu itself

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -523,11 +523,17 @@ func (c Config) Save(path string) error {
 	if err != nil {
 		return err
 	}
+	return writeAtomic(path, data)
+}
+
+// writeAtomic writes a file through a temporary one beside it, so an interrupted
+// write leaves what was there before rather than half of what replaces it.
+func writeAtomic(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, dirPerm); err != nil {
 		return fmt.Errorf("creating %s: %w", dir, err)
 	}
-	tmp, err := os.CreateTemp(dir, ".config-*.toml")
+	tmp, err := os.CreateTemp(dir, ".saral-*.tmp")
 	if err != nil {
 		return fmt.Errorf("creating a temporary file in %s: %w", dir, err)
 	}

--- a/internal/config/uistate.go
+++ b/internal/config/uistate.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/BurntSushi/toml"
+)
+
+// uiStateFile is where the arrangement of the panes is kept, under the cache
+// directory rather than beside config.toml.
+const uiStateFile = "ui.toml"
+
+// SplitScale is what a stored split is a share of: a sidebar taking a third of
+// its pane is 333.
+const SplitScale = 1000
+
+// uiWrite serialises the read-merge-write below, so two views choosing a split
+// at once cannot each write a file missing the other's.
+var uiWrite sync.Mutex
+
+// UIState is what this machine remembers about how a view is arranged.
+//
+// It is deliberately not part of a Profile, for three reasons. A pane width
+// belongs to the terminal it was chosen in and not to a Jira account, so two
+// profiles on one machine want one answer and a config.toml copied to a laptop
+// should not carry a desktop's proportions. Onboarding rebuilds a profile from a
+// zero value and drops every field it did not collect, so a number kept there is
+// lost the next time somebody re-checks their token. And config.toml is a file
+// people hand-edit and hand to each other, which a number a drag rewrites is not.
+type UIState struct {
+	// Splits maps a view id to the share of that view's pane its sidebar takes,
+	// out of SplitScale. A share and not a column count, because the same
+	// terminal is not always the same width.
+	Splits map[string]int `toml:"splits"`
+}
+
+// UIStatePath is the file the arrangement is kept in.
+func UIStatePath() (string, error) {
+	dir, err := CacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, uiStateFile), nil
+}
+
+// LoadUIState reads what this machine remembers, and remembers nothing when it
+// cannot: a first run, no home directory, an unreadable cache, or a file edited
+// into something TOML will not parse. This is the program's own record of how a
+// pane was left rather than anything a person wrote, and none of those is worth
+// refusing to open an issue over — the answer a comment draft gives a read it
+// cannot satisfy.
+func LoadUIState() UIState {
+	path, err := UIStatePath()
+	if err != nil {
+		return UIState{}
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // the path is the cache directory's own file
+	if err != nil {
+		return UIState{}
+	}
+	var state UIState
+	if _, err := toml.Decode(string(data), &state); err != nil {
+		return UIState{}
+	}
+	return state
+}
+
+// Split is the share the named view keeps, and whether it keeps one at all. A
+// share outside the scale is a file somebody has edited into something no
+// gesture could have produced, and is read as no choice rather than obeyed.
+func (s UIState) Split(view string) (share int, ok bool) {
+	share, kept := s.Splits[view]
+	if !kept || share <= 0 || share >= SplitScale {
+		return 0, false
+	}
+	return share, true
+}
+
+// SaveSplit records one view's share of its pane and writes the file, keeping
+// every other view's. A share of zero is a view that has gone back to the answer
+// its width alone gives, and is removed rather than written as a number nothing
+// would produce.
+func SaveSplit(view string, share int) error {
+	path, err := UIStatePath()
+	if err != nil {
+		return err
+	}
+	uiWrite.Lock()
+	defer uiWrite.Unlock()
+
+	state := LoadUIState()
+	if state.Splits == nil {
+		state.Splits = make(map[string]int, 1)
+	}
+	if share <= 0 || share >= SplitScale {
+		delete(state.Splits, view)
+	} else {
+		state.Splits[view] = share
+	}
+	var b strings.Builder
+	if err := toml.NewEncoder(&b).Encode(state); err != nil {
+		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	return writeAtomic(path, []byte(b.String()))
+}

--- a/internal/config/uistate_test.go
+++ b/internal/config/uistate_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ownCache points the lookup at a directory of this test's own. t.Setenv rules
+// out t.Parallel, which is why nothing in this file runs in parallel.
+func ownCache(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("SARAL_CACHE_DIR", dir)
+	return dir
+}
+
+func TestSaveSplit_ComesBackAsTheShareItWasGiven(t *testing.T) {
+	ownCache(t)
+
+	if _, kept := LoadUIState().Split("issue"); kept {
+		t.Fatal("a machine that has never chosen a split remembers one")
+	}
+	if err := SaveSplit("issue", 366); err != nil {
+		t.Fatalf("SaveSplit: %v", err)
+	}
+	share, kept := LoadUIState().Split("issue")
+	if !kept || share != 366 {
+		t.Errorf("the split came back as %d, kept=%v, want 366", share, kept)
+	}
+}
+
+// The file holds one entry per view, so writing one must not lose another. The
+// read-merge-write is what makes that true, and it is the reason a second copy
+// of Saral choosing a split for a different view does not cost this one its own.
+func TestSaveSplit_KeepsEveryOtherViewsShare(t *testing.T) {
+	ownCache(t)
+
+	for view, share := range map[string]int{"issue": 300, "board": 480} {
+		if err := SaveSplit(view, share); err != nil {
+			t.Fatalf("SaveSplit(%q): %v", view, err)
+		}
+	}
+	state := LoadUIState()
+	for view, want := range map[string]int{"issue": 300, "board": 480} {
+		if got, kept := state.Split(view); !kept || got != want {
+			t.Errorf("%s kept %d (kept=%v), want %d", view, got, kept, want)
+		}
+	}
+}
+
+// Going back to the width's own answer is not a share, so it is removed rather
+// than written as a number no gesture would produce.
+func TestSaveSplit_ZeroForgetsTheChoiceRatherThanRecordingIt(t *testing.T) {
+	dir := ownCache(t)
+
+	if err := SaveSplit("issue", 420); err != nil {
+		t.Fatalf("SaveSplit: %v", err)
+	}
+	if err := SaveSplit("issue", 0); err != nil {
+		t.Fatalf("SaveSplit(0): %v", err)
+	}
+	if share, kept := LoadUIState().Split("issue"); kept {
+		t.Errorf("the view still remembers a share of %d", share)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, uiStateFile))
+	if err != nil {
+		t.Fatalf("reading the state file: %v", err)
+	}
+	if strings.Contains(string(data), "420") {
+		t.Errorf("the forgotten share is still in the file:\n%s", data)
+	}
+}
+
+// The file is the program's own record of how a pane was left, so anything it
+// cannot read is worth ignoring rather than refusing to open an issue over.
+func TestLoadUIState_RemembersNothingRatherThanFailing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		file string
+	}{
+		{name: "a file TOML cannot parse", file: "splits = [[[["},
+		{name: "a share nothing would produce", file: "[splits]\nissue = 4000\n"},
+		{name: "a share of zero", file: "[splits]\nissue = 0\n"},
+		{name: "a negative share", file: "[splits]\nissue = -3\n"},
+		{name: "a section with nothing in it", file: "[splits]\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := ownCache(t)
+			if err := os.WriteFile(filepath.Join(dir, uiStateFile), []byte(tc.file), 0o600); err != nil {
+				t.Fatalf("seeding: %v", err)
+			}
+			if share, kept := LoadUIState().Split("issue"); kept {
+				t.Errorf("%s was read as a choice of %d", tc.name, share)
+			}
+		})
+	}
+}
+
+func TestSaveSplit_ReportsWhyItCouldNotWrite(t *testing.T) {
+	dir := ownCache(t)
+
+	blocker := filepath.Join(dir, uiStateFile)
+	if err := os.MkdirAll(blocker, 0o700); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	err := SaveSplit("issue", 400)
+	if err == nil {
+		t.Fatal("SaveSplit succeeded with a directory where the file should be")
+	}
+	if !strings.Contains(err.Error(), blocker) {
+		t.Errorf("error %q does not say which path it failed on", err)
+	}
+}
+
+// The split is not a field of Profile, which is what keeps it out of the way of
+// the thing that drops profile fields: onboarding builds the profile it writes
+// from a zero value and the four fields on screen, so Theme, Glyphs, Timeline
+// and the saved queries all go when somebody re-runs setup to re-check a token.
+// This walks that same overwrite and asserts the split is still there, because
+// it was never in the file being rewritten.
+func TestSaveSplit_SurvivesAProfileBeingRebuiltFromAZeroValue(t *testing.T) {
+	dir := ownCache(t)
+	t.Setenv("SARAL_CONFIG_DIR", dir)
+
+	if err := SaveSplit("issue", 358); err != nil {
+		t.Fatalf("SaveSplit: %v", err)
+	}
+	path := filepath.Join(dir, fileName)
+	before := Config{Active: "work", Mouse: true, Profiles: map[string]Profile{
+		"work": {
+			Name: "work", Site: "example.atlassian.net", Email: "you@example.com",
+			Project: "PROJ", Token: TokenSource{Env: "JIRA_TOKEN"},
+			Theme: "dark", Glyphs: "ascii",
+		},
+	}}
+	if err := before.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// What onboarding does to a profile that already exists.
+	after, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	after.Profiles["work"] = Profile{
+		Name: "work", Site: "example.atlassian.net", Email: "you@example.com",
+		Project: "PROJ", Token: TokenSource{Env: "JIRA_TOKEN"},
+	}
+	if err := after.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reloaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if theme := reloaded.Profiles["work"].Theme; theme != "" {
+		t.Fatalf("the rewrite kept the theme %q, so it is not the overwrite this is about", theme)
+	}
+	share, kept := LoadUIState().Split("issue")
+	if !kept || share != 358 {
+		t.Errorf("the split came back as %d (kept=%v) after a profile was rebuilt, want 358", share, kept)
+	}
+}
+
+// And it is not in config.toml at all, which is the other half of the same
+// decision: that file has to stay safe to hand somebody and readable by hand.
+func TestSave_WritesNoSplitIntoTheConfigFile(t *testing.T) {
+	dir := ownCache(t)
+
+	if err := SaveSplit("issue", 358); err != nil {
+		t.Fatalf("SaveSplit: %v", err)
+	}
+	path := filepath.Join(dir, fileName)
+	cfg := Config{Active: "work", Mouse: true, Profiles: map[string]Profile{
+		"work": {Site: "example.atlassian.net", Email: "you@example.com", Token: TokenSource{Env: "T"}},
+	}}
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // the path is this test's own temporary directory
+	if err != nil {
+		t.Fatalf("reading the config: %v", err)
+	}
+	for _, unwanted := range []string{"split", "358"} {
+		if strings.Contains(string(data), unwanted) {
+			t.Errorf("config.toml carries %q:\n%s", unwanted, data)
+		}
+	}
+}

--- a/internal/ui/issue/bench_test.go
+++ b/internal/ui/issue/bench_test.go
@@ -86,6 +86,21 @@ func settle(tb testing.TB, m *Model, cmd tea.Cmd) *Model {
 	return m
 }
 
+// benchDrag is the pane with its boundary held, which is the state a stream of
+// motion messages arrives in. The press is made on the widget directly, because
+// a benchmark has no zone manager for a hit test to resolve through.
+func benchDrag(tb testing.TB, w, h int) (m *Model, boundaryX int) {
+	tb.Helper()
+
+	m = benchPane(tb, w, h)
+	m.dragFrom, m.dragSide = m.split, sideWidth(m.width, m.split)
+	boundaryX = m.width - m.dragSide - divider
+	if !m.drag.Start(dividerZone, pressAt(boundaryX, headerHeight)) {
+		tb.Fatal("the press started no drag")
+	}
+	return m, boundaryX
+}
+
 func BenchmarkIssueView(b *testing.B) {
 	m := benchPane(b, 120, 40)
 	b.ReportAllocs()
@@ -126,6 +141,73 @@ func BenchmarkIssueScroll(b *testing.B) {
 			press = up
 		}
 		next, _ := m.Update(press)
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+}
+
+// BenchmarkIssueDragFrame is a frame drawn while the boundary is held. Holding
+// one is not a state the pane draws differently, so this is the frame at rest
+// with a gesture under way over it.
+func BenchmarkIssueDragFrame(b *testing.B) {
+	m, _ := benchDrag(b, 120, 40)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = m.View()
+	}
+}
+
+// BenchmarkIssueDragHold is the half of a drag that moves the pointer without
+// moving the boundary — up and down the column it grabbed. Most of the messages
+// a real gesture sends are these, and none of them may cost a render.
+func BenchmarkIssueDragHold(b *testing.B) {
+	m, x := benchDrag(b, 120, 40)
+	up, down := motionAt(x, headerHeight+1), motionAt(x, headerHeight+2)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		at := up
+		if i%2 == 1 {
+			at = down
+		}
+		next, _ := m.Update(at)
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+}
+
+// BenchmarkIssueDragMove is the other half: a motion that really does move the
+// boundary, which gives both panes a width they have not been rendered at. That
+// is a resize of two regions and costs what one costs, which is what
+// BenchmarkIssueResize is here to be compared against.
+func BenchmarkIssueDragMove(b *testing.B) {
+	m, x := benchDrag(b, 120, 40)
+	here, over := motionAt(x, headerHeight+1), motionAt(x-1, headerHeight+1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		at := here
+		if i%2 == 1 {
+			at = over
+		}
+		next, _ := m.Update(at)
+		m, _ = next.(*Model)
+		_ = m.View()
+	}
+}
+
+func BenchmarkIssueResize(b *testing.B) {
+	m := benchPane(b, 120, 40)
+	wide, narrow := kernel.SizeMsg{Width: 120, Height: 40}, kernel.SizeMsg{Width: 118, Height: 40}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		to := wide
+		if i%2 == 1 {
+			to = narrow
+		}
+		next, _ := m.Update(to)
 		m, _ = next.(*Model)
 		_ = m.View()
 	}

--- a/internal/ui/issue/budget_test.go
+++ b/internal/ui/issue/budget_test.go
@@ -35,6 +35,44 @@ func TestSteadyFrame_CostsTheFrameAndTheThreadAndNothingElse(t *testing.T) {
 	}
 }
 
+// A drag is a stream of motion messages, so what it costs per message is the
+// thing to hold down. Three claims, in the order they matter:
+//
+// A frame drawn while the boundary is held costs what a frame at rest costs.
+// Holding one changes nothing about what is on screen, so nothing about drawing
+// it may change either.
+//
+// A motion that does not move the boundary — most of them, since a pointer
+// dragging a column wanders up and down it — costs no render. It is a keystroke
+// that moves no memo plus the two interface boxes a mouse message pays and a
+// keypress does not: the widget takes a tea.MouseMsg and the thread takes a
+// tea.Msg, and a message arrives here as neither.
+//
+// And a motion that does move it is a resize of two regions, which is what it
+// costs. There is no cheaper honest answer: both panes have a width they have
+// never been rendered at, and the lines are what a width means.
+func TestDrag_CostsAFrameWhileHeldAndAResizeWhileMoving(t *testing.T) {
+	t.Parallel()
+
+	rest := testing.Benchmark(BenchmarkIssueView).AllocsPerOp()
+	if held := testing.Benchmark(BenchmarkIssueDragFrame).AllocsPerOp(); held > rest {
+		t.Errorf("a frame with the boundary held allocates %d times against %d at rest", held, rest)
+	}
+
+	const boxes = 2
+	scrolling := testing.Benchmark(BenchmarkIssueScroll).AllocsPerOp()
+	if holding := testing.Benchmark(BenchmarkIssueDragHold).AllocsPerOp(); holding > scrolling+boxes {
+		t.Errorf("a motion that moves the boundary nowhere allocates %d times against %d for a keystroke "+
+			"that moves nothing, so something is being rendered per motion message", holding, scrolling)
+	}
+
+	resize := testing.Benchmark(BenchmarkIssueResize).AllocsPerOp()
+	if moving := testing.Benchmark(BenchmarkIssueDragMove).AllocsPerOp(); moving > resize {
+		t.Errorf("a motion that moves the boundary allocates %d times against %d for the resize it is",
+			moving, resize)
+	}
+}
+
 // A keystroke that only moves the description must not re-render anything: the
 // memo key has not moved, so a scroll costs a frame and the keypress itself.
 func TestScrolling_CostsNoMoreThanStandingStill(t *testing.T) {

--- a/internal/ui/issue/issue.go
+++ b/internal/ui/issue/issue.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/config"
 	"github.com/varijkapil13/saral/internal/ui/comment"
 	"github.com/varijkapil13/saral/internal/ui/kernel"
 	"github.com/varijkapil13/saral/internal/ui/richtext"
@@ -63,6 +64,17 @@ type Model struct {
 	marks     [regionCount]string
 	pendingGo bool
 
+	// split is the share of the pane the sidebar takes, and the drag is the
+	// gesture that moves it. dragFrom and dragSide are what the press found, so
+	// that a resize, a key or a view switch can put the boundary back where it
+	// was rather than leaving it wherever the pointer had reached.
+	split       split
+	drag        widget.Drag
+	dragFrom    split
+	dragSide    int
+	dividerMark string
+	splitFailed bool
+
 	// open holds the expands the reader has opened, by the index the renderer
 	// gave them; folded counts the times that set has changed, because a memo
 	// keyed on a map would never see one.
@@ -91,13 +103,18 @@ type Model struct {
 //
 // The row is drawn immediately and the full issue replaces it when it arrives:
 // docs/UX.md asks for a first paint that never waits, and the list already has
-// the key, the summary and the status.
+// the key, the summary and the status. The split the reader last chose is read
+// here for the same reason: a constructor runs before the first frame and Init
+// does not.
 func New(d kernel.Deps, seed jira.Issue) kernel.View {
 	m := &Model{
 		deps:  d,
 		keys:  defaultKeys(),
 		issue: seed,
 		open:  map[int]bool{},
+	}
+	if share, chosen := config.LoadUIState().Split(ViewID); chosen {
+		m.split = split(share)
 	}
 	if m.deps.Theme == nil {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
@@ -107,6 +124,7 @@ func New(d kernel.Deps, seed jira.Issue) kernel.View {
 	for r := range regionCount {
 		m.marks[r] = marker(m.zones, zoneNames[r])
 	}
+	m.dividerMark = marker(m.zones, dividerZone)
 	if d.Jira != nil {
 		m.search = app.NewSearch(d.Jira)
 	}
@@ -165,17 +183,33 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case comment.WriteMsg, comment.EditMsg, comment.DeleteMsg:
 		cmd = m.commentAction(msg)
 
+	case splitFailedMsg:
+		// Said once: the split works either way, and a warning on every stroke
+		// would bury whatever came before it.
+		m.splitFailed = true
+		cmd = kernel.Warn("this split is not being remembered: " + msg.err.Error())
+
 	case tea.KeyPressMsg:
+		// Any key ends a gesture the pointer is in the middle of, which is what
+		// keeps the boundary from following a pointer nobody is watching.
+		m.cancelDrag()
 		cmd = m.key(msg)
 
 	case tea.MouseClickMsg:
 		m.clicked(msg)
 
+	case tea.MouseMotionMsg:
+		m.dragDivider(msg)
+		cmd = m.tell(msg)
+
+	case tea.MouseReleaseMsg:
+		cmd = join(m.dropDivider(msg), m.tell(msg))
+
 	case tea.MouseWheelMsg:
 		cmd = m.wheel(msg)
 
 	default:
-		cmd = join(m.editMsg(msg), m.tell(msg))
+		cmd = join(m.splitMsg(msg), join(m.editMsg(msg), m.tell(msg)))
 	}
 	// The regions are laid out here rather than only in View so that a key
 	// pressed before the first frame moves the content that is already in hand,
@@ -223,8 +257,10 @@ func (m *Model) stop() {
 func (m *Model) focused(on bool) tea.Cmd {
 	if !on {
 		// A pushed view that loses focus has either been popped or been covered,
-		// and either way nobody is waiting for this issue.
+		// and either way nobody is waiting for this issue — or is still holding
+		// its divider.
 		m.stop()
+		m.cancelDrag()
 		return m.tell(kernel.FocusMsg{})
 	}
 	if m.pushed {
@@ -242,6 +278,9 @@ func (m *Model) resize(w, h int) {
 	if w == m.width && h == m.height {
 		return
 	}
+	// The boundary was grabbed at a width that has gone, so the delta measured
+	// from the press means nothing now.
+	m.cancelDrag()
 	m.width, m.height = w, h
 	if len(m.blank) < w {
 		m.blank = strings.Repeat(" ", w)
@@ -260,7 +299,7 @@ func (m *Model) build() {
 	}
 	descW, sideW := m.contentWidths()
 	m.refresh(regionDetails, sideW, m.detailContent)
-	m.lay = newLayout(m.width, m.height, len(m.panes[regionDetails].lines), m.focus)
+	m.lay = newLayout(m.width, m.height, len(m.panes[regionDetails].lines), m.focus, m.split)
 	m.refresh(regionDesc, descW, m.descLines)
 	m.buildHeader()
 	for r := range regionCount {
@@ -285,7 +324,7 @@ func (m *Model) contentWidths() (desc, side int) {
 		w := max(m.width-gutter, 1)
 		return w, w
 	}
-	side = sideWidth(m.width)
+	side = sideWidth(m.width, m.split)
 	return max(m.width-side-divider-gutter, 1), max(side-gutter, 1)
 }
 
@@ -353,6 +392,12 @@ func (m *Model) key(msg tea.KeyPressMsg) tea.Cmd {
 		return m.pan(m.focus, -1)
 	case actRight:
 		return m.pan(m.focus, 1)
+	case actSidebar:
+		return m.moveDivider(-splitStep)
+	case actDescribe:
+		return m.moveDivider(splitStep)
+	case actReset:
+		return m.resetSplit()
 	case actComments:
 		return m.openComments()
 	case actEdit, actMove:
@@ -444,6 +489,14 @@ func (m *Model) foldAt(msg tea.MouseMsg) bool {
 }
 
 func (m *Model) clicked(msg tea.MouseClickMsg) {
+	if m.grabDivider(msg) {
+		return
+	}
+	// A press anywhere else ends a gesture whose release never arrived. The help
+	// overlay swallows everything from the mouse while it is up, so a boundary
+	// grabbed before ? was pressed is still held after it, and the next release
+	// would otherwise apply a delta measured from a press two gestures ago.
+	m.cancelDrag()
 	r, ok := m.regionAt(msg)
 	if !ok {
 		return

--- a/internal/ui/issue/keys.go
+++ b/internal/ui/issue/keys.go
@@ -21,9 +21,29 @@ type keyMap struct {
 	Pane     kernel.Binding
 	PrevPane kernel.Binding
 	Expands  kernel.Binding
+	Sidebar  kernel.Binding
+	Describe kernel.Binding
+	Reset    kernel.Binding
 	Edit     kernel.Binding
 	Move     kernel.Binding
 	Comments kernel.Binding
+}
+
+// The three strokes that move the boundary between the regions. Every letter
+// this pane has is spent on the document or on the issue, so punctuation is what
+// was left; < and > point the way the divider goes rather than naming a region,
+// which is the half that reads the same to a reader who came for the prose and
+// one who came for the fields.
+func sidebarBinding() kernel.Binding {
+	return kernel.Bind([]string{"<"}, "<", "wider sidebar")
+}
+
+func descriptionBinding() kernel.Binding {
+	return kernel.Bind([]string{">"}, ">", "wider description")
+}
+
+func resetBinding() kernel.Binding {
+	return kernel.Bind([]string{"="}, "=", "reset the split")
 }
 
 func defaultKeys() keyMap {
@@ -45,6 +65,9 @@ func defaultKeys() keyMap {
 		Pane:     kernel.Bind([]string{"tab"}, "tab", "next pane"),
 		PrevPane: kernel.Bind([]string{"shift+tab"}, "shift+tab", "previous pane"),
 		Expands:  kernel.Bind([]string{"z"}, "z", "expand or collapse"),
+		Sidebar:  sidebarBinding(),
+		Describe: descriptionBinding(),
+		Reset:    resetBinding(),
 		Edit:     editBinding(),
 		Move:     moveBinding(),
 		Comments: commentsBinding(),
@@ -71,6 +94,9 @@ const (
 	actPane
 	actPrevPane
 	actExpands
+	actSidebar
+	actDescribe
+	actReset
 	actEdit
 	actMove
 	actComments
@@ -108,6 +134,7 @@ var strokes = func() map[string]action {
 		{k.Go, actGo},
 		{k.Pane, actPane}, {k.PrevPane, actPrevPane},
 		{k.Expands, actExpands},
+		{k.Sidebar, actSidebar}, {k.Describe, actDescribe}, {k.Reset, actReset},
 		{k.Edit, actEdit}, {k.Move, actMove}, {k.Comments, actComments},
 	} {
 		for _, stroke := range pair.binding.Keys() {
@@ -125,7 +152,9 @@ var strokes = func() map[string]action {
 // only way to reach the fields and the thread at all, and above it the rails say
 // which region the keyboard is in. z is not: a description with no expand in it
 // has nothing for it to open, and the footer names what can be done rather than
-// every stroke the pane answers to.
+// every stroke the pane answers to. Nor are the three that move the divider:
+// below the breakpoint there is no divider on screen to move, and a row naming a
+// key that answers with a refusal is the failure principle 2 describes.
 func (k keyMap) keySet() kernel.KeySet {
 	return kernel.KeySet{
 		Acts: []kernel.Binding{
@@ -138,10 +167,13 @@ func (k keyMap) keySet() kernel.KeySet {
 		// columns shared with the globals, which take 47 of a 120-column screen,
 		// and the actions column another 21 — so a third motion column, or a
 		// description long enough to widen one of these two, pushes the globals
-		// off the right of it.
+		// off the right of it. The three splitting strokes go in the second
+		// column, whose key cell already holds shift+tab and whose widest
+		// sentence is still expand or collapse, so the row does not grow.
 		Full: [][]kernel.Binding{
 			{k.Down, k.Up, k.PageDown, k.PageUp, k.Right, k.Left},
-			{k.HalfDown, k.HalfUp, k.Top, k.Bottom, k.PrevPane, k.Expands},
+			{k.HalfDown, k.HalfUp, k.Top, k.Bottom, k.PrevPane, k.Expands,
+				k.Sidebar, k.Describe, k.Reset},
 			{k.Pane, k.Edit, k.Move, k.Comments},
 		},
 	}

--- a/internal/ui/issue/layout.go
+++ b/internal/ui/issue/layout.go
@@ -18,11 +18,18 @@ const (
 	// rather than taking its turn in front of it.
 	wideAt = 90
 
-	// sideMin and sideMax bound the sidebar. Thirty-five is labelWidth plus a
-	// value somebody can read; past forty-five a column of short values is
-	// spending width the description wants.
+	// sideMin and sideMax bound the sidebar the width alone chooses. Thirty-five
+	// is labelWidth plus a value somebody can read; past forty-five a column of
+	// short values is spending width the description wants. A reader who asks for
+	// more than forty-five gets it: sideMax is where the arithmetic stops, not
+	// where the sidebar does.
 	sideMin = 35
 	sideMax = 45
+
+	// descMin is the description's floor, gutter included: fifty-three cells of
+	// prose. Below that the same paragraph loses about two words a line, which is
+	// what layout_test measures rather than assumes.
+	descMin = 54
 
 	// gutter is every region's leftmost column: the focus rail and the
 	// scrollbar in one, which costs a column instead of a title bar's whole row.
@@ -78,10 +85,23 @@ type layout struct {
 	boxes [regionCount]box
 }
 
-// sideWidth is the sidebar's width in the wide mode. It is a function of the
-// pane's width alone so that the fields can be rendered before the layout that
-// places them.
-func sideWidth(w int) int { return min(max(w/3, sideMin), sideMax) }
+// sideWidth is the sidebar's width in the wide mode: the share the reader chose
+// where there is one, and a third of the pane where there is not, held between
+// the two floors either way. It is a function of the pane's width and that share
+// alone, so that the fields can be rendered before the layout that places them.
+func sideWidth(w int, s split) int {
+	if s <= 0 {
+		return clampSide(w, min(max(w/3, sideMin), sideMax))
+	}
+	return clampSide(w, s.cells(w))
+}
+
+// clampSide keeps the sidebar wide enough for a label and a value, and the
+// description wide enough to read a paragraph in. At ninety columns the two
+// floors meet, so the split there has exactly one legal value.
+func clampSide(w, sideW int) int {
+	return min(max(sideW, sideMin), max(w-divider-descMin, sideMin))
+}
 
 // newLayout places the regions.
 //
@@ -93,7 +113,7 @@ func sideWidth(w int) int { return min(max(w/3, sideMin), sideMax) }
 // In the narrow mode every region gets the same full-width box even though only
 // the focused one is drawn. Sizing the thread to a box that appears and vanishes
 // with the focus would reflow its whole content on every tab.
-func newLayout(w, h, detailsNeed int, focus region) layout {
+func newLayout(w, h, detailsNeed int, focus region, s split) layout {
 	l := layout{wide: w >= wideAt, paneH: max(h-headerHeight, 0), focus: focus}
 	if !l.wide {
 		full := box{y: headerHeight, w: max(w, gutter+1), h: l.paneH}
@@ -102,7 +122,7 @@ func newLayout(w, h, detailsNeed int, focus region) layout {
 		}
 		return l
 	}
-	sideW := sideWidth(w)
+	sideW := sideWidth(w, s)
 	descW := max(w-sideW-divider, gutter+1)
 	floor := max(l.paneH/3, minThread)
 	detailsH := min(max(detailsNeed, 1), max(l.paneH-floor, 1))

--- a/internal/ui/issue/layout_test.go
+++ b/internal/ui/issue/layout_test.go
@@ -29,7 +29,7 @@ func TestLayout_TheBreakpointIsWhereTheSidebarStartsFitting(t *testing.T) {
 	} {
 		m := &Model{width: tc.w}
 		desc, side := m.contentWidths()
-		lay := newLayout(tc.w, 28, 4, regionDesc)
+		lay := newLayout(tc.w, 28, 4, regionDesc, 0)
 		switch {
 		case lay.wide != tc.wide:
 			t.Errorf("%d columns is wide=%v, want %v", tc.w, lay.wide, tc.wide)

--- a/internal/ui/issue/render.go
+++ b/internal/ui/issue/render.go
@@ -173,7 +173,7 @@ func (m *Model) View() string {
 			continue
 		}
 		buf = m.appendRegion(buf, regionDesc, row)
-		buf = append(buf, ' ')
+		buf = m.appendDivider(buf, row)
 		if at := row - m.lay.boxes[regionDetails].h; at >= 0 {
 			buf = m.appendRegion(buf, regionComments, at)
 			continue

--- a/internal/ui/issue/sidebar.go
+++ b/internal/ui/issue/sidebar.go
@@ -98,6 +98,25 @@ func (m *Model) appendRegion(buf []byte, r region, row int) []byte {
 	return buf
 }
 
+// appendDivider writes the column between the description and the sidebar, with
+// the zone marker at the top of it and again at the bottom so that the rectangle
+// bubblezone records is the whole boundary rather than one cell of it.
+//
+// The column itself stays blank. A rule drawn here would stand next to the
+// sidebar's own gutter, and two vertical lines in adjacent columns say less than
+// one — so what says the boundary can be moved is the ? overlay, the palette and
+// docs/UX.md's gesture table, not a glyph.
+func (m *Model) appendDivider(buf []byte, row int) []byte {
+	if row == 0 {
+		buf = append(buf, m.dividerMark...)
+	}
+	buf = append(buf, ' ')
+	if row == m.lay.paneH-1 {
+		buf = append(buf, m.dividerMark...)
+	}
+	return buf
+}
+
 // appendWindow writes the w cells of a line that start at pan, with the theme's
 // ellipsis where there is still more of it to the right. Cutting is done here and
 // never at build time, because the same rendered line is drawn at every pan.

--- a/internal/ui/issue/split.go
+++ b/internal/ui/issue/split.go
@@ -1,0 +1,228 @@
+package issue
+
+import (
+	"strconv"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// dividerZone is the column between the description and the sidebar, marked so
+// that a press on it resolves the way every other press here does.
+const dividerZone = "divider"
+
+// splitStep is how far one stroke moves the divider. Four crosses the whole
+// range a 120-column terminal allows in eight strokes and still lands on a
+// column somebody meant.
+const splitStep = 4
+
+// split is the sidebar's share of the pane, out of config.SplitScale. Zero is a
+// reader who has not chosen one, and the width decides.
+//
+// A share rather than a column count, because the same terminal is not always
+// the same width: a choice made in a full-screen window has to mean something in
+// half of one.
+type split int
+
+// cells is the sidebar width this share asks for at this pane width, before the
+// floors are applied.
+func (s split) cells(w int) int {
+	return (int(s)*w + config.SplitScale/2) / config.SplitScale
+}
+
+// shareOf is the split a sidebar of this width is, at this pane width. It is the
+// inverse of cells over every width a terminal reaches, which is what lets a
+// chosen split be stored as a share and come back as the same column.
+func shareOf(w, sideW int) split {
+	if w <= 0 {
+		return 0
+	}
+	return split((sideW*config.SplitScale + w/2) / w)
+}
+
+// WidenSidebarMsg asks whichever detail pane is open to move the divider left,
+// giving the fields and the thread the room. It is how the command palette
+// reaches the same gesture the key does rather than a second implementation of
+// it: the palette knows which command was run and never which pane is on screen.
+type WidenSidebarMsg struct{}
+
+// WidenDescriptionMsg asks the open detail pane to move the divider right.
+type WidenDescriptionMsg struct{}
+
+// ResetSplitMsg asks the open detail pane to put the divider back where its
+// width alone would have put it.
+type ResetSplitMsg struct{}
+
+func init() {
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "issue.split.sidebar",
+		Title: "Widen the fields and the thread",
+		Group: "Issue",
+		Keys:  []string{sidebarBinding().Help().Key},
+		Run:   func(kernel.Deps) tea.Cmd { return kernel.Broadcast(WidenSidebarMsg{}) },
+	})
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "issue.split.description",
+		Title: "Widen the description",
+		Group: "Issue",
+		Keys:  []string{descriptionBinding().Help().Key},
+		Run:   func(kernel.Deps) tea.Cmd { return kernel.Broadcast(WidenDescriptionMsg{}) },
+	})
+	kernel.RegisterCommand(kernel.Command{
+		ID:    "issue.split.reset",
+		Title: "Put the split back where the width chooses",
+		Group: "Issue",
+		Keys:  []string{resetBinding().Help().Key},
+		Run:   func(kernel.Deps) tea.Cmd { return kernel.Broadcast(ResetSplitMsg{}) },
+	})
+}
+
+// splitMsg answers the palette's way to the three gestures the keys reach.
+func (m *Model) splitMsg(msg tea.Msg) tea.Cmd {
+	switch msg.(type) {
+	case WidenSidebarMsg:
+		return m.moveDivider(-splitStep)
+	case WidenDescriptionMsg:
+		return m.moveDivider(splitStep)
+	case ResetSplitMsg:
+		return m.resetSplit()
+	}
+	return nil
+}
+
+// canSplit reports whether this frame has a boundary on it at all. It reads the
+// width rather than the last layout, so a gesture that arrives before the first
+// frame is answered by the size the pane actually has.
+func (m *Model) canSplit() bool { return m.width >= wideAt }
+
+// moveDivider takes the boundary by cells, positively to the right, which is the
+// direction that gives the description the room. It answers with what has to be
+// said: a refusal where there is no split to move or no room left to move it in,
+// and otherwise the write that remembers where it now is.
+func (m *Model) moveDivider(by int) tea.Cmd {
+	if !m.canSplit() {
+		return m.noSplitHere()
+	}
+	m.cancelDrag()
+	was := sideWidth(m.width, m.split)
+	if m.setSide(was-by) == was {
+		return kernel.Warn(atFloor(by))
+	}
+	return m.keepSplit()
+}
+
+// resetSplit gives the divider back to the width, which is where it starts and
+// where a terminal that changes size wants it.
+func (m *Model) resetSplit() tea.Cmd {
+	if !m.canSplit() {
+		return m.noSplitHere()
+	}
+	m.cancelDrag()
+	if m.split == 0 {
+		return kernel.Warn("the split is already the one this width chooses")
+	}
+	m.split = 0
+	return m.keepSplit()
+}
+
+// noSplitHere is what the three gestures say below the breakpoint, where the
+// regions take the screen in turn and there is no boundary on it to move.
+func (m *Model) noSplitHere() tea.Cmd {
+	return kernel.Warn("the regions take the screen in turn below " + strconv.Itoa(wideAt) +
+		" columns, so there is no split to move; tab brings up the next one")
+}
+
+// atFloor names the floor a move ran into, in what the floor is for rather than
+// in cells: the numbers are measurements of what content needs and mean nothing
+// to somebody holding a key down.
+func atFloor(toward int) string {
+	if toward > 0 {
+		return "the fields are as narrow as a label and its value fit in"
+	}
+	return "the description is as narrow as a paragraph reads in"
+}
+
+// setSide puts the sidebar at a width, clamped to the floors, and answers with
+// the width it settled on so that a caller can tell a move from a refusal.
+func (m *Model) setSide(sideW int) int {
+	m.split = shareOf(m.width, clampSide(m.width, sideW))
+	return sideWidth(m.width, m.split)
+}
+
+// grabDivider starts a drag when a press landed on the boundary. The press is
+// what decides what is being dragged; nothing after it can change that, which is
+// why a release outside the column still lands on this divider.
+func (m *Model) grabDivider(msg tea.MouseClickMsg) bool {
+	if !m.canSplit() || msg.Button != tea.MouseLeft || !m.zones.Hit(dividerZone, msg) {
+		return false
+	}
+	m.dragFrom, m.dragSide = m.split, sideWidth(m.width, m.split)
+	return m.drag.Start(dividerZone, msg)
+}
+
+// dragDivider follows the pointer while the boundary is held.
+func (m *Model) dragDivider(msg tea.MouseMsg) {
+	if dx, _, ok := m.drag.Move(msg); ok {
+		m.dragTo(dx)
+	}
+}
+
+// dropDivider ends the gesture wherever the pointer is and remembers the split
+// it left behind. A press and release that never moved is a click on a
+// one-column target rather than a choice, and is not written down.
+func (m *Model) dropDivider(msg tea.MouseMsg) tea.Cmd {
+	dx, _, ok := m.drag.Release(msg)
+	if !ok {
+		return nil
+	}
+	m.dragTo(dx)
+	if dx == 0 {
+		return nil
+	}
+	return m.keepSplit()
+}
+
+// dragTo puts the boundary where a delta from the press asks for it. A delta of
+// zero puts the split back rather than recomputing it, because recomputing turns
+// whatever the width was choosing into a share pinned at that width — the same
+// frame today and a different one in a window of another size.
+func (m *Model) dragTo(dx int) {
+	if dx == 0 {
+		m.split = m.dragFrom
+		return
+	}
+	m.setSide(m.dragSide - dx)
+}
+
+// cancelDrag drops a gesture in progress and puts the split back where the press
+// found it, which is what a resize, a key or a view switch does to one.
+func (m *Model) cancelDrag() {
+	if !m.drag.Active() {
+		return
+	}
+	m.drag.Cancel()
+	m.split = m.dragFrom
+}
+
+// keepSplit writes the share to the cache directory, off the event loop. The
+// split already works when this runs, so a failure is reported rather than
+// undone — and said once, because a warning on every stroke would bury whatever
+// came before it.
+func (m *Model) keepSplit() tea.Cmd {
+	if m.splitFailed {
+		return nil
+	}
+	share := int(m.split)
+	return func() tea.Msg {
+		if err := config.SaveSplit(ViewID, share); err != nil {
+			return splitFailedMsg{err: err}
+		}
+		return nil
+	}
+}
+
+// splitFailedMsg reports that the split on screen is not the one the next
+// session will open with.
+type splitFailedMsg struct{ err error }

--- a/internal/ui/issue/split_test.go
+++ b/internal/ui/issue/split_test.go
@@ -1,0 +1,513 @@
+package issue
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	zone "github.com/lrstanley/bubblezone/v2"
+
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// ownCache points the split this test chooses at a directory of its own. The
+// pane writes the split it is left with to the cache directory and this package
+// shares one, so a test that chooses a split writes somewhere private — and
+// t.Setenv rules out t.Parallel, which is why nothing in this file runs in
+// parallel.
+func ownCache(t *testing.T) {
+	t.Helper()
+	t.Setenv("SARAL_CACHE_DIR", t.TempDir())
+}
+
+// splitPane is a pane with an issue read in full and a thread beside it, at a
+// size the sidebar fits at.
+func splitPane(t *testing.T, w, h int) (*driver, kernel.Deps, *jiratest.Fake) {
+	t.Helper()
+
+	f := newFake(8)
+	d := testDeps(f)
+	addComment(t, f, "PROJ-3", "Reproduced on staging, twice.")
+	full := readIssue(t, f, "PROJ-3")
+	full.Description = longDoc(20)
+	dr := newDriver(t, d, seedOf(t, f, "PROJ-3"), w, h)
+	dr.send(loadedMsg{gen: dr.m.gen, issue: full})
+	return dr, d, f
+}
+
+// boundary is where the divider was drawn, resolved the way a press resolves:
+// by zone lookup rather than by arithmetic. The manager records on a goroutine
+// of its own, so the zone is looked for until it appears.
+func boundary(t *testing.T, dr *driver, d kernel.Deps) *zone.ZoneInfo {
+	t.Helper()
+
+	id := dr.m.zones.ID(dividerZone)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		d.Zones.Scan(dr.m.View())
+		if at := d.Zones.Get(id); !at.IsZero() {
+			return at
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nothing on screen is marked %q", id)
+		}
+		runtime.Gosched()
+	}
+}
+
+func pressAt(x, y int) tea.MouseClickMsg {
+	return tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
+
+func motionAt(x, y int) tea.MouseMotionMsg {
+	return tea.MouseMotionMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
+
+func releaseAt(x, y int) tea.MouseReleaseMsg {
+	return tea.MouseReleaseMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
+
+// sideOf is the sidebar's width as this frame has it.
+func sideOf(m *Model) int { return m.lay.boxes[regionDetails].w }
+
+// The gesture the whole packet is about: grab the boundary, move it, and have
+// the panes follow. Both floors are measurements of what content needs, so a
+// pointer dragged past either one stops there rather than squeezing a pane into
+// something nobody can read.
+func TestSplit_ADragMovesTheBoundaryAndStopsAtBothFloors(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, dr, d)
+	if want := 120 - sideOf(dr.m) - divider; at.StartX != want {
+		t.Fatalf("the divider is marked at column %d, want %d", at.StartX, want)
+	}
+	if at.StartX != at.EndX {
+		t.Errorf("the divider is marked %d columns wide, want the one it draws", at.EndX-at.StartX+1)
+	}
+
+	y := at.StartY + 2
+	dr.send(pressAt(at.StartX, y))
+	if !dr.m.drag.Active() {
+		t.Fatal("a press on the divider started no drag")
+	}
+	if dr.m.focus != regionDesc {
+		t.Errorf("the press moved the keyboard to region %d; the divider belongs to neither side", dr.m.focus)
+	}
+
+	for _, tc := range []struct {
+		name string
+		x    int
+		side int
+	}{
+		{name: "four columns to the left", x: at.StartX - 4, side: 44},
+		{name: "twenty to the left", x: at.StartX - 20, side: 60},
+		{name: "past what the description can give up", x: at.StartX - 40, side: 65},
+		{name: "three columns to the right", x: at.StartX + 3, side: 37},
+		{name: "past what the sidebar can give up", x: at.StartX + 40, side: 35},
+	} {
+		dr.send(motionAt(tc.x, y))
+		if got := sideOf(dr.m); got != tc.side {
+			t.Errorf("%s put the sidebar at %d cells, want %d", tc.name, got, tc.side)
+		}
+		if got := dr.m.lay.boxes[regionDesc].w; got < descMin {
+			t.Errorf("%s left the description %d cells, under its floor of %d", tc.name, got, descMin)
+		}
+	}
+
+	dr.send(releaseAt(at.StartX-15, y))
+	if dr.m.drag.Active() {
+		t.Error("the release left a drag under way")
+	}
+	if got := sideOf(dr.m); got != 55 {
+		t.Errorf("the release settled the sidebar at %d cells, want the 55 the pointer was over", got)
+	}
+	// And the frame really is drawn to the split, not merely recorded at it.
+	if got := lineWidth(t, dr, 0); got != 120 {
+		t.Errorf("a row is %d cells wide after the drag, want the terminal's 120", got)
+	}
+}
+
+// A pointer that leaves the frame is still holding the divider it grabbed. The
+// gesture ends where the pointer is, which for a release above the pane means
+// the horizontal distance it travelled and nothing about the vertical.
+func TestSplit_AReleaseOutsideTheFrameStillEndsTheDrag(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, dr, d)
+
+	dr.send(pressAt(at.StartX, at.StartY+1))
+	dr.send(releaseAt(at.StartX-12, -40))
+
+	if dr.m.drag.Active() {
+		t.Error("a release off the top of the screen left the drag under way")
+	}
+	if got := sideOf(dr.m); got != 52 {
+		t.Errorf("the sidebar ended at %d cells, want the 52 the pointer had reached", got)
+	}
+}
+
+// A resize takes the width the delta was measured against away, so the gesture
+// it belongs to is dropped rather than applied against a pane of another size.
+func TestSplit_AResizeMidGestureCancelsTheDrag(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, dr, d)
+
+	dr.send(pressAt(at.StartX, at.StartY+1))
+	dr.send(motionAt(at.StartX-16, at.StartY+1))
+	if got := sideOf(dr.m); got != 56 {
+		t.Fatalf("the drag moved the sidebar to %d cells, want 56 before the resize", got)
+	}
+
+	dr.send(kernel.SizeMsg{Width: 140, Height: 30})
+	if dr.m.drag.Active() {
+		t.Error("the resize left the drag under way")
+	}
+	if got, want := sideOf(dr.m), sideWidth(140, 0); got != want {
+		t.Errorf("the cancelled drag left the sidebar at %d cells, want the %d the width chooses", got, want)
+	}
+
+	// The release the terminal still owes us applies nothing.
+	dr.send(releaseAt(at.StartX-30, at.StartY+1))
+	if got, want := sideOf(dr.m), sideWidth(140, 0); got != want {
+		t.Errorf("the release after the cancel moved the sidebar to %d cells, want %d", got, want)
+	}
+}
+
+// A key ends a gesture too, and then does its own job from where the press
+// started rather than from wherever the pointer had wandered.
+func TestSplit_AKeyCancelsTheDragAndThenActsOnTheSplitItFound(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, dr, d)
+	was := sideOf(dr.m)
+
+	dr.send(pressAt(at.StartX, at.StartY+1))
+	dr.send(motionAt(at.StartX-20, at.StartY+1))
+	dr.key("<")
+
+	if dr.m.drag.Active() {
+		t.Error("a keypress left the drag under way")
+	}
+	if got := sideOf(dr.m); got != was+splitStep {
+		t.Errorf("the sidebar is %d cells, want %d — one step from where the press found it", got, was+splitStep)
+	}
+}
+
+// The help overlay swallows everything from the mouse while it is up, so a
+// release can go missing. The next press is what ends the gesture it belonged
+// to, rather than that gesture's stale delta being applied to it.
+func TestSplit_APressElsewhereEndsAGestureWhoseReleaseNeverArrived(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, dr, d)
+	was := sideOf(dr.m)
+
+	dr.send(pressAt(at.StartX, at.StartY+1))
+	dr.send(motionAt(at.StartX-20, at.StartY+1))
+
+	fields := regionZone(t, dr, d, regionDetails)
+	dr.send(pressAt(fields.StartX+2, fields.StartY+1))
+	if dr.m.drag.Active() {
+		t.Error("a press in the fields left the divider held")
+	}
+	if got := sideOf(dr.m); got != was {
+		t.Errorf("the abandoned gesture left the sidebar at %d cells, want the %d the press found", got, was)
+	}
+
+	dr.send(releaseAt(at.StartX-40, at.StartY+1))
+	if got := sideOf(dr.m); got != was {
+		t.Errorf("the stale release moved the sidebar to %d cells, want %d", got, was)
+	}
+}
+
+// A release nobody pressed for, and a press on the boundary that never moved,
+// are the two gestures that must leave the split exactly as they found it — a
+// one-column target is easy to click by accident, and pinning a share there
+// would quietly stop the split following the width.
+func TestSplit_AClickOnTheBoundaryChoosesNothing(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, dr, d)
+
+	dr.send(pressAt(at.StartX, at.StartY+1))
+	dr.send(releaseAt(at.StartX, at.StartY+1))
+	if dr.m.split != 0 {
+		t.Errorf("a click on the boundary pinned a share of %d, want the width still choosing", dr.m.split)
+	}
+
+	dr.key("<", "<")
+	chosen := dr.m.split
+	dr.send(releaseAt(4, 4))
+	if dr.m.split != chosen {
+		t.Errorf("a release with nothing held moved the split from %d to %d", chosen, dr.m.split)
+	}
+}
+
+// The keyboard route is the same state by another road, because a drag is
+// mouse-only and docs/UX.md asks for three ways to everything.
+func TestSplit_TheKeysReachTheSameStateAsTheDrag(t *testing.T) {
+	ownCache(t)
+
+	// Both panes are built before either is touched: the first to choose a split
+	// writes it, and the second would otherwise open on it.
+	byKey, _, _ := splitPane(t, 120, 30)
+	byDrag, d, _ := splitPane(t, 120, 30)
+	at := boundary(t, byDrag, d)
+
+	byKey.key("<", "<", "<")
+	byDrag.send(pressAt(at.StartX, at.StartY+1))
+	byDrag.send(releaseAt(at.StartX-3*splitStep, at.StartY+1))
+
+	if byKey.m.split != byDrag.m.split {
+		t.Errorf("three strokes left the split at %d and the same drag at %d", byKey.m.split, byDrag.m.split)
+	}
+	if byKey.view() != byDrag.view() {
+		t.Errorf("the two routes draw different frames\n--- keys ---\n%s\n--- drag ---\n%s",
+			byKey.view(), byDrag.view())
+	}
+}
+
+// The palette is the third way, and it reaches the same three gestures the keys
+// do rather than a second implementation of them.
+func TestSplit_ThePaletteReachesTheSameThreeGestures(t *testing.T) {
+	ownCache(t)
+
+	dr, _, _ := splitPane(t, 120, 30)
+	was := sideOf(dr.m)
+
+	dr.send(WidenSidebarMsg{})
+	if got := sideOf(dr.m); got != was+splitStep {
+		t.Errorf("widening the sidebar from the palette gave it %d cells, want %d", got, was+splitStep)
+	}
+	dr.send(WidenDescriptionMsg{})
+	if got := sideOf(dr.m); got != was {
+		t.Errorf("widening the description from the palette left the sidebar at %d cells, want %d", got, was)
+	}
+	dr.send(WidenSidebarMsg{})
+	dr.send(ResetSplitMsg{})
+	if dr.m.split != 0 {
+		t.Errorf("resetting from the palette left a chosen split of %d", dr.m.split)
+	}
+	if got, want := sideOf(dr.m), sideWidth(120, 0); got != want {
+		t.Errorf("the reset left the sidebar at %d cells, want the %d the width chooses", got, want)
+	}
+}
+
+// Both floors refuse in words. Silence there is indistinguishable from a key
+// that is not bound at all, which is the thing a reader cannot act on.
+func TestSplit_AGestureWithNowhereLeftToGoSaysSo(t *testing.T) {
+	ownCache(t)
+
+	dr, _, _ := splitPane(t, 120, 30)
+	for range 10 {
+		dr.key("<")
+	}
+	if got := dr.lastStatus().Text; !strings.Contains(got, "description") {
+		t.Errorf("running the description into its floor said %q", got)
+	}
+	if got := dr.m.lay.boxes[regionDesc].w; got != descMin {
+		t.Errorf("the description settled at %d cells, want its floor of %d", got, descMin)
+	}
+	for range 10 {
+		dr.key(">")
+	}
+	if got := dr.lastStatus().Text; !strings.Contains(got, "fields") {
+		t.Errorf("running the sidebar into its floor said %q", got)
+	}
+	if got := sideOf(dr.m); got != sideMin {
+		t.Errorf("the sidebar settled at %d cells, want its floor of %d", got, sideMin)
+	}
+
+	dr.key("=")
+	dr.key("=")
+	if got := dr.lastStatus().Text; !strings.Contains(got, "already") {
+		t.Errorf("resetting a split that is already the default said %q", got)
+	}
+}
+
+// Below the breakpoint the regions take the screen in turn, so there is no
+// boundary on it. The keys say that rather than doing nothing, and there is
+// nothing marked for a press to land on.
+func TestSplit_TheNarrowModeSaysThereIsNoSplitToMove(t *testing.T) {
+	ownCache(t)
+
+	dr, d, _ := splitPane(t, 80, 20)
+	for _, stroke := range []string{"<", ">", "="} {
+		dr.key(stroke)
+		got := dr.lastStatus().Text
+		if !strings.Contains(got, "turn") || !strings.Contains(got, "tab") {
+			t.Errorf("%q at 80 columns said %q, which does not say why or what to do instead", stroke, got)
+		}
+		if dr.m.split != 0 {
+			t.Errorf("%q at 80 columns chose a split of %d anyway", stroke, dr.m.split)
+		}
+	}
+
+	id := dr.m.zones.ID(dividerZone)
+	d.Zones.Scan(dr.m.View())
+	if at := d.Zones.Get(id); !at.IsZero() {
+		t.Errorf("the narrow mode marked a divider at %d,%d", at.StartX, at.StartY)
+	}
+	if dr.m.drag.Active() {
+		t.Error("something started a drag with no divider on screen")
+	}
+}
+
+// The choice is a share of the pane rather than a column count, so it means the
+// same thing in a window of another size — and it comes back as the column it
+// was chosen at, at every width a terminal reaches.
+func TestSplit_AShareSurvivesTheWidthItWasChosenAt(t *testing.T) {
+	ownCache(t)
+
+	for w := wideAt; w <= 400; w++ {
+		for sideW := sideMin; sideW <= max(w-divider-descMin, sideMin); sideW++ {
+			if got := sideWidth(w, shareOf(w, sideW)); got != sideW {
+				t.Fatalf("%d cells at %d columns came back as %d", sideW, w, got)
+			}
+		}
+	}
+
+	dr, _, _ := splitPane(t, 120, 30)
+	dr.key("<", "<")
+	chosen := dr.m.split
+	if got := sideOf(dr.m); got != 48 {
+		t.Fatalf("two strokes put the sidebar at %d cells, want 48", got)
+	}
+	dr.send(kernel.SizeMsg{Width: 200, Height: 30})
+	if dr.m.split != chosen {
+		t.Errorf("a resize changed the share from %d to %d", chosen, dr.m.split)
+	}
+	if got, want := sideOf(dr.m), int(chosen)*200/config.SplitScale; got != want {
+		t.Errorf("the share gives %d cells of 200, want about %d", got, want)
+	}
+}
+
+// At ninety columns the two floors meet, so there is exactly one legal split and
+// the gesture says so rather than pretending to move.
+func TestSplit_AtTheBreakpointThereIsOnlyOneLegalSplit(t *testing.T) {
+	ownCache(t)
+
+	dr, _, _ := splitPane(t, wideAt, 28)
+	was := sideOf(dr.m)
+	for _, stroke := range []string{"<", ">"} {
+		dr.key(stroke)
+		if got := sideOf(dr.m); got != was {
+			t.Errorf("%q at %d columns moved the sidebar to %d cells; the floors leave it %d",
+				stroke, wideAt, got, was)
+		}
+		if got := dr.lastStatus().Text; !strings.Contains(got, "narrow") {
+			t.Errorf("%q at %d columns said %q", stroke, wideAt, got)
+		}
+	}
+}
+
+// The whole point of writing it down: the next pane opens where the last one was
+// left. The write is a command, so this only holds once the driver has run it.
+func TestSplit_TheChoiceIsThereWhenTheNextPaneOpens(t *testing.T) {
+	ownCache(t)
+
+	dr, _, f := splitPane(t, 120, 30)
+	dr.key("<", "<")
+	chosen := dr.m.split
+	if chosen == 0 {
+		t.Fatal("two strokes chose nothing")
+	}
+
+	next, ok := New(testDeps(f), seedOf(t, f, "PROJ-3")).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	if next.split != chosen {
+		t.Errorf("a fresh pane opened at %d, want the %d the last one was left at", next.split, chosen)
+	}
+
+	dr.key("=")
+	after, ok := New(testDeps(f), seedOf(t, f, "PROJ-3")).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	if after.split != 0 {
+		t.Errorf("a fresh pane opened at %d after the split was reset", after.split)
+	}
+}
+
+// A machine with nowhere to write is a first run, another copy of Saral holding
+// the directory, or a home that is not writable. The split still moves; it is
+// only not remembered, and it says so once rather than on every stroke.
+func TestSplit_SaysOnceWhenItCannotBeRemembered(t *testing.T) {
+	t.Setenv("SARAL_CACHE_DIR", "/dev/null/nowhere")
+
+	dr, _, _ := splitPane(t, 120, 30)
+	was := sideOf(dr.m)
+	dr.key("<")
+
+	if got := sideOf(dr.m); got != was+splitStep {
+		t.Errorf("the sidebar is %d cells, want %d; a failed write must not undo the split", got, was+splitStep)
+	}
+	said := 0
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "not being remembered") {
+			said++
+		}
+	}
+	if said != 1 {
+		t.Errorf("a split that cannot be written said so %d times, want once", said)
+	}
+	dr.key("<", "<")
+	said = 0
+	for _, status := range dr.statuses {
+		if strings.Contains(status.Text, "not being remembered") {
+			said++
+		}
+	}
+	if said != 1 {
+		t.Errorf("two more strokes brought the warning back; it was said %d times", said)
+	}
+}
+
+// Goldens at the three widths the sidebar exists at, with the split moved off
+// the one the width chooses. Ninety is in here because it is the width at which
+// the two floors meet, so what it proves is that the frame there is the same one
+// either way.
+func TestSplit_Goldens(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		w, h    int
+		strokes []string
+	}{
+		{name: "split_90x28", w: 90, h: 28, strokes: []string{"<", "<"}},
+		{name: "split_100x28", w: 100, h: 28, strokes: []string{"<"}},
+		{name: "split_120x38", w: 120, h: 38, strokes: []string{"<", "<", "<"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ownCache(t)
+			dr, _, _ := splitPane(t, tc.w, tc.h)
+			dr.key(tc.strokes...)
+			golden(t, tc.name+".golden", dr.view())
+		})
+	}
+}
+
+// lineWidth is how wide one row of the pane is drawn, measured the only way a
+// display string may be measured.
+func lineWidth(t *testing.T, dr *driver, row int) int {
+	t.Helper()
+
+	rows := strings.Split(dr.view(), "\n")
+	if row+headerHeight >= len(rows) {
+		t.Fatalf("the frame has %d rows, so row %d of the pane is not in it", len(rows), row)
+	}
+	return ansi.StringWidth(rows[row+headerHeight])
+}

--- a/internal/ui/issue/strokes_test.go
+++ b/internal/ui/issue/strokes_test.go
@@ -17,7 +17,8 @@ func TestStrokes_TheTableIsTheKeymapTurnedInsideOut(t *testing.T) {
 	for _, b := range []kernel.Binding{
 		k.Up, k.Down, k.PageUp, k.PageDown, k.HalfUp, k.HalfDown,
 		k.Go, k.Top, k.Bottom, k.Left, k.Right,
-		k.Pane, k.PrevPane, k.Expands, k.Edit, k.Move, k.Comments,
+		k.Pane, k.PrevPane, k.Expands, k.Sidebar, k.Describe, k.Reset,
+		k.Edit, k.Move, k.Comments,
 	} {
 		for _, stroke := range b.Keys() {
 			if other, clash := bound[stroke]; clash {
@@ -48,7 +49,7 @@ func TestStrokes_EveryMotionActionHasAStep(t *testing.T) {
 	}
 	for _, at := range []action{
 		actNone, actLeft, actRight, actGo, actPane, actPrevPane,
-		actExpands, actEdit, actMove, actComments,
+		actExpands, actSidebar, actDescribe, actReset, actEdit, actMove, actComments,
 	} {
 		if _, ok := steps[at]; ok {
 			t.Errorf("action %d is not a motion and has a step, so it would scroll as well", at)

--- a/internal/ui/issue/testdata/split_100x28.golden
+++ b/internal/ui/issue/testdata/split_100x28.golden
@@ -1,0 +1,28 @@
+PROJ-3  Investigate the onboarding wizard
+Story | Triage (to do) | Urgent | Ada Lovelace | updated 02 Mar 2025 16:00
+----------------------------------------------------------------------------------------------------
+#Paragraph 1 of something worth several lines when the pane  |Details                               
+#is narrow.                                                  |  Project      PROJ PROJ Project      
+#                                                            |  Reporter     Grace Hopper           
+#Paragraph 2 of something worth several lines when the pane  |  Created      02 Mar 2025 12:00      
+#is narrow.                                                  |Fields                                
+#                                                            |  customfield_13404 0|i00003:         
+#Paragraph 3 of something worth several lines when the pane  |PROJ-3 | 1 comment                    
+#is narrow.                                                  |--------------------------------------
+#                                                            |> Sam Tester | 02 Mar 2026 09:00      
+#Paragraph 4 of something worth several lines when the pane  |    Reproduced on staging, twice.     
+|is narrow.                                                  |                                      
+|                                                            |                                      
+|Paragraph 5 of something worth several lines when the pane  |                                      
+|is narrow.                                                  |                                      
+|                                                            |                                      
+|Paragraph 6 of something worth several lines when the pane  |                                      
+|is narrow.                                                  |                                      
+|                                                            |                                      
+|Paragraph 7 of something worth several lines when the pane  |                                      
+|is narrow.                                                  |                                      
+|                                                            |                                      
+|Paragraph 8 of something worth several lines when the pane  |                                      
+|is narrow.                                                  |                                      
+|                                                            |                                      
+|Paragraph 9 of something worth several lines when the pane  |                                      

--- a/internal/ui/issue/testdata/split_120x38.golden
+++ b/internal/ui/issue/testdata/split_120x38.golden
@@ -1,0 +1,38 @@
+PROJ-3  Investigate the onboarding wizard
+Story | Triage (to do) | Urgent | Ada Lovelace | updated 02 Mar 2025 16:00
+------------------------------------------------------------------------------------------------------------------------
+#Paragraph 1 of something worth several lines when the pane is      |Details                                            
+#narrow.                                                            |  Project      PROJ PROJ Project                   
+#                                                                   |  Reporter     Grace Hopper                        
+#Paragraph 2 of something worth several lines when the pane is      |  Created      02 Mar 2025 12:00                   
+#narrow.                                                            |Fields                                             
+#                                                                   |  customfield_13404 0|i00003:                      
+#Paragraph 3 of something worth several lines when the pane is      |PROJ-3 | 1 comment              write  edit  delete
+#narrow.                                                            |---------------------------------------------------
+#                                                                   |> Sam Tester | 02 Mar 2026 09:00                   
+#Paragraph 4 of something worth several lines when the pane is      |    Reproduced on staging, twice.                  
+#narrow.                                                            |                                                   
+#                                                                   |                                                   
+#Paragraph 5 of something worth several lines when the pane is      |                                                   
+#narrow.                                                            |                                                   
+#                                                                   |                                                   
+#Paragraph 6 of something worth several lines when the pane is      |                                                   
+#narrow.                                                            |                                                   
+#                                                                   |                                                   
+#Paragraph 7 of something worth several lines when the pane is      |                                                   
+#narrow.                                                            |                                                   
+|                                                                   |                                                   
+|Paragraph 8 of something worth several lines when the pane is      |                                                   
+|narrow.                                                            |                                                   
+|                                                                   |                                                   
+|Paragraph 9 of something worth several lines when the pane is      |                                                   
+|narrow.                                                            |                                                   
+|                                                                   |                                                   
+|Paragraph 10 of something worth several lines when the pane is     |                                                   
+|narrow.                                                            |                                                   
+|                                                                   |                                                   
+|Paragraph 11 of something worth several lines when the pane is     |                                                   
+|narrow.                                                            |                                                   
+|                                                                   |                                                   
+|Paragraph 12 of something worth several lines when the pane is     |                                                   
+|narrow.                                                            |                                                   

--- a/internal/ui/issue/testdata/split_90x28.golden
+++ b/internal/ui/issue/testdata/split_90x28.golden
@@ -1,0 +1,28 @@
+PROJ-3  Investigate the onboarding wizard
+Story | Triage (to do) | Urgent | Ada Lovelace | updated 02 Mar 2025 16:00
+------------------------------------------------------------------------------------------
+#Paragraph 1 of something worth several lines when the |Details                           
+#pane is narrow.                                       |  Project      PROJ PROJ Project  
+#                                                      |  Reporter     Grace Hopper       
+#Paragraph 2 of something worth several lines when the |  Created      02 Mar 2025 12:00  
+#pane is narrow.                                       |Fields                            
+#                                                      |  customfield_13404 0|i00003:     
+#Paragraph 3 of something worth several lines when the |PROJ-3 | 1 comment                
+#pane is narrow.                                       |----------------------------------
+#                                                      |> Sam Tester | 02 Mar 2026 09:00  
+#Paragraph 4 of something worth several lines when the |    Reproduced on staging, twice. 
+|pane is narrow.                                       |                                  
+|                                                      |                                  
+|Paragraph 5 of something worth several lines when the |                                  
+|pane is narrow.                                       |                                  
+|                                                      |                                  
+|Paragraph 6 of something worth several lines when the |                                  
+|pane is narrow.                                       |                                  
+|                                                      |                                  
+|Paragraph 7 of something worth several lines when the |                                  
+|pane is narrow.                                       |                                  
+|                                                      |                                  
+|Paragraph 8 of something worth several lines when the |                                  
+|pane is narrow.                                       |                                  
+|                                                      |                                  
+|Paragraph 9 of something worth several lines when the |                                  

--- a/internal/ui/keys_test.go
+++ b/internal/ui/keys_test.go
@@ -17,16 +17,19 @@ import (
 // A command that reaches a view by its footer slot names the view; its key is
 // the gesture that slot is reached by.
 var keyOwners = map[string]string{
-	"comments.write":    comment.ViewID,
-	"comments.edit":     comment.ViewID,
-	"comments.delete":   comment.ViewID,
-	"issue.comments":    issue.ViewID,
-	"issue.edit":        issue.ViewID,
-	"issue.transition":  issue.ViewID,
-	"issues.save-query": list.ViewID,
-	"issues.edit-query": list.ViewID,
-	"issues.all":        list.ViewID,
-	"issues.open":       list.ViewID,
+	"comments.write":          comment.ViewID,
+	"comments.edit":           comment.ViewID,
+	"comments.delete":         comment.ViewID,
+	"issue.comments":          issue.ViewID,
+	"issue.edit":              issue.ViewID,
+	"issue.transition":        issue.ViewID,
+	"issue.split.sidebar":     issue.ViewID,
+	"issue.split.description": issue.ViewID,
+	"issue.split.reset":       issue.ViewID,
+	"issues.save-query":       list.ViewID,
+	"issues.edit-query":       list.ViewID,
+	"issues.all":              list.ViewID,
+	"issues.open":             list.ViewID,
 }
 
 func TestCommands_TeachTheKeyTheirViewActuallyShows(t *testing.T) {

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -1,6 +1,6 @@
  saral | Commands                                                                          PROJ | example.atlassian.net 
 > what do you want to do?                                                                                               
------------------------------------------------------------------------------------------------------------- 22 commands
+------------------------------------------------------------------------------------------------------------ 25 commands
 > Follow the terminal's own colours             Appearance                                                              
   Turn colour off                               Appearance                                                              
   Use the dark theme                            Appearance                                                              
@@ -12,6 +12,9 @@
   Change this issue's status                    Issue                                                                  t
   Comment on this issue                         Issue                                                                  C
   Edit this issue                               Issue                                                                  e
+  Put the split back where the width chooses    Issue                                                                  =
+  Widen the description                         Issue                                                                  >
+  Widen the fields and the thread               Issue                                                                  <
   Clear the filter on these rows                Search                                                                  
   Edit this search                              Search                                                                 e
   Every issue in this project                   Search                                                                 a
@@ -23,8 +26,5 @@
   Show only rows with this row's status         Search                                                                  
   Show only rows with this row's type           Search                                                                  
   Unassigned issues                             Search                                                                  
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
                                                                                                                         
  Issues  enter run it  esc close                                                                                  ctrl+k

--- a/internal/ui/testdata/overlay_120x38.golden
+++ b/internal/ui/testdata/overlay_120x38.golden
@@ -20,6 +20,9 @@ t   change status    f/pgdn page down    g g       top                   esc   b
 C   comment          b/pgup page up      G         bottom                r     refresh
                      →/l    pan right    shift+tab previous pane         R     refetch everything
                      ←/h    pan left     z         expand or collapse
+                                         <         wider sidebar
+                                         >         wider description
+                                         =         reset the split
 
 issue.edit
 enter  change this field    ↓/j down    ←/h previous value    1-9   saved query           ctrl+k commands


### PR DESCRIPTION
## R5 — let the reader choose the split · closes #75

R4 shipped the two-pane issue view with `sideW = clamp(bodyW/3, 35, 45)`. It is computed and cannot
be changed, so a reader who wants more prose, or a wider sidebar for one long custom-field value, has
no way to ask. This binds `widget.Drag` — shipped by P3.3 and wired to nothing ever since — to the
column between the description and the sidebar, adds a keyboard and a palette route, and remembers
the ratio.

Horizontal panning (`h`/`l`) and expand folds (`z`) were already taken by R4 and are untouched.

### The drag

`internal/ui/issue` marks the divider column as a zone the way it marks a region — the marker at the
top of the column and again at the bottom, so what bubblezone records is a one-column rectangle over
the whole boundary. A press there starts the drag, motion recomputes `sideW` clamped to the floors,
release keeps it and writes it down.

Four things end a gesture without applying it: a resize (the width the delta was measured against has
gone), a key, a view switch, and **a press anywhere else**. That last one is not decoration — nothing
from the mouse reaches a view while the help overlay is up, so pressing `?` mid-drag swallows the
release and leaves the divider held. Without it, the next click's release applied a delta measured
from a press two gestures ago.

A press and release with no movement is a click on a one-column target rather than a choice, so it is
not written down: pinning the share there would silently stop the split following the width.

### The keyboard and the palette

`<` widens the sidebar, `>` widens the description, `=` gives the split back to the width — four cells
a stroke. Three palette commands reach the same three gestures by broadcast, the way `issue.edit` and
`issue.comments` already do.

**Key inventory before choosing.** The pane already spends `j/k`, `↑/↓`, `f/b/pgup/pgdn/space`,
`u/d/ctrl+u/ctrl+d`, `g`, `home/G/end`, `h/l/←/→`, `tab`, `shift+tab`, `z`, `e`, `t`, `C`; the kernel
takes `?`, `ctrl+k`, `q`, `esc`, `r`, `R`, `g` and `1`–`9`. Every letter is spent, so the punctuation
is what was left.

They are on the `?` overlay and **not** on the footer's action row, deliberately. The row names what
can be done to the *issue*; the split is a property of the window. And below 90 columns the keys have
nothing to move, so a row naming them there would name keys that answer with a refusal — the failure
principle 2 describes rather than a smaller version of it. They go in the overlay's second column,
whose key cell already holds `shift+tab` and whose widest sentence is still *expand or collapse*, so
the row does not grow: it is 116 of 120 columns before and after.

### The narrow mode, and 90 itself

Below 90 there is one region at a time and no boundary on screen. Nothing is marked, so a press
cannot start a drag; the three keys refuse in words — *the regions take the screen in turn below 90
columns, so there is no split to move; tab brings up the next one*.

At 90 exactly, the two floors meet: `sideMin` is 35 and `w - divider - descMin` is 35, so there is
exactly one legal split. The keys say which floor they ran into rather than pretending to move. The
same refusal covers both floors at every width. `=` on a split that is already the default says so.

### Where the ratio lives — and #63

**Not in the profile.** `config.UIState` writes `ui.toml` under the **cache** directory, keyed by
view id, holding the sidebar's share of the pane in permille.

Three reasons, and #63 is one of them. Onboarding rebuilds the profile it writes from a zero value
and the four fields it collects, so `Theme`, `Glyphs`, `Timeline` and the saved queries are dropped
whenever somebody re-runs setup to re-check a token — and a split kept there would be the fifth. That
bug is **neither fixed nor made worse here**: nothing was added to `config.Profile`, so there is
nothing new for the overwrite to eat. `TestSaveSplit_SurvivesAProfileBeingRebuiltFromAZeroValue`
performs that same overwrite and asserts the split is still there afterwards, and
`TestSave_WritesNoSplitIntoTheConfigFile` asserts it never reaches `config.toml` at all.

The other two reasons: a pane width belongs to the terminal it was chosen in rather than to a Jira
account, so two profiles on one machine want one answer and a `config.toml` handed to a colleague
should not carry your proportions; and `config.toml` is a file people hand-edit, which a number a
drag rewrites is not.

A **share** rather than a column count, so it means the same thing in a window of another size; the
encode/decode pair is asserted to round-trip for every legal column at every width from 90 to 400.
`SaveSplit` re-reads and merges under a mutex so one view's entry cannot lose another's; `LoadUIState`
answers with nothing where it cannot read — the answer `drafts.read` already gives. The write is a
`tea.Cmd`, and a failure is reported once on the status line rather than undoing a split that already
works.

### Budget — measured, not assumed

`internal/ui/issue/budget_test.go` asserts all three; numbers from an M2 Pro at `-count=6`.

| Benchmark | main | this branch |
|---|---|---|
| `BenchmarkIssueView` | 2 allocs, 9984 B, ~2.53–2.63 µs | 2 allocs, 9984 B, ~2.60–2.65 µs |
| `BenchmarkIssueViewNarrow` | 1 alloc, 2688 B, ~586 ns | 1 alloc, 2688 B, ~587 ns |
| `BenchmarkIssueRedraw200x60` | 2 allocs, 21504 B, ~4.47 µs | 2 allocs, 21504 B, ~4.57 µs |
| `BenchmarkIssueScroll` | 3 allocs, 10032 B, ~2.71 µs | 3 allocs, 10032 B, ~2.79 µs |
| `BenchmarkIssueDragFrame` | — | **2 allocs**, 9984 B, ~2.63 µs |
| `BenchmarkIssueDragHold` | — | 5 allocs, 10080 B, ~2.77 µs |
| `BenchmarkIssueDragMove` | — | 767 allocs, 315 kB, ~240 µs |
| `BenchmarkIssueResize` | — | 807 allocs, 318 kB, ~261 µs |

`allocs/op` and `B/op` are byte-identical to main on every pre-existing benchmark; the ns/op spread is
within the run-to-run variance seen on both sides (benchstat is not installed here and installing it
was out of scope).

**A frame during a drag costs what a frame at rest costs** — 2 against 2, the brief's requirement.
**A motion that moves the boundary nowhere costs no render**: 5 against the 3 a keystroke that moves
no memo pays, and the 2 extra are interface boxes rather than work — `widget.Drag.Move` takes a
`tea.MouseMsg` and the embedded thread takes a `tea.Msg`, and a message arrives in `Update` as
neither.

**A motion that does move it is honestly a resize**, and there is no cheaper true answer: both panes
have a width they have never been rendered at, and lines are what a width means. It measures at 767
allocations against the 807 the equivalent terminal resize costs, and 240 µs against a 16 ms
keystroke budget. The brief asked for "a frame during a drag does not allocate more than a frame at
rest" as a flat statement; that holds for the frame and for the motions that do not move the
boundary, and cannot hold for the ones that do unless the panes stop following the pointer — flagged
rather than fudged.

### Tests

`internal/ui/issue/split_test.go` (13 tests) and `internal/config/uistate_test.go` (7):

- a drag moving the boundary and stopping at both floors, with the description held above its floor
  at every step
- a release outside the frame (off the top of the screen) still ending the gesture
- a resize mid-gesture cancelling it, and the release that follows applying nothing
- a key cancelling it and then acting on the split the press found
- a press elsewhere ending a gesture whose release never arrived, plus a stale release changing
  nothing
- a click on the boundary that never moved choosing nothing
- the keyboard route reaching the same split *and the same frame* as the equivalent drag
- the palette reaching the same three gestures
- both floors and the already-default reset refusing in words
- the narrow mode's answer: the words, no split chosen, nothing marked to press
- the share round-tripping for every legal column at widths 90–400, and surviving a resize
- 90 columns having exactly one legal split
- the choice being there when the next pane opens, and gone again after `=`
- a machine with nowhere to write saying so once and not undoing the split
- goldens at 90, 100 and 120 with a non-default split (90's proves the frame is the same either way,
  since the floors meet there)
- config: round trip, keeping other views' entries, zero forgetting rather than recording, four
  unreadable-file cases, a write failure naming its path, surviving a profile rebuilt from a zero
  value, and never appearing in `config.toml`

### Ownership

Inside the packet's paths except for three files, all mechanical consequences of registering a
command and changing a key set, and each named here rather than slipped in:

- `internal/ui/keys_test.go` — three entries in `keyOwners`. The sweep lives above every view by
  design and fails with *add it to keyOwners* until it is told; it cannot be satisfied from inside
  `internal/ui/issue`. The alternative was registering the commands with no `Keys`, which is a lie
  when a key exists.
- `internal/ui/testdata/overlay_120x38.golden` and `internal/ui/palette/testdata/session_120x30.golden`
  — regenerated with `-update`. Three overlay rows and three palette rows. R4 (#114) touched the same
  two files for the same reason.

`widget.Drag`'s own doc comment still opens *"Nothing binds it yet"*, which is now false —
`internal/ui/widget` belongs to the kernel/mouse packet and is not this packet's to edit. Filed as a
follow-up; `docs/ARCHITECTURE.md` (which is owned here) is corrected.

### Checks

`go mod tidy` clean · `go vet` clean · `golangci-lint run` 0 issues · `scripts/checkleak.py` clean ·
stripped binary 11 MiB, under the 15 MiB gate · full suite run **six times, six green** (three under
`-race`). No `go.mod` change, no test weakened, deleted or skipped.
