### PR TITLE
feat(port): choose a person, a status, a priority or a label without writing JQL

### DIFF
--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -108,6 +108,32 @@ Three of them can hand you text no user should ever see.
 | live | `expand=schema` on `/search/jql` answers one entry per **requested** field, keyed by field id, and `names`/`schema` come back only if asked for — while each issue's own `expand` string lists them either way | That is enough to type a custom field in the same round trip, so a search need not call `/field` to decode its own answer. A query of nothing but system fields should not ask. Do not read the `expand` string as evidence anything was expanded. |
 | schema | `GET /issue/{key}` accepts `expand=schema`, one entry per field on the issue | Worth sending on a single-issue read: without it a custom field's value is typed by its shape alone, which cannot tell a number from a number-shaped string, or a sprint array from an option array. |
 
+## People, and the words a filter narrows by
+
+Everything in this section was read from one Cloud site in August 2026. It is the half of the API a
+filter picker lives on, and almost none of it is shaped like the rest.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| live | **`GET /rest/api/3/user/search` answers a bare JSON array.** No envelope, no `total`, no `isLast` — neither paginator in `pkg/jira/cloud/paginate.go` reads that shape | Decode it as a slice. It takes `startAt`/`maxResults` and a page past the end is `[]`, so a walk is possible; nothing here needs one, because a person is found by typing more rather than by paging. |
+| live | `?query=` **absent** is a 400 (`"The username or property query parameter must be provided"`); `?query=` **present and empty** is a 200 listing every account | So the parameter is always sent, including from the state a picker opens in. There is no way to ask this endpoint for nothing. |
+| live | **Matching is neither substring nor fuzzy.** A two-letter needle that appears inside the one human account's surname found nobody; the same account's two initials found it; and a needle that appears only inside the email address found it too | It is word-prefix, initials and email tokens, in some combination no read reveals. Nothing local reproduces it, type-ahead cannot narrow what it already holds — a longer needle can match what a shorter one did not — and the caller must rank what comes back rather than present Jira's order as its own. |
+| live | **`GET /rest/api/3/user/assignable/search?project=X` with no query answers only real people**, dropping app accounts. The measured site had **11 accounts, 10 of them `accountType:"app"`** | It is the endpoint a picker should prefer wherever a project is in hand, and not only for assigning: it is the difference between a readable list and a page of robots. Without a project it is a 400 in the classic envelope; with an unknown one, a 404 in the classic envelope. |
+| live | **`/user/assignable/multiProjectSearch` answers RFC 7807** (`detail: "Required parameter 'projectKeys' is not present."`) while its sibling one path up answers the classic envelope | Two error envelopes one path segment apart. `parseErrorBody` reads both; nothing may assume which a neighbouring route uses. |
+| live | **`GET /rest/api/3/user/bulk` defaults to `maxResults: 10`** whatever it was asked for, and answers `{self, startAt, maxResults, total, isLast, values}` — the Agile offset envelope, on a platform endpoint | Eleven ids came back as ten and `isLast: false`. It has to be walked even for a short list. |
+| live | **A bulk read answers JSON `null` inside `values`** for an id the site does not know, and `total` counts the ids **asked for** rather than the ones found | A decoder reading into a struct gets a zero value with an empty name, and a caller drawing a row per id puts a blank row on screen. Drop them — but count them first, or the offset walk ends a page early. |
+| live | **Three of eleven account ids contain a colon**: a numeric prefix, a colon, then a UUID. `url.Values` escapes it and Jira answers the escaped form with the raw one — the same body carried the escaped spelling in `self` and the raw one in `accountId` | Never build the query string by hand, and never compare two spellings of one id without decoding first. Anything that splits an id on a separator, or drops one into a JQL clause or a cache key, has to survive it. |
+| live | **One account answered to two different display names on two endpoints** — one name on `/user/search` and another on `/user/bulk`, same account id, same minute | A name is not an identity even within one site and one session. Join on `accountId`; a name hydrated later may differ from the one the picker showed. |
+| live | `emailAddress` is `""` on `/user/search` for an app account and the key is **absent entirely** on `/user/bulk` | Absent and empty are one answer here, but only because nothing may depend on an email at all: an account's privacy settings decide whether it is there. |
+| live | `accountType` is one of `atlassian`, `app`, `customer`. It is an enum and not display text, so unlike a status or a priority name it did not move between locales | `jira.AccountKind` labels with it; it must never filter. An app account is assigned work and reports issues exactly as a person does, so hiding one loses rows. |
+| live | **`/user/picker` and the JQL autocomplete endpoints wrap the matched span in HTML** — `<b>`, `<strong>` — inside the field they call `displayName`, and spell a person as `Name - email` in it. `/user/picker` also carries a localised prose `header` (`"Showing 1 of 1 matching users"`) | Neither is data: rendering one puts markup on screen, and the markup lands mid-grapheme on a non-ASCII value. `/user/picker` 400s in RFC 7807 without a `query`. Use `/user/search`. |
+| schema | A token without **Browse users and groups** (`USER_PICKER`, id 27, `type: GLOBAL`) cannot search users | The probe reads a 403 from `/user/search` as the refusal and shows the site's own sentence. No token without the permission was available to provoke it, so the 403 itself is unconfirmed. |
+| live | **`mypermissions` does not know `BROWSE_USERS`.** It answered `400 {"errorMessages":[],"errors":{"BROWSE_USERS":"Unrecognized permission"}}` — the Agile-shaped refusal, on a platform endpoint | The key is `USER_PICKER`. And since one unrecognised key fails the whole request, a probe that folds a new key into an existing list puts every capability in that list behind whether the site knows it. `CapPeople` calls the endpoint instead. |
+| live | **`GET /rest/api/3/project/{key}/statuses` answers a bare array of issue types, each with its own `statuses`**, and two types in one project can carry different ones | It is the only read that says which statuses a filter may offer. Each status carries `untranslatedName` and a nested `statusCategory`; a bad project key is a 404 in the classic envelope. |
+| live | `GET /rest/api/3/priority` is a **bare array**; `GET /rest/api/3/priority/search` is the paged envelope and adds `isDefault` | The bare one is deprecated. The order is the ranking order and is not alphabetical. On the measured site `isDefault` was `false` on all five, so nothing may assume one is flagged. |
+| live | **`GET /rest/api/3/label` ignores a `query`.** A narrowed request answered byte-identically to the unnarrowed one | So there is no server-side label search. Walk it — `{startAt, maxResults, total, isLast, values}` with `values` an array of **bare strings**, `maxResults` defaulting to 1000 — and filter locally. |
+| live | Labels are whatever anybody typed, and the measured site held a German one and a Japanese one among seventeen | A width taken with `len()` over one is wrong. `ansi.StringWidth`, as everywhere. The list came back sorted, and `startAt` past the end answers `values: []` with `isLast: true`. |
+
 ## Create screens and transitions
 
 | Source | Fact | Consequence |
@@ -139,6 +165,9 @@ Three of them can hand you text no user should ever see.
 | live | The site's feature switches and its working day | `GET /rest/api/3/configuration`: voting, watching, unassigned issues, sub-tasks, issue linking, time tracking and attachments, plus a `timeTrackingConfiguration` carrying working hours per day and days per week as **floats**. A "3d" estimate is three of *those* days, not seventy-two hours, so any conversion of `originalEstimateSeconds` to days reads them first |
 | live | Permissions | `GET /rest/api/3/mypermissions?permissions=…&projectKey=…` |
 | schema | The user's timezone | `GET /rest/api/3/myself` |
+| live | Who a filter may name | `GET /rest/api/3/user/search`, or `…/user/assignable/search?project=` where a project is in hand; ids resolve back through `GET /rest/api/3/user/bulk`. Never a display name — see People |
+| live | Which statuses a project's issue types can reach | `GET /rest/api/3/project/{key}/statuses`, per issue type, by **id** |
+| live | The site's priorities and its labels | `GET /rest/api/3/priority/search` and `GET /rest/api/3/label`. Both are site-wide; the label endpoint cannot be narrowed |
 | live | Which projects exist, and which this token can see | `GET /rest/api/3/project/search` — paginated, and the only endpoint that answers it. The port has no method for it, so onboarding derives keys from a `/search/jql` page instead, which answers a shorter question: what the account has touched, not what it could reach. And that page cannot be unbounded, so it cannot even ask for everything |
 
 ## Permissions, which is what the capability probe reads
@@ -214,7 +243,7 @@ do not, and no read tells you which kind you are holding.
 | live | Jira flags an ambiguous field with a bracketed clause name `Name[Field Type]`, and a field `name` may itself contain brackets | So the bracketed form is not reliably parseable either. Use `cf[NNNNN]` where it exists and the id otherwise. |
 | live | `PUT /rest/api/3/mypreferences/locale` is **eventually consistent** — minutes, not seconds — and `Accept-Language` on a request is **ignored outright** | There is no per-request language, so nothing can ask for a stable one, and a read straight after the write still answers in the old language. |
 | live | The language of `name` was seen **changing mid-session** on an account whose `locale` read `en_US`, with `/rest/api/3/status` answering English and `/issue/{key}/transitions` answering German **at the same instant** | Language is a property of neither the request, nor the account, nor reliably the endpoint. This single observation is the whole argument for the rule, and the reason a display name must never be cached as though it identified anything. |
-| live | Every person picker on a create screen carries a site-absolute `autoCompleteUrl` — except a group picker, which carries none, and a labels field, whose URL is on a **different API version** | `internal/ui` takes the port and never an adapter, so a view holding one cannot call it anyway. A picker offers the field's own `allowedValues` plus the authenticated account until the port grows a user search ([#69](https://github.com/varijkapil13/saral/issues/69)). |
+| live | Every person picker on a create screen carries a site-absolute `autoCompleteUrl` — except a group picker, which carries none, and a labels field, whose URL is on a **different API version** | `internal/ui` takes the port and never an adapter, so a view holding one cannot call it anyway, and it never needs to: `FindPeople` and `Labels` reach the same answers in domain terms. The URL stays unread. |
 | schema | `untranslatedName` appears on `/field` and **not** in createmeta | A form builder holding only a create screen cannot know it; join to the `/field` catalogue on the field id. |
 
 ## Boards differ from each other far more than the schema suggests
@@ -296,6 +325,12 @@ any poller on the first 429. Cost-based limits mean a burst of narrow requests b
   bodies above are trustworthy and the move's own caps, permissions and failure detail are not.
 - Whether `Retry-After` ever arrives as an HTTP-date. No 429 was provoked.
 - Whether `isAvailable` on a transition is ever `false` without asking for unavailable ones.
+- What `/user/search` answers a token that lacks **Browse users and groups**. The testbed account
+  held it, so the 403 the `CapPeople` probe is written around has never been seen. A site that
+  answers `200 []` instead would read as "nobody is here", which is the wrong sentence.
+- Whether `/user/search` caps `maxResults` the way `/search/jql` silently caps at 100. The measured
+  site had eleven accounts and never reached a cap, so `FindPeople` holds its own ceiling as well as
+  asking for one.
 
 Fixtures under `pkg/jira/jiratest/fixtures/` are corrected from a capture's **shape** and given
 invented words; captures themselves stay in the gitignored `testdata/live/`. A shape here marked

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,12 @@ type Client interface {
 	Task(ctx context.Context, ref TaskRef) (TaskStatus, error)
 	Plans(ctx context.Context) ([]Plan, error)
 	Me(ctx context.Context) (User, error)
+
+	FindPeople(ctx context.Context, q PeopleQuery) ([]User, error)
+	People(ctx context.Context, accountIDs []string) ([]User, error)
+	IssueTypeStatuses(ctx context.Context, projectKey string) ([]IssueTypeStatuses, error)
+	Priorities(ctx context.Context) ([]Priority, error)
+	Labels(ctx context.Context) (Page[string], error)
 }
 ```
 
@@ -113,6 +119,42 @@ Rules for the port:
   and anything that merges, caches or writes an issue back has to tell those apart.
 - **Every method takes `context.Context`** and must honour cancellation — views cancel in-flight
   work when they close.
+- **Nobody is named by a display name.** A person is chosen from `FindPeople`, stored as an account
+  id and drawn back through `People`; a status is chosen by id from `IssueTypeStatuses`. Both exist
+  because the alternative was measured and does not work: a name is localised, a name is not unique
+  on one site, and one account answered to two different names on two endpoints within a minute.
+
+### Filtering by a person, and by the site's own words
+
+The five methods above are one amendment rather than five, because `pkg/jira/port.go` is a serial
+`contract` change that blocks other work while it lands and the owner would rather block it once.
+They cover every facet a filter picker narrows by, and each carries a trap the signature is shaped
+around:
+
+- **`FindPeople` does not rank.** Jira's matching is undocumented and is neither substring nor fuzzy;
+  it takes word prefixes, initials and email tokens in a combination no read reveals, so a needle two
+  letters longer can match what a shorter one did not. Type-ahead therefore goes back to the site
+  rather than narrowing what it holds, and the caller ranks the answer instead of presenting Jira's
+  order as its own. `PeopleQuery.Project` is worth setting wherever a project is in hand even when the
+  search is not about assigning: the assignable endpoint drops app accounts, which on the measured
+  site was ten of eleven.
+- **`User.Kind` labels; it never filters.** An app account is assigned work and reports issues exactly
+  as a person does, so hiding one loses rows — but a site that is ten robots and one human is
+  unreadable without the distinction, which is what a picker sinks and badges by. It is
+  `AccountUnknown` on any read that did not carry an `accountType`, which is most of them.
+- **`People` answers fewer accounts than it was asked for.** An id this site does not know comes back
+  as a JSON `null` inside the page, and a blank row is worse than an absence, so the result is keyed
+  by `AccountID` and never by position.
+- **`IssueTypeStatuses` carries ids** because a status name is localised *and* a team-managed project
+  mints project-scoped statuses reusing the stock names, so two distinct ids answer to one string on
+  one site. It is per issue type because two types in one project run different workflows.
+- **`Labels` pages and cannot be narrowed.** The endpoint takes no query and ignores one sent anyway,
+  so a caller filters what it walked.
+
+`CapPeople` is the site-wide *Browse users and groups* permission, which a perfectly ordinary token
+can lack. Like every other negative here it is a `Capability` carrying the site's own sentence, and
+the two people methods raise a `*CapabilityError` naming `CapPeople` so that a picker can offer the
+ids it already holds instead of disappearing.
 
 ### Roles: what a caller asks for
 
@@ -127,6 +169,8 @@ type Prober         interface{ Capabilities(ctx, projectKey) (Capabilities, erro
 type Identifier     interface{ Me(ctx) (User, error) }
 type Searcher       interface{ Search(ctx, Query) (Page[Issue], error) }
 type FieldCatalogue interface{ Fields(ctx) ([]Field, error) }
+type PeopleFinder   interface{ FindPeople; People }
+type FilterVocabulary interface{ IssueTypeStatuses; Priorities; Labels }
 // … SchemaReader, IssueWriter, Mover, CommentReader, Commenter
 
 // SessionClient is the union of every role the views in this build call.
@@ -186,6 +230,7 @@ type Capabilities struct {
 	Boards         Capability // project has at least one board
 	Attachments    Capability // instance-wide setting
 	DeleteIssues   Capability
+	People         Capability // Browse users and groups, site-wide
 	Graphics       GraphicsMode // kitty | iterm2 | halfblocks | none
 	TimeZone       *time.Location
 	TimeZoneReason string // why the zone is not the account's own; empty when it is
@@ -209,6 +254,13 @@ may be an hour out.
 The probe is scoped to a project, because three of these are: boards belong to a project, and Jira
 scopes Move, Delete and Create as project permissions, so one token answers differently in two
 projects on one site. Probing with no project leaves those three unavailable with a reason saying so.
+`People` is site-wide and is therefore answered either way.
+
+Two probes ask `mypermissions` and four call the endpoint they are about. Calling it is preferred
+where there is an endpoint cheap enough to call: the refusal is then the site's own sentence about the
+thing that was actually refused, and `mypermissions` fails the **whole** request with a 400 when one
+key in it is unrecognised — so folding a new key into the existing list would put Bulk Change and
+Delete Issues behind whether this site knows that key.
 
 ## The UI kernel and its registries
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -560,6 +560,44 @@ of headroom under the 15 MiB binary gate. So the display renderer is written her
   signature is 79 cells and the widest description box at 120 columns is 78, so a code block is cut at
   every width the sidebar leaves and something had to reach the rest of it.
 
+## Filtering by a person · the port amendment first
+
+The owner, after a session with the issue list: *"there is no easy way to filter by person. I do not
+want to write JQL queries — this should be accessible on the UI."* The port had `Me` and nothing else
+about accounts, so a person could not be chosen at all, and the only person-ish filter narrowed
+already-fetched rows by **display name**. The picker is a later packet; the contract it codes against
+lands first, because `pkg/jira/port.go` blocks everyone while it is open.
+
+- [x] **FP.1 — The port amendment a filter picker needs** ·
+  [#69](https://github.com/varijkapil13/saral/issues/69) · `contract` · **owns**
+  `pkg/jira/{port,types,roles}.go`, `pkg/jira/cloud/{people,vocab,caps,assert}.go`,
+  `pkg/jira/jiratest/**` including `fixtures/**`, the tests for all of those,
+  `docs/{API-NOTES,ARCHITECTURE,ROADMAP}.md`
+  **One amendment covering every facet a filter narrows by, rather than five.** Five methods appended
+  to the port — `FindPeople`, `People`, `IssueTypeStatuses`, `Priorities`, `Labels` — plus
+  `jira.AccountKind` on `User`, `jira.PeopleQuery`, `jira.IssueTypeStatuses` and `CapPeople`. No
+  existing signature moved; `SessionClient` gains `PeopleFinder` and `FilterVocabulary`, which is
+  additive, and both adapters plus `pkg/jira/cloud/assert.go` pin the two roles at build time.
+  **The wire is not shaped like the rest of the API and the signatures are built around that.**
+  `/user/search` answers a **bare JSON array** that neither paginator here reads, 400s without a
+  `query` and lists everybody with an empty one. Its matching is undocumented and is neither substring
+  nor fuzzy — word prefixes, initials and email tokens — so `PeopleQuery.Match` says in the port's own
+  documentation that the caller ranks the answer and never presents Jira's order as its own.
+  `/user/bulk` defaults to **ten per page** whatever it is asked for and answers **JSON `null` inside
+  `values`** for an id the site does not know, which decodes into a blank row; those are counted for
+  the walk and then dropped, because a blank row is worse than an absence.
+  `AccountKind` **labels and never filters**: an app account is assigned work like a person, and the
+  measured site was ten apps and one human. `IssueTypeStatuses` carries **ids**, per issue type,
+  because a name is localised and a team-managed project mints project-scoped statuses reusing the
+  stock names. `Labels` cannot be narrowed — the endpoint ignores a `query`, measured byte-identical.
+  `CapPeople` probes *Browse users and groups* by **calling the endpoint** rather than by asking
+  `mypermissions` for a fifth key: one unrecognised key fails that whole request, so the existing four
+  would have gone behind whether a site knows the new one.
+  **A conformance table per role, run over both adapters**, because [#74](https://github.com/varijkapil13/saral/issues/74)
+  exists and five more methods must not be five more chances to drift: an unknown id is absent rather
+  than blank, a `Limit` is a ceiling, a refusal names `CapPeople`, a status is identified by its id,
+  and both sites hold two ids under one display name.
+
 ## Batch 4 — Attachments · parallel ×3
 
 - [ ] **P4.1 — List and download** · [#17](https://github.com/varijkapil13/saral/issues/17) · **owns** `pkg/jira/cloud/attachment.go`

--- a/pkg/jira/cloud/assert.go
+++ b/pkg/jira/cloud/assert.go
@@ -21,6 +21,9 @@ var (
 	_ jira.Mover          = (*Client)(nil)
 	_ jira.CommentReader  = (*Client)(nil)
 	_ jira.Commenter      = (*Client)(nil)
+	_ jira.PeopleFinder   = (*Client)(nil)
+
+	_ jira.FilterVocabulary = (*Client)(nil)
 
 	// The composite a session is built with.
 	_ jira.SessionClient = (*Client)(nil)

--- a/pkg/jira/cloud/caps.go
+++ b/pkg/jira/cloud/caps.go
@@ -54,7 +54,7 @@ func (c *Client) Capabilities(ctx context.Context, projectKey string) (jira.Capa
 	project := strings.TrimSpace(projectKey)
 	caps := jira.Capabilities{Graphics: capsDetectGraphics(os.Getenv)}
 
-	probes := []capsProbe{c.capsAttachments, c.capsTimeZone, c.capsPlans}
+	probes := []capsProbe{c.capsAttachments, c.capsTimeZone, c.capsPlans, c.capsPeople}
 	if project == "" {
 		capsWithoutProject(&caps)
 	} else {
@@ -241,6 +241,37 @@ func (c *Client) capsPlans(ctx context.Context) (capsApply, error) {
 		got.Reason = capsFailed("whether this token can read plans", err)
 	}
 	return func(caps *jira.Capabilities) { caps.Plans = got }, err
+}
+
+// capsPeople asks whether this token may look accounts up at all, by asking for
+// one account. Browse users and groups is a site-wide permission, so this runs
+// whether or not a project was named, and a refusal is a 403 the same way the
+// Plans API's is.
+//
+// It calls the endpoint rather than asking mypermissions for the permission
+// behind it, for two reasons. The answer is then the site's own sentence about
+// the search that was actually refused. And mypermissions fails the whole
+// request with a 400 when one key in it is unrecognised, so folding a fifth key
+// into the probe's list would put Bulk Change and Delete Issues behind whether
+// this site knows that key.
+func (c *Client) capsPeople(ctx context.Context) (capsApply, error) {
+	_, err := c.do(ctx, request{
+		method: http.MethodGet,
+		path:   peopleSearchPath,
+		// An empty query matches every account and is not the same as sending
+		// none, which is a 400. One row is all the question needs.
+		query: url.Values{"query": []string{""}, "maxResults": []string{"1"}},
+		kind:  "the site's accounts",
+		id:    peopleSearchPath,
+	})
+
+	var got jira.Capability
+	if err == nil {
+		got.OK = true
+	} else {
+		got.Reason = capsFailed("whether this token can look accounts up", err)
+	}
+	return func(caps *jira.Capabilities) { caps.People = got }, err
 }
 
 // capsBoards asks whether the project has a board. Absence is an ordinary

--- a/pkg/jira/cloud/caps_test.go
+++ b/pkg/jira/cloud/caps_test.go
@@ -91,14 +91,62 @@ func TestCapabilities_AnswersEveryCapabilityForATokenThatMayDoEverything(t *test
 		{name: "Boards", got: got.Boards, wantOK: true},
 		{name: "BulkMove", got: got.BulkMove, wantOK: true},
 		{name: "DeleteIssues", got: got.DeleteIssues, wantOK: true},
+		{name: "People", got: got.People, wantOK: true},
 		{name: "Plans", got: got.Plans, reason: capsPlansReason},
 	}
 	for _, tt := range tests {
 		capsAssert(t, tt.name, tt.got, tt.wantOK, tt.reason)
 	}
 
-	if served := len(s.Requests()); served != 5 {
+	if served := len(s.Requests()); served != 6 {
 		t.Errorf("the site served %d requests, want one per probe", served)
+	}
+}
+
+func TestCapabilities_SaysWhenThisTokenMayNotLookAccountsUp(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer(jiratest.WithStatus(http.MethodGet, peopleSearchPath,
+		http.StatusForbidden, "forbidden_browse_users.json"))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), capsProject)
+	if err != nil {
+		t.Fatalf("probing %s: %v", capsProject, err)
+	}
+	capsAssert(t, "People", got.People, false,
+		"You do not have the Browse users and groups global permission, which is required to search for users.")
+}
+
+// Browse users and groups is site-wide, so the answer does not depend on a
+// project and the probe still runs when there is none. It also asks with an
+// empty query rather than none: none is a 400, and empty matches everybody.
+func TestCapabilities_ProbesPeopleWithNoProjectAndAnEmptyQuery(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Capabilities(t.Context(), "")
+	if err != nil {
+		t.Fatalf("probing with no project: %v", err)
+	}
+	capsAssert(t, "People", got.People, true, "")
+
+	asked, err := url.ParseQuery(capsServed(t, s, peopleSearchPath).Query)
+	if err != nil {
+		t.Fatalf("reading the account query: %v", err)
+	}
+	if _, sent := asked["query"]; !sent {
+		t.Errorf("the probe sent no query parameter (%q), which is a 400 rather than an answer", asked.Encode())
+	}
+	if asked.Get("query") != "" {
+		t.Errorf("query = %q, want the empty one that matches every account", asked.Get("query"))
+	}
+	if asked.Get("maxResults") != "1" {
+		t.Errorf("maxResults = %q, want the one account that answers the question", asked.Get("maxResults"))
 	}
 }
 
@@ -548,6 +596,7 @@ func TestCapabilities_ProbesEachEndpointOnce(t *testing.T) {
 
 	for _, path := range []string{
 		capsPermissionsPath, capsConfigurationPath, capsMyselfPath, capsPlansPath, capsBoardsPath,
+		peopleSearchPath,
 	} {
 		if n := capsCount(s, path); n != 1 {
 			t.Errorf("%s was requested %d times, want once", path, n)

--- a/pkg/jira/cloud/conformance_people_test.go
+++ b/pkg/jira/cloud/conformance_people_test.go
@@ -1,0 +1,425 @@
+package cloud
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// One set of assertions, run against both adapters, for the five methods a
+// filter picker calls. Everything above the port is tested against the fake, so
+// a rule only the cloud adapter holds is a rule no test meets — the suite stays
+// green and the binary fails against a site.
+//
+// The cases are properties, not answers. The two adapters describe different
+// sites on purpose and cannot agree on who is in them; what they must agree on
+// is that an unknown id is absent rather than blank, that a ceiling is a
+// ceiling, that a refusal names CapPeople, and that a status is identified by
+// its id.
+
+type (
+	peopleBuilder func(*testing.T) jira.PeopleFinder
+	vocabBuilder  func(*testing.T) jira.FilterVocabulary
+)
+
+func peopleFromSite(t *testing.T, opts ...jiratest.ServerOption) jira.PeopleFinder {
+	t.Helper()
+
+	s := jiratest.NewServer(opts...)
+	t.Cleanup(s.Close)
+	c, _ := testClient(t, s.URL())
+	return c
+}
+
+func vocabFromSite(t *testing.T, opts ...jiratest.ServerOption) jira.FilterVocabulary {
+	t.Helper()
+
+	s := jiratest.NewServer(opts...)
+	t.Cleanup(s.Close)
+	c, _ := testClient(t, s.URL())
+	return c
+}
+
+// conformProject is a project both adapters have: EX is the fixture site's, and
+// the fake is given one under the same key.
+const conformProject = "EX"
+
+func conformFake(t *testing.T, opts ...jiratest.Option) *jiratest.Fake {
+	t.Helper()
+	return jiratest.New(append([]jiratest.Option{jiratest.WithProject(conformProject, jiratest.Scrum)}, opts...)...)
+}
+
+func TestFindPeople_BothAdaptersAnswerTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		cloud  peopleBuilder
+		fake   peopleBuilder
+		query  jira.PeopleQuery
+		assert func(*testing.T, []jira.User, error)
+	}{
+		{
+			name:  "an empty needle asks for everybody rather than nobody",
+			cloud: func(t *testing.T) jira.PeopleFinder { return peopleFromSite(t) },
+			fake:  func(t *testing.T) jira.PeopleFinder { return conformFake(t) },
+			query: jira.PeopleQuery{},
+			assert: func(t *testing.T, got []jira.User, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("searching with no needle: %v", err)
+				}
+				if len(got) == 0 {
+					t.Fatal("an empty needle came back with nobody, and it is the state a picker opens in")
+				}
+				conformNamesEverybody(t, got)
+			},
+		},
+		{
+			name:  "every account says what kind of account it is",
+			cloud: func(t *testing.T) jira.PeopleFinder { return peopleFromSite(t) },
+			fake:  func(t *testing.T) jira.PeopleFinder { return conformFake(t) },
+			query: jira.PeopleQuery{},
+			assert: func(t *testing.T, got []jira.User, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("searching with no needle: %v", err)
+				}
+				for _, u := range got {
+					if u.Kind == jira.AccountUnknown {
+						t.Errorf("%s (%s) came back with no kind, and a people read states one", u.DisplayName, u.AccountID)
+					}
+				}
+				// A site that is mostly robots is unreadable without the
+				// distinction, and one that hides them loses rows, so both
+				// adapters have to hold more than one kind.
+				kinds := make(map[jira.AccountKind]bool, len(got))
+				for _, u := range got {
+					kinds[u.Kind] = true
+				}
+				if len(kinds) < 2 {
+					t.Errorf("every account is a %v; the site is supposed to hold more than one kind", got[0].Kind)
+				}
+			},
+		},
+		{
+			name:  "a ceiling the caller named is a ceiling",
+			cloud: func(t *testing.T) jira.PeopleFinder { return peopleFromSite(t) },
+			fake:  func(t *testing.T) jira.PeopleFinder { return conformFake(t) },
+			query: jira.PeopleQuery{Limit: 2},
+			assert: func(t *testing.T, got []jira.User, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("searching with a ceiling: %v", err)
+				}
+				if len(got) > 2 {
+					t.Errorf("got %d accounts for a Limit of 2; a picker sized on Limit has nowhere to draw them", len(got))
+				}
+				if len(got) == 0 {
+					t.Error("a ceiling of two came back with nobody")
+				}
+			},
+		},
+		{
+			name: "a project the site does not have",
+			cloud: func(t *testing.T) jira.PeopleFinder {
+				return peopleFromSite(t, jiratest.WithStatus(
+					http.MethodGet, peopleAssignablePath, http.StatusNotFound, "not_found_board.json"))
+			},
+			fake:  func(t *testing.T) jira.PeopleFinder { return conformFake(t) },
+			query: jira.PeopleQuery{Project: "NOSUCH"},
+			assert: func(t *testing.T, got []jira.User, err error) {
+				t.Helper()
+				var missing *jira.NotFoundError
+				if !errors.As(err, &missing) {
+					t.Fatalf("got %+v, %T (%v); want a *jira.NotFoundError", got, err, err)
+				}
+			},
+		},
+		{
+			name: "a token that may not browse users",
+			cloud: func(t *testing.T) jira.PeopleFinder {
+				return peopleFromSite(t, jiratest.WithStatus(
+					http.MethodGet, peopleSearchPath, http.StatusForbidden, "forbidden_browse_users.json"))
+			},
+			fake: func(t *testing.T) jira.PeopleFinder {
+				return conformFake(t, jiratest.WithCapabilities(jiratest.NoPeople))
+			},
+			query:  jira.PeopleQuery{},
+			assert: conformRefusedPeople,
+		},
+	}
+
+	for _, tt := range cases {
+		for _, adapter := range []struct {
+			name string
+			open peopleBuilder
+		}{
+			{name: "cloud", open: tt.cloud},
+			{name: "fake", open: tt.fake},
+		} {
+			t.Run(tt.name+"/"+adapter.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, err := adapter.open(t).FindPeople(t.Context(), tt.query)
+				tt.assert(t, got, err)
+			})
+		}
+	}
+}
+
+func TestPeople_BothAdaptersAnswerTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		cloud  peopleBuilder
+		fake   peopleBuilder
+		ids    []string
+		assert func(*testing.T, []jira.User, error)
+	}{
+		{
+			name:  "an id this site does not know is absent, never a blank row",
+			cloud: func(t *testing.T) jira.PeopleFinder { return peopleFromSite(t) },
+			fake:  func(t *testing.T) jira.PeopleFinder { return conformFake(t) },
+			ids:   []string{"5b10a2844c20165700ede21g", "acct-ada", "nobody-at-all"},
+			assert: func(t *testing.T, got []jira.User, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("resolving account ids: %v", err)
+				}
+				if len(got) == 0 {
+					t.Fatal("an id the site does know resolved to nothing")
+				}
+				conformNamesEverybody(t, got)
+				for _, u := range got {
+					if u.AccountID == "nobody-at-all" {
+						t.Errorf("the site invented %+v for an id it does not have", u)
+					}
+				}
+			},
+		},
+		{
+			name:  "nobody asked for means nothing asked of the site",
+			cloud: func(t *testing.T) jira.PeopleFinder { return peopleFromSite(t) },
+			fake:  func(t *testing.T) jira.PeopleFinder { return conformFake(t) },
+			ids:   nil,
+			assert: func(t *testing.T, got []jira.User, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("resolving no ids at all: %v", err)
+				}
+				if len(got) != 0 {
+					t.Errorf("got %+v for no ids at all", got)
+				}
+			},
+		},
+		{
+			name: "a token that may not browse users",
+			cloud: func(t *testing.T) jira.PeopleFinder {
+				return peopleFromSite(t, jiratest.WithStatus(
+					http.MethodGet, peopleBulkPath, http.StatusForbidden, "forbidden_browse_users.json"))
+			},
+			fake: func(t *testing.T) jira.PeopleFinder {
+				return conformFake(t, jiratest.WithCapabilities(jiratest.NoPeople))
+			},
+			ids:    []string{"5b10a2844c20165700ede21g", "acct-ada"},
+			assert: conformRefusedPeople,
+		},
+	}
+
+	for _, tt := range cases {
+		for _, adapter := range []struct {
+			name string
+			open peopleBuilder
+		}{
+			{name: "cloud", open: tt.cloud},
+			{name: "fake", open: tt.fake},
+		} {
+			t.Run(tt.name+"/"+adapter.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, err := adapter.open(t).People(t.Context(), tt.ids)
+				tt.assert(t, got, err)
+			})
+		}
+	}
+}
+
+func TestFilterVocabulary_BothAdaptersAnswerTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		cloud vocabBuilder
+		fake  vocabBuilder
+		run   func(*testing.T, jira.FilterVocabulary)
+	}{
+		{
+			name:  "statuses are identified by id, because a name can be shared",
+			cloud: func(t *testing.T) jira.FilterVocabulary { return vocabFromSite(t) },
+			fake:  func(t *testing.T) jira.FilterVocabulary { return conformFake(t) },
+			run: func(t *testing.T, c jira.FilterVocabulary) {
+				t.Helper()
+				got, err := c.IssueTypeStatuses(t.Context(), conformProject)
+				if err != nil {
+					t.Fatalf("reading the statuses in %s: %v", conformProject, err)
+				}
+				if len(got) == 0 {
+					t.Fatal("the project came back with no issue types")
+				}
+
+				ids := make(map[string]map[string]bool)
+				for _, entry := range got {
+					if entry.Type.ID == "" {
+						t.Errorf("the issue type %q has no id", entry.Type.Name)
+					}
+					if len(entry.Statuses) == 0 {
+						t.Errorf("%q reaches no status at all", entry.Type.Name)
+					}
+					for _, status := range entry.Statuses {
+						if status.ID == "" {
+							t.Errorf("the status %q has no id", status.Name)
+						}
+						if status.Category == jira.CategoryUnknown {
+							t.Errorf("the status %q (%s) has no category", status.Name, status.ID)
+						}
+						if ids[status.Name] == nil {
+							ids[status.Name] = make(map[string]bool)
+						}
+						ids[status.Name][status.ID] = true
+					}
+				}
+				shared := false
+				for _, under := range ids {
+					shared = shared || len(under) > 1
+				}
+				if !shared {
+					t.Errorf("no display name in %v is shared by two ids, and both sites are supposed to hold one", ids)
+				}
+			},
+		},
+		{
+			name:  "there is no site-wide answer about statuses",
+			cloud: func(t *testing.T) jira.FilterVocabulary { return vocabFromSite(t) },
+			fake:  func(t *testing.T) jira.FilterVocabulary { return conformFake(t) },
+			run: func(t *testing.T, c jira.FilterVocabulary) {
+				t.Helper()
+				got, err := c.IssueTypeStatuses(t.Context(), "")
+				var invalid *jira.ValidationError
+				if !errors.As(err, &invalid) {
+					t.Fatalf("got %+v, %T (%v); want a *jira.ValidationError", got, err, err)
+				}
+				if _, named := invalid.For("projectKey"); !named {
+					t.Errorf("the refusal does not name projectKey: %v", invalid)
+				}
+			},
+		},
+		{
+			name:  "priorities come back in the site's order and not the alphabet",
+			cloud: func(t *testing.T) jira.FilterVocabulary { return vocabFromSite(t) },
+			fake:  func(t *testing.T) jira.FilterVocabulary { return conformFake(t) },
+			run: func(t *testing.T, c jira.FilterVocabulary) {
+				t.Helper()
+				got, err := c.Priorities(t.Context())
+				if err != nil {
+					t.Fatalf("reading the priorities: %v", err)
+				}
+				if len(got) < 2 {
+					t.Fatalf("got %d priorities, want the site's whole list", len(got))
+				}
+				names := make([]string, 0, len(got))
+				for _, p := range got {
+					if p.ID == "" {
+						t.Errorf("the priority %q has no id", p.Name)
+					}
+					names = append(names, p.Name)
+				}
+				if slices.IsSorted(names) {
+					t.Errorf("got %v, which is the alphabet; a priority list is in ranking order", names)
+				}
+			},
+		},
+		{
+			name:  "labels page, and one of them is not ASCII",
+			cloud: func(t *testing.T) jira.FilterVocabulary { return vocabFromSite(t) },
+			fake:  func(t *testing.T) jira.FilterVocabulary { return conformFake(t, jiratest.WithPageSize(3)) },
+			run: func(t *testing.T, c jira.FilterVocabulary) {
+				t.Helper()
+				page, err := c.Labels(t.Context())
+				if err != nil {
+					t.Fatalf("reading the labels: %v", err)
+				}
+				if !page.HasMore() {
+					t.Error("the whole site fitted on one page, so nothing here exercises the walk")
+				}
+				got, err := jira.Collect(t.Context(), page, 0)
+				if err != nil {
+					t.Fatalf("walking the labels: %v", err)
+				}
+				if len(got) == 0 {
+					t.Fatal("the site came back with no labels at all")
+				}
+				if slices.Contains(got, "") {
+					t.Errorf("an empty label reached the caller: %q", got)
+				}
+				// A label is whatever anybody typed, so a column measured with
+				// len() over one is wrong. Both sites carry one that proves it.
+				if !slices.ContainsFunc(got, func(l string) bool { return utf8.RuneCountInString(l) != len(l) }) {
+					t.Errorf("every label in %q is ASCII, and a real site's are not", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		for _, adapter := range []struct {
+			name string
+			open vocabBuilder
+		}{
+			{name: "cloud", open: tt.cloud},
+			{name: "fake", open: tt.fake},
+		} {
+			t.Run(tt.name+"/"+adapter.name, func(t *testing.T) {
+				t.Parallel()
+				tt.run(t, adapter.open(t))
+			})
+		}
+	}
+}
+
+// conformNamesEverybody holds both adapters to the rule a blank row breaks: an
+// account that reached a caller has an id to act on and a name to draw.
+func conformNamesEverybody(t *testing.T, got []jira.User) {
+	t.Helper()
+
+	for _, u := range got {
+		if strings.TrimSpace(u.AccountID) == "" || strings.TrimSpace(u.DisplayName) == "" {
+			t.Errorf("a row with nothing on it reached the caller: %+v", u)
+		}
+	}
+}
+
+func conformRefusedPeople(t *testing.T, got []jira.User, err error) {
+	t.Helper()
+
+	var refused *jira.CapabilityError
+	if !errors.As(err, &refused) {
+		t.Fatalf("got %+v, %T (%v); want a *jira.CapabilityError", got, err, err)
+	}
+	if refused.Capability != jira.CapPeople {
+		t.Errorf("Capability = %q, want %q so a caller can tell this refusal from every other", refused.Capability, jira.CapPeople)
+	}
+	if refused.Reason == "" {
+		t.Error("the refusal carries no reason, and the reason is what the UI shows instead of the picker")
+	}
+	if len(got) != 0 {
+		t.Errorf("the refusal came back with %+v attached", got)
+	}
+}

--- a/pkg/jira/cloud/people.go
+++ b/pkg/jira/cloud/people.go
@@ -1,0 +1,241 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const (
+	peopleSearchPath     = "/rest/api/3/user/search"
+	peopleAssignablePath = "/rest/api/3/user/assignable/search"
+	peopleBulkPath       = "/rest/api/3/user/bulk"
+)
+
+// peopleDefaultLimit is how many accounts a search asks for when the caller
+// names no ceiling. A picker shows a screenful and asks the user to type more.
+const peopleDefaultLimit = 50
+
+// peopleBulkChunk is how many account ids go into one /user/bulk request. They
+// travel in the query string, one parameter each, so the bound is on the length
+// of a URL rather than on anything Jira states.
+const peopleBulkChunk = 50
+
+// FindPeople searches the site's accounts.
+//
+// Two endpoints, and the query's project decides which. /user/assignable/search
+// answers only accounts that can be assigned work in that project, which drops
+// app accounts without being asked — on the site this was measured against that
+// was ten of eleven accounts. /user/search is the site-wide fallback.
+//
+// Neither is a ranking. What matches is Jira's own undocumented rule and the
+// order is Jira's own; jira.PeopleQuery is where that contract is written down
+// for the caller.
+func (c *Client) FindPeople(ctx context.Context, q jira.PeopleQuery) ([]jira.User, error) {
+	limit := peopleLimit(q.Limit)
+	query := url.Values{"maxResults": []string{strconv.Itoa(limit)}}
+	// query must be sent even when it is empty: absent is a 400, and empty
+	// matches every account. There is no way to ask this endpoint for nothing.
+	query.Set("query", q.Match)
+
+	r := request{
+		method: http.MethodGet,
+		path:   peopleSearchPath,
+		query:  query,
+		kind:   "the site's accounts",
+		id:     peopleSearchPath,
+	}
+	if project := strings.TrimSpace(q.Project); project != "" {
+		query.Set("project", project)
+		r.path, r.kind, r.id = peopleAssignablePath, "project", project
+	}
+
+	var body []peopleAccount
+	if err := c.doJSON(ctx, r, &body); err != nil {
+		return nil, peopleRefusal(err)
+	}
+	out := make([]jira.User, 0, min(limit, len(body)))
+	for _, account := range body {
+		// The ceiling is honoured here as well as asked for, because maxResults
+		// is a request rather than a promise: Jira caps it silently on other
+		// endpoints and never echoes what it used, so a caller sizing a picker
+		// on Limit cannot be left holding more rows than it has room for.
+		if len(out) >= limit {
+			break
+		}
+		if account.AccountID == "" {
+			continue
+		}
+		out = append(out, account.domain())
+	}
+	return out, nil
+}
+
+// People resolves account ids to accounts.
+//
+// /user/bulk answers a JSON null inside values for an id it does not know, which
+// decodes into an account with no id and no name. Those are dropped: a caller
+// asking for five ids and drawing five rows would put a blank one on screen, and
+// a blank row is worse than an absence. So the answer is keyed by AccountID, and
+// an id this site does not know is simply not in it.
+//
+// It also defaults to ten per page whatever it was asked for, so this pages even
+// for a list of eleven.
+func (c *Client) People(ctx context.Context, accountIDs []string) ([]jira.User, error) {
+	wanted := peopleIDs(accountIDs)
+	if len(wanted) == 0 {
+		// A bulk read with no accountId parameter is a 400. Nobody asked for
+		// anything, so there is nothing to report and nothing to ask.
+		return nil, nil
+	}
+
+	out := make([]jira.User, 0, len(wanted))
+	for chunk := range slices.Chunk(wanted, peopleBulkChunk) {
+		found, err := c.peopleChunk(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, found...)
+	}
+	return out, nil
+}
+
+func (c *Client) peopleChunk(ctx context.Context, chunk []string) ([]jira.User, error) {
+	page, err := offsetPages(ctx, c, func(startAt int) request {
+		return request{
+			method: http.MethodGet,
+			path:   peopleBulkPath,
+			query:  peopleBulkQuery(chunk, startAt),
+			kind:   "the site's accounts",
+			id:     peopleBulkPath,
+		}
+	}, peopleDecodeBulk)
+	if err != nil {
+		return nil, peopleRefusal(err)
+	}
+	walked, err := jira.Collect(ctx, page, 0)
+	if err != nil {
+		return nil, peopleRefusal(err)
+	}
+	out := make([]jira.User, 0, len(walked))
+	for _, u := range walked {
+		if u.AccountID != "" {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
+// peopleDecodeBulk keeps the unknown ids in the page it hands back, as zero
+// users. Dropping them here would shorten the page, and an offset walk ends on a
+// short page — so a chunk whose last ten ids are all unknown would stop the walk
+// with the rest of the ids unread.
+func peopleDecodeBulk(resp *response) (items []jira.User, total int, isLast bool, err error) {
+	slots, total, isLast, err := decodeAgilePage[*peopleAccount](resp, http.MethodGet+" "+peopleBulkPath)
+	if err != nil {
+		return nil, -1, false, err
+	}
+	out := make([]jira.User, len(slots))
+	for i, slot := range slots {
+		if slot != nil {
+			out[i] = slot.domain()
+		}
+	}
+	return out, total, isLast, nil
+}
+
+// peopleBulkQuery names every id in the chunk as its own parameter, which is
+// what this endpoint takes instead of a list. Two account ids on the measured
+// site contained a colon, and Jira answers a percent-encoded one with the raw
+// form, so nothing may build this string by hand or compare the two spellings.
+func peopleBulkQuery(chunk []string, startAt int) url.Values {
+	query := url.Values{
+		"accountId":  slices.Clone(chunk),
+		"maxResults": []string{strconv.Itoa(len(chunk))},
+	}
+	if startAt > 0 {
+		query.Set("startAt", strconv.Itoa(startAt))
+	}
+	return query
+}
+
+// peopleIDs drops the empty ids and the repeats. A repeat costs a row Jira would
+// have sent twice, and an empty one widens the request for nothing.
+func peopleIDs(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, id := range in {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
+			continue
+		}
+		if _, dup := seen[trimmed]; dup {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func peopleLimit(limit int) int {
+	if limit <= 0 {
+		return peopleDefaultLimit
+	}
+	return limit
+}
+
+// peopleRefusal names the capability on a 403, so a caller can tell the one
+// refusal it can act on — offer the ids it already holds instead of a picker —
+// from every other way a call can fail.
+func peopleRefusal(err error) error {
+	var refused *jira.CapabilityError
+	if !errors.As(err, &refused) || refused.Capability != "" {
+		return err
+	}
+	return &jira.CapabilityError{Capability: jira.CapPeople, Reason: refused.Reason}
+}
+
+// peopleAccount is a user as the people endpoints send one. The issue reader has
+// a decoder of its own that does not read accountType, so an account off an issue
+// carries no Kind and one from here does.
+type peopleAccount struct {
+	AccountID   string            `json:"accountId"`
+	AccountType string            `json:"accountType"`
+	DisplayName string            `json:"displayName"`
+	Email       string            `json:"emailAddress"`
+	Active      bool              `json:"active"`
+	TimeZone    string            `json:"timeZone"`
+	AvatarURLs  map[string]string `json:"avatarUrls"`
+}
+
+func (a peopleAccount) domain() jira.User {
+	out := jira.User{
+		AccountID:   a.AccountID,
+		DisplayName: a.DisplayName,
+		Email:       a.Email,
+		Active:      a.Active,
+		Kind:        jira.ParseAccountKind(a.AccountType),
+	}
+	for _, size := range avatarSizes {
+		if link := a.AvatarURLs[size]; link != "" {
+			out.AvatarURL = link
+			break
+		}
+	}
+	// A zone this machine has no database for is a rendering detail, never a
+	// reason to lose the account it belongs to.
+	if a.TimeZone != "" {
+		if loc, err := time.LoadLocation(a.TimeZone); err == nil {
+			out.TimeZone = loc
+		}
+	}
+	return out
+}

--- a/pkg/jira/cloud/people_test.go
+++ b/pkg/jira/cloud/people_test.go
@@ -1,0 +1,513 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// peopleColonID is the account id in the fixtures that carries a colon. Two of
+// the eleven accounts on the site this was measured against did, so it is not a
+// curiosity: it goes into a query parameter, and it is what a caller keys a
+// cache or builds a JQL clause with.
+const peopleColonID = "140022:example-app-0001"
+
+func peopleNames(users []jira.User) []string {
+	out := make([]string, 0, len(users))
+	for _, u := range users {
+		out = append(out, u.DisplayName)
+	}
+	return out
+}
+
+func TestFindPeople_ReadsTheBareArrayTheEndpointAnswers(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.FindPeople(t.Context(), jira.PeopleQuery{Match: "exa"})
+	if err != nil {
+		t.Fatalf("searching for accounts: %v", err)
+	}
+
+	// No envelope, no total, no isLast: neither paginator in this package reads
+	// this shape, which is why the search does not use one.
+	if len(got) != 5 {
+		t.Fatalf("got %d accounts (%v), want the five the site listed", len(got), peopleNames(got))
+	}
+	first := got[0]
+	if first.AccountID == "" || first.DisplayName == "" || first.AvatarURL == "" {
+		t.Errorf("the first account reads as %+v, want the id, name and avatar the site sent", first)
+	}
+	if first.TimeZone == nil {
+		t.Error("the account came back with no timezone, and the site names one")
+	}
+}
+
+func TestFindPeople_LabelsEachKindOfAccountWithoutHidingAny(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.FindPeople(t.Context(), jira.PeopleQuery{})
+	if err != nil {
+		t.Fatalf("searching for accounts: %v", err)
+	}
+
+	kinds := make(map[string]jira.AccountKind, len(got))
+	for _, u := range got {
+		kinds[u.DisplayName] = u.Kind
+	}
+	want := map[string]jira.AccountKind{
+		"Example User":    jira.AccountPerson,
+		"Second Example":  jira.AccountPerson,
+		"Retired Example": jira.AccountPerson,
+		"Nightly Runner":  jira.AccountApp,
+		"Portal Visitor":  jira.AccountCustomer,
+	}
+	for name, kind := range want {
+		if kinds[name] != kind {
+			t.Errorf("%s reads as %v, want %v", name, kinds[name], kind)
+		}
+	}
+	// An app account is assigned work and reports issues like anybody else, so
+	// the kind is a label a picker sinks and badges by, never a filter here.
+	if len(got) != len(want) {
+		t.Errorf("got %d accounts (%v), want every one the site listed", len(got), peopleNames(got))
+	}
+}
+
+func TestFindPeople_AsksTheAssignableEndpointWhenTheQueryNamesAProject(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.FindPeople(t.Context(), jira.PeopleQuery{Match: "exa", Project: "EX", Limit: 7})
+	if err != nil {
+		t.Fatalf("searching for accounts in EX: %v", err)
+	}
+
+	// The assignable endpoint answers only accounts that can be given work,
+	// which drops the app and the customer without being asked for that.
+	for _, u := range got {
+		if u.Kind != jira.AccountPerson {
+			t.Errorf("%s came back as %v from the assignable search", u.DisplayName, u.Kind)
+		}
+	}
+
+	asked := peopleQueryOn(t, s, peopleAssignablePath)
+	if asked.Get("project") != "EX" {
+		t.Errorf("project = %q, want the one the query named", asked.Get("project"))
+	}
+	if asked.Get("query") != "exa" {
+		t.Errorf("query = %q, want what the caller typed", asked.Get("query"))
+	}
+	if asked.Get("maxResults") != "7" {
+		t.Errorf("maxResults = %q, want the caller's own ceiling", asked.Get("maxResults"))
+	}
+	if n := peopleCount(s, peopleSearchPath); n != 0 {
+		t.Errorf("the site-wide search was called %d times as well", n)
+	}
+}
+
+// query absent is a 400 and query empty matches everybody, so the parameter is
+// always sent — including when the caller has typed nothing, which is the state
+// a picker opens in.
+func TestFindPeople_AlwaysSendsAQueryParameterEvenWhenItIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.FindPeople(t.Context(), jira.PeopleQuery{}); err != nil {
+		t.Fatalf("searching with no needle: %v", err)
+	}
+
+	asked := peopleQueryOn(t, s, peopleSearchPath)
+	if _, sent := asked["query"]; !sent {
+		t.Fatalf("no query parameter was sent (%q), and its absence is a 400", asked.Encode())
+	}
+	if asked.Get("query") != "" {
+		t.Errorf("query = %q, want the empty one", asked.Get("query"))
+	}
+	if asked.Get("maxResults") != "50" {
+		t.Errorf("maxResults = %q, want the adapter's own ceiling for a caller that named none", asked.Get("maxResults"))
+	}
+}
+
+func TestFindPeople_DropsAnEntryThatNamesNoAccount(t *testing.T) {
+	t.Parallel()
+
+	const body = `[{"accountId":"5b10a2844c20165700ede21g","displayName":"Example User","active":true},
+		{"displayName":"","active":true}]`
+
+	s := jiratest.NewServer(peopleAnswering(peopleSearchPath, body))
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.FindPeople(t.Context(), jira.PeopleQuery{})
+	if err != nil {
+		t.Fatalf("searching for accounts: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d accounts (%+v), want the one that names somebody", len(got), got)
+	}
+}
+
+func TestPeople_WalksThePagesTheBulkReadDefaultsTo(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.People(t.Context(), []string{"5b10a2844c20165700ede21g", peopleColonID, "5b10ffffffffffffffffffff"})
+	if err != nil {
+		t.Fatalf("resolving account ids: %v", err)
+	}
+
+	// Three ids asked for, two accounts back: the third is the JSON null the
+	// site answers for an id it does not know, and a blank row is worse than an
+	// absence. The second page is only reached because the null was counted.
+	if names := peopleNames(got); !slices.Equal(names, []string{"Example User", "Nightly Runner"}) {
+		t.Fatalf("got %v, want the two accounts the site knows and no blank row", names)
+	}
+	for _, u := range got {
+		if u.AccountID == "" || u.DisplayName == "" {
+			t.Errorf("a blank row reached the caller: %+v", u)
+		}
+	}
+	if n := peopleCount(s, peopleBulkPath); n != 2 {
+		t.Errorf("the bulk endpoint was called %d times, want the two pages it answers in", n)
+	}
+}
+
+func TestPeople_EscapesAnAccountIdThatCarriesAColon(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.People(t.Context(), []string{peopleColonID})
+	if err != nil {
+		t.Fatalf("resolving an account id with a colon in it: %v", err)
+	}
+	if !slices.ContainsFunc(got, func(u jira.User) bool { return u.AccountID == peopleColonID }) {
+		t.Fatalf("got %+v, want the account whose id carries a colon, spelt as the site spells it", got)
+	}
+
+	raw := peopleRawQueryOn(t, s, peopleBulkPath)
+	if !strings.Contains(raw, "accountId=140022%3Aexample-app-0001") {
+		t.Errorf("the id went on the wire as %q, want the colon percent-encoded", raw)
+	}
+	// The site answers the escaped form with the raw one, so the two spellings
+	// of one id must never be compared without decoding first.
+	asked := peopleQueryOn(t, s, peopleBulkPath)
+	if got := asked.Get("accountId"); got != peopleColonID {
+		t.Errorf("the decoded id is %q, want %q", got, peopleColonID)
+	}
+}
+
+func TestPeople_AsksForNothingWhenThereAreNoIdsToResolve(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	for name, ids := range map[string][]string{
+		"no ids at all":          nil,
+		"an empty list":          {},
+		"nothing but blank ones": {"", "   "},
+	} {
+		got, err := c.People(t.Context(), ids)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("%s came back with %+v", name, got)
+		}
+	}
+	// A bulk read with no accountId is a 400, so asking is worse than not.
+	if n := len(s.Requests()); n != 0 {
+		t.Errorf("the site was asked %d times for nobody", n)
+	}
+}
+
+func TestPeople_AsksForEachIdOnceHoweverManyTimesItWasNamed(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.People(t.Context(), []string{"a-1", " a-1 ", "a-2", "a-1"}); err != nil {
+		t.Fatalf("resolving repeated ids: %v", err)
+	}
+
+	asked := peopleQueryOn(t, s, peopleBulkPath)
+	if ids := asked["accountId"]; !slices.Equal(ids, []string{"a-1", "a-2"}) {
+		t.Errorf("the request named %v, want each id once", ids)
+	}
+}
+
+func TestPeople_ChunksALongListOfIdsAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	ids := make([]string, peopleBulkChunk+1)
+	for i := range ids {
+		ids[i] = "acct-" + strconv.Itoa(i)
+	}
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.People(t.Context(), ids); err != nil {
+		t.Fatalf("resolving %d ids: %v", len(ids), err)
+	}
+
+	for _, req := range s.Requests() {
+		asked, err := url.ParseQuery(req.Query)
+		if err != nil {
+			t.Fatalf("reading the bulk query: %v", err)
+		}
+		if n := len(asked["accountId"]); n > peopleBulkChunk {
+			t.Errorf("one request carried %d ids, want at most %d", n, peopleBulkChunk)
+		}
+	}
+	if n := peopleCount(s, peopleBulkPath); n < 2 {
+		t.Errorf("%d ids went out in %d requests, want more than one chunk", len(ids), n)
+	}
+}
+
+func TestPeople_ReportsARefusalRateLimitAndTransportFailureAsThemselves(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		path   string
+		call   func(context.Context, *Client) error
+		opt    func(path string) jiratest.ServerOption
+		assert func(*testing.T, error)
+	}{
+		{
+			name: "a search this token may not run",
+			path: peopleSearchPath,
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithStatus(http.MethodGet, path, http.StatusForbidden, "forbidden_browse_users.json")
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var refused *jira.CapabilityError
+				if !errors.As(err, &refused) {
+					t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+				}
+				if refused.Capability != jira.CapPeople {
+					t.Errorf("Capability = %q, want %q", refused.Capability, jira.CapPeople)
+				}
+				// The site knows which permission scheme refused and this client
+				// does not, so the sentence has to be the site's own.
+				if !strings.Contains(refused.Reason, "Browse users and groups") {
+					t.Errorf("Reason = %q, want the site's own words", refused.Reason)
+				}
+			},
+		},
+		{
+			name: "a site that is rate limiting",
+			path: peopleSearchPath,
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithRateLimit(http.MethodGet, path, 30*time.Second)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var limited *jira.RateLimitError
+				if !errors.As(err, &limited) {
+					t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+				}
+				if limited.RetryAfter != 30*time.Second {
+					t.Errorf("RetryAfter = %s, want the 30s the site asked for", limited.RetryAfter)
+				}
+			},
+		},
+		{
+			name: "a site that broke",
+			path: peopleSearchPath,
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithStatus(http.MethodGet, path, http.StatusInternalServerError, "")
+			},
+			assert: peopleWantTransport,
+		},
+		{
+			name: "an answer that is not JSON",
+			path: peopleSearchPath,
+			opt: func(path string) jiratest.ServerOption {
+				return peopleAnswering(path, "<html>a proxy answered instead</html>")
+			},
+			assert: peopleWantTransport,
+		},
+		{
+			name: "an answer that is the wrong JSON",
+			path: peopleSearchPath,
+			opt: func(path string) jiratest.ServerOption {
+				return peopleAnswering(path, `{"values":[]}`)
+			},
+			assert: peopleWantTransport,
+		},
+		{
+			name: "a bulk read this token may not run",
+			path: peopleBulkPath,
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.People(ctx, []string{"5b10a2844c20165700ede21g"})
+				return err
+			},
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithStatus(http.MethodGet, path, http.StatusForbidden, "forbidden_browse_users.json")
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var refused *jira.CapabilityError
+				if !errors.As(err, &refused) {
+					t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+				}
+				if refused.Capability != jira.CapPeople {
+					t.Errorf("Capability = %q, want %q", refused.Capability, jira.CapPeople)
+				}
+			},
+		},
+		{
+			name: "a bulk read whose body is the wrong JSON",
+			path: peopleBulkPath,
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.People(ctx, []string{"5b10a2844c20165700ede21g"})
+				return err
+			},
+			opt: func(path string) jiratest.ServerOption {
+				return peopleAnswering(path, `["not an envelope"]`)
+			},
+			assert: peopleWantTransport,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := jiratest.NewServer(tt.opt(tt.path))
+			defer s.Close()
+
+			c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+			var err error
+			if tt.call != nil {
+				err = tt.call(t.Context(), c)
+			} else {
+				_, err = c.FindPeople(t.Context(), jira.PeopleQuery{})
+			}
+			if err == nil {
+				t.Fatal("the failure came back as an answer")
+			}
+			tt.assert(t, err)
+		})
+	}
+}
+
+func TestFindPeople_HonoursACancelledContext(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	arrived := make(chan struct{})
+	var once sync.Once
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, peopleSearchPath, func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(arrived) })
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	c, _ := testClient(t, s.URL())
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.FindPeople(ctx, jira.PeopleQuery{})
+		errs <- err
+	}()
+
+	<-arrived
+	cancel()
+
+	if err := <-errs; !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the caller's own cancellation", err)
+	}
+}
+
+func peopleWantTransport(t *testing.T, err error) {
+	t.Helper()
+
+	var broken *jira.TransportError
+	if !errors.As(err, &broken) {
+		t.Fatalf("got %T (%v), want a *jira.TransportError", err, err)
+	}
+}
+
+func peopleAnswering(path, body string) jiratest.ServerOption {
+	return jiratest.WithHandler(http.MethodGet, path, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+func peopleRawQueryOn(t *testing.T, s *jiratest.Server, path string) string {
+	t.Helper()
+
+	for _, req := range s.Requests() {
+		if req.Path == path {
+			return req.Query
+		}
+	}
+	t.Fatalf("nothing was served for %s", path)
+	return ""
+}
+
+func peopleQueryOn(t *testing.T, s *jiratest.Server, path string) url.Values {
+	t.Helper()
+
+	asked, err := url.ParseQuery(peopleRawQueryOn(t, s, path))
+	if err != nil {
+		t.Fatalf("reading the query for %s: %v", path, err)
+	}
+	return asked
+}
+
+func peopleCount(s *jiratest.Server, path string) int {
+	n := 0
+	for _, req := range s.Requests() {
+		if req.Path == path {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/jira/cloud/vocab.go
+++ b/pkg/jira/cloud/vocab.go
@@ -1,0 +1,165 @@
+package cloud
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+const (
+	vocabPriorityPath = "/rest/api/3/priority/search"
+	vocabLabelPath    = "/rest/api/3/label"
+)
+
+// vocabPriorityBound is how many priorities a walk will take before it stops. A
+// site has a handful; the bound is there so that a paged endpoint answering
+// something unexpected cannot become an unbounded read on a first-paint path.
+const vocabPriorityBound = 500
+
+// vocabLabelPage is the page size the label endpoint is asked for. It is also
+// its own default, which is worth sending anyway: a walk whose page size comes
+// from the site changes length when the site does.
+const vocabLabelPage = 1000
+
+func vocabProjectStatusesPath(projectKey string) string {
+	return "/rest/api/3/project/" + url.PathEscape(projectKey) + "/statuses"
+}
+
+// IssueTypeStatuses lists each of a project's issue types with the statuses its
+// workflow can reach.
+//
+// The endpoint answers a bare array — no envelope, no paging — of issue types
+// each carrying its own statuses, so two types in one project can and do differ.
+// Each status arrives with its category nested inside it, which is the copy to
+// read: the name beside it is localised and, in a team-managed project, is
+// reused by a project-scoped status with a different id.
+func (c *Client) IssueTypeStatuses(ctx context.Context, projectKey string) ([]jira.IssueTypeStatuses, error) {
+	project := strings.TrimSpace(projectKey)
+	if project == "" {
+		return nil, &jira.ValidationError{Fields: []jira.FieldError{{
+			Field:   "projectKey",
+			Message: "a project is required: statuses are per project, and there is no site-wide answer to give",
+		}}}
+	}
+
+	var body []vocabIssueTypeStatuses
+	err := c.doJSON(ctx, request{
+		method: http.MethodGet,
+		path:   vocabProjectStatusesPath(project),
+		kind:   "project",
+		id:     project,
+	}, &body)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]jira.IssueTypeStatuses, 0, len(body))
+	for _, entry := range body {
+		out = append(out, entry.domain())
+	}
+	return out, nil
+}
+
+// Priorities lists the site's priorities in the order they rank in.
+//
+// It reads the paged /priority/search rather than the bare-array /priority,
+// which Atlassian deprecated. Both were seen answering; the paged one is the one
+// with a future.
+func (c *Client) Priorities(ctx context.Context) ([]jira.Priority, error) {
+	page, err := offsetPages(ctx, c, func(startAt int) request {
+		return request{
+			method: http.MethodGet,
+			path:   vocabPriorityPath,
+			query:  pagedQuery(nil, startAt, 0),
+			kind:   "the site's priorities",
+			id:     vocabPriorityPath,
+		}
+	}, func(resp *response) ([]jira.Priority, int, bool, error) {
+		rows, total, isLast, err := decodeAgilePage[vocabPriority](resp, http.MethodGet+" "+vocabPriorityPath)
+		if err != nil {
+			return nil, -1, false, err
+		}
+		out := make([]jira.Priority, 0, len(rows))
+		for _, row := range rows {
+			out = append(out, row.domain())
+		}
+		return out, total, isLast, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return jira.Collect(ctx, page, vocabPriorityBound)
+}
+
+// Labels lists every label in use on the site.
+//
+// The endpoint takes no query. One sent anyway is accepted and ignored — the
+// answer to a narrowed request was byte-identical to the unnarrowed one — so
+// nothing is sent, and a caller filtering by what somebody typed filters what it
+// walked rather than asking the site to.
+//
+// The values are bare strings, not objects, and they are whatever anyone has
+// ever typed: they carry non-ASCII, and a width taken with len() over one is
+// wrong.
+func (c *Client) Labels(ctx context.Context) (jira.Page[string], error) {
+	return offsetPages(ctx, c, func(startAt int) request {
+		return request{
+			method: http.MethodGet,
+			path:   vocabLabelPath,
+			query:  pagedQuery(nil, startAt, vocabLabelPage),
+			kind:   "the site's labels",
+			id:     vocabLabelPath,
+		}
+	}, func(resp *response) ([]string, int, bool, error) {
+		return decodeAgilePage[string](resp, http.MethodGet+" "+vocabLabelPath)
+	})
+}
+
+type vocabIssueTypeStatuses struct {
+	ID       string        `json:"id"`
+	Name     string        `json:"name"`
+	Subtask  bool          `json:"subtask"`
+	IconURL  string        `json:"iconUrl"`
+	Statuses []vocabStatus `json:"statuses"`
+}
+
+func (t vocabIssueTypeStatuses) domain() jira.IssueTypeStatuses {
+	out := jira.IssueTypeStatuses{
+		Type: jira.IssueType{ID: t.ID, Name: t.Name, Subtask: t.Subtask, IconURL: t.IconURL},
+	}
+	out.Statuses = make([]jira.Status, 0, len(t.Statuses))
+	for _, status := range t.Statuses {
+		out.Statuses = append(out.Statuses, status.domain())
+	}
+	return out
+}
+
+// vocabStatus is a status on a project's issue type. Its iconUrl is not read at
+// all: a status created through the API carries the bare site root there and one
+// a template made carries a placeholder, so no value of it renders anything.
+type vocabStatus struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Category *struct {
+		Key string `json:"key"`
+	} `json:"statusCategory"`
+}
+
+func (s vocabStatus) domain() jira.Status {
+	out := jira.Status{ID: s.ID, Name: s.Name}
+	if s.Category != nil {
+		out.Category = jira.ParseStatusCategory(s.Category.Key)
+	}
+	return out
+}
+
+type vocabPriority struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (p vocabPriority) domain() jira.Priority {
+	return jira.Priority{ID: p.ID, Name: p.Name}
+}

--- a/pkg/jira/cloud/vocab_test.go
+++ b/pkg/jira/cloud/vocab_test.go
@@ -1,0 +1,330 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+const (
+	vocabProject      = "EX"
+	vocabStatusesPath = "/rest/api/3/project/{key}/statuses"
+)
+
+func TestIssueTypeStatuses_ReadsEachTypesOwnWorkflow(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.IssueTypeStatuses(t.Context(), vocabProject)
+	if err != nil {
+		t.Fatalf("reading the statuses in %s: %v", vocabProject, err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d issue types, want the three the project has", len(got))
+	}
+
+	byName := make(map[string][]jira.Status, len(got))
+	for _, entry := range got {
+		if entry.Type.ID == "" {
+			t.Errorf("%q came back with no id, and an id is the only thing that identifies it", entry.Type.Name)
+		}
+		byName[entry.Type.Name] = entry.Statuses
+	}
+	// Two types in one project run different workflows, so "every status here"
+	// is a union and never one type's list.
+	if len(byName["Task"]) == len(byName["Bug"]) {
+		t.Errorf("Task and Bug both list %d statuses, and the fixture gives them different workflows", len(byName["Task"]))
+	}
+	if !slices.ContainsFunc(got, func(e jira.IssueTypeStatuses) bool { return e.Type.Subtask }) {
+		t.Error("no subtask type came back, and the answer covers every type in the project")
+	}
+}
+
+// A status name identifies nothing: it is localised, and a team-managed project
+// mints project-scoped statuses that reuse the stock names. Two ids under one
+// name is the shape that proves an id-keyed reader from a name-keyed one.
+func TestIssueTypeStatuses_CarriesTwoIdsUnderOneDisplayName(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.IssueTypeStatuses(t.Context(), vocabProject)
+	if err != nil {
+		t.Fatalf("reading the statuses in %s: %v", vocabProject, err)
+	}
+
+	ids := make(map[string]map[string]bool)
+	for _, entry := range got {
+		for _, status := range entry.Statuses {
+			if ids[status.Name] == nil {
+				ids[status.Name] = make(map[string]bool)
+			}
+			ids[status.Name][status.ID] = true
+			if status.Category == jira.CategoryUnknown {
+				t.Errorf("%s (%s) has no category, and the category is the only property that is the same on every site",
+					status.Name, status.ID)
+			}
+		}
+	}
+	if len(ids["In Review"]) < 2 {
+		t.Errorf(`"In Review" resolved to %v, want the two distinct ids one site can hold under one name`, ids["In Review"])
+	}
+}
+
+func TestIssueTypeStatuses_RefusesToAskWithoutAProject(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	for _, key := range []string{"", "   "} {
+		got, err := c.IssueTypeStatuses(t.Context(), key)
+		var invalid *jira.ValidationError
+		if !errors.As(err, &invalid) {
+			t.Fatalf("asking for %q gave %+v, %T (%v); want a *jira.ValidationError", key, got, err, err)
+		}
+		if _, named := invalid.For("projectKey"); !named {
+			t.Errorf("the refusal does not name projectKey: %v", invalid)
+		}
+	}
+	if n := len(s.Requests()); n != 0 {
+		t.Errorf("the site was asked %d times for a project nobody named", n)
+	}
+}
+
+func TestPriorities_KeepsTheSitesOwnOrderAndItsOwnNames(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	got, err := c.Priorities(t.Context())
+	if err != nil {
+		t.Fatalf("reading the priorities: %v", err)
+	}
+
+	names := make([]string, 0, len(got))
+	for _, p := range got {
+		if p.ID == "" {
+			t.Errorf("%q came back with no id", p.Name)
+		}
+		names = append(names, p.Name)
+	}
+	// Ranking order, which is neither alphabetical nor anything a client can
+	// derive: an administrator can add a priority and put it anywhere.
+	if want := []string{"Highest", "High", "Medium", "Someday"}; !slices.Equal(names, want) {
+		t.Errorf("got %v, want %v in the site's own order", names, want)
+	}
+}
+
+func TestLabels_WalksEveryPageOfBareStrings(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	page, err := c.Labels(t.Context())
+	if err != nil {
+		t.Fatalf("reading the labels: %v", err)
+	}
+	if total, ok := page.Count(); !ok || total != 5 {
+		t.Errorf("the first page reports %d labels (stated %v), want the 5 the site claims", total, ok)
+	}
+
+	got, err := jira.Collect(t.Context(), page, 0)
+	if err != nil {
+		t.Fatalf("walking the labels: %v", err)
+	}
+	want := []string{"cache-layer", "prüfung", "release-blocker", "wire-shape", "優先度"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if n := peopleCount(s, vocabLabelPath); n != 2 {
+		t.Errorf("the label endpoint was called %d times, want one per page", n)
+	}
+}
+
+// The endpoint takes no query and ignores one sent anyway — a narrowed request
+// answered byte-identically to the unnarrowed one — so sending one would teach a
+// caller that the site is filtering when it is not.
+func TestLabels_SendsNoQueryBecauseTheEndpointIgnoresOne(t *testing.T) {
+	t.Parallel()
+
+	s := jiratest.NewServer()
+	defer s.Close()
+
+	c, _ := testClient(t, s.URL())
+	if _, err := c.Labels(t.Context()); err != nil {
+		t.Fatalf("reading the labels: %v", err)
+	}
+
+	asked := peopleQueryOn(t, s, vocabLabelPath)
+	if _, sent := asked["query"]; sent {
+		t.Errorf("a query was sent (%q), and this endpoint does not narrow on one", asked.Encode())
+	}
+	if asked.Get("maxResults") == "" {
+		t.Error("no maxResults was sent, so the page size comes from the site and moves when it does")
+	}
+}
+
+func TestVocabulary_ReportsARefusalRateLimitAndTransportFailureAsThemselves(t *testing.T) {
+	t.Parallel()
+
+	calls := map[string]struct {
+		path string
+		run  func(context.Context, *Client) error
+	}{
+		"the statuses in a project": {
+			path: vocabStatusesPath,
+			run: func(ctx context.Context, c *Client) error {
+				_, err := c.IssueTypeStatuses(ctx, vocabProject)
+				return err
+			},
+		},
+		"the site's priorities": {
+			path: vocabPriorityPath,
+			run: func(ctx context.Context, c *Client) error {
+				_, err := c.Priorities(ctx)
+				return err
+			},
+		},
+		"the site's labels": {
+			path: vocabLabelPath,
+			run: func(ctx context.Context, c *Client) error {
+				_, err := c.Labels(ctx)
+				return err
+			},
+		},
+	}
+
+	failures := map[string]struct {
+		opt    func(path string) jiratest.ServerOption
+		assert func(*testing.T, error)
+	}{
+		"the token may not ask": {
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithStatus(http.MethodGet, path, http.StatusForbidden, "")
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var refused *jira.CapabilityError
+				if !errors.As(err, &refused) {
+					t.Fatalf("got %T (%v), want a *jira.CapabilityError", err, err)
+				}
+			},
+		},
+		"the site is rate limiting": {
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithRateLimit(http.MethodGet, path, 30*time.Second)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var limited *jira.RateLimitError
+				if !errors.As(err, &limited) {
+					t.Fatalf("got %T (%v), want a *jira.RateLimitError", err, err)
+				}
+				if limited.RetryAfter != 30*time.Second {
+					t.Errorf("RetryAfter = %s, want the 30s the site asked for", limited.RetryAfter)
+				}
+			},
+		},
+		"there is no such project": {
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithStatus(http.MethodGet, path, http.StatusNotFound, "")
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				var missing *jira.NotFoundError
+				if !errors.As(err, &missing) {
+					t.Fatalf("got %T (%v), want a *jira.NotFoundError", err, err)
+				}
+			},
+		},
+		"the site broke": {
+			opt: func(path string) jiratest.ServerOption {
+				return jiratest.WithStatus(http.MethodGet, path, http.StatusInternalServerError, "")
+			},
+			assert: peopleWantTransport,
+		},
+		"the answer is not JSON": {
+			opt: func(path string) jiratest.ServerOption {
+				return peopleAnswering(path, "<html>a proxy answered instead</html>")
+			},
+			assert: peopleWantTransport,
+		},
+		"the answer is the wrong JSON": {
+			opt: func(path string) jiratest.ServerOption {
+				return peopleAnswering(path, `"a string where a body should be"`)
+			},
+			assert: peopleWantTransport,
+		},
+	}
+
+	for name, call := range calls {
+		for failure, tt := range failures {
+			t.Run(name+"/"+failure, func(t *testing.T) {
+				t.Parallel()
+
+				s := jiratest.NewServer(tt.opt(call.path))
+				defer s.Close()
+
+				c, _ := testClient(t, s.URL(), WithRetry(RetryPolicy{Attempts: 1}))
+				err := call.run(t.Context(), c)
+				if err == nil {
+					t.Fatal("the failure came back as an answer")
+				}
+				tt.assert(t, err)
+			})
+		}
+	}
+}
+
+func TestVocabulary_HonoursACancelledContext(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	arrived := make(chan struct{})
+	var once sync.Once
+
+	s := jiratest.NewServer(jiratest.WithHandler(http.MethodGet, vocabStatusesPath, func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(arrived) })
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	c, _ := testClient(t, s.URL())
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := c.IssueTypeStatuses(ctx, vocabProject)
+		errs <- err
+	}()
+
+	<-arrived
+	cancel()
+
+	if err := <-errs; !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want the caller's own cancellation", err)
+	}
+}

--- a/pkg/jira/jiratest/fixtures/README.md
+++ b/pkg/jira/jiratest/fixtures/README.md
@@ -45,6 +45,27 @@ decoder that reads only the common one comes back empty rather than failing:
 envelope, and its issues carry an Agile `self` (`/rest/agile/1.0/issue/{id}`) with `/rest/api/2`
 links inside them, which is what that endpoint really sends.
 
+## Accounts, and the words a filter narrows by
+
+Five more shapes, none of them the shape beside it:
+
+| fixture | shape | what it is there to catch |
+|---|---|---|
+| `user_search.json` | a **bare array**, no envelope at all | neither paginator here reads it; it also holds all three `accountType`s, an inactive account, an id with a **colon** in it, and an app whose `emailAddress` is `""` |
+| `user_assignable.json` | the same bare array, people only | the assignable endpoint drops app accounts without being asked, which is the difference between a readable picker and a page of robots |
+| `user_bulk.json` / `user_bulk_page2.json` | the Agile offset envelope, on a platform endpoint | `values` carries a **JSON `null`** for an id the site does not know, and `total` counts the ids asked for — so the null has to be counted for the walk and dropped for the caller |
+| `project_statuses.json` | a bare array of issue types, each with its own `statuses` | two types in one project run different workflows, and **two distinct ids share the display name `In Review`**, which is what a team-managed project mints |
+| `priority_search.json` | the paged envelope, in ranking order | the order is not alphabetical, and `isDefault` is not always set on one of them |
+| `labels.json` / `labels_page2.json` | a paged envelope whose `values` are **bare strings** | one label is not ASCII, because a label is whatever anybody typed and a width taken with `len()` over one is wrong |
+
+`forbidden_browse_users.json` is the 403 a token without *Browse users and groups* is expected to
+get. It is hand-authored: the testbed account held the permission, so the refusal has never been seen
+and its wording is invented rather than corrected from a capture.
+
+The account ids here are the older opaque form plus one that carries a colon. A real colon id is a
+numeric prefix and a UUID, which is exactly the shape `TestFixtures_CarryNoRealAccountID` refuses, so
+the one here keeps the prefix and the colon and is visibly not a UUID.
+
 ## A site refuses in two different envelopes
 
 `not_found_board.json` is the Agile one: `errorMessages` empty, and the sentence in `errors` under

--- a/pkg/jira/jiratest/fixtures/forbidden_browse_users.json
+++ b/pkg/jira/jiratest/fixtures/forbidden_browse_users.json
@@ -1,0 +1,6 @@
+{
+  "errorMessages": [
+    "You do not have the Browse users and groups global permission, which is required to search for users."
+  ],
+  "errors": {}
+}

--- a/pkg/jira/jiratest/fixtures/labels.json
+++ b/pkg/jira/jiratest/fixtures/labels.json
@@ -1,0 +1,11 @@
+{
+  "maxResults": 3,
+  "startAt": 0,
+  "total": 5,
+  "isLast": false,
+  "values": [
+    "cache-layer",
+    "prüfung",
+    "release-blocker"
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/labels_page2.json
+++ b/pkg/jira/jiratest/fixtures/labels_page2.json
@@ -1,0 +1,10 @@
+{
+  "maxResults": 3,
+  "startAt": 3,
+  "total": 5,
+  "isLast": true,
+  "values": [
+    "wire-shape",
+    "優先度"
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/priority_search.json
+++ b/pkg/jira/jiratest/fixtures/priority_search.json
@@ -1,0 +1,45 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/priority/search?startAt=0",
+  "maxResults": 50,
+  "startAt": 0,
+  "total": 4,
+  "isLast": true,
+  "values": [
+    {
+      "self": "https://example.atlassian.net/rest/api/3/priority/1",
+      "statusColor": "#d04437",
+      "description": "Stops a release.",
+      "iconUrl": "https://example.atlassian.net/images/icons/priorities/highest_new.svg",
+      "name": "Highest",
+      "id": "1",
+      "isDefault": false
+    },
+    {
+      "self": "https://example.atlassian.net/rest/api/3/priority/2",
+      "statusColor": "#f15c75",
+      "description": "Wanted for this release.",
+      "iconUrl": "https://example.atlassian.net/images/icons/priorities/high_new.svg",
+      "name": "High",
+      "id": "2",
+      "isDefault": false
+    },
+    {
+      "self": "https://example.atlassian.net/rest/api/3/priority/3",
+      "statusColor": "#f79232",
+      "description": "Scheduled work.",
+      "iconUrl": "https://example.atlassian.net/images/icons/priorities/medium_new.svg",
+      "name": "Medium",
+      "id": "3",
+      "isDefault": true
+    },
+    {
+      "self": "https://example.atlassian.net/rest/api/3/priority/10100",
+      "statusColor": "#707070",
+      "description": "Worth doing if nothing else is waiting.",
+      "iconUrl": "https://example.atlassian.net/images/icons/priorities/low_new.svg",
+      "name": "Someday",
+      "id": "10100",
+      "isDefault": false
+    }
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/project_statuses.json
+++ b/pkg/jira/jiratest/fixtures/project_statuses.json
@@ -1,0 +1,131 @@
+[
+  {
+    "self": "https://example.atlassian.net/rest/api/3/issuetype/10001",
+    "id": "10001",
+    "name": "Task",
+    "subtask": false,
+    "statuses": [
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10000",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/",
+        "name": "Backlog",
+        "untranslatedName": "Backlog",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10001",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/images/icons/statuses/generic.png",
+        "name": "In Review",
+        "untranslatedName": "In Review",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/4",
+          "id": 4,
+          "key": "indeterminate",
+          "colorName": "yellow",
+          "name": "In Progress"
+        }
+      },
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10002",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Released",
+        "untranslatedName": "Released",
+        "id": "10002",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/3",
+          "id": 3,
+          "key": "done",
+          "colorName": "green",
+          "name": "Done"
+        }
+      }
+    ]
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/issuetype/10004",
+    "id": "10004",
+    "name": "Bug",
+    "subtask": false,
+    "statuses": [
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10000",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/",
+        "name": "Backlog",
+        "untranslatedName": "Backlog",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10002",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Released",
+        "untranslatedName": "Released",
+        "id": "10002",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/3",
+          "id": 3,
+          "key": "done",
+          "colorName": "green",
+          "name": "Done"
+        }
+      }
+    ]
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/issuetype/10005",
+    "id": "10005",
+    "name": "Sub-task",
+    "subtask": true,
+    "statuses": [
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10000",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/",
+        "name": "Backlog",
+        "untranslatedName": "Backlog",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      {
+        "self": "https://example.atlassian.net/rest/api/3/status/10007",
+        "description": "",
+        "iconUrl": "https://example.atlassian.net/",
+        "name": "In Review",
+        "untranslatedName": "In Review",
+        "id": "10007",
+        "statusCategory": {
+          "self": "https://example.atlassian.net/rest/api/3/statuscategory/4",
+          "id": 4,
+          "key": "indeterminate",
+          "colorName": "yellow",
+          "name": "In Progress"
+        }
+      }
+    ]
+  }
+]

--- a/pkg/jira/jiratest/fixtures/user_assignable.json
+++ b/pkg/jira/jiratest/fixtures/user_assignable.json
@@ -1,0 +1,36 @@
+[
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g",
+    "accountId": "5b10a2844c20165700ede21g",
+    "accountType": "atlassian",
+    "emailAddress": "user@example.com",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+      "24x24": "https://example.atlassian.net/secure/useravatar?size=small&ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+      "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall&ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10a2844c20165700ede21g&avatarId=10345"
+    },
+    "displayName": "Example User",
+    "active": true,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": false
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10ac8d82e05b22cc7d4ef5",
+    "accountId": "5b10ac8d82e05b22cc7d4ef5",
+    "accountType": "atlassian",
+    "emailAddress": "",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346",
+      "24x24": "https://example.atlassian.net/secure/useravatar?size=small&ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346",
+      "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall&ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346"
+    },
+    "displayName": "Second Example",
+    "active": true,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": false
+  }
+]

--- a/pkg/jira/jiratest/fixtures/user_bulk.json
+++ b/pkg/jira/jiratest/fixtures/user_bulk.json
@@ -1,0 +1,25 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/user/bulk?accountId=5b10a2844c20165700ede21g&accountId=140022%3Aexample-app-0001&accountId=5b10ffffffffffffffffffff&startAt=0&maxResults=2",
+  "maxResults": 2,
+  "startAt": 0,
+  "total": 3,
+  "isLast": false,
+  "values": [
+    {
+      "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g",
+      "accountId": "5b10a2844c20165700ede21g",
+      "accountType": "atlassian",
+      "emailAddress": "user@example.com",
+      "avatarUrls": {
+        "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+        "24x24": "https://example.atlassian.net/secure/useravatar?size=small&ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+        "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall&ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+        "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10a2844c20165700ede21g&avatarId=10345"
+      },
+      "displayName": "Example User",
+      "active": true,
+      "timeZone": "Europe/Berlin"
+    },
+    null
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/user_bulk_page2.json
+++ b/pkg/jira/jiratest/fixtures/user_bulk_page2.json
@@ -1,0 +1,21 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/user/bulk?accountId=5b10a2844c20165700ede21g&accountId=140022%3Aexample-app-0001&accountId=5b10ffffffffffffffffffff&startAt=2&maxResults=2",
+  "maxResults": 2,
+  "startAt": 2,
+  "total": 3,
+  "isLast": true,
+  "values": [
+    {
+      "self": "https://example.atlassian.net/rest/api/3/user?accountId=140022%3Aexample-app-0001",
+      "accountId": "140022:example-app-0001",
+      "accountType": "app",
+      "avatarUrls": {
+        "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=140022&avatarId=10350",
+        "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=140022&avatarId=10350"
+      },
+      "displayName": "Nightly Runner",
+      "active": true,
+      "timeZone": "Europe/Berlin"
+    }
+  ]
+}

--- a/pkg/jira/jiratest/fixtures/user_search.json
+++ b/pkg/jira/jiratest/fixtures/user_search.json
@@ -1,0 +1,80 @@
+[
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g",
+    "accountId": "5b10a2844c20165700ede21g",
+    "accountType": "atlassian",
+    "emailAddress": "user@example.com",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+      "24x24": "https://example.atlassian.net/secure/useravatar?size=small&ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+      "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall&ownerId=5b10a2844c20165700ede21g&avatarId=10345",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10a2844c20165700ede21g&avatarId=10345"
+    },
+    "displayName": "Example User",
+    "active": true,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": false
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10ac8d82e05b22cc7d4ef5",
+    "accountId": "5b10ac8d82e05b22cc7d4ef5",
+    "accountType": "atlassian",
+    "emailAddress": "",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346",
+      "24x24": "https://example.atlassian.net/secure/useravatar?size=small&ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346",
+      "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall&ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10ac8d82e05b22cc7d4ef5&avatarId=10346"
+    },
+    "displayName": "Second Example",
+    "active": true,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": false
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10ac8d82e05b22cc7d4a10",
+    "accountId": "5b10ac8d82e05b22cc7d4a10",
+    "accountType": "atlassian",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10ac8d82e05b22cc7d4a10&avatarId=10347",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10ac8d82e05b22cc7d4a10&avatarId=10347"
+    },
+    "displayName": "Retired Example",
+    "active": false,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": false
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=140022%3Aexample-app-0001",
+    "accountId": "140022:example-app-0001",
+    "accountType": "app",
+    "emailAddress": "",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=140022&avatarId=10350",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=140022&avatarId=10350"
+    },
+    "displayName": "Nightly Runner",
+    "active": true,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": false
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10ac8d82e05b22cc7d4b20",
+    "accountId": "5b10ac8d82e05b22cc7d4b20",
+    "accountType": "customer",
+    "emailAddress": "",
+    "avatarUrls": {
+      "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=5b10ac8d82e05b22cc7d4b20&avatarId=10351",
+      "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=5b10ac8d82e05b22cc7d4b20&avatarId=10351"
+    },
+    "displayName": "Portal Visitor",
+    "active": true,
+    "timeZone": "Europe/Berlin",
+    "locale": "en_GB",
+    "guest": true
+  }
+]

--- a/pkg/jira/jiratest/fixtures_test.go
+++ b/pkg/jira/jiratest/fixtures_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/varijkapil13/saral/pkg/adf"
 	"github.com/varijkapil13/saral/pkg/jira/jiratest"
@@ -195,15 +196,20 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 		"createmeta_task.json",
 		"field.json",
 		"field_localised.json",
+		"forbidden_browse_users.json",
 		"issue_rich_adf.json",
+		"labels.json",
+		"labels_page2.json",
 		"mypermissions_admin.json",
 		"mypermissions_basic.json",
 		"myself.json",
 		"not_found_board.json",
 		"plans_403.json",
 		"plans_ok.json",
+		"priority_search.json",
 		"problem_method_not_allowed.json",
 		"problem_no_endpoint.json",
+		"project_statuses.json",
 		"rate_limited.json",
 		"search_page1.json",
 		"search_page2.json",
@@ -213,6 +219,10 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 		"task_failed.json",
 		"task_running.json",
 		"transitions.json",
+		"user_assignable.json",
+		"user_bulk.json",
+		"user_bulk_page2.json",
+		"user_search.json",
 		"validation_error.json",
 		"versions.json",
 	}
@@ -220,6 +230,164 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Errorf("fixture set drifted:\n got %v\nwant %v", got, want)
 	}
+}
+
+// The shapes a filter picker reads, none of which is the shape beside it.
+func TestFixtures_CoverTheShapesAPeoplePickerReads(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an account search is a bare array with no envelope at all", func(t *testing.T) {
+		t.Parallel()
+
+		for _, name := range []string{"user_search.json", "user_assignable.json"} {
+			var rows []map[string]any
+			if err := json.Unmarshal(srvFixture(t, name), &rows); err != nil {
+				t.Fatalf("%s is not the bare array the endpoint answers: %v", name, err)
+			}
+			if len(rows) == 0 {
+				t.Fatalf("%s has no rows, so nothing decodes it wrongly and passes", name)
+			}
+			for _, row := range rows {
+				for _, key := range []string{"accountId", "accountType", "displayName"} {
+					if _, ok := row[key]; !ok {
+						t.Errorf("%s: an account sends no %s", name, key)
+					}
+				}
+			}
+		}
+	})
+
+	t.Run("the site-wide search answers every kind of account", func(t *testing.T) {
+		t.Parallel()
+
+		kinds := srvAccountTypes(t, "user_search.json")
+		for _, want := range []string{"atlassian", "app", "customer"} {
+			if !slices.Contains(kinds, want) {
+				t.Errorf("user_search.json lists %v, and a real site holds a %q too", kinds, want)
+			}
+		}
+		// The assignable endpoint drops the accounts that cannot be given work,
+		// which is a shape claim and not a convenience: it is what makes the
+		// scoped search readable on a site that is mostly robots.
+		for _, kind := range srvAccountTypes(t, "user_assignable.json") {
+			if kind != "atlassian" {
+				t.Errorf("user_assignable.json lists a %q account, and the endpoint answers only people", kind)
+			}
+		}
+	})
+
+	t.Run("an account id can carry a colon", func(t *testing.T) {
+		t.Parallel()
+
+		found := false
+		for _, row := range srvAccounts(t, "user_search.json") {
+			id, _ := row["accountId"].(string)
+			found = found || strings.Contains(id, ":")
+		}
+		if !found {
+			t.Error("no account id carries a colon, and anything that splits an id or builds a JQL clause has to survive one")
+		}
+	})
+
+	t.Run("a bulk read answers null for an id the site does not know", func(t *testing.T) {
+		t.Parallel()
+
+		page := srvDecode(t, srvFixture(t, "user_bulk.json"))
+		values, ok := page["values"].([]any)
+		if !ok || len(values) == 0 {
+			t.Fatalf("user_bulk.json values = %v, want the array the envelope carries", page["values"])
+		}
+		if !slices.Contains(values, nil) {
+			t.Error("no entry is null, and a null is what an unknown id decodes into as a blank row")
+		}
+		// The pages have to chain, or the walk that counts the null never
+		// reaches the account after it.
+		if last, _ := page["isLast"].(bool); last {
+			t.Error("the first page says isLast, so the second is never asked for")
+		}
+		if final, _ := srvDecode(t, srvFixture(t, "user_bulk_page2.json"))["isLast"].(bool); !final {
+			t.Error("the last page does not say isLast")
+		}
+	})
+
+	t.Run("a project's statuses are per issue type, and two ids share a name", func(t *testing.T) {
+		t.Parallel()
+
+		var types []struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			Statuses []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"statuses"`
+		}
+		if err := json.Unmarshal(srvFixture(t, "project_statuses.json"), &types); err != nil {
+			t.Fatalf("project_statuses.json is not the bare array the endpoint answers: %v", err)
+		}
+		if len(types) < 2 {
+			t.Fatalf("got %d issue types, want more than one so that two workflows can differ", len(types))
+		}
+
+		ids := make(map[string]map[string]bool)
+		widths := make(map[int]bool)
+		for _, entry := range types {
+			widths[len(entry.Statuses)] = true
+			for _, status := range entry.Statuses {
+				if ids[status.Name] == nil {
+					ids[status.Name] = make(map[string]bool)
+				}
+				ids[status.Name][status.ID] = true
+			}
+		}
+		if len(widths) < 2 {
+			t.Error("every issue type reaches the same number of statuses, and two types in one project run different workflows")
+		}
+		if len(ids["In Review"]) < 2 {
+			t.Errorf(`"In Review" resolves to %v, want the two ids a team-managed project mints under one name`, ids["In Review"])
+		}
+	})
+
+	t.Run("labels are bare strings and not all of them are ASCII", func(t *testing.T) {
+		t.Parallel()
+
+		seen := make([]string, 0, 8)
+		for _, name := range []string{"labels.json", "labels_page2.json"} {
+			var page struct {
+				Values []string `json:"values"`
+			}
+			if err := json.Unmarshal(srvFixture(t, name), &page); err != nil {
+				t.Fatalf("%s does not carry an array of bare strings: %v", name, err)
+			}
+			seen = append(seen, page.Values...)
+		}
+		if len(seen) == 0 {
+			t.Fatal("the label pages are empty")
+		}
+		if !slices.ContainsFunc(seen, func(l string) bool { return utf8.RuneCountInString(l) != len(l) }) {
+			t.Errorf("every label in %q is ASCII, and a label is whatever anybody typed", seen)
+		}
+	})
+}
+
+func srvAccounts(t *testing.T, fixture string) []map[string]any {
+	t.Helper()
+
+	var rows []map[string]any
+	if err := json.Unmarshal(srvFixture(t, fixture), &rows); err != nil {
+		t.Fatalf("%s is not a bare array of accounts: %v", fixture, err)
+	}
+	return rows
+}
+
+func srvAccountTypes(t *testing.T, fixture string) []string {
+	t.Helper()
+
+	out := make([]string, 0, 8)
+	for _, row := range srvAccounts(t, fixture) {
+		kind, _ := row["accountType"].(string)
+		out = append(out, kind)
+	}
+	return out
 }
 
 // Three paging envelopes, and no endpoint says which one it answers in.

--- a/pkg/jira/jiratest/gen.go
+++ b/pkg/jira/jiratest/gen.go
@@ -28,6 +28,16 @@ var fakeStatuses = []jira.Status{
 	{ID: "10203", Name: "Shipped", Category: jira.CategoryDone},
 }
 
+// fakeSubtaskStatuses is the workflow the subtask type runs, which is not the
+// one the other types run. Its middle status shares a display name with 10202
+// and has a different id: that is what a team-managed project mints on a real
+// site, and it is why an answer about statuses carries ids rather than names.
+var fakeSubtaskStatuses = []jira.Status{
+	{ID: "10201", Name: "Triage", Category: jira.CategoryToDo},
+	{ID: "10204", Name: "Building", Category: jira.CategoryInProgress},
+	{ID: "10203", Name: "Shipped", Category: jira.CategoryDone},
+}
+
 var fakeIssueTypes = []jira.IssueType{
 	{ID: "10301", Name: "Story", IconURL: fakeBaseURL + "/icons/story.png"},
 	{ID: "10302", Name: "Defect", IconURL: fakeBaseURL + "/icons/defect.png"},
@@ -60,6 +70,32 @@ var fakeDefaultMe = jira.User{
 	TimeZone:    time.UTC,
 	Active:      true,
 	AvatarURL:   fakeBaseURL + "/avatar/me",
+}
+
+// fakePeople is the fake site's account directory, and deliberately not the same
+// list as fakeUsers: an account read through a people endpoint says what kind of
+// account it is, and one read off an issue does not, so the accounts that appear
+// in both places appear with a Kind in one and without in the other.
+//
+// It holds an account that is not a person because a real site does — on the one
+// this was measured against, ten of the eleven accounts were apps — and one whose
+// id contains a colon, because two of those eleven did and anything that splits
+// an id on a separator or builds a JQL clause out of one has to survive it.
+var fakePeople = []jira.User{
+	{AccountID: "acct-ada", DisplayName: "Ada Lovelace", Email: "ada@example.invalid", Active: true, TimeZone: time.UTC, AvatarURL: fakeBaseURL + "/avatar/ada", Kind: jira.AccountPerson},
+	{AccountID: "acct-alan", DisplayName: "Alan Turing", Active: false, TimeZone: time.UTC, AvatarURL: fakeBaseURL + "/avatar/alan", Kind: jira.AccountPerson},
+	{AccountID: "acct-grace", DisplayName: "Grace Hopper", Email: "grace@example.invalid", Active: true, TimeZone: time.UTC, AvatarURL: fakeBaseURL + "/avatar/grace", Kind: jira.AccountPerson},
+	{AccountID: "acct-me", DisplayName: "Sam Tester", Email: "sam@example.invalid", Active: true, TimeZone: time.UTC, AvatarURL: fakeBaseURL + "/avatar/me", Kind: jira.AccountPerson},
+	{AccountID: "acct:nightly-bot", DisplayName: "Nightly Runner", Active: true, TimeZone: time.UTC, AvatarURL: fakeBaseURL + "/avatar/bot", Kind: jira.AccountApp},
+	{AccountID: "acct-reporter", DisplayName: "Rex Outside", Email: "rex@example.invalid", Active: true, TimeZone: time.UTC, AvatarURL: fakeBaseURL + "/avatar/rex", Kind: jira.AccountCustomer},
+}
+
+// fakeSiteLabelPool is what Labels answers from, over and above whatever the
+// stored issues carry. Two of them are not ASCII: a label is whatever anybody
+// typed, and a column width taken with len() over one is wrong.
+var fakeSiteLabelPool = []string{
+	"backend", "frontend", "infra", "tech-debt", "customer", "flaky",
+	"prüfung", "検索",
 }
 
 var fakeDefaultFields = []jira.Field{

--- a/pkg/jira/jiratest/jiratest.go
+++ b/pkg/jira/jiratest/jiratest.go
@@ -49,7 +49,10 @@ var (
 	_ jira.Mover          = (*Fake)(nil)
 	_ jira.CommentReader  = (*Fake)(nil)
 	_ jira.Commenter      = (*Fake)(nil)
+	_ jira.PeopleFinder   = (*Fake)(nil)
 	_ jira.SessionClient  = (*Fake)(nil)
+
+	_ jira.FilterVocabulary = (*Fake)(nil)
 )
 
 // BoardKind is what WithProject builds alongside a project.
@@ -86,6 +89,9 @@ var (
 	NoAttachments = CapReason(jira.CapAttachments, "attachments are disabled on this site")
 	// NoDeleteIssues turns off the delete-issues capability.
 	NoDeleteIssues = CapReason(jira.CapDeleteIssues, "needs Delete Issues permission")
+	// NoPeople turns off looking accounts up, which is the site-wide Browse
+	// users and groups permission an ordinary token can perfectly well lack.
+	NoPeople = CapReason(jira.CapPeople, "needs the Browse users and groups permission")
 	// NoTimeZone leaves the account timezone unknown, which makes every date
 	// render in UTC with the reason beside it.
 	NoTimeZone = CapZone(nil, "Jira did not answer what timezone this account is in")
@@ -119,6 +125,7 @@ type Fake struct {
 	pageSize int
 	caps     jira.Capabilities
 	me       jira.User
+	people   []jira.User
 	fields   []jira.Field
 
 	projects    map[string]*fakeProject
@@ -173,6 +180,7 @@ func (f *Fake) fakeInit() {
 	f.pageSize = 50
 	f.caps = fakeDefaultCaps()
 	f.me = fakeDefaultMe
+	f.people = slices.Clone(fakePeople)
 	f.fields = fakeCloneFields(fakeDefaultFields)
 	f.projects = make(map[string]*fakeProject)
 	f.projectKeys = nil
@@ -207,6 +215,7 @@ func fakeDefaultCaps() jira.Capabilities {
 		Boards:       ok,
 		Attachments:  ok,
 		DeleteIssues: ok,
+		People:       ok,
 		Graphics:     jira.GraphicsHalfBlocks,
 		TimeZone:     time.UTC,
 	}
@@ -224,6 +233,8 @@ func fakeSetCap(c *jira.Capabilities, k jira.CapabilityKey, v jira.Capability) {
 		c.Attachments = v
 	case jira.CapDeleteIssues:
 		c.DeleteIssues = v
+	case jira.CapPeople:
+		c.People = v
 	}
 }
 
@@ -265,6 +276,15 @@ func WithFields(fields []jira.Field) Option {
 // that answers 200 and names nobody, which Me refuses rather than returns.
 func WithMe(u jira.User) Option {
 	return func(f *Fake) { f.me = u }
+}
+
+// WithPeople replaces the site's account directory, which is what FindPeople
+// searches and People resolves ids against. It is not the same list as the
+// accounts on the seeded issues: setting it does not change who an issue is
+// assigned to, and an id that is on an issue and not here resolves to nothing,
+// which is the site that has forgotten a departed account.
+func WithPeople(people []jira.User) Option {
+	return func(f *Fake) { f.people = slices.Clone(people) }
 }
 
 // WithPageSize sets how many items a page holds, for both paginators. The

--- a/pkg/jira/jiratest/people.go
+++ b/pkg/jira/jiratest/people.go
@@ -1,0 +1,217 @@
+package jiratest
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// fakePeopleLimit is how many accounts a search hands back when the caller names
+// no ceiling, which is what the cloud adapter does with the same input.
+const fakePeopleLimit = 50
+
+// FindPeople searches the fake site's directory.
+//
+// The matching rule here is **not** Jira's. Jira's is undocumented, is neither
+// substring nor fuzzy, and was measured taking word prefixes, initials and part
+// of an email address in one pass with no way to tell which fired. Nothing local
+// reproduces it, so this one is written down instead: a needle matches when it
+// begins a word of the display name, spells the initials, or appears in the
+// email address.
+//
+// The order is deliberately meaningless — by account id, which is not relevance
+// and not the alphabet — because Jira's order is not a ranking either, and a
+// picker that presents whatever arrived as its own ranking has to look wrong
+// somewhere. This is where.
+func (f *Fake) FindPeople(ctx context.Context, q jira.PeopleQuery) ([]jira.User, error) {
+	if err := f.fakeBegin(ctx, "FindPeople"); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.caps.Require(jira.CapPeople); err != nil {
+		return nil, err
+	}
+
+	assignable := false
+	if project := strings.TrimSpace(q.Project); project != "" {
+		if _, ok := f.projects[project]; !ok {
+			return nil, fakeNotFound("project", project)
+		}
+		// The assignable endpoint answers only accounts that can be given work,
+		// which is how a real site drops its app accounts without being asked.
+		assignable = true
+	}
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = fakePeopleLimit
+	}
+	out := make([]jira.User, 0, min(limit, len(f.people)))
+	for _, u := range f.people {
+		if len(out) >= limit {
+			break
+		}
+		if assignable && u.Kind != jira.AccountPerson {
+			continue
+		}
+		if !fakePersonMatches(u, q.Match) {
+			continue
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}
+
+// People resolves account ids to accounts, leaving out the ids this site does
+// not know rather than answering a blank row for one — which is what a real
+// bulk read's JSON null decodes into if nothing drops it.
+func (f *Fake) People(ctx context.Context, accountIDs []string) ([]jira.User, error) {
+	if len(accountIDs) == 0 {
+		// A real bulk read with no ids is a 400 rather than an empty answer, so
+		// nothing asks for one. No call is recorded, because none is made.
+		return nil, nil
+	}
+	if err := f.fakeBegin(ctx, "People"); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.caps.Require(jira.CapPeople); err != nil {
+		return nil, err
+	}
+
+	out := make([]jira.User, 0, len(accountIDs))
+	seen := make(map[string]struct{}, len(accountIDs))
+	for _, id := range accountIDs {
+		wanted := strings.TrimSpace(id)
+		if wanted == "" {
+			continue
+		}
+		if _, dup := seen[wanted]; dup {
+			continue
+		}
+		seen[wanted] = struct{}{}
+		for _, u := range f.people {
+			if u.AccountID == wanted {
+				out = append(out, u)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// fakePersonMatches is the rule described on FindPeople. An empty needle matches
+// everybody, which is what an empty query does on a real site.
+func fakePersonMatches(u jira.User, match string) bool {
+	needle := strings.ToLower(strings.TrimSpace(match))
+	if needle == "" {
+		return true
+	}
+	if strings.Contains(strings.ToLower(u.Email), needle) {
+		return true
+	}
+	name := strings.ToLower(u.DisplayName)
+	var initials strings.Builder
+	for _, word := range strings.FieldsFunc(name, unicode.IsSpace) {
+		if strings.HasPrefix(word, needle) {
+			return true
+		}
+		first, _ := utf8.DecodeRuneInString(word)
+		initials.WriteRune(first)
+	}
+	return initials.Len() > 0 && strings.HasPrefix(initials.String(), needle)
+}
+
+// IssueTypeStatuses lists the fake project's issue types with the statuses each
+// one's workflow reaches. The subtask type runs a different workflow from the
+// rest, and one of its statuses shares a display name with a status of another
+// id — which is what a team-managed project mints on a real site, and the reason
+// this answer carries ids at all.
+func (f *Fake) IssueTypeStatuses(ctx context.Context, projectKey string) ([]jira.IssueTypeStatuses, error) {
+	if err := f.fakeBegin(ctx, "IssueTypeStatuses"); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	project := strings.TrimSpace(projectKey)
+	if project == "" {
+		return nil, fakeInvalid("projectKey",
+			"a project is required: statuses are per project, and there is no site-wide answer to give")
+	}
+	if _, ok := f.projects[project]; !ok {
+		return nil, fakeNotFound("project", project)
+	}
+
+	out := make([]jira.IssueTypeStatuses, 0, len(fakeIssueTypes))
+	for _, typ := range fakeIssueTypes {
+		statuses := fakeStatuses
+		if typ.Subtask {
+			statuses = fakeSubtaskStatuses
+		}
+		out = append(out, jira.IssueTypeStatuses{Type: typ, Statuses: slices.Clone(statuses)})
+	}
+	return out, nil
+}
+
+// Priorities lists the site's priorities in ranking order, which is the order
+// they are declared in and not the alphabet.
+func (f *Fake) Priorities(ctx context.Context) ([]jira.Priority, error) {
+	if err := f.fakeBegin(ctx, "Priorities"); err != nil {
+		return nil, err
+	}
+	return slices.Clone(fakePriorities), nil
+}
+
+// Labels pages the labels in use on the fake site: the seeded pool, whatever the
+// stored issues carry, and two that are not ASCII — a label is whatever somebody
+// typed, and a column measured with len() over one is wrong.
+func (f *Fake) Labels(ctx context.Context) (jira.Page[string], error) {
+	return jira.Offset(ctx, func(ctx context.Context, startAt int) ([]string, int, bool, error) {
+		if err := f.fakeBegin(ctx, "Labels"); err != nil {
+			return nil, -1, false, err
+		}
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		all := f.fakeSiteLabels()
+		if startAt > len(all) {
+			startAt = len(all)
+		}
+		end := min(startAt+f.pageSize, len(all))
+		return slices.Clone(all[startAt:end]), len(all), end >= len(all), nil
+	})
+}
+
+// fakeSiteLabels is every label the site knows, sorted and deduplicated the way
+// the endpoint answers them.
+func (f *Fake) fakeSiteLabels() []string {
+	seen := make(map[string]struct{}, len(fakeSiteLabelPool))
+	out := make([]string, 0, len(fakeSiteLabelPool))
+	add := func(label string) {
+		if label == "" {
+			return
+		}
+		if _, dup := seen[label]; dup {
+			return
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+	for _, label := range fakeSiteLabelPool {
+		add(label)
+	}
+	for _, key := range f.issueKeys {
+		for _, label := range f.issues[key].Labels {
+			add(label)
+		}
+	}
+	slices.Sort(out)
+	return out
+}

--- a/pkg/jira/jiratest/people_test.go
+++ b/pkg/jira/jiratest/people_test.go
@@ -1,0 +1,336 @@
+package jiratest_test
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+func peopleNamesOf(users []jira.User) []string {
+	out := make([]string, 0, len(users))
+	for _, u := range users {
+		out = append(out, u.DisplayName)
+	}
+	return out
+}
+
+func peopleFound(t *testing.T, f *jiratest.Fake, q jira.PeopleQuery) []jira.User {
+	t.Helper()
+
+	got, err := f.FindPeople(t.Context(), q)
+	if err != nil {
+		t.Fatalf("FindPeople(%+v): %v", q, err)
+	}
+	return got
+}
+
+func TestFindPeople_MatchesAWordPrefixInitialsOrAnEmailAddress(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New()
+	tests := map[string]struct {
+		match string
+		want  []string
+	}{
+		"a prefix of the first word":  {match: "ada", want: []string{"Ada Lovelace"}},
+		"a prefix of the last word":   {match: "hopp", want: []string{"Grace Hopper"}},
+		"the initials":                {match: "gh", want: []string{"Grace Hopper"}},
+		"part of the email address":   {match: "sam@", want: []string{"Sam Tester"}},
+		"a needle inside a word":      {match: "ovelace", want: nil},
+		"a needle nobody answers to":  {match: "zzz", want: nil},
+		"nothing typed matches all":   {match: "", want: nil},
+		"case is folded on both ends": {match: "ADA", want: []string{"Ada Lovelace"}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := peopleNamesOf(peopleFound(t, f, jira.PeopleQuery{Match: tt.match}))
+			if tt.match == "" {
+				if len(got) < 2 {
+					t.Fatalf("an empty needle matched %v, want every account", got)
+				}
+				return
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Jira's own order is not a ranking, so the fake's is deliberately not one
+// either: a picker that presents whatever arrived as its own ranking has to look
+// wrong somewhere, and this is where.
+func TestFindPeople_AnswersInAnOrderThatIsNotRelevance(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New()
+	got := peopleFound(t, f, jira.PeopleQuery{Match: "e"})
+	if len(got) < 2 {
+		t.Fatalf("got %v, want more than one account to order", peopleNamesOf(got))
+	}
+
+	ids := make([]string, 0, len(got))
+	for _, u := range got {
+		ids = append(ids, u.AccountID)
+	}
+	if !slices.IsSorted(ids) {
+		t.Errorf("the answer came back in %v, want the account-id order the fake promises", ids)
+	}
+}
+
+func TestFindPeople_ScopedToAProjectOffersOnlyAccountsThatCanBeGivenWork(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithProject("PROJ", jiratest.Kanban))
+
+	site := peopleFound(t, f, jira.PeopleQuery{})
+	if !slices.ContainsFunc(site, func(u jira.User) bool { return u.Kind != jira.AccountPerson }) {
+		t.Fatal("the site-wide search hides the accounts that are not people, and it must not")
+	}
+
+	scoped := peopleFound(t, f, jira.PeopleQuery{Project: "PROJ"})
+	if len(scoped) == 0 {
+		t.Fatal("the project came back with nobody to assign work to")
+	}
+	for _, u := range scoped {
+		if u.Kind != jira.AccountPerson {
+			t.Errorf("%s (%v) is assignable in PROJ, and the assignable endpoint answers only people", u.DisplayName, u.Kind)
+		}
+	}
+}
+
+func TestFindPeople_RefusesAProjectTheSiteDoesNotHave(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithProject("PROJ", jiratest.Kanban))
+	got, err := f.FindPeople(t.Context(), jira.PeopleQuery{Project: "NOSUCH"})
+	var missing *jira.NotFoundError
+	if !errors.As(err, &missing) {
+		t.Fatalf("got %+v, %T (%v); want a *jira.NotFoundError", got, err, err)
+	}
+}
+
+func TestFindPeople_HonoursTheCeilingAndTreatsZeroAsNoCeiling(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New()
+	if got := peopleFound(t, f, jira.PeopleQuery{Limit: 2}); len(got) != 2 {
+		t.Errorf("got %d accounts for a Limit of 2", len(got))
+	}
+	if got := peopleFound(t, f, jira.PeopleQuery{Limit: -1}); len(got) < 2 {
+		t.Errorf("a negative Limit came back with %v, want the default rather than nothing", peopleNamesOf(got))
+	}
+}
+
+func TestFindPeople_SearchesTheDirectoryItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	only := []jira.User{{AccountID: "acct-one", DisplayName: "Only Person", Active: true, Kind: jira.AccountPerson}}
+	f := jiratest.New(jiratest.WithPeople(only))
+
+	got := peopleNamesOf(peopleFound(t, f, jira.PeopleQuery{}))
+	if !slices.Equal(got, []string{"Only Person"}) {
+		t.Errorf("got %v, want only the directory the test set", got)
+	}
+}
+
+func TestPeople_LeavesOutAnIdTheSiteDoesNotKnow(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New()
+	got, err := f.People(t.Context(), []string{"acct-ada", "acct-gone", "acct-ada", " acct-grace "})
+	if err != nil {
+		t.Fatalf("People: %v", err)
+	}
+	if names := peopleNamesOf(got); !slices.Equal(names, []string{"Ada Lovelace", "Grace Hopper"}) {
+		t.Fatalf("got %v, want the two ids the site knows, each once", names)
+	}
+	for _, u := range got {
+		if u.AccountID == "" || u.DisplayName == "" {
+			t.Errorf("a blank row reached the caller: %+v", u)
+		}
+	}
+}
+
+func TestPeople_AsksNothingWhenThereIsNothingToAsk(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New()
+	got, err := f.People(t.Context(), nil)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("got %+v, %v; want nothing and no error", got, err)
+	}
+	// A real bulk read with no accountId is a 400, so the call is not made at
+	// all rather than made and forgiven.
+	if calls := f.Calls(); len(calls) != 0 {
+		t.Errorf("the fake recorded %v for a request nobody could have sent", calls)
+	}
+}
+
+func TestPeopleAndFindPeople_RefuseWhenTheTokenMayNotBrowseUsers(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithCapabilities(jiratest.NoPeople))
+
+	for name, call := range map[string]func() ([]jira.User, error){
+		"a search":    func() ([]jira.User, error) { return f.FindPeople(t.Context(), jira.PeopleQuery{}) },
+		"a bulk read": func() ([]jira.User, error) { return f.People(t.Context(), []string{"acct-ada"}) },
+	} {
+		got, err := call()
+		var refused *jira.CapabilityError
+		if !errors.As(err, &refused) {
+			t.Fatalf("%s gave %+v, %T (%v); want a *jira.CapabilityError", name, got, err, err)
+		}
+		if refused.Capability != jira.CapPeople {
+			t.Errorf("%s named the capability %q, want %q", name, refused.Capability, jira.CapPeople)
+		}
+	}
+}
+
+func TestIssueTypeStatuses_GivesTheSubtaskTypeItsOwnWorkflow(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithProject("PROJ", jiratest.Scrum))
+	got, err := f.IssueTypeStatuses(t.Context(), "PROJ")
+	if err != nil {
+		t.Fatalf("IssueTypeStatuses: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("PROJ came back with no issue types")
+	}
+
+	ids := make(map[string]map[string]bool)
+	subtasks := 0
+	for _, entry := range got {
+		if entry.Type.Subtask {
+			subtasks++
+		}
+		for _, status := range entry.Statuses {
+			if ids[status.Name] == nil {
+				ids[status.Name] = make(map[string]bool)
+			}
+			ids[status.Name][status.ID] = true
+		}
+	}
+	if subtasks == 0 {
+		t.Error("no subtask type came back, and the answer covers every type in the project")
+	}
+	// Two ids under one name is what a team-managed project mints, and it is the
+	// whole reason this answer carries ids.
+	if len(ids["Building"]) != 2 {
+		t.Errorf(`"Building" resolved to %v, want the two distinct ids one site can hold under one name`, ids["Building"])
+	}
+}
+
+func TestIssueTypeStatuses_RefusesAMissingOrUnknownProject(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithProject("PROJ", jiratest.Kanban))
+
+	got, err := f.IssueTypeStatuses(t.Context(), "  ")
+	var invalid *jira.ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("got %+v, %T (%v); want a *jira.ValidationError", got, err, err)
+	}
+	if _, named := invalid.For("projectKey"); !named {
+		t.Errorf("the refusal does not name projectKey: %v", invalid)
+	}
+
+	got, err = f.IssueTypeStatuses(t.Context(), "NOSUCH")
+	var missing *jira.NotFoundError
+	if !errors.As(err, &missing) {
+		t.Fatalf("got %+v, %T (%v); want a *jira.NotFoundError", got, err, err)
+	}
+}
+
+func TestIssueTypeStatuses_HandsBackACopyOfEachWorkflow(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithProject("PROJ", jiratest.Kanban))
+	first, err := f.IssueTypeStatuses(t.Context(), "PROJ")
+	if err != nil {
+		t.Fatalf("IssueTypeStatuses: %v", err)
+	}
+	first[0].Statuses[0] = jira.Status{ID: "written-through", Name: "written through"}
+
+	second, err := f.IssueTypeStatuses(t.Context(), "PROJ")
+	if err != nil {
+		t.Fatalf("IssueTypeStatuses: %v", err)
+	}
+	if second[0].Statuses[0].ID == "written-through" {
+		t.Error("a caller writing into what it was handed changed the fake site")
+	}
+}
+
+func TestPriorities_KeepRankingOrderRatherThanTheAlphabet(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New()
+	got, err := f.Priorities(t.Context())
+	if err != nil {
+		t.Fatalf("Priorities: %v", err)
+	}
+	names := make([]string, 0, len(got))
+	for _, p := range got {
+		if p.ID == "" {
+			t.Errorf("the priority %q has no id", p.Name)
+		}
+		names = append(names, p.Name)
+	}
+	if slices.IsSorted(names) {
+		t.Errorf("got %v, which is the alphabet; a priority list is in ranking order", names)
+	}
+}
+
+func TestLabels_PageEveryLabelTheSiteHasIncludingTheIssuesOwn(t *testing.T) {
+	t.Parallel()
+
+	f := fakeNewWithIssues(t, 40, jiratest.WithPageSize(4))
+	page, err := f.Labels(t.Context())
+	if err != nil {
+		t.Fatalf("Labels: %v", err)
+	}
+	if !page.HasMore() {
+		t.Error("the whole site fitted on one page, so nothing here exercises the walk")
+	}
+	got, err := jira.Collect(t.Context(), page, 0)
+	if err != nil {
+		t.Fatalf("walking the labels: %v", err)
+	}
+
+	if !slices.IsSorted(got) {
+		t.Errorf("got %q, want the sorted order the endpoint answers in", got)
+	}
+	if len(slices.Compact(slices.Clone(got))) != len(got) {
+		t.Errorf("got %q, which repeats a label", got)
+	}
+	// A label is whatever anybody typed, so a column measured with len() over one
+	// is wrong. The site carries two that prove it.
+	for _, want := range []string{"prüfung", "検索"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("%q is not in %q", want, got)
+		}
+	}
+	if total, ok := page.Count(); !ok || total != len(got) {
+		t.Errorf("the first page claimed %d labels (stated %v) and the walk found %d", total, ok, len(got))
+	}
+}
+
+func TestWithPeople_SurvivesAReset(t *testing.T) {
+	t.Parallel()
+
+	f := jiratest.New(jiratest.WithPeople(nil))
+	if got := peopleFound(t, f, jira.PeopleQuery{}); len(got) != 0 {
+		t.Fatalf("got %v, want the empty directory the option set", peopleNamesOf(got))
+	}
+	f.Reset()
+	if got := peopleFound(t, f, jira.PeopleQuery{}); len(got) != 0 {
+		t.Errorf("Reset did not re-apply WithPeople: %v", peopleNamesOf(got))
+	}
+}

--- a/pkg/jira/jiratest/server.go
+++ b/pkg/jira/jiratest/server.go
@@ -218,6 +218,15 @@ var srvDefaultRoutes = []srvRoute{
 	{http.MethodGet, "/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes", srvFixtureHandler(http.StatusOK, "createmeta_issuetypes.json")},
 	{http.MethodGet, "/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}", srvCreateMeta},
 	{http.MethodGet, "/rest/api/3/myself", srvFixtureHandler(http.StatusOK, "myself.json")},
+	// Two user searches, and the difference between them is the point: the
+	// site-wide one answers every kind of account, and the assignable one answers
+	// only the people, which is how a real site drops its app accounts.
+	{http.MethodGet, "/rest/api/3/user/search", srvFixtureHandler(http.StatusOK, "user_search.json")},
+	{http.MethodGet, "/rest/api/3/user/assignable/search", srvFixtureHandler(http.StatusOK, "user_assignable.json")},
+	{http.MethodGet, "/rest/api/3/user/bulk", srvOffsetPages("user_bulk.json", "user_bulk_page2.json")},
+	{http.MethodGet, "/rest/api/3/project/{key}/statuses", srvFixtureHandler(http.StatusOK, "project_statuses.json")},
+	{http.MethodGet, "/rest/api/3/priority/search", srvFixtureHandler(http.StatusOK, "priority_search.json")},
+	{http.MethodGet, "/rest/api/3/label", srvOffsetPages("labels.json", "labels_page2.json")},
 	{http.MethodGet, "/rest/api/3/configuration", srvFixtureHandler(http.StatusOK, "configuration.json")},
 	{http.MethodGet, "/rest/api/3/mypermissions", srvFixtureHandler(http.StatusOK, "mypermissions_admin.json")},
 	// versions.json is a paged envelope, which is what the singular /version
@@ -293,6 +302,44 @@ func srvSearch(w http.ResponseWriter, r *http.Request) {
 	default:
 		srvWriteError(w, http.StatusBadRequest, "The nextPageToken is not one this search issued.")
 	}
+}
+
+// srvOffsetPages replays an offset-paginated endpoint one page per startAt, so
+// that a walk over it terminates on the fixtures rather than on the first page
+// answered forever. A startAt past the last page answers the last page, which
+// still says isLast and so still ends the walk.
+func srvOffsetPages(pages ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		at := 0
+		for i, name := range pages {
+			body, err := Fixture(name)
+			if err != nil {
+				srvWriteError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			var page struct {
+				MaxResults int `json:"maxResults"`
+			}
+			if err := json.Unmarshal(body, &page); err != nil {
+				srvWriteError(w, http.StatusInternalServerError, "jiratest: parsing "+name+": "+err.Error())
+				return
+			}
+			if at == srvStartAt(r) || i == len(pages)-1 {
+				srvWriteJSON(w, http.StatusOK, body)
+				return
+			}
+			at += page.MaxResults
+		}
+		srvWriteError(w, http.StatusInternalServerError, "jiratest: srvOffsetPages was given no pages")
+	}
+}
+
+func srvStartAt(r *http.Request) int {
+	at, err := strconv.Atoi(r.URL.Query().Get("startAt"))
+	if err != nil || at < 0 {
+		return 0
+	}
+	return at
 }
 
 func srvCreateMeta(w http.ResponseWriter, r *http.Request) {

--- a/pkg/jira/jiratest/server_test.go
+++ b/pkg/jira/jiratest/server_test.go
@@ -99,6 +99,12 @@ func TestServer_ServesEveryDefaultRouteWithItsFixture(t *testing.T) {
 		{"bulk move submitted", http.MethodPost, "/rest/api/3/bulk/issues/move", http.StatusCreated, "bulkmove_submit.json"},
 		{"generic task", http.MethodGet, "/rest/api/3/task/11072", http.StatusOK, "task_complete.json"},
 		{"bulk queue task", http.MethodGet, "/rest/api/3/bulk/queue/10641", http.StatusOK, "bulkmove_task_complete.json"},
+		{"a site-wide account search", http.MethodGet, "/rest/api/3/user/search?query=ex", http.StatusOK, "user_search.json"},
+		{"an assignable account search", http.MethodGet, "/rest/api/3/user/assignable/search?project=EX&query=", http.StatusOK, "user_assignable.json"},
+		{"accounts by id", http.MethodGet, "/rest/api/3/user/bulk?accountId=5b10a2844c20165700ede21g", http.StatusOK, "user_bulk.json"},
+		{"a project's statuses", http.MethodGet, "/rest/api/3/project/EX/statuses", http.StatusOK, "project_statuses.json"},
+		{"the site's priorities", http.MethodGet, "/rest/api/3/priority/search", http.StatusOK, "priority_search.json"},
+		{"the site's labels", http.MethodGet, "/rest/api/3/label", http.StatusOK, "labels.json"},
 	}
 
 	for _, tc := range cases {

--- a/pkg/jira/port.go
+++ b/pkg/jira/port.go
@@ -119,4 +119,23 @@ type Client interface {
 	Plans(ctx context.Context) ([]Plan, error)
 	// Me returns the authenticated account, including its timezone.
 	Me(ctx context.Context) (User, error)
+
+	// FindPeople searches the site's accounts. The site decides what matches and
+	// in what order; see PeopleQuery, whose documentation is the contract.
+	FindPeople(ctx context.Context, q PeopleQuery) ([]User, error)
+	// People resolves account ids to accounts, which is how an id written into a
+	// saved filter becomes a name to draw. An id this site does not know is
+	// absent from the answer rather than a blank row in it, so the result is
+	// keyed by AccountID and never by position.
+	People(ctx context.Context, accountIDs []string) ([]User, error)
+	// IssueTypeStatuses lists each of a project's issue types with the statuses
+	// its workflow can put an issue in.
+	IssueTypeStatuses(ctx context.Context, projectKey string) ([]IssueTypeStatuses, error)
+	// Priorities lists the site's priorities, in the site's own order — which is
+	// the order they rank in, and is not alphabetical.
+	Priorities(ctx context.Context) ([]Priority, error)
+	// Labels lists every label in use on the site. It pages, because a busy site
+	// has thousands, and it cannot be narrowed: the endpoint takes no query and
+	// ignores one sent anyway, so a caller filters what it walked.
+	Labels(ctx context.Context) (Page[string], error)
 }

--- a/pkg/jira/roles.go
+++ b/pkg/jira/roles.go
@@ -81,6 +81,30 @@ type Commenter interface {
 	DeleteComment(ctx context.Context, key, id string) error
 }
 
+// PeopleFinder looks accounts up: by typing, and by the ids a saved filter
+// holds. A filter that names a person stores the account id and nothing else,
+// because a display name is neither unique nor stable, so both halves are one
+// role — whatever can offer a picker must also be able to draw the choice back.
+//
+// Holding this role is not permission to use it: Browse users and groups is
+// site-wide, and a token without it gets a *CapabilityError naming CapPeople
+// rather than an empty list.
+type PeopleFinder interface {
+	FindPeople(ctx context.Context, q PeopleQuery) ([]User, error)
+	People(ctx context.Context, accountIDs []string) ([]User, error)
+}
+
+// FilterVocabulary is the site's own words for the things a filter narrows by,
+// resolved at runtime because every one of them is site configuration. Nothing
+// here may be written down in the source: statuses are minted per project, a
+// priority is a row an administrator can rename, and labels are whatever anyone
+// has typed.
+type FilterVocabulary interface {
+	IssueTypeStatuses(ctx context.Context, projectKey string) ([]IssueTypeStatuses, error)
+	Priorities(ctx context.Context) ([]Priority, error)
+	Labels(ctx context.Context) (Page[string], error)
+}
+
 // SessionClient is every role a view in this build actually calls, and nothing
 // else. It is what a session is built with.
 //
@@ -99,4 +123,6 @@ type SessionClient interface {
 	IssueWriter
 	Mover
 	Commenter
+	PeopleFinder
+	FilterVocabulary
 }

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -61,8 +61,61 @@ func (d Date) In(loc *time.Location) time.Time {
 // Before reports whether d falls before other.
 func (d Date) Before(other Date) bool { return d.In(time.UTC).Before(other.In(time.UTC)) }
 
+// AccountKind is what sort of account this is. It labels; it does not filter.
+// An app account is assigned work and reports issues exactly as a person does,
+// so hiding one loses rows — but a site whose account list is ten robots and one
+// human is unreadable without the distinction, which is what a picker sinks and
+// badges by.
+type AccountKind int
+
+// The account kinds, in the order a picker prefers them.
+const (
+	// AccountUnknown is a read that did not say. It is not a fourth kind of
+	// account: several endpoints answer a user with no accountType at all.
+	AccountUnknown AccountKind = iota
+	AccountPerson
+	AccountApp
+	AccountCustomer
+)
+
+// ParseAccountKind maps the API's accountType to an AccountKind. The values are
+// an enum rather than display text, so unlike a status or a priority name they
+// are the same on a site in any language.
+func ParseAccountKind(accountType string) AccountKind {
+	switch strings.ToLower(strings.TrimSpace(accountType)) {
+	case "atlassian":
+		return AccountPerson
+	case "app":
+		return AccountApp
+	case "customer":
+		return AccountCustomer
+	default:
+		return AccountUnknown
+	}
+}
+
+// String returns the kind's name for a badge, and "" for a read that did not
+// say, so that a picker drawing it puts nothing rather than the word "unknown"
+// beside every row on an endpoint that omits the field.
+func (k AccountKind) String() string {
+	switch k {
+	case AccountPerson:
+		return "person"
+	case AccountApp:
+		return "app"
+	case AccountCustomer:
+		return "customer"
+	default:
+		return ""
+	}
+}
+
 // User is a Jira account. Email is often absent — Jira hides it unless the
 // account's privacy settings allow it, so nothing may depend on having one.
+//
+// Kind is AccountUnknown on any read that did not carry an accountType, which is
+// most of them: it is filled by the people endpoints, and its absence elsewhere
+// means the answer was silent rather than that the account is odd.
 type User struct {
 	AccountID   string
 	DisplayName string
@@ -70,6 +123,52 @@ type User struct {
 	TimeZone    *time.Location
 	Active      bool
 	AvatarURL   string
+	Kind        AccountKind
+}
+
+// PeopleQuery narrows a search for accounts.
+//
+// Match is handed to Jira, which is the whole difficulty. Its matching is
+// neither substring nor fuzzy and is documented nowhere: measured on a real
+// site, it takes a prefix of any word of the display name, the initials of it,
+// and part of the email address, so a two-letter needle found an account by its
+// initials and a different two-letter needle found nobody although a surname on
+// the site contains it. Nothing local reproduces that, and no read says which
+// rule fired.
+//
+// Two consequences for a caller. Type-ahead has to go back to the site rather
+// than narrow what it already holds, because a longer needle can match what a
+// shorter one did not. And the order the answer arrives in is Jira's, not a
+// ranking: a picker ranks what comes back itself and never presents that order
+// as its own.
+//
+// Project scopes the search to accounts that can be assigned work in one
+// project. It is worth setting for a picker even where the search is not about
+// assigning: the assignable endpoint drops app accounts for free, and on the
+// measured site that was ten of eleven accounts.
+//
+// Limit is a ceiling, not a page size — the port does not page people, because a
+// person is found by typing more rather than by paging. Zero asks for the
+// adapter's own default.
+type PeopleQuery struct {
+	Match   string
+	Project string
+	Limit   int
+}
+
+// IssueTypeStatuses is the statuses one issue type can be in, in one project.
+//
+// It carries ids because neither name identifies anything: a status name is
+// localised, and a team-managed project mints project-scoped statuses that reuse
+// the stock names, so two distinct ids answer to one string on one site. Grouping
+// or filtering by the name silently merges them.
+//
+// The statuses are per issue type and not per project — two types in one project
+// can run different workflows — so a filter offering "every status here" is the
+// union of these and has to say which types it came from.
+type IssueTypeStatuses struct {
+	Type     IssueType
+	Statuses []Status
 }
 
 // ProjectRef identifies a project.
@@ -1096,6 +1195,11 @@ const (
 	CapBoards       CapabilityKey = "boards"
 	CapAttachments  CapabilityKey = "attachments"
 	CapDeleteIssues CapabilityKey = "delete-issues"
+	// CapPeople is whether this token may look accounts up at all. Browse users
+	// and groups is a site-wide permission a perfectly ordinary token can lack,
+	// and without it a person can only be named by an account id somebody
+	// already has.
+	CapPeople CapabilityKey = "people"
 )
 
 // Capability is one probe result. A negative is an answer with a reason
@@ -1113,6 +1217,7 @@ type Capabilities struct {
 	Boards       Capability
 	Attachments  Capability
 	DeleteIssues Capability
+	People       Capability
 	Graphics     GraphicsMode
 	TimeZone     *time.Location
 	// TimeZoneReason is why TimeZone is not the account's own, worded the way a
@@ -1136,6 +1241,8 @@ func (c Capabilities) Capability(k CapabilityKey) Capability {
 		return c.Attachments
 	case CapDeleteIssues:
 		return c.DeleteIssues
+	case CapPeople:
+		return c.People
 	default:
 		return Capability{Reason: fmt.Sprintf("unknown capability %q", k)}
 	}

--- a/pkg/jira/types_test.go
+++ b/pkg/jira/types_test.go
@@ -540,6 +540,7 @@ func capsWithout(t *testing.T, absent jira.CapabilityKey, reason string) jira.Ca
 		Boards:       jira.Capability{OK: true},
 		Attachments:  jira.Capability{OK: true},
 		DeleteIssues: jira.Capability{OK: true},
+		People:       jira.Capability{OK: true},
 	}
 	missing := jira.Capability{Reason: reason}
 	switch absent {
@@ -553,6 +554,8 @@ func capsWithout(t *testing.T, absent jira.CapabilityKey, reason string) jira.Ca
 		caps.Attachments = missing
 	case jira.CapDeleteIssues:
 		caps.DeleteIssues = missing
+	case jira.CapPeople:
+		caps.People = missing
 	default:
 		t.Fatalf("capsWithout does not know the capability %q", absent)
 	}
@@ -568,6 +571,7 @@ func TestCapabilities_AnswerForEveryProbedKey(t *testing.T) {
 		jira.CapBoards,
 		jira.CapAttachments,
 		jira.CapDeleteIssues,
+		jira.CapPeople,
 	}
 
 	for _, absent := range keys {
@@ -710,6 +714,49 @@ func TestCapabilities_StaysComparable(t *testing.T) {
 	withReason := jira.Capabilities{TimeZoneReason: "Jira did not say what timezone this account is in"}
 	if withReason == unprobed {
 		t.Error("a value carrying a timezone reason compares equal to an unprobed one")
+	}
+}
+
+func TestParseAccountKind_ReadsTheEnumAndNotADisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]jira.AccountKind{
+		"atlassian":  jira.AccountPerson,
+		"ATLASSIAN":  jira.AccountPerson,
+		" customer ": jira.AccountCustomer,
+		"app":        jira.AccountApp,
+		// A read that did not say. Several endpoints send no accountType at all,
+		// and an absence is not a fourth kind of account.
+		"":            jira.AccountUnknown,
+		"   ":         jira.AccountUnknown,
+		"service":     jira.AccountUnknown,
+		"Atlassianer": jira.AccountUnknown,
+	}
+
+	for in, want := range tests {
+		if got := jira.ParseAccountKind(in); got != want {
+			t.Errorf("ParseAccountKind(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// A badge draws the kind beside a row, and a picker on an endpoint that states
+// none would otherwise put the word "unknown" beside every account on screen.
+func TestAccountKind_NamesOnlyWhatTheReadStated(t *testing.T) {
+	t.Parallel()
+
+	tests := map[jira.AccountKind]string{
+		jira.AccountPerson:   "person",
+		jira.AccountApp:      "app",
+		jira.AccountCustomer: "customer",
+		jira.AccountUnknown:  "",
+		jira.AccountKind(99): "",
+	}
+
+	for kind, want := range tests {
+		if got := kind.String(); got != want {
+			t.Errorf("AccountKind(%d).String() = %q, want %q", kind, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #69.

> *"there is no easy way to filter by person. I do not want to write JQL queries — this should be accessible on the UI."*

The port had `Me(ctx)` and nothing else about accounts, so a person could not be chosen at all; the only person-ish filter narrowed already-fetched rows by **display name**. This is the contract the picker packet codes against. It lands on its own and first, because `docs/PARALLEL.md` makes `pkg/jira/port.go` a serial `contract` change that blocks other work while it is open — so it is opened **once**, for every facet a filter narrows by, rather than five times.

## The frozen signatures

The picker packet can code against exactly this. Nothing existing moved.

```go
// pkg/jira/port.go — five methods appended to Client
FindPeople(ctx context.Context, q PeopleQuery) ([]User, error)
People(ctx context.Context, accountIDs []string) ([]User, error)
IssueTypeStatuses(ctx context.Context, projectKey string) ([]IssueTypeStatuses, error)
Priorities(ctx context.Context) ([]Priority, error)
Labels(ctx context.Context) (Page[string], error)

// pkg/jira/types.go
type AccountKind int
const (
	AccountUnknown AccountKind = iota
	AccountPerson
	AccountApp
	AccountCustomer
)
func ParseAccountKind(accountType string) AccountKind
func (k AccountKind) String() string        // "" for AccountUnknown

type User struct {
	AccountID   string
	DisplayName string
	Email       string
	TimeZone    *time.Location
	Active      bool
	AvatarURL   string
	Kind        AccountKind                  // new
}

type PeopleQuery struct {
	Match   string
	Project string
	Limit   int
}

type IssueTypeStatuses struct {
	Type     IssueType
	Statuses []Status
}

const CapPeople CapabilityKey = "people"
// Capabilities gains People Capability; Capability(k), Allows and Require answer for it.

// pkg/jira/roles.go
type PeopleFinder interface {
	FindPeople(ctx context.Context, q PeopleQuery) ([]User, error)
	People(ctx context.Context, accountIDs []string) ([]User, error)
}
type FilterVocabulary interface {
	IssueTypeStatuses(ctx context.Context, projectKey string) ([]IssueTypeStatuses, error)
	Priorities(ctx context.Context) ([]Priority, error)
	Labels(ctx context.Context) (Page[string], error)
}
// SessionClient gains both. Additive: nothing that compiled stops compiling.
```

## What the wire actually does, and where each fact went

Every claim below was read from a real Cloud site on 2026-08-25 and is now a `live` row in `docs/API-NOTES.md`.

| Measured | Where it landed |
|---|---|
| **`/user/search` answers a bare JSON array.** No envelope, no `total`, no `isLast` — neither paginator in `pkg/jira/cloud/paginate.go` reads that shape | `FindPeople` decodes a slice and does not page. A person is found by typing more. |
| **`?query=` absent is a 400; present-but-empty lists everybody** | The parameter is always sent, including from the state a picker opens in. `TestFindPeople_AlwaysSendsAQueryParameterEvenWhenItIsEmpty`. |
| **Matching is neither substring nor fuzzy** — word prefixes, initials and email tokens, in a combination no read reveals | Written into `PeopleQuery.Match`'s own documentation: type-ahead goes back to the site rather than narrowing what it holds, and **the caller ranks what comes back and never presents Jira's order as its own.** The fake orders by account id — deliberately meaningless — so a caller that does present it looks wrong somewhere. |
| **`/user/assignable/search?project=X` answers only real people**, dropping app accounts. The site had **11 accounts, 10 of them `accountType:"app"`** | `PeopleQuery.Project` switches endpoint. Worth setting even where the search is not about assigning. |
| **`/user/bulk` defaults to `maxResults:10`** whatever it is asked | `People` walks it, even for eleven ids. |
| **`/user/bulk` answers JSON `null` inside `values`** for an unknown id, and `total` counts the ids *asked for* | The nulls are **counted for the walk and dropped for the caller** — dropping them in the decoder shortens the page and an offset walk ends on a short page. A blank row is worse than an absence, so the answer is keyed by `AccountID` and never by position. |
| **`/user/assignable/multiProjectSearch` answers RFC 7807** while its sibling one path up answers the classic envelope | Re-checked: `parseErrorBody` reads both; `TestVocabulary_…` and `TestPeople_…` cover the classic, RFC 7807 and empty-body refusals. |
| **Three of eleven account ids contain a colon** — and one body carried the escaped spelling in `self` and the raw one in `accountId` | `peopleBulkQuery` builds through `url.Values`; `TestPeople_EscapesAnAccountIdThatCarriesAColon` asserts `accountId=140022%3A…` on the wire and the raw form back. |
| **One account answered to two different display names on two endpoints**, same id, same minute | New `live` row. It is the sharpest argument yet for the id-only rule. |
| **`mypermissions` does not know `BROWSE_USERS`** — `400 {"errorMessages":[],"errors":{"BROWSE_USERS":"Unrecognized permission"}}`, the Agile-shaped refusal on a platform endpoint. The key is `USER_PICKER`, `type: GLOBAL` | See *CapPeople* below. |
| **`/user/picker` and the JQL autocomplete endpoints wrap the match in HTML** (`<b>`, `<strong>`) inside a field called `displayName`, and carry a localised prose `header` | Neither is data. Documented, and not used. |
| **`GET /project/{key}/statuses` is a bare array of issue types each with its own `statuses`**, and two types in one project differ | `IssueTypeStatuses` is per type, carries **ids**, and reads the category from inside each status. |
| **`GET /label` ignores a `query`** — a narrowed request answered byte-identically | `Labels` sends none and says so. A caller filters what it walked. |
| `GET /priority` is a bare array and is deprecated; `/priority/search` is the paged envelope | `Priorities` reads the paged one, in the site's ranking order. |

`AccountKind` **labels, it does not filter**. An app account is assigned work and reports issues exactly as a person does, so hiding one loses rows; a site that is ten robots and one human is unreadable without the distinction. `FindPeople` returns all of them and `Kind` is what a picker sinks and badges by.

## CapPeople probes by calling, not by asking

*Browse users and groups* is site-wide and a perfectly ordinary token can lack it. The probe calls `/user/search?query=&maxResults=1` rather than adding `USER_PICKER` to the `mypermissions` list, for two reasons both measured here: an unrecognised key fails that **whole** request with a 400, so a fifth key would put Bulk Change and Delete Issues behind whether a site knows it; and a 403 from the endpoint is the site's own sentence about the search that was actually refused. It runs whether or not a project was named, because the permission is global. `FindPeople` and `People` raise a `*CapabilityError` naming `CapPeople`, so a picker can offer the ids it already holds instead of disappearing.

## Conformance, because five methods is five chances to drift

`pkg/jira/cloud/conformance_people_test.go` runs one table per role over **both** adapters — #74 exists because the fake and the adapter drifted on `Me` and nothing caught it. The cases are properties, not answers, because the two adapters describe different sites on purpose: an unknown id is absent rather than blank; a `Limit` is a ceiling; an empty needle asks for everybody; a refusal is a `*CapabilityError` naming `CapPeople` with a reason; a status has an id and a category; **both sites hold two ids under one display name**; labels page and one of them is not ASCII.

`jiratest.Fake` implements all five. `pkg/jira/cloud/assert.go` and `pkg/jira/jiratest/jiratest.go` pin `PeopleFinder` and `FilterVocabulary` at **build** time.

## Consumers

`SessionClient` widened, so I grepped for every implementation rather than every compile:

- `pkg/jira/cloud.Client` — implements all five; `assert.go` pins the roles.
- `pkg/jira/jiratest.Fake` — implements all five; `jiratest.go` pins `jira.Client`, both roles and `SessionClient`.
- `internal/ui/onboarding.refusesToSearch` — embeds `*jiratest.Fake`, so it inherits them.
- Everything else (`cmd/saral`, `internal/ui/kernel.Deps`, `onboarding.Connector`) *takes* a `SessionClient` and never implements one.

No `internal/**` file is touched. The picker that consumes this is a later packet.

## New fixtures

`user_search.json` (bare array; all three `accountType`s, an inactive account, an id with a colon, an app whose `emailAddress` is `""`), `user_assignable.json` (people only), `user_bulk.json` + `user_bulk_page2.json` (the envelope, with a `null` in `values` and a real second page), `project_statuses.json` (two workflows, and **two ids under `In Review`**), `priority_search.json`, `labels.json` + `labels_page2.json` (bare strings, one not ASCII), `forbidden_browse_users.json`. All in the manifest test, all with a shape test, words invented. A real colon id is a numeric prefix and a UUID — exactly what `TestFixtures_CarryNoRealAccountID` refuses — so the one here keeps the prefix and the colon and is visibly not a UUID.

## Verification

- `go mod tidy` clean, `go vet`, `golangci-lint run` — 0 issues. **No `go.mod` change.**
- `go test -race -count=1 ./...` run **six times: 6 of 6 green.**
- `go build -trimpath -ldflags "-s -w"` → 11 MiB, under the 15 MiB gate.
- `scripts/checkleak.py` clean.
- **Allocations, measured rather than assumed.** `BenchmarkFrame` **297 allocs/op on main and 297 on this branch**; `BenchmarkKeyToFrame` **310 and 310** (`-count=5`, M2 Pro, `origin/main` extracted and benchmarked side by side). Nothing on the frame path is touched. ns/op swung 119k–159k on *main alone* across runs on this machine, so the timing column here is noise and only the allocation column is worth reading.
- No existing test was weakened, skipped or deleted. Three were **extended**: the probe now serves six requests rather than five and the two tests that count them say so, and `capsWithout` in `pkg/jira/types_test.go` gained the new key.

## Two things a reviewer should know

- **`User.Kind` is `AccountUnknown` on an issue's assignee**, because `pkg/jira/cloud/search.go`'s own user decoder does not read `accountType` — and that file is outside this packet's owned paths. A `/search/jql` response does carry the key, so this is information on the floor rather than a wrong answer. Filed as #116 with the two-line fix and the fake change that has to go with it.
- **`scripts/checkleak.py` finds 13 shared strings against the capture where `origin/main` already finds 12.** The one this PR adds is `In Review` in `project_statuses.json` — the fixture site's own invented status name, already committed in five other fixtures, which happens to be a substring of a status on the testbed. Every other overlap predates this branch. The required check — `scripts/checkleak.py` with no capture present — passes.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
