### PR TITLE
fix(fixtures): run the leak check on every pull request, and prove it catches a leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
             exit 1
           fi
 
+  fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # In this order: a check that has never been seen to fail proves nothing green.
+      - name: the leak check catches what it claims to
+        run: python3 scripts/checkleak_test.py
+      - name: nothing from a real instance reached the fixtures
+        run: python3 scripts/checkleak.py
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,12 @@ You are one of several agents working on this repository at the same time. Read 
   gitignored and stays that way. `pkg/jira/jiratest/fixtures/**` is synthetic: a capture is used to
   correct the *shape* of a fixture — keys, nesting, types, date formats, paging envelopes — and the
   words are invented. The scrubber is best-effort and cannot remove prose: ticket summaries, release
-  names, board names and custom field names are all somebody's private information. Run
-  `scripts/checkleak.py` before you commit, read the diff, and never `git add -A` when a capture has
-  been run in this tree.
+  names, board names and custom field names are all somebody's private information. CI runs
+  `scripts/checkleak.py` on every pull request, which fails on a fixture naming any host but the
+  invented site, on a capture that reached the index, and on `testdata/live/` losing its ignore rule.
+  The half of it that compares the fixtures against a capture can only run where the capture is, so
+  after one, run `scripts/checkleak.py --require-capture` yourself, read the diff, and never
+  `git add -A` when a capture has been run in this tree.
 - **Never expose a raw destructive API shape.** The canonical example: `PUT` on a sprint nulls every
   omitted field, so the port exposes `StartSprint`/`CompleteSprint`/`UpdateSprint` instead.
 - **Tests must not touch the network.** Use `pkg/jira/jiratest`. CI runs the race suite inside a

--- a/docs/PARALLEL.md
+++ b/docs/PARALLEL.md
@@ -56,8 +56,9 @@ A packet is done when all of these hold. A PR missing any of them is not ready f
 - [ ] Public API in `pkg/**` has doc comments; `internal/**` does not need them
 - [ ] Keybindings registered, not hardcoded; mouse zones added for anything clickable
 - [ ] Benchmarks added if the packet touches a render path or a list
-- [ ] Nothing from a real instance in the diff — `scripts/checkleak.py` clean, and the fixtures you
-      touched still describe the invented site
+- [ ] Nothing from a real instance in the diff — CI runs the half of `scripts/checkleak.py` that
+      needs no capture; if you took one, `scripts/checkleak.py --require-capture` is yours to run
+      and no runner can run it for you
 - [ ] Every consumer of anything shared you changed has actually adopted it, by name
 - [ ] `docs/ROADMAP.md` checkbox ticked in the same PR
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,9 +42,23 @@ different and much smaller problem.
 
 What a capture is for is the **shape**: the keys, the nesting, the types, the date formats, the paging
 envelopes. When a committed fixture is wrong about one of those, correct it from the capture and
-invent the words. `scripts/checkleak.py` then proves no string of yours came across; run it before
-committing. There are also tests asserting no fixture contains an `@` beyond the placeholder, a host
-other than `example.atlassian.net`, or anything shaped like a live Atlassian account ID.
+invent the words.
+
+`scripts/checkleak.py` is what proves the second half happened, and it runs in two halves because
+only one of them can be mechanical. The half CI runs on every pull request needs no capture: the
+fixture tree has to be non-empty, every file in it has to parse, every absolute URL has to name the
+invented site, and `testdata/live/` has to be both untracked and still ignored — deleting that
+ignore rule is the quiet way a capture ends up in the history, because nothing breaks until the next
+`git add -A`. `pkg/jira/jiratest/fixtures_test.go` asserts the rest of the shape rules over the same
+tree: no `@` beyond the placeholder, no host other than `example.atlassian.net`, nothing shaped like
+a live Atlassian account ID or a credential.
+
+The other half compares the committed fixtures against your capture, string by string, ignoring the
+vocabulary Jira and HTTP ship identically everywhere. **No runner can run it** — a capture only
+exists on the machine that took one, and a CI step over that half would be green for the same reason
+it was green before anyone wrote it. So it is yours: `scripts/checkleak.py --require-capture` after a
+capture, which fails rather than skips when there is nothing to compare against. `scripts/checkleak_test.py`
+covers both halves against planted leaks, and CI runs it before it runs the check.
 
 Fixtures to keep, at minimum: a rich ADF description, a paginated search response and its second
 page, `createmeta` for two different projects, a board configuration with and without estimation,

--- a/scripts/checkleak.py
+++ b/scripts/checkleak.py
@@ -1,21 +1,33 @@
 #!/usr/bin/env python3
 """Prove that nothing from a real Jira capture reached the committed fixtures.
 
-    scripts/checkleak.py [live-dir] [fixture-dir]
+    scripts/checkleak.py [live-dir] [fixture-dir] [--require-capture]
 
 Captures live outside the tracked tree because they carry the words a company
 wrote — ticket summaries, release names, custom field names, board and plan
 names. Fixtures are corrected from a capture's *shape* and given invented words.
 This checks that the second half actually happened.
 
-It compares the distinctive strings of the two trees and ignores the vocabulary
-Jira ships identically on every site, which the fixtures are supposed to share.
-Exits non-zero if anything company-specific appears in both.
+It runs in two halves and says which of them ran.
+
+The first needs no capture, so CI runs it on every pull request: the fixture tree
+has to hold on its own — it is not empty, every file in it parses, and every
+absolute URL names the invented site — and no capture may be tracked by git or
+have lost the ignore rule that keeps it untracked.
+
+The second compares the distinctive strings of the two trees, ignoring the
+vocabulary Jira ships identically on every site. It only runs where a capture is,
+which is the machine that ran scripts/capture.sh and never a CI runner. Pass
+--require-capture to make its absence an error rather than a skip.
+
+Exits non-zero if either half finds something.
 """
 
+import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 
 # Vocabulary every Jira site has. Sharing these is the point, not a leak.
@@ -31,9 +43,12 @@ STOCK = {
     "task", "bug", "story", "epic", "sub-task", "subtask",
     "a task that needs to be done.",
     "a problem which impairs or prevents the functions of the product.",
+    "a problem or error.",
     "stories track functionality or features expressed as user goals.",
     "a big user story that needs to be broken down. created by jira software - do not edit or delete.",
     "the sub-task of the issue",
+    # validation messages Jira writes itself
+    "you must specify a summary of the issue.",
     # system field names
     "summary", "description", "assignee", "reporter", "creator", "priority",
     "labels", "components", "fix versions", "affects versions", "due date",
@@ -45,6 +60,25 @@ STOCK = {
     "resolved", "target start", "target end", "start date", "rank", "sprint",
     "development", "request type", "approvals", "time to resolution",
     "steps to reproduce", "acceptance criteria", "definition of done",
+}
+
+# HTTP reason phrases, which an RFC 7807 problem document repeats verbatim in its
+# `title`. They come from the specification rather than from a site, so a capture
+# and a fixture answering the same status say the same word by construction.
+#
+# These are matched only against a whole value, never against a word inside one:
+# "Forbidden" alone is the protocol's word for 403, but "forbidden" in the middle
+# of a sentence is somebody's prose and has to stay catchable.
+STOCK_EXACT = {
+    "bad request", "unauthorized", "payment required", "forbidden", "not found",
+    "method not allowed", "not acceptable", "proxy authentication required",
+    "request timeout", "conflict", "gone", "length required",
+    "precondition failed", "content too large", "payload too large",
+    "uri too long", "unsupported media type", "range not satisfiable",
+    "expectation failed", "misdirected request", "unprocessable content",
+    "unprocessable entity", "too many requests", "request header fields too large",
+    "internal server error", "not implemented", "bad gateway",
+    "service unavailable", "gateway timeout", "http version not supported",
 }
 
 # Jira writes every permission description as "Ability to ...", so the prefix is
@@ -89,6 +123,17 @@ WORD = re.compile(r"[A-Za-z][A-Za-z0-9_-]{3,}")
 TEXT_KEYS = {"name", "summary", "description", "value", "text", "title", "goal",
              "untranslatedName", "displayName", "label"}
 
+# The invented site, and the hosts a fixture may name beside it. A captured
+# response reaches for a great many others — an avatar CDN, api.media.atlassian.com,
+# whatever a description links to on the company's own intranet — and none of
+# them survives being pasted into a fixture.
+ALLOWED_HOSTS = {"example.atlassian.net", "example.com", "www.example.com",
+                 "localhost", "127.0.0.1"}
+
+URL_HOST = re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://([^/\s\"'\\<>]+)")
+
+CAPTURE_DIR = "testdata/live"
+
 
 def strings(path):
     """Every human-written string in a JSON tree, by the key that held it."""
@@ -118,7 +163,7 @@ def distinctive(value):
     long word.
     """
     text = " ".join(value.split()).lower()
-    if text in STOCK or text.startswith(STOCK_PREFIXES):
+    if text in STOCK or text in STOCK_EXACT or text.startswith(STOCK_PREFIXES):
         return set()
 
     out = set()
@@ -140,51 +185,173 @@ def distinctive(value):
     return out
 
 
+def fixtures(directory):
+    """Every .json file under directory, deepest paths included."""
+    out = []
+    for parent, dirs, names in os.walk(directory):
+        dirs.sort()
+        for name in sorted(names):
+            if name.endswith(".json"):
+                out.append(os.path.join(parent, name))
+    return out
+
+
 def load(directory):
     found = {}
-    for name in sorted(os.listdir(directory)):
-        if not name.endswith(".json"):
-            continue
+    for path in fixtures(directory):
         try:
-            found[name] = strings(os.path.join(directory, name))
+            found[os.path.relpath(path, directory)] = strings(path)
         except (json.JSONDecodeError, UnicodeDecodeError):
             continue
     return found
 
 
-def main() -> int:
-    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    live_dir = sys.argv[1] if len(sys.argv) > 1 else f"{root}/testdata/live/fixtures"
-    fix_dir = sys.argv[2] if len(sys.argv) > 2 else f"{root}/pkg/jira/jiratest/fixtures"
+def hosts(text):
+    """Every host an absolute URL in text points at, without userinfo or port."""
+    out = []
+    for authority in URL_HOST.findall(text):
+        host = authority.rsplit("@", 1)[-1]
+        if host.startswith("["):
+            host = host.partition("]")[0] + "]"
+        else:
+            host = host.partition(":")[0]
+        if host:
+            out.append(host.lower())
+    return out
 
-    if not os.path.isdir(live_dir):
-        print(f"no capture at {live_dir}; nothing to compare against")
-        return 0
 
+def standalone(fix_dir):
+    """What the fixture tree has to satisfy with no capture to compare against.
+
+    The email, credential and account-id shapes are asserted next door, over the
+    same tree, by pkg/jira/jiratest/fixtures_test.go, and are deliberately not
+    repeated here.
+    """
+    if not os.path.isdir(fix_dir):
+        return [f"{fix_dir} is not a directory, so this check would pass by reading nothing"]
+
+    found = fixtures(fix_dir)
+    if not found:
+        return [f"no .json fixture under {fix_dir}, so this check would pass by reading nothing"]
+
+    problems = []
+    for path in found:
+        name = os.path.relpath(path, fix_dir)
+        try:
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+            json.loads(text)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as err:
+            problems.append(f"{name}: the leak check cannot read this fixture: {err}")
+            continue
+        for host in hosts(text):
+            if host not in ALLOWED_HOSTS:
+                problems.append(f"{name}: names the host {host}, which is not the invented site")
+    return problems
+
+
+def git(root, *args):
+    try:
+        return subprocess.run(["git", "-C", root, *args],
+                              capture_output=True, text=True, check=False)
+    except OSError:
+        return None
+
+
+def untracked_capture(root):
+    """A capture must stay outside the tracked tree, and stay ignored.
+
+    Deleting the ignore rule is the quiet way this goes wrong: nothing breaks
+    until the next `git add -A` after a capture, and by then it is in the history.
+    """
+    inside = git(root, "rev-parse", "--is-inside-work-tree")
+    if inside is None or inside.returncode != 0:
+        return [], f"skipped: {root} is not a git checkout"
+
+    problems = []
+    tracked = git(root, "ls-files", "--", CAPTURE_DIR)
+    for name in tracked.stdout.split("\n"):
+        if name.strip():
+            problems.append(f"{name.strip()} is tracked by git; a capture is never committed")
+
+    probe = f"{CAPTURE_DIR}/fixtures/probe.json"
+    if git(root, "check-ignore", "-q", probe).returncode != 0:
+        problems.append(f"{CAPTURE_DIR}/ is no longer ignored, so the next `git add -A` "
+                        f"after a capture commits it")
+    return problems, f"{CAPTURE_DIR}/ is ignored and holds nothing tracked"
+
+
+def differential(live_dir, fix_dir):
     live_words = set()
     for values in load(live_dir).values():
         for value in values:
             live_words |= distinctive(value)
 
     hits = []
-    for name, values in load(fix_dir).items():
-        for value in values:
+    for name, values in sorted(load(fix_dir).items()):
+        for value in sorted(values):
             shared = distinctive(value) & live_words
             if shared:
                 hits.append((name, value, sorted(shared)[:6]))
+    return hits
 
-    if not hits:
-        print(f"clean: no distinctive string from {live_dir} appears in {fix_dir}")
-        return 0
 
-    print(f"{len(hits)} string(s) in the committed fixtures also appear in your capture:\n")
-    for name, value, shared in hits:
-        print(f"  {name}")
-        print(f"    {value!r}")
-        print(f"    shares: {', '.join(shared)}")
-    print("\nEvery one of these is either a word Jira ships on every site — add it to STOCK —")
-    print("or something your company wrote, which must not be committed.")
-    return 1
+def parse(argv):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    parser.add_argument("live_dir", nargs="?")
+    parser.add_argument("fix_dir", nargs="?")
+    parser.add_argument("--require-capture", action="store_true",
+                        help="fail if there is no capture to compare the fixtures against")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse(argv)
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    live_dir = args.live_dir or f"{root}/{CAPTURE_DIR}/fixtures"
+    fix_dir = args.fix_dir or f"{root}/pkg/jira/jiratest/fixtures"
+
+    failed = False
+
+    print(f"the fixture tree on its own: {fix_dir}")
+    problems = standalone(fix_dir)
+    for problem in problems:
+        print(f"  {problem}")
+    if problems:
+        failed = True
+    else:
+        print(f"  clean: {len(fixtures(fix_dir))} fixtures, every URL on the invented site")
+
+    print("no capture in the tracked tree:")
+    problems, note = untracked_capture(root)
+    for problem in problems:
+        print(f"  {problem}")
+    print(f"  {note}")
+    if problems:
+        failed = True
+
+    print(f"the fixtures against your capture: {live_dir}")
+    if not os.path.isdir(live_dir):
+        print("  skipped: no capture here, so nothing was compared. Only the machine that ran")
+        print("  scripts/capture.sh can run this half; CI has no capture and never will.")
+        if args.require_capture:
+            print("  --require-capture was given and there is nothing to compare against")
+            failed = True
+    else:
+        hits = differential(live_dir, fix_dir)
+        for name, value, shared in hits:
+            print(f"  {name}")
+            print(f"    {value!r}")
+            print(f"    shares: {', '.join(shared)}")
+        if hits:
+            print(f"  {len(hits)} string(s) in the committed fixtures also appear in your capture.")
+            print("  Every one is either a word Jira ships on every site — add it to STOCK —")
+            print("  or something your company wrote, which must not be committed.")
+            failed = True
+        else:
+            print("  clean: no distinctive string from the capture appears in the fixtures")
+
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/scripts/checkleak_test.py
+++ b/scripts/checkleak_test.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Tests for scripts/checkleak.py.
+
+    python3 scripts/checkleak_test.py
+
+A leak check nobody has run against a planted leak is a claim, not a check, so
+every assertion here is either "this tree is clean" or "this tree is not, and the
+message says which file". Standard library only: CI runs this before it runs the
+check itself, on a runner with nothing installed but Go.
+"""
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(SCRIPTS)
+sys.path.insert(0, SCRIPTS)
+# Importing the check is the only reason anything here is a module, and a
+# __pycache__ beside it is a directory nobody has a reason to gitignore.
+sys.dont_write_bytecode = True
+
+import checkleak  # noqa: E402
+
+
+def write(root, files):
+    for name, body in files.items():
+        path = os.path.join(root, *name.split("/"))
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(body if isinstance(body, str) else json.dumps(body, indent=2))
+    return root
+
+
+def run(*argv):
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        code = checkleak.main(list(argv))
+    return code, out.getvalue()
+
+
+def git(root, *args):
+    env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull)
+    return subprocess.run(["git", "-C", root, *args], capture_output=True, text=True,
+                          check=True, env=env)
+
+
+class Trees(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="checkleak-")
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.live = os.path.join(self.dir, "live")
+        self.fix = os.path.join(self.dir, "fixtures")
+        os.makedirs(self.live)
+        os.makedirs(self.fix)
+
+
+class TestTheCheckCatchesALeak(Trees):
+    def test_a_summary_copied_out_of_a_capture(self):
+        write(self.live, {"search.json": {"summary": "Rollout of the Fenwick ledger import"}})
+        write(self.fix, {"search_page1.json": {"summary": "Rollout of the Fenwick ledger import"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("search_page1.json", out)
+        self.assertIn("phrase:rollout of the fenwick ledger import", out)
+
+    def test_one_distinctive_word_reused_in_a_sentence_of_its_own(self):
+        write(self.live, {"board.json": {"name": "Ledgerbridge delivery board"}})
+        write(self.fix, {"board.json": {"name": "The Ledgerbridge cutover"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("ledgerbridge", out)
+
+    def test_a_fixture_in_a_subdirectory_is_read_like_any_other(self):
+        write(self.live, {"board.json": {"name": "Fenwick delivery board"}})
+        write(self.fix, {"agile/board/board.json": {"name": "Fenwick delivery board"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn(os.path.join("agile", "board", "board.json"), out)
+
+
+class TestTheCheckPassesACleanTree(Trees):
+    def test_invented_words_beside_a_capture_that_shares_none_of_them(self):
+        write(self.live, {"search.json": {"summary": "Rollout of the Fenwick ledger import"}})
+        write(self.fix, {"search_page1.json": {"summary": "Checkout fails when the basket is empty"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 0, out)
+        self.assertIn("clean", out)
+
+    def test_an_http_reason_phrase_shared_by_both_is_not_a_leak(self):
+        problem = {"type": "about:blank", "title": "Not Found", "status": 404}
+        write(self.live, {"problem.json": problem})
+        write(self.fix, {"problem_no_endpoint.json": problem})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 0, out)
+
+    def test_every_reason_phrase_a_jira_site_answers_with(self):
+        for phrase in ["Bad Request", "Unauthorized", "Forbidden", "Not Found",
+                       "Method Not Allowed", "Conflict", "Too Many Requests",
+                       "Internal Server Error", "Service Unavailable"]:
+            with self.subTest(phrase=phrase):
+                self.assertEqual(checkleak.distinctive(phrase), set())
+
+    def test_a_reason_phrase_does_not_excuse_the_same_word_inside_a_sentence(self):
+        self.assertIn("phrase:forbidden while the fenwick cutover runs",
+                      checkleak.distinctive("Forbidden while the Fenwick cutover runs"))
+        self.assertIn("conflict", checkleak.distinctive("Conflict with the Fenwick rollout"))
+
+
+class TestTheTreeHasToHoldOnItsOwn(Trees):
+    def test_a_host_that_is_not_the_invented_site(self):
+        write(self.fix, {"myself.json": {"self": "https://acme.atlassian.net/rest/api/3/myself"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("acme.atlassian.net", out)
+
+    def test_an_avatar_host_the_atlassian_net_rule_does_not_cover(self):
+        write(self.fix, {"myself.json": {"avatar": "https://api.media.atlassian.com/file/abc"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("api.media.atlassian.com", out)
+
+    def test_a_link_to_a_company_intranet_inside_a_description(self):
+        write(self.fix, {"issue.json": {"description": "see https://wiki.acme.example.org/runbook"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("wiki.acme.example.org", out)
+
+    def test_a_fixture_that_does_not_parse_is_not_quietly_skipped(self):
+        write(self.fix, {"broken.json": "{ this is not json"})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("broken.json", out)
+        self.assertIn("cannot read", out)
+
+    def test_an_empty_tree_is_not_a_pass(self):
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("reading nothing", out)
+
+    def test_a_missing_tree_is_not_a_pass(self):
+        code, out = run(self.live, os.path.join(self.dir, "gone"))
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("reading nothing", out)
+
+    def test_the_site_the_fixtures_are_supposed_to_name(self):
+        write(self.fix, {"board.json": {"self": "https://example.atlassian.net/rest/agile/1.0/board/10"}})
+
+        code, out = run(self.live, self.fix)
+
+        self.assertEqual(code, 0, out)
+
+
+class TestTheDifferentialHalfIsNeverAssumed(Trees):
+    def test_no_capture_says_so_rather_than_reporting_clean(self):
+        write(self.fix, {"board.json": {"name": "EX Scrum board"}})
+
+        code, out = run(os.path.join(self.dir, "gone"), self.fix)
+
+        self.assertEqual(code, 0, out)
+        self.assertIn("nothing was compared", out)
+
+    def test_require_capture_fails_when_there_is_nothing_to_compare(self):
+        write(self.fix, {"board.json": {"name": "EX Scrum board"}})
+
+        code, out = run(os.path.join(self.dir, "gone"), self.fix, "--require-capture")
+
+        self.assertEqual(code, 1, out)
+        self.assertIn("--require-capture", out)
+
+    def test_require_capture_passes_once_the_capture_is_there(self):
+        write(self.live, {"board.json": {"name": "Fenwick delivery board"}})
+        write(self.fix, {"board.json": {"name": "EX Scrum board"}})
+
+        code, out = run(self.live, self.fix, "--require-capture")
+
+        self.assertEqual(code, 0, out)
+
+
+@unittest.skipIf(shutil.which("git") is None, "git is not installed")
+class TestTheCaptureStaysOutOfTheTrackedTree(Trees):
+    def repo(self, ignore=f"/{checkleak.CAPTURE_DIR}/\n"):
+        root = os.path.join(self.dir, "repo")
+        os.makedirs(root)
+        git(root, "init", "-q")
+        write(root, {".gitignore": ignore})
+        return root
+
+    def test_a_checkout_that_still_ignores_it(self):
+        problems, note = checkleak.untracked_capture(self.repo())
+
+        self.assertEqual(problems, [])
+        self.assertIn("is ignored", note)
+
+    def test_the_ignore_rule_deleted(self):
+        problems, _ = checkleak.untracked_capture(self.repo(ignore="/dist/\n"))
+
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("no longer ignored", problems[0])
+
+    def test_a_capture_forced_into_the_index(self):
+        root = self.repo()
+        write(root, {f"{checkleak.CAPTURE_DIR}/fixtures/search.json": {"summary": "x"}})
+        git(root, "add", "-f", "--", f"{checkleak.CAPTURE_DIR}/fixtures/search.json")
+
+        problems, _ = checkleak.untracked_capture(root)
+
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("tracked by git", problems[0])
+
+    def test_somewhere_that_is_not_a_checkout_says_so(self):
+        problems, note = checkleak.untracked_capture(self.dir)
+
+        self.assertEqual(problems, [])
+        self.assertIn("skipped", note)
+
+
+class TestThisRepository(unittest.TestCase):
+    def test_the_committed_fixtures_are_clean(self):
+        code, out = run()
+
+        self.assertEqual(code, 0, out)
+
+    def test_the_script_runs_as_a_command(self):
+        done = subprocess.run([sys.executable, os.path.join(SCRIPTS, "checkleak.py")],
+                              capture_output=True, text=True, check=False)
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+
+    def test_ci_runs_the_check_and_these_tests(self):
+        with open(os.path.join(ROOT, ".github", "workflows", "ci.yml"), encoding="utf-8") as f:
+            workflow = f.read()
+        commands = [line.strip() for line in workflow.split("\n")
+                    if line.strip().startswith(("run:", "- run:"))]
+
+        for script in ["scripts/checkleak.py", "scripts/checkleak_test.py"]:
+            with self.subTest(script=script):
+                self.assertTrue(any(script in command for command in commands),
+                                f"no CI step runs {script}, so the rule that no capture reaches "
+                                "the fixtures is back to being asked for politely")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #53. Closes #106.

`AGENTS.md` and `docs/PARALLEL.md` both told you to run `scripts/checkleak.py` before committing, and
nothing ran it — no CI step, no hook. The naive fix was worthless: with no capture in
`testdata/live/fixtures/` the script printed *"nothing to compare against"* and exited **0**, so a CI
step over it would have been permanently green over a tree it never opened. That is worse than no
check, because it looks like one.

## What I chose, and why

The script now has **two halves and says which one ran**, because only one of them can ever be
mechanical.

**The half CI runs, on every PR.** It needs no capture, so it is never green by vacuum:

| Assertion | Why it is not already covered |
|---|---|
| Every absolute URL names the invented site | `fixtures_test.go` matches `[a-z0-9.-]*atlassian\.net`. An avatar CDN (`avatar-management--avatars.us-west-2.amazonaws.com`), `api.media.atlassian.com` and a link to a company intranet are all invisible to it, and a capture carries all three. |
| The tree is non-empty and every file in it parses | `load()` swallowed a `JSONDecodeError` and carried on, and `os.listdir` never descended — a fixture in `fixtures/<area>/` (the layout `docs/PARALLEL.md` anticipates) was silently not read. Both are the same green-by-vacuum shape as the missing capture. |
| No capture is tracked by git, and `testdata/live/` is still ignored | The quiet failure: delete the ignore rule and nothing breaks until the next `git add -A` after a capture, by which time it is in the history. |

The email, credential and account-id shapes stay in `pkg/jira/jiratest/fixtures_test.go`, which
already asserts them over the same tree. I did not duplicate them, and the script says so where the
next reader would otherwise be tempted.

**The half no runner can run.** The differential comparison against a capture only works on the
machine that took one. So it is now explicitly the human's, and it stops pretending: `--require-capture`
fails rather than skips when there is nothing to compare against. `docs/TESTING.md`, `docs/PARALLEL.md`
and `AGENTS.md:36` now say which half is which, rather than leaving the reader the stronger reading.

I rejected the two other options on the table. A **git hook** only helps whoever installs it, which
`#53` already says is a reminder and not enforcement. **Failing when a capture is present** would fire
on the one machine where the differential check can actually run — it punishes the right behaviour.
No `.go` file changed: `internal/arch/**` is where a "CI still runs this" rule belongs, and it is not
this packet's to touch (see follow-ups).

## #106 — the reason phrase

`{"title": "Not Found"}` in an RFC 7807 fixture read as a leak against any capture that hit a routing
failure. Reason phrases are the HTTP specification's vocabulary, so they now sit in `STOCK_EXACT`,
the full 4xx/5xx set.

**They are matched only against a whole value, which is stricter than the issue asked for.**
"Forbidden" alone is the protocol's word for 403; "forbidden" in the middle of a sentence is
somebody's prose, and `STOCK` suppresses a word everywhere it appears, not just as a whole value. Four
of the phrases the issue names — `unauthorized`, `forbidden`, `conflict`, `gone` — are long enough to
be caught by the word check today, and blinding it to them is a false negative I did not want to buy.
A test pins the distinction.

Two more strings joined `STOCK` proper, on the rule that they are present in the tree **and**
demonstrably Atlassian's own text rather than anyone's words:

- `a problem or error.` — the team-managed Bug issue-type description. `STOCK` already had the
  company-managed wording and not this one.
- `you must specify a summary of the issue.` — Jira's own required-field validation message, in
  `validation_error.json`.

Everything else in the tree is invented prose and stays catchable. I deliberately did **not** add
status names like `In Review`: those are instance-specific, which is the thing being looked for.

## Proof each fix bites

Mutated back, watched red, restored:

| Mutation | Test that went red |
|---|---|
| `STOCK_EXACT` dropped from the whole-value check | `test_an_http_reason_phrase_shared_by_both_is_not_a_leak`: `AssertionError: 1 != 0` |
| `STOCK_EXACT` also consulted in the word loop | `test_a_reason_phrase_does_not_excuse_the_same_word_inside_a_sentence`: `'conflict' not found in {'phrase:conflict with the fenwick rollout'}` |
| The `fixtures` CI job removed | `test_ci_runs_the_check_and_these_tests`: `no CI step runs scripts/checkleak.py, so the rule that no capture reaches the fixtures is back to being asked for politely` |
| `os.walk` back to `os.listdir` | `test_a_fixture_in_a_subdirectory_is_read_like_any_other`, reporting the old vacuum verbatim: `no .json fixture under …` |
| The empty-tree guard and the ignore-rule gate deleted | `test_an_empty_tree_is_not_a_pass`, `test_the_ignore_rule_deleted` |

And the gate itself, with no capture anywhere — the exact CI case — over a copy of the real fixture
tree with a captured avatar URL pasted into `myself.json`:

```
$ python3 scripts/checkleak.py /tmp/nocapture /tmp/fixcopy
the fixture tree on its own: /tmp/fixcopy
  myself.json: names the host avatar-management--avatars.us-west-2.amazonaws.com, which is not the invented site
...
exit=1
```

## Tests

`scripts/checkleak_test.py`, 24 cases, standard library only (the runner has nothing but Go): a
planted summary, one distinctive word reused in a sentence of its own, a leak in a subdirectory, a
clean tree beside a capture sharing none of its words, every reason phrase, a foreign host in three
shapes, a fixture that does not parse, an empty tree, a missing tree, `--require-capture` both ways,
a capture forced into the index with `git add -f`, a deleted ignore rule, this repository's own
fixtures, and the workflow still naming both scripts under a `run:`.

## Verification

`go mod tidy` clean · `go vet` · `golangci-lint run` (0 issues) · `go build -trimpath` · the full
suite plus both Python steps run **six times, six green** · no `go.mod` change · no `.go` file
touched · nothing under `pkg/jira/jiratest/fixtures/**` touched.

## Follow-ups, not done here

- `internal/arch/ci_test.go` is where "the workflow still runs this" belongs, beside the network-jail
  rule. `checkleak_test.py` asserts it instead, which cannot survive the whole job being deleted.
  `internal/arch/**` is not this packet's to touch.
- `make check` does not run the leak check; the `Makefile` is not an owned path.
- `TEXT_KEYS` does not include `detail`, and `errorMessages` arrays are not read at all, so the prose
  in those fields is invisible to the differential half. Widening it means more `STOCK`, which means
  more permanent blind spots — worth its own decision, not a drive-by here.
- `scripts/capture.sh:368` still suggests the bare command. It is still correct (a capture is present
  at that point, so the differential half runs), but `--require-capture` would be better; `scripts/capture.sh`
  is not an owned path.

- The `test` job failed once on this branch and passed on a rerun of the same commit:
  `TestScrolling_CostsTheSameUnderTermsInForce` in `internal/ui/list`, a package with no `.go` change
  in this diff. It compares two `testing.Benchmark` runs that pick their own iteration counts while
  the rest of the package runs in parallel, so a smaller `N` on one side divides the memo's fill cost
  by a smaller number and reads as `9 against 1`. Characterised and filed as #120 rather than widened
  into this diff.

https://claude.ai/code/session_01XzD8fje8Nrd2H6DwHrh3VB
