### PR TITLE
fix(kernel): give a view its own answer, and stop only the views that are thrown away

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,6 +374,57 @@ Which views owe the interface is not something the kernel can check — it may n
 `internal/ui/livekeys_test.go` holds the table: every view something pushes implements `Closer`, and
 every view nothing pushes is listed with the reason a discard never reaches it.
 
+### A view's own answer belongs to the view that asked
+
+`Model.route`'s default is `forwardTop`, so a message the kernel does not recognise goes to whatever
+is on top of the stack. That is right for a widget's own message — a cursor blink, a spinner tick
+belongs to whoever is being looked at — and wrong for the answer to a question a view asked the site,
+because **a view is blurred by exactly the thing that makes it not the top.** Every answer landing
+while the palette was up was delivered to the palette and dropped.
+
+A view that asks the site for something therefore mints an address for itself and wraps the command
+in it:
+
+```go
+type Addr uint64
+
+func NewAddr() Addr
+func Reply(cmd tea.Cmd, to ...Addr) tea.Cmd
+
+type Addressed interface {
+	Addr() Addr
+}
+```
+
+`Reply` puts a `ReplyMsg` envelope around whatever the command comes back with. The kernel takes the
+envelope off and delivers the message to the view holding that address — wherever it is on the stack,
+or parked in `live` after a root switch — and **drops it when no address resolves**, because a
+discarded view has no frame left to draw the answer into. `Addressed` is how the kernel finds the
+view without knowing a single one of its message types.
+
+Three consequences, each of them the reason for a part of the shape:
+
+- **It is opt-in.** Everything unaddressed still goes to the top, so a `bubbles` tick stays exactly
+  where it was. Addressing them instead would blink every input in the program.
+- **The address is a number and not the `View`.** A view need not be a pointer — onboarding is a
+  struct the kernel copies on every `Update` — and comparing two interfaces holding the same
+  non-comparable type panics rather than answering.
+- **`To` is a list, most particular first.** The issue pane draws the comment thread in its sidebar
+  and that thread is a model inside a view, never an entry on the stack, so the kernel cannot deliver
+  to it at all. Its answer names itself and then the pane, and the kernel takes the first address it
+  can see: the thread itself while `C` has it lent to the whole screen, and the pane otherwise, whose
+  `Update` forwards what it does not recognise to the thread. A view that holds a child hands it
+  nothing but its own address.
+
+The recovery this replaces was a view re-reading on regaining focus when it had nothing — which the
+detail pane did and the editor, the transition picker and the create form did not. There is no such
+recovery anywhere now: an answer arrives, so there is nothing to ask for a second time.
+
+`internal/ui/livekeys_test.go` holds the table of which views owe an address, beside the `Closer` and
+`KeyReporter` ones. `internal/ui/reply_test.go` drives the whole program — the kernel, the real
+palette on `ctrl+k` — for every view that asks the site for anything, and holds the answer back until
+the palette is up so the delivery decision is really made with the view underneath.
+
 A view whose keys move with its state implements `kernel.KeyReporter`:
 
 ```go
@@ -484,12 +535,15 @@ directly.
 KeyPressMsg / MouseClickMsg
         │
         ▼
-  kernel.Update ──► focused view.Update ──► tea.Cmd (async IO)
+  kernel.Update ──► focused view.Update ──► kernel.Reply(cmd, addr)
         │                                        │
         │                                        ▼
         │                                  jira.Client call
         │                                        │
-        └──────────◄── typed result Msg ◄────────┘
+        └──◄── ReplyMsg{To: addr} ───────────────┘
+        │
+        ▼
+  the view at that address, wherever it is now
 ```
 
 Conventions:
@@ -497,7 +551,8 @@ Conventions:
 - One message type per outcome, named for the outcome: `IssuesLoadedMsg`, `IssueLoadFailedMsg`.
   Never a generic `DataMsg` with an `error` field and a switch on nil.
 - Commands are pure functions returning `tea.Cmd`; they close over a context tied to the view's
-  lifetime.
+  lifetime, and a view wraps its own in `kernel.Reply` with its address so that the answer comes back
+  to it rather than to whatever the stack has on top when it lands.
 - Cross-view effects go through `kernel.Broadcast` (e.g. an issue edited in the detail view tells
   the board to refresh that one row) — not by holding a pointer to another model.
 - **Request coalescing:** identical in-flight requests are deduplicated in `internal/app` with a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -335,6 +335,45 @@ quitting and switching root view ask **every** entry on the stack, because both 
 and the entry holding the draft is usually not the top one — the palette is pushed over whatever it
 was opened from and holds nothing itself.
 
+A view that starts work outliving a frame implements `kernel.Closer`, and is told once, when the
+kernel throws it away:
+
+```go
+type Closer interface {
+	Close()
+}
+```
+
+`Blocker` refuses the close; `Closer` is told about the one that happened. **The whole value is in
+which moments count.** `FocusMsg{false}` reaches a view in three different situations that mean three
+different things — pushed over and still on the stack, switched away from and parked in `live`, or
+popped and gone — and it distinguishes none of them. Cancelling a read on all three is how opening
+the palette over a loading comment thread cancelled the load. So `Close` is called on exactly two
+paths and no others: **the entry a pop takes off, and every entry a root switch throws away above
+entry zero.** A root the user switched away from is kept, comes back on `g` and its digit and is
+never closed; a project switch discards nothing, because every view hears `ProjectMsg` and stays;
+and there is no path that evicts a view from `live` to rebuild it. Quitting discards everything and
+tells nothing — the process is ending, so every context it would cancel dies with it, and a view
+given the news has no frame left to draw and no command that would run.
+
+It is a call and not a message for two reasons. `Update` hands back a `View` the kernel is about to
+drop, so anything a discarded view recorded there goes with it, and the only effect it could have is
+one it can perform on the spot. And a message is broadcastable: `kernel.Broadcast(CloseMsg{})` would
+let any view tell every other one it was finished. Whether a view is gone is the kernel's to say, and
+it says it to that view alone.
+
+**A pushed view is not always the kernel's to close.** The issue detail pane draws the comment thread
+in its sidebar and `C` hands the kernel *that same model* for the whole screen; closing it on `esc`
+would cancel a read the sidebar is still waiting for. `kernel.Lend` is the push that says so — the
+kernel draws it, routes keys to it and drops it like any other entry, and leaves closing it to the
+lender, which does that in its own `Close`. `kernel.Push` is the ordinary case and the default: a view
+built for the push, which the kernel then owns. `kernel.CloseView` is how a pane passes the news to a
+child view it holds.
+
+Which views owe the interface is not something the kernel can check — it may not import one — so
+`internal/ui/livekeys_test.go` holds the table: every view something pushes implements `Closer`, and
+every view nothing pushes is listed with the reason a discard never reaches it.
+
 A view whose keys move with its state implements `kernel.KeyReporter`:
 
 ```go

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -713,11 +713,47 @@ three situations that mean three different things, and every view had to guess w
   create form and the filter picker. The issue list and onboarding are listed as exempt with the
   reason — nothing pushes either, so a discard never reaches them — and
   `internal/ui/livekeys_test.go` fails on a seventh view that is in neither half.
-  **Not fixed here, and filed instead**: a view's own answer is delivered to whatever is on top of the
-  stack when it lands ([#125](https://github.com/varijkapil13/saral/issues/125)), so an answer
-  arriving while the palette is up still reaches the palette. Not cancelling the read is necessary
-  but not sufficient for that case, and the delivery half has to keep a spinner tick apart from a
-  search result without walking every view under every tick.
+  **Necessary and not sufficient**: not cancelling the read only helps if the answer then reaches the
+  view that asked, which it did not — see K2 below, which ships in the same pull request because
+  without it this packet is a regression.
+
+- [x] **K2 — A view's own answer is delivered to the view that asked for it** ·
+  [#125](https://github.com/varijkapil13/saral/issues/125) ·
+  **owns** `internal/ui/kernel/**`, the fetch handling of
+  `internal/ui/{list,issue,comment,form,filter,onboarding}`, `internal/ui/*_test.go`,
+  `docs/{ARCHITECTURE,UX,ROADMAP}.md`
+  `Model.route`'s default is `forwardTop`, so a message the kernel does not recognise goes to
+  whatever is on top **when it lands** — and a view is blurred by exactly the thing that makes it not
+  the top. So every answer arriving while the palette was up was delivered to the palette and
+  dropped. Cancelling on blur had been hiding it: the pane cancelled, and on regaining focus
+  `!m.loadedIssue` sent it to read again, which recovered the answer. K1 removed the cancel and
+  guarded that recovery with `!m.loadingIssue` — a flag only `loadedMsg` and `failedMsg` clear, which
+  are the very messages the palette ate. **The pane never asked again.**
+  **`kernel.Reply` and `kernel.Addressed` are the fifth optional interface and its command wrapper.**
+  A view mints a `kernel.Addr` for itself and wraps its own commands in it; the kernel takes the
+  envelope off and delivers to the view holding that address, wherever it is on the stack or parked
+  in `live`, and drops it when no address resolves. **Opt-in on purpose**: everything unaddressed
+  still goes to the top, which is where a `bubbles` cursor blink and a spinner tick belong, and
+  addressing those would blink every input in the program and walk the session under every tick.
+  The address is a number rather than the `View` because a view need not be a pointer — onboarding is
+  a struct the kernel copies on every `Update` — and `==` on two interfaces holding the same
+  non-comparable type panics rather than answering.
+  **`To` is a list, most particular first.** The comment thread in the issue pane's sidebar is a
+  model inside a view and never an entry, so the kernel cannot deliver to it at all: its answer names
+  itself and then the pane, and the kernel takes the first address it can see — the thread while `C`
+  has it lent to the whole screen, the pane otherwise, which forwards what it does not recognise.
+  **The recovery is gone rather than renamed.** The detail pane no longer re-reads on regaining
+  focus and `loadingIssue` is deleted; the editor, the transition picker, the create form and the
+  filter picker never had a recovery and no longer need one. Eight adopters, one per key scope, and
+  `internal/ui/livekeys_test.go` fails on a ninth view in neither half of the table. The list's poll
+  tick is addressed too — `pollArmed` is cleared by the tick and by nothing else, so one eaten by the
+  palette stopped the poller for the rest of the session.
+  Held to it by `internal/ui/reply_test.go`, which drives the whole program — the kernel, the real
+  palette on `ctrl+k` — for each of the list, the detail pane, the field editor, the transition
+  picker, the filter picker, the create form and the thread in both the places it is drawn, holding
+  each answer back until the palette is up so that the delivery decision is really made with the view
+  underneath. Every guard was checked by mutation: removing the kernel's routing, and dropping the
+  address from any one view, turns exactly that view's case red.
 
 ## Batch 4 — Attachments · parallel ×3
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -680,6 +680,45 @@ lands first, because `pkg/jira/port.go` blocks everyone while it is open.
   is unchanged at 297, and the picker is virtualized and memoized — 3 allocations a frame scrolling
   two thousand labels, 94µs from keystroke to frame.
 
+## Kernel · being covered is not being thrown away
+
+Found while building the comment thread. The kernel said one thing — `FocusMsg{Focused: false}` — in
+three situations that mean three different things, and every view had to guess which it was in.
+
+- [x] **K1 — A view learns when it is being discarded** · [#124](https://github.com/varijkapil13/saral/issues/124) ·
+  **owns** `internal/ui/kernel/**`, the focus and fetch handling of
+  `internal/ui/{list,issue,comment,form,filter,onboarding}`, `internal/ui/livekeys_test.go`,
+  `docs/{ARCHITECTURE,UX,ROADMAP}.md`
+  A view pushed over is still there, a root switched away from is parked and comes back on its digit,
+  and a popped view is gone — and one message covered all three. `internal/ui/comment` had cancelled
+  its read on blur, so **opening the palette over a loading thread cancelled the load**; the fix was
+  to stop cancelling on blur at all, which left every discarded view fetching for an answer nothing
+  would draw. `internal/ui/issue`'s detail pane, field editor and transition picker and
+  `internal/ui/onboarding` all still had the original bug, and the editor and the picker never
+  re-read on coming back, so `ctrl+k` over a loading one left it loading for as long as it was open.
+  **`kernel.Closer` is the fourth optional interface and not a fourth shape**, next to `KeyCapturer`,
+  `Blocker` and `KeyReporter`. `Blocker` refuses a close; `Closer` is told about the one that
+  happened. A call and not a message, because `Update` hands back a `View` the kernel is about to drop
+  — so anything a discarded view records there is thrown away with it — and because a message is
+  broadcastable, which would let any view tell every other one it was finished.
+  **Two paths call it and no others**: the entry a pop takes off, and everything above entry zero
+  that a root switch throws away. A parked root is never closed, a project switch discards nothing —
+  every view hears `ProjectMsg` and stays — and nothing evicts a view from `live` to rebuild it.
+  Quitting discards everything and tells nobody: the process is ending, so every context it would
+  cancel dies with it and no command it returned would run.
+  **`kernel.Lend` is the push that keeps the view.** The issue pane hands the kernel the very thread
+  its sidebar draws, so closing it on `esc` would cancel a read the sidebar is still waiting for. The
+  kernel drops a lent entry without closing it and leaves that to the lender, which does it in its own
+  `Close`. Six adopters: the thread, the detail pane, the field editor, the transition picker, the
+  create form and the filter picker. The issue list and onboarding are listed as exempt with the
+  reason — nothing pushes either, so a discard never reaches them — and
+  `internal/ui/livekeys_test.go` fails on a seventh view that is in neither half.
+  **Not fixed here, and filed instead**: a view's own answer is delivered to whatever is on top of the
+  stack when it lands ([#125](https://github.com/varijkapil13/saral/issues/125)), so an answer
+  arriving while the palette is up still reaches the palette. Not cancelling the read is necessary
+  but not sufficient for that case, and the delivery half has to keep a spinner tick apart from a
+  search result without walking every view under every tick.
+
 ## Batch 4 — Attachments · parallel ×3
 
 - [ ] **P4.1 — List and download** · [#17](https://github.com/varijkapil13/saral/issues/17) · **owns** `pkg/jira/cloud/attachment.go`

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -139,8 +139,8 @@ visible in what happens to whatever it was fetching.
 
 | Gesture | The view you were in | Its in-flight read |
 |---|---|---|
-| `ctrl+k`, or anything else pushed over it | still there, underneath | carries on |
-| `g` and a digit, to another root | kept, and comes back on its own digit with the same row under the cursor | carries on |
+| `ctrl+k`, or anything else pushed over it | still there, underneath | carries on, and lands in it |
+| `g` and a digit, to another root | kept, and comes back on its own digit with the same row under the cursor | carries on, and lands in it |
 | `esc` from a pushed view | gone | given up |
 
 The first row is the one worth stating out loud: **opening the palette over something that is still
@@ -155,6 +155,11 @@ when you switch away with `g`: that stack is gone, and only the root underneath 
 
 `q` and `ctrl+c` end the program, which throws every view away and stops nothing on the way out:
 there is no next frame for an answer to land in.
+
+And what a view was waiting for arrives in the view that asked for it, whatever is on screen by then.
+Open the palette over a loading issue, read a command, press `esc`, and the issue is there — it
+finished loading while you were reading, underneath. Nothing is asked for twice on the way back, so
+coming out of the palette never costs a second round trip to the site.
 
 ### Inside the palette
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -132,6 +132,30 @@ refresh                r / R          current view / purge and refetch. both say
 
 Vim keys and arrows are both always bound. `j/k` and `↑/↓` are not a preference to configure.
 
+### What happens to a view you leave
+
+Three of these gestures take a view off the screen and they do not mean the same thing, which is
+visible in what happens to whatever it was fetching.
+
+| Gesture | The view you were in | Its in-flight read |
+|---|---|---|
+| `ctrl+k`, or anything else pushed over it | still there, underneath | carries on |
+| `g` and a digit, to another root | kept, and comes back on its own digit with the same row under the cursor | carries on |
+| `esc` from a pushed view | gone | given up |
+
+The first row is the one worth stating out loud: **opening the palette over something that is still
+loading must not cancel the load.** It used to, because the only thing a view was told was that it
+had lost the keyboard, and a thread in a sidebar loses that whenever the pane beside it takes it.
+Nothing about losing the keys means nobody wants the answer.
+
+The last row is the other half. A pushed view that `esc` takes away is not coming back — the next
+`enter` builds a new one — so the request it is waiting on is one nobody will ever draw, and it is
+cut short rather than left to finish into nothing. The same is true of everything stacked over a root
+when you switch away with `g`: that stack is gone, and only the root underneath is kept.
+
+`q` and `ctrl+c` end the program, which throws every view away and stops nothing on the way out:
+there is no next frame for an answer to land in.
+
 ### Inside the palette
 
 Every letter is the filter's, which is the one place `j` and `k` do not move a selection: `↑`/`↓` and

--- a/internal/ui/comment/comment.go
+++ b/internal/ui/comment/comment.go
@@ -72,6 +72,7 @@ var (
 	_ kernel.View        = (*Model)(nil)
 	_ kernel.KeyCapturer = (*Model)(nil)
 	_ kernel.Blocker     = (*Model)(nil)
+	_ kernel.Addressed   = (*Model)(nil)
 )
 
 // ThreadMsg points the view at an issue's thread. It is exported so that a view
@@ -148,6 +149,13 @@ type Model struct {
 	gen           int
 	cancel        context.CancelFunc
 
+	// addr is where this thread's own answers come back to, and holder is the
+	// view drawing it when that view is a pane rather than the kernel. A thread
+	// in a sidebar is not on the stack, so its answer reaches it through the
+	// pane, which forwards everything it does not know.
+	addr   kernel.Addr
+	holder kernel.Addr
+
 	zones  widget.Zoner
 	clicks *widget.Clicks
 }
@@ -156,6 +164,10 @@ type Model struct {
 // the view is reachable by name and from the palette, and is told which issue
 // it is about by a ThreadMsg.
 func New(d kernel.Deps) kernel.View { return build(d, "") }
+
+// Addr is where the kernel delivers what this thread asked the site for,
+// whatever has since been pushed over it.
+func (m *Model) Addr() kernel.Addr { return m.addr }
 
 // Thread builds the thread for one issue, which is how a view holding an issue
 // opens it — pushed over that view, or held as a child model inside it.
@@ -166,7 +178,17 @@ func New(d kernel.Deps) kernel.View { return build(d, "") }
 // Everything else — one fetch, one draft, one cursor, one composer with the text
 // still in it — follows from there being one of these however many boxes it is
 // drawn in.
-func Thread(d kernel.Deps, key string) *Model { return build(d, key) }
+// held names the view drawing this one when a pane embeds it instead of
+// pushing it. The kernel cannot see a model inside another, so an answer is
+// addressed to this thread first and to its holder after, and the holder hands
+// it on.
+func Thread(d kernel.Deps, key string, held ...kernel.Addr) *Model {
+	m := build(d, key)
+	if len(held) > 0 {
+		m.holder = held[0]
+	}
+	return m
+}
 
 // Push returns the command that opens the thread for one issue on top of
 // whatever is on screen.
@@ -182,6 +204,7 @@ func build(d kernel.Deps, key string) *Model {
 		drafts: openDrafts(),
 		issue:  strings.TrimSpace(key),
 		editor: newEditor(),
+		addr:   kernel.NewAddr(),
 	}
 	if m.deps.Theme == nil {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
@@ -376,6 +399,12 @@ func (m *Model) stop() {
 	m.loading = false
 }
 
+// reply puts this thread's address on a command, and its holder's after, so the
+// answer comes back here rather than to whatever the stack has on top by then.
+func (m *Model) reply(cmd tea.Cmd) tea.Cmd {
+	return kernel.Reply(withCancel(m.cancel, cmd), m.addr, m.holder)
+}
+
 // Close lets go of the read, the paging and the send. A thread the kernel has
 // discarded is one nothing can draw the answer into; a pane that embeds one is
 // lending it instead, so this is not reached by esc coming back from the whole
@@ -390,7 +419,7 @@ func (m *Model) load() tea.Cmd {
 	}
 	ctx, gen := m.begin()
 	m.loading = true
-	return withCancel(m.cancel, load(ctx, m.deps.Jira, m.issue, gen))
+	return m.reply(load(ctx, m.deps.Jira, m.issue, gen))
 }
 
 func (m *Model) loadedPage(msg loadedMsg) tea.Cmd {
@@ -443,7 +472,7 @@ func (m *Model) pageAheadIfNeeded() tea.Cmd {
 	}
 	ctx, gen := m.begin()
 	m.loading = true
-	return withCancel(m.cancel, more(ctx, m.page, gen))
+	return m.reply(more(ctx, m.page, gen))
 }
 
 func (m *Model) failed(msg failedMsg) tea.Cmd {
@@ -573,9 +602,9 @@ func (m *Model) send() tea.Cmd {
 	m.sending = true
 	ctx, gen := m.begin()
 	if m.editing == "" {
-		return withCancel(m.cancel, add(ctx, m.deps.Jira, m.issue, body, gen))
+		return m.reply(add(ctx, m.deps.Jira, m.issue, body, gen))
 	}
-	return withCancel(m.cancel, edit(ctx, m.deps.Jira, m.issue, m.editing, body, gen))
+	return m.reply(edit(ctx, m.deps.Jira, m.issue, m.editing, body, gen))
 }
 
 // unreadable turns a parse failure into the sentence a user reads: which line
@@ -642,7 +671,7 @@ func (m *Model) confirmDelete() tea.Cmd {
 	}
 	ctx, gen := m.begin()
 	m.loading = true
-	return withCancel(m.cancel, remove(ctx, m.deps.Jira, m.issue, id, gen))
+	return m.reply(remove(ctx, m.deps.Jira, m.issue, id, gen))
 }
 
 func (m *Model) deleted(msg deletedMsg) tea.Cmd {

--- a/internal/ui/comment/comment.go
+++ b/internal/ui/comment/comment.go
@@ -376,6 +376,12 @@ func (m *Model) stop() {
 	m.loading = false
 }
 
+// Close lets go of the read, the paging and the send. A thread the kernel has
+// discarded is one nothing can draw the answer into; a pane that embeds one is
+// lending it instead, so this is not reached by esc coming back from the whole
+// screen.
+func (m *Model) Close() { m.stop() }
+
 func (m *Model) current(gen int) bool { return gen == m.gen }
 
 func (m *Model) load() tea.Cmd {

--- a/internal/ui/comment/comment_test.go
+++ b/internal/ui/comment/comment_test.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -799,4 +800,41 @@ func countCalls(f *jiratest.Fake, name string) int {
 		}
 	}
 	return n
+}
+
+// The thread loses the keyboard whenever the pane beside it takes them, whenever
+// something is pushed over it, and when it is thrown away, and only the last of
+// those is a reason to give up the read.
+func TestThread_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(4)
+	comment(t, f, "PROJ-1", "Something to read.")
+
+	var kept kernel.View = Thread(testDeps(t, f), "PROJ-1")
+	kept, _ = kept.Update(kernel.SizeMsg{Width: 100, Height: 30})
+	reading := kept.Init()
+	if _, more := kept.Update(kernel.FocusMsg{}); more != nil {
+		t.Fatal("losing the keyboard asked for more work")
+	}
+	if _, gaveUp := reading().(failedMsg); gaveUp {
+		t.Error("the thread gave up its read when it merely lost the keyboard")
+	}
+
+	var dropped kernel.View = Thread(testDeps(t, f), "PROJ-1")
+	dropped, _ = dropped.Update(kernel.SizeMsg{Width: 100, Height: 30})
+	cmd := dropped.Init()
+	closer, ok := dropped.(kernel.Closer)
+	if !ok {
+		t.Fatal("the thread does not implement kernel.Closer, so nothing stops its read")
+	}
+	closer.Close()
+
+	failed, ok := cmd().(failedMsg)
+	if !ok {
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", cmd())
+	}
+	if !errors.Is(failed.err, context.Canceled) {
+		t.Errorf("err = %v, want the context's own error", failed.err)
+	}
 }

--- a/internal/ui/comment/comment_test.go
+++ b/internal/ui/comment/comment_test.go
@@ -817,7 +817,7 @@ func TestThread_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	if _, more := kept.Update(kernel.FocusMsg{}); more != nil {
 		t.Fatal("losing the keyboard asked for more work")
 	}
-	if _, gaveUp := reading().(failedMsg); gaveUp {
+	if _, gaveUp := answer(reading).(failedMsg); gaveUp {
 		t.Error("the thread gave up its read when it merely lost the keyboard")
 	}
 
@@ -830,11 +830,21 @@ func TestThread_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	}
 	closer.Close()
 
-	failed, ok := cmd().(failedMsg)
+	failed, ok := answer(cmd).(failedMsg)
 	if !ok {
-		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", cmd())
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", answer(cmd))
 	}
 	if !errors.Is(failed.err, context.Canceled) {
 		t.Errorf("err = %v, want the context's own error", failed.err)
 	}
+}
+
+// answer is what the kernel hands a view: the command's own reply with the
+// envelope the kernel addresses it by taken off.
+func answer(cmd tea.Cmd) tea.Msg {
+	msg := cmd()
+	if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+		return reply.Msg
+	}
+	return msg
 }

--- a/internal/ui/comment/harness_test.go
+++ b/internal/ui/comment/harness_test.go
@@ -142,6 +142,11 @@ func (d *driver) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer and hands the
+		// message inside to the view the address names. There is one view here.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		if status, ok := msg.(kernel.StatusMsg); ok {
 			d.statuses = append(d.statuses, status)
 			continue

--- a/internal/ui/filter/filter.go
+++ b/internal/ui/filter/filter.go
@@ -430,6 +430,10 @@ func (m *Model) stop() {
 	m.loading = false
 }
 
+// Close lets go of the vocabulary read and of an account search still out with
+// the site. A picker that has been thrown away has nothing to rank.
+func (m *Model) Close() { m.stop() }
+
 // fetch asks the site for the facet on screen. needle is only ever non-empty
 // for the accounts, which are the one vocabulary this site will not let anybody
 // narrow locally.

--- a/internal/ui/filter/filter.go
+++ b/internal/ui/filter/filter.go
@@ -46,6 +46,7 @@ const maxLabels = 2000
 var (
 	_ kernel.View        = (*Model)(nil)
 	_ kernel.KeyCapturer = (*Model)(nil)
+	_ kernel.Addressed   = (*Model)(nil)
 )
 
 // state is which of the picker's two screens is up.
@@ -116,6 +117,7 @@ type Model struct {
 	failure error
 	gen     int
 	cancel  context.CancelFunc
+	addr    kernel.Addr
 
 	styles *styles
 	memo   *rowCache
@@ -133,7 +135,7 @@ type Model struct {
 // New builds the picker. It opens on the facets, which need nothing of the
 // site, so its first frame costs no round trip.
 func New(d kernel.Deps, opts ...Option) kernel.View {
-	m := &Model{deps: d, input: newInput()}
+	m := &Model{deps: d, input: newInput(), addr: kernel.NewAddr()}
 	for _, opt := range opts {
 		opt(m)
 	}
@@ -430,6 +432,16 @@ func (m *Model) stop() {
 	m.loading = false
 }
 
+// Addr is where the kernel delivers the vocabulary and the accounts this picker
+// asked for, whatever has since been pushed over it.
+func (m *Model) Addr() kernel.Addr { return m.addr }
+
+// reply puts this picker's address on a command, so what it asked for comes
+// back here rather than to whatever the stack has on top by then.
+func (m *Model) reply(cmd tea.Cmd) tea.Cmd {
+	return kernel.Reply(withCancel(m.cancel, cmd), m.addr)
+}
+
 // Close lets go of the vocabulary read and of an account search still out with
 // the site. A picker that has been thrown away has nothing to rank.
 func (m *Model) Close() { m.stop() }
@@ -445,11 +457,11 @@ func (m *Model) fetch(needle string) tea.Cmd {
 	facet := m.facet
 	if facet.people() {
 		m.asked[needle] = true
-		return withCancel(m.cancel, findPeople(ctx, m.deps.Jira, facet, jira.PeopleQuery{
+		return m.reply(findPeople(ctx, m.deps.Jira, facet, jira.PeopleQuery{
 			Match: needle, Project: m.peopleProject(facet), Limit: peopleLimit,
 		}, m.inForceIDs(facet), gen))
 	}
-	return withCancel(m.cancel, vocabulary(ctx, m.deps.Jira, facet, m.deps.Project, gen))
+	return m.reply(vocabulary(ctx, m.deps.Jira, facet, m.deps.Project, gen))
 }
 
 // inForceIDs are the accounts this facet is already being filtered by, which

--- a/internal/ui/filter/filter_test.go
+++ b/internal/ui/filter/filter_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -657,4 +658,58 @@ func TestPicker_AnAnswerThatLandsLateLeavesTheCursorOnTheSameValue(t *testing.T)
 			}
 		})
 	}
+}
+
+// The picker is pushed over the list and the palette is pushed over the picker,
+// so a vocabulary read given up on a blur is one nothing asks for again. A
+// picker the kernel has thrown away lets it go.
+func TestPicker_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(20)
+
+	kept := openOnAFacet(t, testDeps(f))
+	reading := kept.cmd
+	if _, more := kept.view.Update(kernel.FocusMsg{}); more != nil {
+		t.Fatal("losing the keyboard asked for more work")
+	}
+	if _, gaveUp := reading().(failedMsg); gaveUp {
+		t.Error("the picker gave up its read when it merely lost the keyboard")
+	}
+
+	dropped := openOnAFacet(t, testDeps(f))
+	closer, ok := dropped.view.(kernel.Closer)
+	if !ok {
+		t.Fatal("the picker does not implement kernel.Closer, so nothing stops its read")
+	}
+	closer.Close()
+
+	failed, ok := dropped.cmd().(failedMsg)
+	if !ok {
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", dropped.cmd())
+	}
+	if !errors.Is(failed.err, context.Canceled) {
+		t.Errorf("err = %v, want the context's own error", failed.err)
+	}
+}
+
+// openOnAFacet drives the picker to the state where it has asked the site for a
+// vocabulary, and hands back the command carrying that read rather than running
+// it, so a test can decide what happens to it first.
+type facetOpen struct {
+	view kernel.View
+	cmd  tea.Cmd
+}
+
+func openOnAFacet(t *testing.T, d kernel.Deps) facetOpen {
+	t.Helper()
+
+	view := New(d)
+	view, _ = view.Update(kernel.SizeMsg{Width: 120, Height: 30})
+	view, _ = view.Update(kernel.FocusMsg{Focused: true})
+	view, cmd := view.Update(keyPress("enter"))
+	if cmd == nil {
+		t.Fatal("choosing a facet asked the site for nothing")
+	}
+	return facetOpen{view: view, cmd: cmd}
 }

--- a/internal/ui/filter/filter_test.go
+++ b/internal/ui/filter/filter_test.go
@@ -673,7 +673,7 @@ func TestPicker_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	if _, more := kept.view.Update(kernel.FocusMsg{}); more != nil {
 		t.Fatal("losing the keyboard asked for more work")
 	}
-	if _, gaveUp := reading().(failedMsg); gaveUp {
+	if _, gaveUp := answer(reading).(failedMsg); gaveUp {
 		t.Error("the picker gave up its read when it merely lost the keyboard")
 	}
 
@@ -684,9 +684,9 @@ func TestPicker_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	}
 	closer.Close()
 
-	failed, ok := dropped.cmd().(failedMsg)
+	failed, ok := answer(dropped.cmd).(failedMsg)
 	if !ok {
-		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", dropped.cmd())
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", answer(dropped.cmd))
 	}
 	if !errors.Is(failed.err, context.Canceled) {
 		t.Errorf("err = %v, want the context's own error", failed.err)
@@ -712,4 +712,14 @@ func openOnAFacet(t *testing.T, d kernel.Deps) facetOpen {
 		t.Fatal("choosing a facet asked the site for nothing")
 	}
 	return facetOpen{view: view, cmd: cmd}
+}
+
+// answer is what the kernel hands a view: the command's own reply with the
+// envelope the kernel addresses it by taken off.
+func answer(cmd tea.Cmd) tea.Msg {
+	msg := cmd()
+	if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+		return reply.Msg
+	}
+	return msg
 }

--- a/internal/ui/filter/harness_test.go
+++ b/internal/ui/filter/harness_test.go
@@ -133,6 +133,11 @@ func (d *driver) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer and hands the
+		// message inside to the view the address names. There is one view here.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		switch msg := msg.(type) {
 		case kernel.StatusMsg:
 			d.statuses = append(d.statuses, msg)

--- a/internal/ui/form/form.go
+++ b/internal/ui/form/form.go
@@ -39,6 +39,7 @@ var (
 	_ kernel.View        = (*Model)(nil)
 	_ kernel.KeyCapturer = (*Model)(nil)
 	_ kernel.Blocker     = (*Model)(nil)
+	_ kernel.Addressed   = (*Model)(nil)
 )
 
 // stage is which half of the flow the form is in: an issue type has to be
@@ -118,6 +119,7 @@ type Model struct {
 
 	gen    int
 	cancel context.CancelFunc
+	addr   kernel.Addr
 
 	// lines is the frame under construction and head the caption above it, kept
 	// between frames so that drawing a screen allocates neither.
@@ -144,12 +146,17 @@ type choice struct {
 // New builds the create form for the project this session is scoped to.
 func New(d kernel.Deps) kernel.View { return newWith(d, schemas, drafts) }
 
+// Addr is where the kernel delivers the issue types, the create screen and the
+// issue this form asked for, whatever has since been pushed over it.
+func (m *Model) Addr() kernel.Addr { return m.addr }
+
 func newWith(d kernel.Deps, cache *schemaCache, store *draftStore) *Model {
 	if d.Theme == nil {
 		d.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
 	}
 	m := &Model{
 		deps:    d,
+		addr:    kernel.NewAddr(),
 		cache:   cache,
 		drafts:  store,
 		styles:  newStyles(d.Theme),
@@ -321,6 +328,12 @@ func (m *Model) stop() {
 	m.loading, m.busy = false, false
 }
 
+// reply puts this form's address on a command, so what it asked for comes back
+// here rather than to whatever the stack has on top by then.
+func (m *Model) reply(cmd tea.Cmd) tea.Cmd {
+	return kernel.Reply(withCancel(m.cancel, cmd), m.addr)
+}
+
 // Close lets go of the issue types and the field schema behind them. A create
 // screen that has been thrown away has nowhere to draw either.
 func (m *Model) Close() { m.stop() }
@@ -338,7 +351,7 @@ func (m *Model) loadTypes() tea.Cmd {
 	}
 	ctx, gen := m.begin()
 	m.loading, m.stage = true, stageTypes
-	return withCancel(m.cancel, loadTypes(ctx, m.search, m.project, gen))
+	return m.reply(loadTypes(ctx, m.search, m.project, gen))
 }
 
 func (m *Model) typesFound(msg typesFoundMsg) tea.Cmd {
@@ -398,9 +411,9 @@ func (m *Model) openType(typ jira.IssueType) tea.Cmd {
 	m.chosen = typ
 	ctx, gen := m.begin()
 	m.loading = true
-	cmds := []tea.Cmd{withCancel(m.cancel, loadSchema(ctx, m.deps.Jira, m.cache, m.screenKey(), gen))}
+	cmds := []tea.Cmd{m.reply(loadSchema(ctx, m.deps.Jira, m.cache, m.screenKey(), gen))}
 	if !m.haveMe {
-		cmds = append(cmds, loadAccount(context.WithoutCancel(ctx), m.deps.Jira, gen))
+		cmds = append(cmds, kernel.Reply(loadAccount(context.WithoutCancel(ctx), m.deps.Jira, gen), m.addr))
 	}
 	return tea.Batch(cmds...)
 }
@@ -993,7 +1006,7 @@ func (m *Model) submit() tea.Cmd {
 	in := m.issueInput()
 	ctx, gen := m.begin()
 	m.busy = true
-	return withCancel(m.cancel, create(ctx, m.deps.Jira, in, gen))
+	return m.reply(create(ctx, m.deps.Jira, in, gen))
 }
 
 // missingRequired names the fields Jira requires that the form does not offer.

--- a/internal/ui/form/form.go
+++ b/internal/ui/form/form.go
@@ -321,6 +321,10 @@ func (m *Model) stop() {
 	m.loading, m.busy = false, false
 }
 
+// Close lets go of the issue types and the field schema behind them. A create
+// screen that has been thrown away has nowhere to draw either.
+func (m *Model) Close() { m.stop() }
+
 func (m *Model) current(gen int) bool { return gen == m.gen }
 
 func (m *Model) loadTypes() tea.Cmd {

--- a/internal/ui/form/form_test.go
+++ b/internal/ui/form/form_test.go
@@ -732,7 +732,7 @@ func TestForm_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	if _, more := kept.Update(kernel.FocusMsg{}); more != nil {
 		t.Fatal("losing the keyboard asked for more work")
 	}
-	if _, gaveUp := reading().(typesFailedMsg); gaveUp {
+	if _, gaveUp := answer(reading).(typesFailedMsg); gaveUp {
 		t.Error("the create screen gave up its read when it merely lost the keyboard")
 	}
 
@@ -745,11 +745,21 @@ func TestForm_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	}
 	closer.Close()
 
-	failed, ok := cmd().(typesFailedMsg)
+	failed, ok := answer(cmd).(typesFailedMsg)
 	if !ok {
-		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", cmd())
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", answer(cmd))
 	}
 	if !errors.Is(failed.err, context.Canceled) {
 		t.Errorf("err = %v, want the context's own error", failed.err)
 	}
+}
+
+// answer is what the kernel hands a view: the command's own reply with the
+// envelope the kernel addresses it by taken off.
+func answer(cmd tea.Cmd) tea.Msg {
+	msg := cmd()
+	if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+		return reply.Msg
+	}
+	return msg
 }

--- a/internal/ui/form/form_test.go
+++ b/internal/ui/form/form_test.go
@@ -718,3 +718,38 @@ func clickIn(t *testing.T, d kernel.Deps, m *Model, frame, name string) tea.Mous
 	at := d.Zones.Get(id)
 	return tea.MouseClickMsg{Button: tea.MouseLeft, X: at.StartX + 2, Y: at.StartY}
 }
+
+// The palette opens over the create screen, so a read given up on a blur is one
+// nothing asks for again. A screen the kernel has thrown away lets it go.
+func TestForm_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
+	t.Parallel()
+
+	c := newFake(20)
+
+	kept := New(testDeps(c))
+	kept, _ = kept.Update(kernel.SizeMsg{Width: 100, Height: 24})
+	reading := kept.Init()
+	if _, more := kept.Update(kernel.FocusMsg{}); more != nil {
+		t.Fatal("losing the keyboard asked for more work")
+	}
+	if _, gaveUp := reading().(typesFailedMsg); gaveUp {
+		t.Error("the create screen gave up its read when it merely lost the keyboard")
+	}
+
+	dropped := New(testDeps(c))
+	dropped, _ = dropped.Update(kernel.SizeMsg{Width: 100, Height: 24})
+	cmd := dropped.Init()
+	closer, ok := dropped.(kernel.Closer)
+	if !ok {
+		t.Fatal("the create screen does not implement kernel.Closer, so nothing stops its read")
+	}
+	closer.Close()
+
+	failed, ok := cmd().(typesFailedMsg)
+	if !ok {
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", cmd())
+	}
+	if !errors.Is(failed.err, context.Canceled) {
+		t.Errorf("err = %v, want the context's own error", failed.err)
+	}
+}

--- a/internal/ui/form/harness_test.go
+++ b/internal/ui/form/harness_test.go
@@ -123,6 +123,11 @@ func (d *driver) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer and hands the
+		// message inside to the view the address names. There is one view here.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		switch msg := msg.(type) {
 		case kernel.StatusMsg:
 			d.statuses = append(d.statuses, msg)

--- a/internal/ui/issue/bench_test.go
+++ b/internal/ui/issue/bench_test.go
@@ -76,6 +76,9 @@ func settle(tb testing.TB, m *Model, cmd tea.Cmd) *Model {
 			queue = append(queue, cmds...)
 			continue
 		}
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		if _, isStatus := msg.(kernel.StatusMsg); isStatus {
 			continue
 		}

--- a/internal/ui/issue/comments.go
+++ b/internal/ui/issue/comments.go
@@ -35,17 +35,21 @@ func init() {
 	})
 }
 
-// openComments gives the thread the whole screen, pushing the very instance the
+// openComments gives the thread the whole screen, lending the very instance the
 // sidebar holds. Pushing a fresh one would read the thread again and land on the
 // first comment with an empty editor, so esc would not come back to where the
 // reader was; this way the kernel resizes the same model and popping restores
 // the box it had.
+//
+// Lent and not pushed, because this pane keeps it: a kernel that closed it on
+// esc would cancel the read the sidebar is still waiting for, and the sidebar
+// would then show an empty thread for as long as the issue is open.
 func (m *Model) openComments() tea.Cmd {
 	if m.issue.Key == "" || m.thread == nil || m.pushed {
 		return nil
 	}
 	m.pushed = true
-	return kernel.Push(comment.ViewID, m.issue.Key, m.thread)
+	return kernel.Lend(comment.ViewID, m.issue.Key, m.thread)
 }
 
 // commentAction answers the palette's write, edit and delete commands. They are

--- a/internal/ui/issue/comments_kernel_test.go
+++ b/internal/ui/issue/comments_kernel_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/varijkapil13/saral/internal/ui/kernel"
 	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
 )
 
 // rowsViewID is a root view standing in for the issue list. The list is what
@@ -39,9 +40,25 @@ func init() {
 type session struct {
 	t *testing.T
 	m kernel.Model
+
+	// held keeps what a command answered with instead of delivering it, which is
+	// how a read still out when something is pushed over the view that asked for
+	// it is arranged. Delivery is the kernel's decision and it has to be made
+	// after the push, not before.
+	holding bool
+	held    []tea.Msg
 }
 
 func boot(t *testing.T, d kernel.Deps, seed jira.Issue, w, h int) *session {
+	t.Helper()
+
+	s := bootRoot(t, d, w, h)
+	s.send(kernel.PushMsg{ID: ViewID, Title: seed.Key, View: New(d, seed)})
+	return s
+}
+
+// bootRoot is the program with the list standing in and nothing pushed over it.
+func bootRoot(t *testing.T, d kernel.Deps, w, h int) *session {
 	t.Helper()
 
 	m, err := kernel.New(d, kernel.WithSize(w, h), kernel.WithInitialView(rowsViewID), kernel.WithMouse(false))
@@ -51,8 +68,21 @@ func boot(t *testing.T, d kernel.Deps, seed jira.Issue, w, h int) *session {
 	s := &session{t: t, m: m}
 	s.send(tea.WindowSizeMsg{Width: w, Height: h})
 	s.run(s.m.Init())
-	s.send(kernel.PushMsg{ID: ViewID, Title: seed.Key, View: New(d, seed)})
 	return s
+}
+
+func (s *session) hold() { s.holding = true }
+
+// release hands everything that was held to the kernel, in the order it came
+// back, and lets the kernel decide where each of them goes.
+func (s *session) release() {
+	s.t.Helper()
+
+	held := s.held
+	s.holding, s.held = false, nil
+	for _, msg := range held {
+		s.send(msg)
+	}
 }
 
 func (s *session) send(msg tea.Msg) {
@@ -88,6 +118,10 @@ func (s *session) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		if s.holding {
+			s.held = append(s.held, msg)
+			continue
+		}
 		updated, follow := s.m.Update(msg)
 		model, ok := updated.(kernel.Model)
 		if !ok {
@@ -114,6 +148,56 @@ func (s *session) footer() string {
 }
 
 func (s *session) title() string { return strings.SplitN(s.frame(), "\n", 2)[0] }
+
+// cover stands in for anything the kernel pushes over the pane — the palette is
+// the one a user meets, and this package may not import it. What matters is that
+// it is on top and that it ignores every message a detail pane would have taken.
+type cover struct{}
+
+func (cover) Init() tea.Cmd                         { return nil }
+func (cover) Update(tea.Msg) (kernel.View, tea.Cmd) { return cover{}, nil }
+func (cover) View() string                          { return "something else entirely" }
+
+// Through the real kernel: the pane asks, something is pushed over it while the
+// answer is still out, and the answer arrives to find the pane no longer on top.
+// It belongs to the pane either way.
+//
+// Nothing here hands the pane its own answer. The kernel is given the message
+// the read produced and decides where it goes, which is the step that was
+// missing when the pane recovered by asking again.
+func TestSession_AnAnswerLandingWhileThePaneIsCoveredStillReachesThePane(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(20)
+	seed := seedOf(t, f, "PROJ-8")
+	s := bootRoot(t, testDeps(f), 120, 30)
+
+	s.hold()
+	s.send(kernel.PushMsg{ID: ViewID, Title: seed.Key, View: New(testDeps(f), seed)})
+	s.send(kernel.PushMsg{ID: "cover", Title: "Cover", View: cover{}})
+	mustContain(t, s.frame(), "something else entirely")
+
+	reads := countCalls(f, "Search")
+	s.release()
+	s.send(kernel.PopMsg{})
+
+	// The description, and not the summary: the summary was in the row the pane
+	// was built from and is on screen whether or not the read ever landed.
+	mustContain(t, s.frame(), "Filed against PROJ-8.")
+	if got := countCalls(f, "Search") - reads; got != 0 {
+		t.Errorf("coming back read the issue again %d times; the answer to the first read was delivered", got)
+	}
+}
+
+func countCalls(f *jiratest.Fake, name string) int {
+	n := 0
+	for _, call := range f.Calls() {
+		if call == name {
+			n++
+		}
+	}
+	return n
+}
 
 // The gesture through the whole program: the thread takes the whole screen over
 // the issue, and esc lands back on the issue rather than walking past it.

--- a/internal/ui/issue/edit.go
+++ b/internal/ui/issue/edit.go
@@ -161,11 +161,6 @@ func (m *editModel) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case kernel.SizeMsg:
 		m.resize(msg.Width, msg.Height)
 
-	case kernel.FocusMsg:
-		if !msg.Focused {
-			m.stop()
-		}
-
 	case kernel.ThemeMsg:
 		m.deps.Theme = msg.Theme
 		m.styles = newEditStyles(msg.Theme)
@@ -216,6 +211,10 @@ func (m *editModel) stop() {
 		m.cancel = nil
 	}
 }
+
+// Close lets go of the re-read and the schema behind it. The pane is only ever
+// pushed, so this is the whole of its life ending.
+func (m *editModel) Close() { m.stop() }
 
 func (m *editModel) begin() (ctx context.Context, gen int) {
 	m.stop()

--- a/internal/ui/issue/edit.go
+++ b/internal/ui/issue/edit.go
@@ -19,6 +19,7 @@ var (
 	_ kernel.View        = (*editModel)(nil)
 	_ kernel.KeyCapturer = (*editModel)(nil)
 	_ kernel.Blocker     = (*editModel)(nil)
+	_ kernel.Addressed   = (*editModel)(nil)
 )
 
 // editStage is what the pane is doing, which decides both what a key means and
@@ -76,7 +77,12 @@ type editModel struct {
 
 	gen    int
 	cancel context.CancelFunc
+	addr   kernel.Addr
 }
+
+// Addr is where the kernel delivers this pane's re-read and the create screen
+// behind its pickers, whatever has since been pushed over it.
+func (m *editModel) Addr() kernel.Addr { return m.addr }
 
 // editOption configures the pane at construction. Nothing outside the package
 // builds one; the tests use it to stand in for the user's editor.
@@ -104,6 +110,7 @@ func NewEdit(d kernel.Deps, iss jira.Issue, opts ...editOption) kernel.View {
 		issue:  iss,
 		input:  newEditInput(),
 		launch: launchEditor,
+		addr:   kernel.NewAddr(),
 	}
 	if m.deps.Theme == nil {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
@@ -212,6 +219,10 @@ func (m *editModel) stop() {
 	}
 }
 
+// reply puts this pane's address on a command, so what it asked for comes back
+// here rather than to whatever the stack has on top by then.
+func (m *editModel) reply(cmd tea.Cmd) tea.Cmd { return kernel.Reply(cmd, m.addr) }
+
 // Close lets go of the re-read and the schema behind it. The pane is only ever
 // pushed, so this is the whole of its life ending.
 func (m *editModel) Close() { m.stop() }
@@ -232,7 +243,7 @@ func (m *editModel) fetch() tea.Cmd {
 		return m.loadSchema()
 	}
 	ctx, gen := m.begin()
-	return loadForEdit(ctx, m.search, m.issue.Key, gen)
+	return m.reply(loadForEdit(ctx, m.search, m.issue.Key, gen))
 }
 
 // covered reports whether the issue was read with every field the pane offers,
@@ -254,7 +265,7 @@ func (m *editModel) loadSchema() tea.Cmd {
 		return nil
 	}
 	ctx, gen := m.begin()
-	return loadEditSchema(ctx, m.deps.Jira, m.issue.Project.Key, m.issue.Type.ID, gen)
+	return m.reply(loadEditSchema(ctx, m.deps.Jira, m.issue.Project.Key, m.issue.Type.ID, gen))
 }
 
 // loaded takes the re-read issue, keeping whatever the user has already typed.
@@ -489,7 +500,7 @@ func (m *editModel) reread() tea.Cmd {
 	m.stage = stageBrowse
 	m.note = "re-reading " + m.issue.Key + " and putting your edits back on top"
 	ctx, gen := m.begin()
-	return loadForEdit(ctx, m.search, m.issue.Key, gen)
+	return m.reply(loadForEdit(ctx, m.search, m.issue.Key, gen))
 }
 
 // click puts the cursor on the row under the pointer, and opens it on a
@@ -532,7 +543,7 @@ func (m *editModel) wheel(msg tea.MouseWheelMsg) {
 
 func (m *editModel) handOff(row *editRow) tea.Cmd {
 	_, gen := m.begin()
-	return handOffToEditor(m.launch, gen, m.issue.Key, row.documentNow())
+	return handOffToEditor(m.launch, m.addr, gen, m.issue.Key, row.documentNow())
 }
 
 func (m *editModel) edited(msg editedMsg) tea.Cmd {
@@ -584,7 +595,7 @@ func (m *editModel) save() tea.Cmd {
 	m.stage = stageSaving
 	m.fail = ""
 	ctx, gen := m.begin()
-	return saveEdit(ctx, m.deps.Jira, m.issue.Key, patch, gen)
+	return m.reply(saveEdit(ctx, m.deps.Jira, m.issue.Key, patch, gen))
 }
 
 func (m *editModel) saved(msg editSavedMsg) tea.Cmd {

--- a/internal/ui/issue/edit_editor.go
+++ b/internal/ui/issue/edit_editor.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/varijkapil13/saral/internal/ui/kernel"
 	"github.com/varijkapil13/saral/pkg/adf"
 )
 
@@ -62,14 +63,14 @@ func lookEditor(name, env string) error {
 // The markdown is rendered with the zero options on purpose. A width-bounded
 // render truncates a table's cells with an ellipsis, and an edit anywhere in
 // that document would write the truncation back into Jira.
-func handOffToEditor(launch editorLauncher, gen int, key string, original adf.Doc) tea.Cmd {
+func handOffToEditor(launch editorLauncher, addr kernel.Addr, gen int, key string, original adf.Doc) tea.Cmd {
 	rendered := adf.Markdown(original)
 	path, err := writeHandoff(key, rendered)
 	if err != nil {
-		return func() tea.Msg { return editedMsg{gen: gen, err: err} }
+		return func() tea.Msg { return kernel.ReplyTo(editedMsg{gen: gen, err: err}, addr) }
 	}
 	return launch(path, func(runErr error) tea.Msg {
-		return readHandoff(gen, original, rendered, path, runErr)
+		return kernel.ReplyTo(readHandoff(gen, original, rendered, path, runErr), addr)
 	})
 }
 

--- a/internal/ui/issue/edit_harness_test.go
+++ b/internal/ui/issue/edit_harness_test.go
@@ -105,6 +105,11 @@ func (p *panel) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer and hands the
+		// message inside to the view the address names. There is one view here.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		switch msg := msg.(type) {
 		case kernel.StatusMsg:
 			p.statuses = append(p.statuses, msg)
@@ -369,3 +374,13 @@ func docWith(paragraph string) adf.Doc {
 }
 
 func projectionMask() jira.FieldMask { return jira.NewFieldMask(app.ListProjection().IDs) }
+
+// answer is what the kernel hands a view: the command's own reply with the
+// envelope the kernel addresses it by taken off.
+func answer(cmd tea.Cmd) tea.Msg {
+	msg := cmd()
+	if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+		return reply.Msg
+	}
+	return msg
+}

--- a/internal/ui/issue/edit_test.go
+++ b/internal/ui/issue/edit_test.go
@@ -804,7 +804,7 @@ func TestEdit_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	if _, more := kept.Update(kernel.FocusMsg{Focused: false}); more != nil {
 		t.Fatal("losing the keyboard asked for more work")
 	}
-	if _, gaveUp := reading().(editFailedMsg); gaveUp {
+	if _, gaveUp := answer(reading).(editFailedMsg); gaveUp {
 		t.Error("the editor gave up its re-read when it merely lost the keyboard")
 	}
 
@@ -817,9 +817,9 @@ func TestEdit_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
 	}
 	closer.Close()
 
-	failed, ok := cmd().(editFailedMsg)
+	failed, ok := answer(cmd).(editFailedMsg)
 	if !ok {
-		t.Fatalf("the re-read came back as %T, want the failure a cancelled context produces", cmd())
+		t.Fatalf("the re-read came back as %T, want the failure a cancelled context produces", answer(cmd))
 	}
 	if !errors.Is(failed.err, context.Canceled) {
 		t.Errorf("err = %v, want the context's own error", failed.err)

--- a/internal/ui/issue/edit_test.go
+++ b/internal/ui/issue/edit_test.go
@@ -1,6 +1,7 @@
 package issue
 
 import (
+	"context"
 	"errors"
 	"os"
 	"slices"
@@ -785,5 +786,42 @@ func TestDetail_KeepsItsOwnGestureOnG(t *testing.T) {
 	p.keys("g", "e")
 	if len(p.pushes) != 0 {
 		t.Error("g then e opened the editor; it is the gesture that goes to the end of the issue")
+	}
+}
+
+// The editor re-reads the issue for the fields it can change. The palette opens
+// over it, so a read given up on a blur is one nothing asks for again — but a
+// pane the kernel has thrown away lets it go.
+func TestEdit_KeepsItsReadOnABlurAndDropsItOnAClose(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(6)
+	iss := seedOf(t, f, "PROJ-2")
+
+	kept := NewEdit(testDeps(f), iss, withDrafts(tempDrafts(t)))
+	kept, _ = kept.Update(kernel.SizeMsg{Width: 100, Height: 28})
+	reading := kept.Init()
+	if _, more := kept.Update(kernel.FocusMsg{Focused: false}); more != nil {
+		t.Fatal("losing the keyboard asked for more work")
+	}
+	if _, gaveUp := reading().(editFailedMsg); gaveUp {
+		t.Error("the editor gave up its re-read when it merely lost the keyboard")
+	}
+
+	dropped := NewEdit(testDeps(f), iss, withDrafts(tempDrafts(t)))
+	dropped, _ = dropped.Update(kernel.SizeMsg{Width: 100, Height: 28})
+	cmd := dropped.Init()
+	closer, ok := dropped.(kernel.Closer)
+	if !ok {
+		t.Fatal("the editor does not implement kernel.Closer, so nothing stops its re-read")
+	}
+	closer.Close()
+
+	failed, ok := cmd().(editFailedMsg)
+	if !ok {
+		t.Fatalf("the re-read came back as %T, want the failure a cancelled context produces", cmd())
+	}
+	if !errors.Is(failed.err, context.Canceled) {
+		t.Errorf("err = %v, want the context's own error", failed.err)
 	}
 }

--- a/internal/ui/issue/edit_transition.go
+++ b/internal/ui/issue/edit_transition.go
@@ -15,6 +15,7 @@ import (
 var (
 	_ kernel.View        = (*moveModel)(nil)
 	_ kernel.KeyCapturer = (*moveModel)(nil)
+	_ kernel.Addressed   = (*moveModel)(nil)
 )
 
 type moveStage uint8
@@ -65,7 +66,12 @@ type moveModel struct {
 
 	gen    int
 	cancel context.CancelFunc
+	addr   kernel.Addr
 }
+
+// Addr is where the kernel delivers the transitions this picker asked for and
+// the move it is applying, whatever has since been pushed over it.
+func (m *moveModel) Addr() kernel.Addr { return m.addr }
 
 // moveField is one required field of a transition screen. A screen field with
 // no allowed values is one this pane cannot fill: there is nothing to choose
@@ -94,7 +100,7 @@ func (f *moveField) name() string {
 
 // NewMove builds the transition picker for one issue.
 func NewMove(d kernel.Deps, iss jira.Issue) kernel.View {
-	m := &moveModel{deps: d, keys: defaultMoveKeys(), issue: iss}
+	m := &moveModel{deps: d, keys: defaultMoveKeys(), issue: iss, addr: kernel.NewAddr()}
 	if m.deps.Theme == nil {
 		m.deps.Theme = kernel.NewTheme(kernel.ThemeAuto, true, kernel.UnicodeGlyphs())
 	}
@@ -167,6 +173,10 @@ func (m *moveModel) stop() {
 	}
 }
 
+// reply puts this picker's address on a command, so what it asked for comes
+// back here rather than to whatever the stack has on top by then.
+func (m *moveModel) reply(cmd tea.Cmd) tea.Cmd { return kernel.Reply(cmd, m.addr) }
+
 // Close lets go of the transitions read, and of a move that is still being
 // applied. The picker is only ever pushed, so this is the whole of its life
 // ending.
@@ -180,7 +190,7 @@ func (m *moveModel) fetch() tea.Cmd {
 	m.gen++
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-	return loadMoves(ctx, m.deps.Jira, m.issue.Key, m.gen)
+	return m.reply(loadMoves(ctx, m.deps.Jira, m.issue.Key, m.gen))
 }
 
 func (m *moveModel) key(msg tea.KeyPressMsg) tea.Cmd {
@@ -312,7 +322,7 @@ func (m *moveModel) apply() tea.Cmd {
 	m.gen++
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-	return applyMove(ctx, m.deps.Jira, m.issue.Key, move.ID, m.screenPatch(), m.gen)
+	return m.reply(applyMove(ctx, m.deps.Jira, m.issue.Key, move.ID, m.screenPatch(), m.gen))
 }
 
 // screenPatch carries the screen's answers by field id and option id, which is

--- a/internal/ui/issue/edit_transition.go
+++ b/internal/ui/issue/edit_transition.go
@@ -121,11 +121,6 @@ func (m *moveModel) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case kernel.SizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 
-	case kernel.FocusMsg:
-		if !msg.Focused {
-			m.stop()
-		}
-
 	case kernel.ThemeMsg:
 		m.deps.Theme = msg.Theme
 		m.styles = newEditStyles(msg.Theme)
@@ -171,6 +166,11 @@ func (m *moveModel) stop() {
 		m.cancel = nil
 	}
 }
+
+// Close lets go of the transitions read, and of a move that is still being
+// applied. The picker is only ever pushed, so this is the whole of its life
+// ending.
+func (m *moveModel) Close() { m.stop() }
 
 func (m *moveModel) fetch() tea.Cmd {
 	if m.deps.Jira == nil || m.issue.Key == "" {

--- a/internal/ui/issue/edit_transition_test.go
+++ b/internal/ui/issue/edit_transition_test.go
@@ -292,8 +292,8 @@ func TestMove_ReportsEveryWayTheMoveItselfCanFail(t *testing.T) {
 }
 
 // TestMove_StopsReadingWhenThePaneIsClosed is the contract every view here
-// keeps: a pane nobody is looking at cancels what it asked for rather than
-// leaving a request running for an answer that has nowhere to go.
+// keeps: a pane the kernel has thrown away cancels what it asked for rather
+// than leaving a request running for an answer that has nowhere to go.
 func TestMove_StopsReadingWhenThePaneIsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -302,9 +302,12 @@ func TestMove_StopsReadingWhenThePaneIsClosed(t *testing.T) {
 	view := NewMove(testDeps(f), iss)
 	view, _ = view.Update(kernel.SizeMsg{Width: 100, Height: 28})
 	cmd := view.Init()
-	if _, closed := view.Update(kernel.FocusMsg{Focused: false}); closed != nil {
-		t.Fatal("closing the pane asked for more work")
+
+	closer, ok := view.(kernel.Closer)
+	if !ok {
+		t.Fatal("the transition picker does not implement kernel.Closer, so nothing stops its read")
 	}
+	closer.Close()
 
 	failed, ok := cmd().(editFailedMsg)
 	if !ok {
@@ -313,6 +316,30 @@ func TestMove_StopsReadingWhenThePaneIsClosed(t *testing.T) {
 	if !errors.Is(failed.err, context.Canceled) {
 		t.Errorf("err = %v, want the context's own error", failed.err)
 	}
+}
+
+// The other half of the same contract: the palette opens over this pane, and a
+// read given up there is a read nothing asks for again.
+func TestMove_LosingTheKeyboardDoesNotGiveUpTheRead(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(6)
+	iss := fullIssue(t, f, "PROJ-3")
+	view := NewMove(testDeps(f), iss)
+	view, _ = view.Update(kernel.SizeMsg{Width: 100, Height: 28})
+	cmd := view.Init()
+
+	if _, more := view.Update(kernel.FocusMsg{Focused: false}); more != nil {
+		t.Fatal("losing the keyboard asked for more work")
+	}
+	if got := cmd(); !isMovesLoaded(got) {
+		t.Errorf("the read came back as %T, want the transitions it went for", got)
+	}
+}
+
+func isMovesLoaded(msg any) bool {
+	_, ok := msg.(movesLoadedMsg)
+	return ok
 }
 
 type failureCase struct {

--- a/internal/ui/issue/edit_transition_test.go
+++ b/internal/ui/issue/edit_transition_test.go
@@ -309,9 +309,9 @@ func TestMove_StopsReadingWhenThePaneIsClosed(t *testing.T) {
 	}
 	closer.Close()
 
-	failed, ok := cmd().(editFailedMsg)
+	failed, ok := answer(cmd).(editFailedMsg)
 	if !ok {
-		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", cmd())
+		t.Fatalf("the read came back as %T, want the failure a cancelled context produces", answer(cmd))
 	}
 	if !errors.Is(failed.err, context.Canceled) {
 		t.Errorf("err = %v, want the context's own error", failed.err)
@@ -332,7 +332,7 @@ func TestMove_LosingTheKeyboardDoesNotGiveUpTheRead(t *testing.T) {
 	if _, more := view.Update(kernel.FocusMsg{Focused: false}); more != nil {
 		t.Fatal("losing the keyboard asked for more work")
 	}
-	if got := cmd(); !isMovesLoaded(got) {
+	if got := answer(cmd); !isMovesLoaded(got) {
 		t.Errorf("the read came back as %T, want the transitions it went for", got)
 	}
 }

--- a/internal/ui/issue/harness_test.go
+++ b/internal/ui/issue/harness_test.go
@@ -182,6 +182,11 @@ func (d *driver) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer and hands the
+		// message inside to the view the address names. There is one view here.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		if status, ok := msg.(kernel.StatusMsg); ok {
 			d.statuses = append(d.statuses, status)
 			continue

--- a/internal/ui/issue/issue.go
+++ b/internal/ui/issue/issue.go
@@ -35,7 +35,10 @@ var zoneNames = [regionCount]string{
 	regionComments: "region:comments",
 }
 
-var _ kernel.View = (*Model)(nil)
+var (
+	_ kernel.View   = (*Model)(nil)
+	_ kernel.Closer = (*Model)(nil)
+)
 
 // Model is the issue detail pane.
 type Model struct {
@@ -43,9 +46,10 @@ type Model struct {
 	keys   keyMap
 	styles *styles
 
-	issue       jira.Issue
-	labels      app.FieldLabels
-	loadedIssue bool
+	issue        jira.Issue
+	labels       app.FieldLabels
+	loadedIssue  bool
+	loadingIssue bool
 
 	// thread is the comment view itself rather than a second rendering of one.
 	// The full-screen gesture hands this same instance to the kernel, so the
@@ -169,11 +173,13 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case loadedMsg:
 		if m.current(msg.gen) {
 			m.issue, m.labels, m.loadedIssue = msg.issue, msg.labels, true
+			m.loadingIssue = false
 			m.dataGen++
 		}
 
 	case failedMsg:
 		if m.current(msg.gen) {
+			m.loadingIssue = false
 			cmd = kernel.Fail(msg.err)
 		}
 
@@ -241,6 +247,7 @@ func (m *Model) fetch() tea.Cmd {
 	m.gen++
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
+	m.loadingIssue = true
 	return load(ctx, m.search, m.issue.Key, m.gen)
 }
 
@@ -249,6 +256,16 @@ func (m *Model) stop() {
 		m.cancel()
 		m.cancel = nil
 	}
+	m.loadingIssue = false
+}
+
+// Close cuts the read short, and the thread's with it: the sidebar holds that
+// model and nothing else does, so a pane thrown away takes it along.
+func (m *Model) Close() {
+	m.stop()
+	if m.thread != nil {
+		kernel.CloseView(m.thread)
+	}
 }
 
 // focused answers the kernel telling this pane whether it is the one taking
@@ -256,10 +273,8 @@ func (m *Model) stop() {
 // be put back: the kernel gave it the whole screen on the way there.
 func (m *Model) focused(on bool) tea.Cmd {
 	if !on {
-		// A pushed view that loses focus has either been popped or been covered,
-		// and either way nobody is waiting for this issue — or is still holding
-		// its divider.
-		m.stop()
+		// The read carries on: a palette opened over a loading pane must not
+		// cancel what it is loading. Nobody is holding the divider, though.
 		m.cancelDrag()
 		return m.tell(kernel.FocusMsg{})
 	}
@@ -268,7 +283,9 @@ func (m *Model) focused(on bool) tea.Cmd {
 		m.threadAt.w, m.threadAt.h = 0, 0
 	}
 	cmds := []tea.Cmd{m.tell(kernel.FocusMsg{Focused: true})}
-	if !m.loadedIssue {
+	// An answer that landed while this pane was covered went to whatever was on
+	// top, so a pane with nothing and nothing coming asks again.
+	if !m.loadedIssue && !m.loadingIssue {
 		cmds = append(cmds, m.fetch())
 	}
 	return tea.Batch(cmds...)

--- a/internal/ui/issue/issue.go
+++ b/internal/ui/issue/issue.go
@@ -36,8 +36,9 @@ var zoneNames = [regionCount]string{
 }
 
 var (
-	_ kernel.View   = (*Model)(nil)
-	_ kernel.Closer = (*Model)(nil)
+	_ kernel.View      = (*Model)(nil)
+	_ kernel.Closer    = (*Model)(nil)
+	_ kernel.Addressed = (*Model)(nil)
 )
 
 // Model is the issue detail pane.
@@ -46,10 +47,9 @@ type Model struct {
 	keys   keyMap
 	styles *styles
 
-	issue        jira.Issue
-	labels       app.FieldLabels
-	loadedIssue  bool
-	loadingIssue bool
+	issue       jira.Issue
+	labels      app.FieldLabels
+	loadedIssue bool
 
 	// thread is the comment view itself rather than a second rendering of one.
 	// The full-screen gesture hands this same instance to the kernel, so the
@@ -101,7 +101,16 @@ type Model struct {
 	search *app.Search
 	gen    int
 	cancel context.CancelFunc
+
+	// addr is where this pane's own answers come back to, and what the thread it
+	// holds names as its holder: the sidebar is not a stack entry, so the kernel
+	// reaches it through this pane.
+	addr kernel.Addr
 }
+
+// Addr is where the kernel delivers what this pane asked the site for, whatever
+// has been pushed over it since.
+func (m *Model) Addr() kernel.Addr { return m.addr }
 
 // New builds the detail pane around the row the user opened.
 //
@@ -116,6 +125,7 @@ func New(d kernel.Deps, seed jira.Issue) kernel.View {
 		keys:  defaultKeys(),
 		issue: seed,
 		open:  map[int]bool{},
+		addr:  kernel.NewAddr(),
 	}
 	if share, chosen := config.LoadUIState().Split(ViewID); chosen {
 		m.split = split(share)
@@ -132,7 +142,7 @@ func New(d kernel.Deps, seed jira.Issue) kernel.View {
 	if d.Jira != nil {
 		m.search = app.NewSearch(d.Jira)
 	}
-	m.thread = comment.Thread(m.deps, seed.Key)
+	m.thread = comment.Thread(m.deps, seed.Key, m.addr)
 	return m
 }
 
@@ -173,13 +183,11 @@ func (m *Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 	case loadedMsg:
 		if m.current(msg.gen) {
 			m.issue, m.labels, m.loadedIssue = msg.issue, msg.labels, true
-			m.loadingIssue = false
 			m.dataGen++
 		}
 
 	case failedMsg:
 		if m.current(msg.gen) {
-			m.loadingIssue = false
 			cmd = kernel.Fail(msg.err)
 		}
 
@@ -247,8 +255,7 @@ func (m *Model) fetch() tea.Cmd {
 	m.gen++
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-	m.loadingIssue = true
-	return load(ctx, m.search, m.issue.Key, m.gen)
+	return kernel.Reply(load(ctx, m.search, m.issue.Key, m.gen), m.addr)
 }
 
 func (m *Model) stop() {
@@ -256,7 +263,6 @@ func (m *Model) stop() {
 		m.cancel()
 		m.cancel = nil
 	}
-	m.loadingIssue = false
 }
 
 // Close cuts the read short, and the thread's with it: the sidebar holds that
@@ -282,13 +288,7 @@ func (m *Model) focused(on bool) tea.Cmd {
 		m.pushed = false
 		m.threadAt.w, m.threadAt.h = 0, 0
 	}
-	cmds := []tea.Cmd{m.tell(kernel.FocusMsg{Focused: true})}
-	// An answer that landed while this pane was covered went to whatever was on
-	// top, so a pane with nothing and nothing coming asks again.
-	if !m.loadedIssue && !m.loadingIssue {
-		cmds = append(cmds, m.fetch())
-	}
-	return tea.Batch(cmds...)
+	return m.tell(kernel.FocusMsg{Focused: true})
 }
 
 func (m *Model) resize(w, h int) {

--- a/internal/ui/issue/issue_test.go
+++ b/internal/ui/issue/issue_test.go
@@ -225,7 +225,10 @@ func TestIssue_SaysSoWhenTheIssueIsGone(t *testing.T) {
 	}
 }
 
-func TestIssue_LosingFocusStopsTheWorkAndGettingItBackStartsItAgain(t *testing.T) {
+// The pane is blurred whenever anything is pushed over it — the palette, the
+// editor, the thread on the whole screen — and none of those is the pane being
+// thrown away. A read given up there is a read nothing asks for again.
+func TestIssue_LosingTheKeyboardDoesNotGiveUpTheRead(t *testing.T) {
 	t.Parallel()
 
 	f := newFake(20)
@@ -242,17 +245,76 @@ func TestIssue_LosingFocusStopsTheWorkAndGettingItBackStartsItAgain(t *testing.T
 
 	next, _ = m.Update(kernel.FocusMsg{})
 	m, _ = next.(*Model)
-	if msgs := collect(cmd); !allCancelled(msgs) {
-		t.Errorf("the in-flight requests survived the pane losing focus: %+v", msgs)
+
+	msgs := collect(cmd)
+	if !readTheIssue(msgs) {
+		t.Errorf("the read did not survive the pane losing the keyboard: %+v", msgs)
 	}
 
-	f.Delay(0)
+	gen := m.gen
 	dr := &driver{t: t, m: m}
 	dr.send(kernel.FocusMsg{Focused: true})
+	if dr.m.gen != gen {
+		t.Errorf("coming back asked a second time while the first read was still out: generation %d, was %d",
+			dr.m.gen, gen)
+	}
+	for _, msg := range msgs {
+		dr.send(msg)
+	}
 	if !dr.m.loadedIssue {
-		t.Error("getting focus back did not read the issue again")
+		t.Error("the answer to the read issued before the blur was not taken")
 	}
 	mustContain(t, dr.view(), seed.Summary)
+}
+
+// A pane that really has been discarded stops, and takes the thread it holds
+// with it: the sidebar is the only thing drawing that model.
+func TestIssue_ClosingStopsTheReadAndTheThreadItHolds(t *testing.T) {
+	t.Parallel()
+
+	f := newFake(20)
+	seed := seedOf(t, f, "PROJ-8")
+	f.Delay(50 * time.Millisecond)
+
+	view, ok := New(testDeps(f), seed).(*Model)
+	if !ok {
+		t.Fatal("New did not return a *Model")
+	}
+	next, _ := view.Update(kernel.SizeMsg{Width: 120, Height: 30})
+	m, _ := next.(*Model)
+	cmd := m.fetch()
+
+	thread := &closeSpy{}
+	m.thread = thread
+	m.Close()
+
+	if msgs := collect(cmd); !allCancelled(msgs) {
+		t.Errorf("a discarded pane went on reading: %+v", msgs)
+	}
+	if thread.closed != 1 {
+		t.Errorf("the thread was closed %d times, want once", thread.closed)
+	}
+	if m.loadingIssue {
+		t.Error("a closed pane still reports a read in flight")
+	}
+}
+
+// closeSpy stands in for the thread, which answers with a message type this
+// package cannot see into.
+type closeSpy struct{ closed int }
+
+func (s *closeSpy) Init() tea.Cmd                         { return nil }
+func (s *closeSpy) Update(tea.Msg) (kernel.View, tea.Cmd) { return s, nil }
+func (s *closeSpy) View() string                          { return "" }
+func (s *closeSpy) Close()                                { s.closed++ }
+
+func readTheIssue(msgs []tea.Msg) bool {
+	for _, msg := range msgs {
+		if _, ok := msg.(loadedMsg); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func collect(cmd tea.Cmd) []tea.Msg {

--- a/internal/ui/issue/issue_test.go
+++ b/internal/ui/issue/issue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -227,7 +228,14 @@ func TestIssue_SaysSoWhenTheIssueIsGone(t *testing.T) {
 
 // The pane is blurred whenever anything is pushed over it — the palette, the
 // editor, the thread on the whole screen — and none of those is the pane being
-// thrown away. A read given up there is a read nothing asks for again.
+// thrown away. The read carries on, and it carries this pane's address, so the
+// kernel has somewhere to deliver it other than whatever ends up on top.
+//
+// Coming back therefore asks for nothing: there is an answer on its way. That
+// the answer really arrives is asserted through the kernel, in
+// TestSession_AnAnswerLandingWhileThePaneIsCoveredStillReachesThePane — here it
+// would be this test handing the pane its own message, which is exactly the step
+// the kernel used not to take.
 func TestIssue_LosingTheKeyboardDoesNotGiveUpTheRead(t *testing.T) {
 	t.Parallel()
 
@@ -247,8 +255,8 @@ func TestIssue_LosingTheKeyboardDoesNotGiveUpTheRead(t *testing.T) {
 	m, _ = next.(*Model)
 
 	msgs := collect(cmd)
-	if !readTheIssue(msgs) {
-		t.Errorf("the read did not survive the pane losing the keyboard: %+v", msgs)
+	if !readTheIssue(msgs, m.Addr()) {
+		t.Errorf("the read did not survive the pane losing the keyboard, addressed to it: %+v", msgs)
 	}
 
 	gen := m.gen
@@ -258,13 +266,6 @@ func TestIssue_LosingTheKeyboardDoesNotGiveUpTheRead(t *testing.T) {
 		t.Errorf("coming back asked a second time while the first read was still out: generation %d, was %d",
 			dr.m.gen, gen)
 	}
-	for _, msg := range msgs {
-		dr.send(msg)
-	}
-	if !dr.m.loadedIssue {
-		t.Error("the answer to the read issued before the blur was not taken")
-	}
-	mustContain(t, dr.view(), seed.Summary)
 }
 
 // A pane that really has been discarded stops, and takes the thread it holds
@@ -288,14 +289,11 @@ func TestIssue_ClosingStopsTheReadAndTheThreadItHolds(t *testing.T) {
 	m.thread = thread
 	m.Close()
 
-	if msgs := collect(cmd); !allCancelled(msgs) {
+	if msgs := answers(collect(cmd)); !allCancelled(msgs) {
 		t.Errorf("a discarded pane went on reading: %+v", msgs)
 	}
 	if thread.closed != 1 {
 		t.Errorf("the thread was closed %d times, want once", thread.closed)
-	}
-	if m.loadingIssue {
-		t.Error("a closed pane still reports a read in flight")
 	}
 }
 
@@ -308,13 +306,33 @@ func (s *closeSpy) Update(tea.Msg) (kernel.View, tea.Cmd) { return s, nil }
 func (s *closeSpy) View() string                          { return "" }
 func (s *closeSpy) Close()                                { s.closed++ }
 
-func readTheIssue(msgs []tea.Msg) bool {
+// readTheIssue holds the read to two things at once: that it answered with the
+// issue rather than with a cancellation, and that it named this pane on the way
+// out. An answer with no address is one the kernel can only give to the top of
+// the stack, which is the whole of the bug.
+func readTheIssue(msgs []tea.Msg, addr kernel.Addr) bool {
 	for _, msg := range msgs {
-		if _, ok := msg.(loadedMsg); ok {
+		reply, sent := msg.(kernel.ReplyMsg)
+		if !sent || !slices.Contains(reply.To, addr) {
+			continue
+		}
+		if _, ok := reply.Msg.(loadedMsg); ok {
 			return true
 		}
 	}
 	return false
+}
+
+// answers is what the kernel hands a view: the envelope off, the message inside.
+func answers(msgs []tea.Msg) []tea.Msg {
+	out := make([]tea.Msg, 0, len(msgs))
+	for _, msg := range msgs {
+		if reply, sent := msg.(kernel.ReplyMsg); sent {
+			msg = reply.Msg
+		}
+		out = append(out, msg)
+	}
+	return out
 }
 
 func collect(cmd tea.Cmd) []tea.Msg {

--- a/internal/ui/issue/split.go
+++ b/internal/ui/issue/split.go
@@ -215,12 +215,12 @@ func (m *Model) keepSplit() tea.Cmd {
 		return nil
 	}
 	share := int(m.split)
-	return func() tea.Msg {
+	return kernel.Reply(func() tea.Msg {
 		if err := config.SaveSplit(ViewID, share); err != nil {
 			return splitFailedMsg{err: err}
 		}
 		return nil
-	}
+	}, m.addr)
 }
 
 // splitFailedMsg reports that the split on screen is not the one the next

--- a/internal/ui/kernel/close_test.go
+++ b/internal/ui/kernel/close_test.go
@@ -1,0 +1,269 @@
+package kernel
+
+import (
+	"slices"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// The three things a blur has always meant, told apart. Every one of these
+// drives the kernel the way a keypress does rather than calling pop or open, so
+// what is asserted is the gesture and not the helper under it.
+
+func TestClose_APoppedViewIsDiscarded(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	RegisterView(spec("board", 1, "", board))
+
+	m := newAt(t, testDeps(), 120, 30)
+	detail := &stubView{id: "detail", content: "PROJ-1 detail"}
+	next, _ := m.Update(PushMsg{View: detail, ID: "detail", Title: "PROJ-1"})
+	m = next.(Model)
+
+	press(m, "esc")
+	if detail.closed != 1 {
+		t.Errorf("the popped view was closed %d times, want once", detail.closed)
+	}
+	if board.closed != 0 {
+		t.Errorf("the view underneath was closed %d times; it is the one being come back to", board.closed)
+	}
+}
+
+// The regression that started all this. A palette over a loading thread cancelled
+// the load, because the only thing the kernel said was FocusMsg{false} and being
+// covered says that too.
+func TestClose_AViewPushedOverIsNotDiscarded(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	RegisterView(spec("board", 1, "", board))
+	palette := &stubView{id: PaletteViewID}
+	RegisterView(spec(PaletteViewID, 0, "", palette))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "ctrl+k")
+
+	if len(m.stack) != 2 {
+		t.Fatalf("the palette did not open: stack depth %d", len(m.stack))
+	}
+	if board.closed != 0 {
+		t.Errorf("opening the palette closed the view it opened over (%d times), which is the read it would cancel",
+			board.closed)
+	}
+	if !slices.Contains(board.seen, "blur") {
+		t.Errorf("the covered view was never told it lost the keyboard: %v", board.seen)
+	}
+}
+
+func TestClose_ARootSwitchedAwayFromIsNotDiscarded(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	RegisterView(spec("board", 1, "", board))
+	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "g", "2")
+
+	if board.closed != 0 {
+		t.Errorf("the root switched away from was closed %d times; it is parked and comes back on g1", board.closed)
+	}
+	m, _ = press(m, "g", "1")
+	if board.closed != 0 {
+		t.Errorf("coming back found a view that had been closed %d times", board.closed)
+	}
+	if m.top().view != View(board) {
+		t.Error("g1 built a second instance rather than resuming the parked one")
+	}
+}
+
+func TestClose_ARootSwitchDiscardsWhateverWasPushedOverIt(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	RegisterView(spec("board", 1, "", board))
+	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	detail := &stubView{id: "detail"}
+	form := &stubView{id: "form"}
+	for _, v := range []*stubView{detail, form} {
+		next, _ := m.Update(PushMsg{View: v, ID: v.id, Title: v.id})
+		m = next.(Model)
+	}
+
+	m, _ = press(m, "g", "2")
+	if len(m.stack) != 1 {
+		t.Fatalf("a switch left %d entries on the stack, want the new root alone", len(m.stack))
+	}
+	for _, v := range []*stubView{detail, form} {
+		if v.closed != 1 {
+			t.Errorf("%s was closed %d times, want once: a switch throws away everything over the root", v.id, v.closed)
+		}
+	}
+	if board.closed != 0 {
+		t.Errorf("the root under them was closed %d times, want never", board.closed)
+	}
+}
+
+func TestClose_AProjectSwitchDiscardsNothing(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	RegisterView(spec("board", 1, "", board))
+	parked := &stubView{id: "backlog"}
+	RegisterView(spec("backlog", 2, "", parked))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "g", "2")
+	m, _ = press(m, "g", "1")
+	detail := &stubView{id: "detail"}
+	next, _ := m.Update(PushMsg{View: detail, ID: "detail", Title: "PROJ-1"})
+	m = next.(Model)
+
+	next, _ = m.Update(ProjectMsg{Project: "OPS"})
+	scoped, ok := next.(Model)
+	if !ok {
+		t.Fatal("the re-scope did not give back a Model")
+	}
+	if scoped.deps.Project != "OPS" {
+		t.Fatalf("the session is scoped to %q, want OPS", scoped.deps.Project)
+	}
+
+	for _, v := range []*stubView{board, parked, detail} {
+		if v.closed != 0 {
+			t.Errorf("%s was closed %d times by a re-scope; every view hears the new project and stays", v.id, v.closed)
+		}
+	}
+}
+
+// A view that refuses to close is not closed, which is the same order the two
+// have always been asked in: Blocker first, and only then the news.
+func TestClose_ARefusedPopDiscardsNothing(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	draft := &stubView{id: "compose", blocks: "this comment has not been sent"}
+	next, _ := m.Update(PushMsg{View: draft, ID: "compose", Title: "PROJ-1"})
+	m = next.(Model)
+
+	m, _ = press(m, "esc")
+	if draft.closed != 0 {
+		t.Errorf("a view that refused to close was closed %d times", draft.closed)
+	}
+	if len(m.stack) != 2 {
+		t.Fatalf("the refusal did not keep the view on the stack: depth %d", len(m.stack))
+	}
+}
+
+// A lent view is the pusher's, and the pusher goes on drawing it: the issue pane
+// hands over the very thread its sidebar shows.
+func TestClose_ALentViewIsDroppedWithoutBeingDiscarded(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	owner := &stubView{id: "detail"}
+	next, _ := m.Update(PushMsg{View: owner, ID: "detail", Title: "PROJ-1"})
+	m = next.(Model)
+
+	thread := &stubView{id: "comments"}
+	msg, ok := Lend("comments", "PROJ-1", thread)().(PushMsg)
+	if !ok {
+		t.Fatal("Lend did not produce a PushMsg")
+	}
+	if !msg.Lent {
+		t.Fatal("Lend produced a push the kernel would take ownership of")
+	}
+	next, _ = m.Update(msg)
+	m = next.(Model)
+
+	m, _ = press(m, "esc")
+	if thread.closed != 0 {
+		t.Errorf("the lent view was closed %d times; its owner is still drawing it", thread.closed)
+	}
+	if len(m.stack) != 2 || m.top().view != View(owner) {
+		t.Fatalf("esc did not come back to the view that lent the thread: depth %d", len(m.stack))
+	}
+
+	m, _ = press(m, "esc")
+	if owner.closed != 1 {
+		t.Errorf("the lender was closed %d times, want once", owner.closed)
+	}
+}
+
+// A switch away while the lent view is on top throws the lender out and leaves
+// the lent one to it.
+func TestClose_ARootSwitchLeavesALentViewToItsLender(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+	RegisterView(spec("backlog", 2, "", &stubView{id: "backlog"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	owner := &stubView{id: "detail"}
+	next, _ := m.Update(PushMsg{View: owner, ID: "detail", Title: "PROJ-1"})
+	m = next.(Model)
+	thread := &stubView{id: "comments"}
+	next, _ = m.Update(PushMsg{View: thread, ID: "comments", Title: "PROJ-1", Lent: true})
+	m = next.(Model)
+
+	press(m, "g", "2")
+	if owner.closed != 1 {
+		t.Errorf("the lender was closed %d times, want once", owner.closed)
+	}
+	if thread.closed != 0 {
+		t.Errorf("the kernel closed a view it had only borrowed (%d times)", thread.closed)
+	}
+}
+
+// Quitting discards everything and tells nothing: the process is ending, so
+// there is no frame left to draw and no command that would run.
+func TestClose_QuittingTellsNobody(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := &stubView{id: "board"}
+	RegisterView(spec("board", 1, "", board))
+
+	for _, key := range []string{"q", "ctrl+c"} {
+		m := newAt(t, testDeps(), 120, 30)
+		board.closed = 0
+		m, cmd := press(m, key)
+		if cmd == nil {
+			t.Fatalf("%s did not quit", key)
+		}
+		if !m.quitting {
+			t.Fatalf("%s did not put the model into quitting", key)
+		}
+		if board.closed != 0 {
+			t.Errorf("%s closed %d views; quitting is the one discard the kernel stays out of", key, board.closed)
+		}
+	}
+}
+
+// bareView implements nothing optional, which is most of what a view is allowed
+// to be.
+type bareView struct{}
+
+func (bareView) Init() tea.Cmd                  { return nil }
+func (bareView) Update(tea.Msg) (View, tea.Cmd) { return bareView{}, nil }
+func (bareView) View() string                   { return "bare" }
+func TestClose_AViewThatDoesNotWantTheNewsIsJustDropped(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	next, _ := m.Update(PushMsg{View: bareView{}, ID: "bare", Title: "Bare"})
+	m = next.(Model)
+
+	m, _ = press(m, "esc")
+	if len(m.stack) != 1 {
+		t.Errorf("the stack is %d deep after esc, want the root alone", len(m.stack))
+	}
+}

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -58,9 +58,57 @@ type Blocker interface {
 	BlocksClose() (reason string, blocked bool)
 }
 
+// Closer is the optional interface a view implements when it starts work that
+// outlives a frame — a read, a write, a poll — and would want it stopped the
+// moment the stack lets go of it. Blocker refuses a close; this is told about
+// the one that happened.
+//
+// Close is called on a view that is *discarded* and on no other: the entry a pop
+// takes off, and every pushed entry a root switch throws away. It is not called
+// on a view something is pushed over, nor on a root parked off screen while
+// another is shown — both are seen again, and cancelling their reads is how
+// opening the palette over a loading thread cancelled the load. FocusMsg{false}
+// covers all three and distinguishes none of them, which is why this is not a
+// question about focus.
+//
+// It is a call rather than a message because Update hands back a View the kernel
+// is about to drop, so whatever a discarded view recorded there is thrown away
+// with it, and because a message is broadcastable — any view could then tell
+// every other one it was finished. Whether a view is gone is the kernel's to
+// say, and it says it to that view alone.
+//
+// Quitting discards every view too, and does not call this: the process is
+// ending, so every context it would cancel dies with it, and a view told the
+// news has no frame left to draw and no command that would run.
+type Closer interface {
+	Close()
+}
+
+// CloseView tells a view it has been discarded, if it cares. It is what the
+// kernel does to an entry it drops, and what a pane holding a child view owes
+// that child when it is closed itself.
+func CloseView(v View) {
+	if c, ok := v.(Closer); ok {
+		c.Close()
+	}
+}
+
 type stackEntry struct {
 	spec ViewSpec
 	view View
+	// lent marks a view its pusher still holds and goes on drawing, so taking it
+	// off the stack is not discarding it. The issue pane gives the kernel the
+	// very comment thread its sidebar draws.
+	lent bool
+}
+
+// discard drops the kernel's reference to an entry and closes the view, unless
+// the view was only lent.
+func discard(e stackEntry) {
+	if e.lent {
+		return
+	}
+	CloseView(e.view)
 }
 
 type chromeKey struct {
@@ -657,7 +705,17 @@ func (m Model) open(id string) (tea.Model, tea.Cmd) {
 		m.live[id] = view
 	}
 	blurred := m.blur()
+	// keepRoot has already parked entry zero, so what a switch throws away is
+	// everything pushed over it — and a build where nothing was available at
+	// startup has neither.
+	var dropped []stackEntry
+	if len(m.stack) > 1 {
+		dropped = m.stack[1:]
+	}
 	m.stack = []stackEntry{{spec: spec, view: view}}
+	for _, e := range dropped {
+		discard(e)
+	}
 	m.status = ""
 	cmds := []tea.Cmd{blurred, m.focus(), m.resizeAll()}
 	if !resumed {
@@ -745,7 +803,8 @@ func (m Model) push(msg PushMsg) (tea.Model, tea.Cmd) {
 		spec.Title = m.top().spec.Title
 	}
 	blurred := m.blur()
-	m.stack = append(append([]stackEntry(nil), m.stack...), stackEntry{spec: spec, view: msg.View})
+	entry := stackEntry{spec: spec, view: msg.View, lent: msg.Lent}
+	m.stack = append(append([]stackEntry(nil), m.stack...), entry)
 	m.status = ""
 	return m, tea.Batch(blurred, msg.View.Init(), m.focus(), m.resizeAll())
 }
@@ -758,7 +817,10 @@ func (m Model) pop() (tea.Model, tea.Cmd) {
 		return m.refuse(reason)
 	}
 	blurred := m.blur()
+	// Read after the blur, so this is the instance the view last handed back.
+	dropped := m.top()
 	m.stack = append([]stackEntry(nil), m.stack[:len(m.stack)-1]...)
+	discard(dropped)
 	m.status = ""
 	return m, tea.Batch(blurred, m.focus(), m.resizeAll())
 }

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -91,6 +92,47 @@ func CloseView(v View) {
 	if c, ok := v.(Closer); ok {
 		c.Close()
 	}
+}
+
+// Addr is where a view's own answers come back to. A view mints one for itself
+// and hands it to Reply along with the command it is issuing; the kernel gives
+// the answer to the view holding that address wherever it is on the stack, and
+// drops it when that view is gone.
+//
+// It is a number and not the View itself because a view need not be a pointer —
+// onboarding is a struct the kernel copies on every Update — and comparing two
+// interfaces holding the same non-comparable type panics rather than answering.
+// The zero value addresses nothing, which is what a view holding no question of
+// its own has and what Reply skips.
+type Addr uint64
+
+var lastAddr atomic.Uint64
+
+// NewAddr mints an address for one view instance. Two instances never share
+// one: a second detail pane pushed over the first is asking its own question,
+// and the answer to it belongs to whichever asked.
+func NewAddr() Addr { return Addr(lastAddr.Add(1)) }
+
+// Addressed is the optional interface a view implements when the answers to the
+// commands it issues have to reach it rather than whatever has since been put on
+// top of it. It is the pair to Reply: a view that wraps a command in one and does
+// not implement the other is asking a question whose answer nothing can deliver.
+//
+// It is opt-in, and deliberately narrow. The kernel forwards an unrecognised
+// message to the top of the stack, and that is also where every widget's own
+// message goes — a cursor blink, a spinner tick. Those belong to the view that is
+// being looked at and are right where they are; what needs an address is the
+// answer to a question a view asked the site.
+type Addressed interface {
+	Addr() Addr
+}
+
+// addrOf is the address a view answers to, or zero for one that answers to none.
+func addrOf(v View) Addr {
+	if a, ok := v.(Addressed); ok {
+		return a.Addr()
+	}
+	return 0
 }
 
 type stackEntry struct {
@@ -382,6 +424,9 @@ func (m Model) route(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case BroadcastMsg:
 		return m.forwardAll(msg.Msg)
+
+	case ReplyMsg:
+		return m.reply(msg)
 
 	// Every kind, not just the click: a wheel or a drag reaching the view under
 	// the help overlay scrolls something nobody can see.
@@ -863,6 +908,66 @@ func (m Model) resizeAll() tea.Cmd {
 
 func (m Model) forwardTop(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m.forwardTopWith(msg, nil)
+}
+
+// reply hands a view the answer to something it asked for, rather than handing
+// it to whatever the stack has on top by the time it lands.
+//
+// The addresses are tried in order, most particular first, so an answer for a
+// view the kernel is holding goes straight to it and one for a view held by
+// another — the comment thread the issue pane draws in its sidebar is the only
+// one today — is delivered to the holder, whose own Update passes it on. An
+// answer nothing is waiting for any more is dropped: the view that asked has
+// been discarded, and there is nowhere for it to be drawn.
+func (m Model) reply(msg ReplyMsg) (tea.Model, tea.Cmd) {
+	for _, to := range msg.To {
+		if to == 0 {
+			continue
+		}
+		if at := m.entryAt(to); at >= 0 {
+			return m.forwardAt(at, msg.Msg)
+		}
+		if id, parked := m.parkedAt(to); parked {
+			view, cmd := m.live[id].Update(msg.Msg)
+			m.live[id] = view
+			return m, cmd
+		}
+	}
+	return m, nil
+}
+
+// entryAt is where on the stack a given address is, top first, or -1.
+func (m Model) entryAt(to Addr) int {
+	for i := len(m.stack) - 1; i >= 0; i-- {
+		if addrOf(m.stack[i].view) == to {
+			return i
+		}
+	}
+	return -1
+}
+
+// parkedAt is the root kept off screen at a given address. A root switched away
+// from is still alive and still waiting for what it asked for, so its answer is
+// there when it comes back rather than lost for having been away.
+func (m Model) parkedAt(to Addr) (string, bool) {
+	for id, view := range m.live {
+		if addrOf(view) == to {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// forwardAt delivers to one entry wherever it is, which is what a reply needs
+// and what nothing else does: every other message the kernel forwards goes to
+// the top or to all of them.
+func (m Model) forwardAt(at int, msg tea.Msg) (tea.Model, tea.Cmd) {
+	stack := append([]stackEntry(nil), m.stack...)
+	view, cmd := stack[at].view.Update(msg)
+	stack[at].view = view
+	m.stack = stack
+	m.keepRoot()
+	return m, cmd
 }
 
 func (m Model) forwardTopWith(msg tea.Msg, extra tea.Cmd) (tea.Model, tea.Cmd) {

--- a/internal/ui/kernel/msg.go
+++ b/internal/ui/kernel/msg.go
@@ -30,6 +30,17 @@ type OpenMsg struct{ ID string }
 // view tells another that something changed without holding a pointer to it.
 type BroadcastMsg struct{ Msg tea.Msg }
 
+// ReplyMsg carries a view's own answer back to the view that asked for it.
+//
+// To is that view first and whatever holds it after, so a view the kernel cannot
+// see — the comment thread inside the issue pane's sidebar is one — is reached
+// through the entry that can, which passes it on. The kernel delivers Msg to the
+// first address it can resolve and drops it when it can resolve none.
+type ReplyMsg struct {
+	To  []Addr
+	Msg tea.Msg
+}
+
 // RunCommandMsg asks the kernel to run a registered command, named by ID. It is
 // how the palette runs one: the kernel holds the deps a command is given, so
 // they are current as of the keypress rather than as of whenever the palette was
@@ -113,6 +124,37 @@ func Push(id, title string, v View) tea.Cmd {
 // Close of its own when it is discarded in turn.
 func Lend(id, title string, v View) tea.Cmd {
 	return func() tea.Msg { return PushMsg{View: v, ID: id, Title: title, Lent: true} }
+}
+
+// Reply wraps a command so that what it comes back with is delivered to the view
+// that issued it, wherever that view has got to by then, rather than to whatever
+// is on top of the stack when it lands.
+//
+// A view addresses itself first and names whatever holds it after, so that a
+// view the kernel never sees is still reachable through the one it does. An
+// answer for a view that has been discarded resolves to nothing and is dropped.
+//
+// It is for a view's own answers and not for everything it returns. A kernel
+// command — a push, a pop, a status line — is addressed to the kernel and must
+// not be wrapped, and neither must a widget's own tick: a cursor blink belongs to
+// whoever is being looked at, which is exactly where the top of the stack puts
+// it.
+func Reply(cmd tea.Cmd, to ...Addr) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg { return ReplyTo(cmd(), to...) }
+}
+
+// ReplyTo addresses a message a view has already produced. It is what a view
+// wraps a callback's answer in where Reply cannot reach — the editor handoff
+// hands tea.ExecProcess a function rather than a command, and wrapping the
+// command itself would put an envelope round the exec the runtime has to see.
+func ReplyTo(msg tea.Msg, to ...Addr) tea.Msg {
+	if msg == nil {
+		return nil
+	}
+	return ReplyMsg{To: to, Msg: msg}
 }
 
 // Pop returns a command that goes back one view.

--- a/internal/ui/kernel/msg.go
+++ b/internal/ui/kernel/msg.go
@@ -13,6 +13,11 @@ type PushMsg struct {
 	View  View
 	ID    string
 	Title string
+	// Lent says the pusher goes on holding this view after the stack drops it,
+	// so taking it off is not discarding it and the kernel must not close it.
+	// The default is the common case: a view built for the push, which the
+	// kernel then owns.
+	Lent bool
 }
 
 // PopMsg takes the top view off the stack.
@@ -94,9 +99,20 @@ type StatusMsg struct {
 	Level StatusLevel
 }
 
-// Push returns a command that pushes a view onto the stack.
+// Push returns a command that pushes a view onto the stack. The kernel takes it
+// over: popping it discards it, and a view implementing Closer is told so.
 func Push(id, title string, v View) tea.Cmd {
 	return func() tea.Msg { return PushMsg{View: v, ID: id, Title: title} }
+}
+
+// Lend returns a command that puts a view the caller keeps on the stack. The
+// kernel draws it and routes keys to it like any other entry and drops it on
+// esc without closing it, because the caller is still holding it — the issue
+// pane hands over the very thread its sidebar draws, and closing that would
+// cancel a read the sidebar is still waiting for. The lender owes the view a
+// Close of its own when it is discarded in turn.
+func Lend(id, title string, v View) tea.Cmd {
+	return func() tea.Msg { return PushMsg{View: v, ID: id, Title: title, Lent: true} }
 }
 
 // Pop returns a command that goes back one view.

--- a/internal/ui/kernel/registry_test.go
+++ b/internal/ui/kernel/registry_test.go
@@ -88,7 +88,7 @@ func msgName(msg tea.Msg) string {
 	}
 }
 
-func spec(id string, slot int, requires jira.CapabilityKey, v *stubView) ViewSpec {
+func spec(id string, slot int, requires jira.CapabilityKey, v View) ViewSpec {
 	return ViewSpec{
 		ID:       id,
 		Title:    strings.ToUpper(id[:1]) + id[1:],

--- a/internal/ui/kernel/registry_test.go
+++ b/internal/ui/kernel/registry_test.go
@@ -18,6 +18,7 @@ type stubView struct {
 	content   string
 	blocks    string
 	capturing bool
+	closed    int
 }
 
 func (s *stubView) Init() tea.Cmd { return nil }
@@ -45,6 +46,8 @@ func (s *stubView) BlocksClose() (string, bool) {
 	}
 	return s.blocks, true
 }
+
+func (s *stubView) Close() { s.closed++ }
 
 func msgName(msg tea.Msg) string {
 	switch m := msg.(type) {

--- a/internal/ui/kernel/reply_test.go
+++ b/internal/ui/kernel/reply_test.go
@@ -1,0 +1,220 @@
+package kernel
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// privMsg is a message only the view that asked for it knows what to do with,
+// which is what every read, page and write in this program answers with.
+type privMsg struct{ n int }
+
+// asker is a view that holds an address and records what it is given. It counts
+// what it recognises rather than everything, so that the size and focus messages
+// the kernel sends on a push do not have to be spelt out in every assertion.
+type asker struct {
+	id   string
+	addr Addr
+	got  []privMsg
+}
+
+func newAsker(id string) *asker { return &asker{id: id, addr: NewAddr()} }
+
+func (a *asker) Init() tea.Cmd { return nil }
+
+func (a *asker) Update(msg tea.Msg) (View, tea.Cmd) {
+	if mine, ours := msg.(privMsg); ours {
+		a.got = append(a.got, mine)
+	}
+	return a, nil
+}
+
+func (a *asker) View() string { return a.id + " body" }
+
+func (a *asker) Addr() Addr { return a.addr }
+
+// answer is what a view's own command produces once it has been addressed.
+func answer(to ...Addr) ReplyMsg { return ReplyMsg{To: to, Msg: privMsg{n: 1}} }
+
+// The bug this is all for: a view's answer used to be delivered to whatever the
+// stack had on top when it landed, which is never the view that asked — a view
+// is blurred exactly by something being pushed over it.
+func TestReply_AnAnswerGoesToTheViewThatAskedAndNotToWhatIsOnTop(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := newAsker("board")
+	RegisterView(spec("board", 1, "", board))
+	palette := newAsker(PaletteViewID)
+	RegisterView(spec(PaletteViewID, 0, "", palette))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "ctrl+k")
+	if len(m.stack) != 2 {
+		t.Fatalf("the palette did not open: stack depth %d", len(m.stack))
+	}
+
+	next, _ := m.Update(answer(board.addr))
+	m = next.(Model)
+
+	if len(board.got) != 1 {
+		t.Errorf("the view that asked was given %d of its answers, want 1", len(board.got))
+	}
+	if len(palette.got) != 0 {
+		t.Errorf("the view on top was given %d answers it never asked for", len(palette.got))
+	}
+}
+
+// A root switched away from is parked rather than discarded, so it is still
+// waiting for what it asked for and its answer is there when it comes back.
+func TestReply_AnAnswerForARootParkedOffScreenStillReachesIt(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := newAsker("board")
+	RegisterView(spec("board", 1, "", board))
+	backlog := newAsker("backlog")
+	RegisterView(spec("backlog", 2, "", backlog))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "g", "2")
+
+	if _, cmd := m.Update(answer(board.addr)); cmd != nil {
+		t.Error("delivering an answer to a parked root asked for more work")
+	}
+
+	if len(board.got) != 1 {
+		t.Errorf("the parked root was given %d of its answers, want 1", len(board.got))
+	}
+	if len(backlog.got) != 0 {
+		t.Errorf("the root on screen was given %d answers it never asked for", len(backlog.got))
+	}
+}
+
+// A discarded view has no frame left to draw into, so its answer goes nowhere
+// rather than into whatever took its place.
+func TestReply_AnAnswerForADiscardedViewIsDropped(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := newAsker("board")
+	RegisterView(spec("board", 1, "", board))
+
+	m := newAt(t, testDeps(), 120, 30)
+	detail := newAsker("detail")
+	next, _ := m.Update(PushMsg{View: detail, ID: "detail", Title: "PROJ-1"})
+	m = next.(Model)
+	m, _ = press(m, "esc")
+
+	if _, cmd := m.Update(answer(detail.addr)); cmd != nil {
+		t.Error("an answer nobody is waiting for asked for more work")
+	}
+
+	if len(detail.got) != 0 {
+		t.Errorf("a view the kernel has thrown away was given %d answers", len(detail.got))
+	}
+	if len(board.got) != 0 {
+		t.Errorf("the view underneath was given %d answers addressed to another view", len(board.got))
+	}
+}
+
+// A view held inside another is not an entry and cannot be delivered to, so its
+// answer names the holder after itself. The kernel takes the most particular
+// address it can see: the held view where it is on the stack in its own right,
+// and the holder where it is not.
+func TestReply_TheMostParticularAddressTheKernelCanSeeWins(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := newAsker("board")
+	RegisterView(spec("board", 1, "", board))
+
+	m := newAt(t, testDeps(), 120, 30)
+	pane, held := newAsker("pane"), newAsker("thread")
+	next, _ := m.Update(PushMsg{View: pane, ID: "pane", Title: "PROJ-1"})
+	m = next.(Model)
+
+	next, _ = m.Update(answer(held.addr, pane.addr))
+	m = next.(Model)
+	if len(pane.got) != 1 {
+		t.Errorf("the holder was given %d answers for the view it holds, want 1", len(pane.got))
+	}
+	if len(held.got) != 0 {
+		t.Errorf("a view the kernel cannot see was delivered to %d times", len(held.got))
+	}
+
+	next, _ = m.Update(PushMsg{View: held, ID: "thread", Title: "PROJ-1", Lent: true})
+	m = next.(Model)
+	m.Update(answer(held.addr, pane.addr))
+
+	if len(held.got) != 1 {
+		t.Errorf("the lent view on the stack was given %d of its answers, want 1", len(held.got))
+	}
+	if len(pane.got) != 1 {
+		t.Errorf("the holder was given %d answers, want only the one from before it was lent", len(pane.got))
+	}
+}
+
+// The other half of the rule, and the one that keeps a cursor blink where it is:
+// a message with no address on it is still the top of the stack's. A widget's
+// tick belongs to whoever is being looked at.
+func TestReply_AMessageWithNoAddressStillGoesToTheTop(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	board := newAsker("board")
+	RegisterView(spec("board", 1, "", board))
+
+	m := newAt(t, testDeps(), 120, 30)
+	pane := newAsker("pane")
+	next, _ := m.Update(PushMsg{View: pane, ID: "pane", Title: "PROJ-1"})
+	m = next.(Model)
+
+	m.Update(privMsg{n: 1})
+
+	if len(pane.got) != 1 {
+		t.Errorf("the top of the stack was given %d unaddressed messages, want 1", len(pane.got))
+	}
+	if len(board.got) != 0 {
+		t.Errorf("an unaddressed message reached %d views under the top one", len(board.got))
+	}
+}
+
+// Reply is what a view wraps its own command in, and the envelope has to survive
+// whatever the command answers with — including nothing at all, which is what a
+// command that decided there was nothing to do returns.
+func TestReply_WrapsWhatACommandAnswersWithAndLetsNothingThrough(t *testing.T) {
+	at := NewAddr()
+	if got := Reply(nil, at); got != nil {
+		t.Error("wrapping no command produced one")
+	}
+
+	quiet := Reply(func() tea.Msg { return nil }, at)
+	if got := quiet(); got != nil {
+		t.Errorf("a command that answered with nothing was wrapped into %T", got)
+	}
+
+	sent := Reply(func() tea.Msg { return privMsg{n: 7} }, at)
+	reply, addressed := sent().(ReplyMsg)
+	if !addressed {
+		t.Fatalf("the command came back as %T, want it addressed", sent())
+	}
+	if len(reply.To) != 1 || reply.To[0] != at {
+		t.Errorf("the answer is addressed to %v, want %v", reply.To, at)
+	}
+	if got, ours := reply.Msg.(privMsg); !ours || got.n != 7 {
+		t.Errorf("the envelope carries %#v, want the message the command produced", reply.Msg)
+	}
+}
+
+// Two views must never share an address, or an answer to one is drawn into the
+// other — two detail panes on one stack are two different issues.
+func TestReply_EveryAddressIsItsOwn(t *testing.T) {
+	seen := make(map[Addr]bool, 1000)
+	for range 1000 {
+		at := NewAddr()
+		if at == 0 {
+			t.Fatal("an address came back as the zero value, which the kernel resolves to nothing")
+		}
+		if seen[at] {
+			t.Fatalf("%v was handed out twice", at)
+		}
+		seen[at] = true
+	}
+}

--- a/internal/ui/list/cache_test.go
+++ b/internal/ui/list/cache_test.go
@@ -521,6 +521,11 @@ func firstMsg(t *testing.T, cmd tea.Cmd) tea.Msg {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer before it hands
+		// the message inside to the view the address names.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			return reply.Msg
+		}
 		return msg
 	}
 	t.Fatal("the command produced no message")

--- a/internal/ui/list/harness_test.go
+++ b/internal/ui/list/harness_test.go
@@ -123,6 +123,11 @@ func (d *driver) run(cmd tea.Cmd) {
 			queue = append(queue, cmds...)
 			continue
 		}
+		// The kernel takes the envelope off a view's own answer and hands the
+		// message inside to the view the address names. There is one view here.
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		switch msg := msg.(type) {
 		case kernel.StatusMsg:
 			d.statuses = append(d.statuses, msg)

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -43,6 +43,8 @@ var _ kernel.View = (*Model)(nil)
 
 var _ kernel.KeyCapturer = (*Model)(nil)
 
+var _ kernel.Addressed = (*Model)(nil)
+
 // Model is the issue list.
 type Model struct {
 	deps     kernel.Deps
@@ -128,6 +130,7 @@ type Model struct {
 	loaded  bool
 	gen     int
 	cancel  context.CancelFunc
+	addr    kernel.Addr
 
 	// failure is why the search on screen brought back no rows. The status line
 	// kernel.Fail writes is replaced by the next keypress, so the pane keeps its
@@ -183,6 +186,7 @@ func (m *Model) WantsRawKeys() bool { return m.filtering || m.asking || m.bind !
 func New(d kernel.Deps) kernel.View {
 	m := &Model{
 		deps:   d,
+		addr:   kernel.NewAddr(),
 		cache:  d.Cache,
 		styles: newStyles(d.Theme),
 		rows:   newRowCache(rowCacheLimit),
@@ -449,6 +453,18 @@ func (m *Model) stop() {
 	m.loading = false
 }
 
+// Addr is where the kernel delivers the pages and the poll this list asked for,
+// whatever has since been pushed over it and whichever root is on screen.
+func (m *Model) Addr() kernel.Addr { return m.addr }
+
+// reply puts this list's address on a command, so what it asked for comes back
+// here rather than to whatever the stack has on top by then. The list is a root:
+// the detail pane is pushed over it and the palette over that, and it is parked
+// off screen whenever another root is shown.
+func (m *Model) reply(cmd tea.Cmd) tea.Cmd {
+	return kernel.Reply(withCancel(m.cancel, cmd), m.addr)
+}
+
 func (m *Model) current(gen int) bool { return gen == m.gen }
 
 func (m *Model) load() tea.Cmd { return m.loadFor(whyOpen) }
@@ -458,7 +474,7 @@ func (m *Model) loadFor(w why) tea.Cmd {
 		return nil
 	}
 	ctx, gen := m.begin()
-	return withCancel(m.cancel, load(ctx, m.search, m.cache, m.jql, gen, w))
+	return m.reply(load(ctx, m.search, m.cache, m.jql, gen, w))
 }
 
 func (m *Model) refresh(purge bool) tea.Cmd {
@@ -488,7 +504,7 @@ func (m *Model) refetch(w why) tea.Cmd {
 		return tea.Batch(said, m.loadFor(w))
 	}
 	ctx, gen := m.begin()
-	return tea.Batch(said, withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues), gen, w)))
+	return tea.Batch(said, m.reply(reload(ctx, m.search, m.cache, m.jql, len(m.issues), gen, w)))
 }
 
 func (m *Model) retarget(msg QueryMsg) tea.Cmd {
@@ -655,9 +671,9 @@ func (m *Model) pageAheadIfNeeded() tea.Cmd {
 	// Rows that came off disk carry no cursor to follow, so the page after them
 	// is reached by asking the search again and walking to where they end.
 	if !m.page.HasMore() {
-		return withCancel(m.cancel, reload(ctx, m.search, m.cache, m.jql, len(m.issues)+pageSize, gen, whyPage))
+		return m.reply(reload(ctx, m.search, m.cache, m.jql, len(m.issues)+pageSize, gen, whyPage))
 	}
-	return withCancel(m.cancel, more(ctx, m.cache, m.jql, m.issues, m.page, gen))
+	return m.reply(more(ctx, m.cache, m.jql, m.issues, m.page, gen))
 }
 
 // hasMore reports whether anything is left to fetch, from the live page or from

--- a/internal/ui/list/list_test.go
+++ b/internal/ui/list/list_test.go
@@ -504,6 +504,9 @@ func collect(cmd tea.Cmd) []tea.Msg {
 			queue = append(queue, cmds...)
 			continue
 		}
+		if reply, addressed := msg.(kernel.ReplyMsg); addressed {
+			msg = reply.Msg
+		}
 		out = append(out, msg)
 	}
 	return out

--- a/internal/ui/list/poll.go
+++ b/internal/ui/list/poll.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
 )
 
 // pollEvery is how often a focused list re-reads itself, or zero for never,
@@ -41,7 +43,10 @@ func (m *Model) pollTick() tea.Cmd {
 	}
 	m.pollArmed = true
 	gen := m.gen
-	return tea.Tick(m.poll, func(time.Time) tea.Msg { return pollMsg{gen: gen} })
+	// Addressed like a read and unlike a widget's tick: this one is the list's
+	// own, and a tick that came due while the palette was up would otherwise be
+	// eaten there and leave the poller armed for good.
+	return kernel.Reply(tea.Tick(m.poll, func(time.Time) tea.Msg { return pollMsg{gen: gen} }), m.addr)
 }
 
 // polled acts on a tick: re-read what is on screen, which patches the rows and

--- a/internal/ui/list/poll_test.go
+++ b/internal/ui/list/poll_test.go
@@ -1,9 +1,11 @@
 package list
 
 import (
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/varijkapil13/saral/internal/ui/kernel"
 	"github.com/varijkapil13/saral/pkg/jira"
 	"github.com/varijkapil13/saral/pkg/jira/jiratest"
 )
@@ -51,6 +53,31 @@ func TestPoller_OnlyRunsForTheViewWithTheKeyboard(t *testing.T) {
 	dr.m.focused = false
 	if cmd := dr.m.pollTick(); cmd != nil {
 		t.Error("a list nobody is looking at scheduled a poll")
+	}
+}
+
+// A tick is the poller's own answer and not a widget's: pollArmed is cleared by
+// the tick arriving and by nothing else, so one delivered to whatever the
+// palette put on top would stop the poller for the rest of the session.
+func TestPoller_ATickIsAddressedToTheListThatArmedIt(t *testing.T) {
+	t.Parallel()
+
+	dr := openAll(t, testDeps(newFake(10)), 120, 20)
+	dr.m.poll = time.Millisecond
+
+	cmd := dr.m.pollTick()
+	if cmd == nil {
+		t.Fatal("a focused list with polling on scheduled nothing")
+	}
+	reply, addressed := cmd().(kernel.ReplyMsg)
+	if !addressed {
+		t.Fatalf("the tick came back as %T, want it addressed to the list that armed it", cmd())
+	}
+	if !slices.Contains(reply.To, dr.m.Addr()) {
+		t.Errorf("the tick is addressed to %v, which does not include the list at %v", reply.To, dr.m.Addr())
+	}
+	if _, due := reply.Msg.(pollMsg); !due {
+		t.Errorf("the tick carries a %T, want the poll coming due", reply.Msg)
 	}
 }
 

--- a/internal/ui/livekeys_test.go
+++ b/internal/ui/livekeys_test.go
@@ -266,6 +266,97 @@ func TestClose_EveryViewADiscardCanReachStopsItsWork(t *testing.T) {
 	}
 }
 
+// answerable names the views that ask the site for something and therefore owe
+// the kernel an address. An answer is delivered to the view that asked for it,
+// and a view with no address can only be handed one by happening to be on top of
+// the stack when it lands. Like the two sweeps above, the kernel cannot hold the
+// views to this, so the sweep lives here.
+//
+// The command palette is the one view in this build that asks the site for
+// nothing: its commands come out of the registry and its issues out of the local
+// index, both inside the keystroke. It registers no keys, so it is named here
+// rather than listed below.
+var answerable = map[string]func(kernel.Deps) kernel.View{
+	list.ViewID:       list.New,
+	filter.ViewID:     func(d kernel.Deps) kernel.View { return filter.New(d) },
+	form.ViewID:       form.New,
+	comment.ViewID:    comment.New,
+	onboarding.ViewID: onboarding.New,
+	issue.ViewID:      func(d kernel.Deps) kernel.View { return issue.New(d, seed()) },
+	issue.EditViewID:  func(d kernel.Deps) kernel.View { return issue.NewEdit(d, seed()) },
+	issue.MoveViewID:  func(d kernel.Deps) kernel.View { return issue.NewMove(d, seed()) },
+}
+
+// synchronous are the views that answer every question they are asked without
+// leaving the frame, each with the reason. A view lands here because nothing it
+// does outlives a keystroke, not because nobody got round to giving it an
+// address.
+var synchronous = map[string]struct {
+	build func(kernel.Deps) kernel.View
+	why   string
+}{}
+
+func TestAddressed_EveryViewThatAsksTheSiteForSomethingCanBeAnsweredWhereItIs(t *testing.T) {
+	sweepEnv(t)
+	scopes := kernel.KeyScopes()
+	if len(scopes) == 0 {
+		t.Fatal("no view registered any keys, so this sweep is checking nothing")
+	}
+
+	for _, scope := range scopes {
+		build, asks := answerable[scope]
+		local, isLocal := synchronous[scope]
+		switch {
+		case asks && isLocal:
+			t.Errorf("%s is in both halves of the table", scope)
+			continue
+		case !asks && !isLocal:
+			t.Errorf("%s is a view and this sweep does not know whether it asks the site for anything; "+
+				"add it to answerable, or to synchronous with the reason nothing it does outlives a frame", scope)
+			continue
+		case isLocal:
+			build = local.build
+			if local.why == "" {
+				t.Errorf("%s is exempt with no reason given", scope)
+			}
+		}
+
+		view := build(depsFor(t))
+		addressed, implements := view.(kernel.Addressed)
+		switch {
+		case asks && !implements:
+			t.Errorf("%s asks the site for things and does not implement kernel.Addressed, so its answers "+
+				"go to whatever the stack has on top when they land", scope)
+			continue
+		case isLocal && implements:
+			t.Errorf("%s implements kernel.Addressed and has no answer to deliver: %s", scope, local.why)
+			continue
+		case isLocal:
+			continue
+		}
+
+		if addressed.Addr() == 0 {
+			t.Errorf("%s answers to the zero address, which the kernel resolves to nothing, so its "+
+				"answers are dropped rather than delivered", scope)
+		}
+		other, _ := build(depsFor(t)).(kernel.Addressed)
+		if other != nil && other.Addr() == addressed.Addr() {
+			t.Errorf("%s hands two instances the same address, so an answer to one is drawn into the other", scope)
+		}
+	}
+
+	for scope := range answerable {
+		if !known(scopes, scope) {
+			t.Errorf("answerable names %q, which is no longer a view", scope)
+		}
+	}
+	for scope := range synchronous {
+		if !known(scopes, scope) {
+			t.Errorf("synchronous names %q, which is no longer a view", scope)
+		}
+	}
+}
+
 // seed is the row a list would have handed over: a key and nothing else, which
 // is all these panes need to be built.
 func seed() jira.Issue {

--- a/internal/ui/livekeys_test.go
+++ b/internal/ui/livekeys_test.go
@@ -183,6 +183,89 @@ func TestLiveKeys_EveryAdvertisedActionCanBeClicked(t *testing.T) {
 	}
 }
 
+// closers names the views a discard can reach — everything something pushes —
+// and parked names the ones nothing pushes, which the kernel therefore never
+// discards. Like keyReporters above, the kernel cannot hold the views to this —
+// it may not import one — and a view checking itself is the drift, so the sweep
+// lives here.
+//
+// Every scope in the key registry has to appear in exactly one half, so a
+// seventh view fails this until somebody has decided which.
+var closers = map[string]func(kernel.Deps) kernel.View{
+	filter.ViewID:    func(d kernel.Deps) kernel.View { return filter.New(d) },
+	form.ViewID:      form.New,
+	comment.ViewID:   comment.New,
+	issue.ViewID:     func(d kernel.Deps) kernel.View { return issue.New(d, seed()) },
+	issue.EditViewID: func(d kernel.Deps) kernel.View { return issue.NewEdit(d, seed()) },
+	issue.MoveViewID: func(d kernel.Deps) kernel.View { return issue.NewMove(d, seed()) },
+}
+
+// parked are the views nothing ever pushes, each with the reason. A root the
+// user switches away from is kept and comes back on its digit, so a discard
+// never reaches one and a Close on it would be a method nobody calls. A view
+// lands here because of that and not because nobody got round to it: the day
+// something pushes one of these, it owes the interface.
+var parked = map[string]struct {
+	build func(kernel.Deps) kernel.View
+	why   string
+}{
+	list.ViewID: {
+		build: list.New,
+		why:   "the issue list holds a footer slot and nothing pushes it, so it is only ever a root",
+	},
+	onboarding.ViewID: {
+		build: onboarding.New,
+		why:   "setup is where the program starts and what the palette reopens, and neither of those is a push",
+	},
+}
+
+func TestClose_EveryViewADiscardCanReachStopsItsWork(t *testing.T) {
+	sweepEnv(t)
+	scopes := kernel.KeyScopes()
+	if len(scopes) == 0 {
+		t.Fatal("no view registered any keys, so this sweep is checking nothing")
+	}
+
+	for _, scope := range scopes {
+		build, pushed := closers[scope]
+		root, isRoot := parked[scope]
+		switch {
+		case pushed && isRoot:
+			t.Errorf("%s is in both halves of the table", scope)
+			continue
+		case !pushed && !isRoot:
+			t.Errorf("%s is a view and this sweep does not know whether anything pushes it; add it to "+
+				"closers, or to parked with the reason a discard never reaches it", scope)
+			continue
+		case isRoot:
+			build = root.build
+			if root.why == "" {
+				t.Errorf("%s is exempt with no reason given", scope)
+			}
+		}
+
+		_, implements := build(depsFor(t)).(kernel.Closer)
+		switch {
+		case pushed && !implements:
+			t.Errorf("%s can be discarded and does not implement kernel.Closer, so a read it started "+
+				"goes on running for an answer the kernel has thrown the view away for", scope)
+		case isRoot && implements:
+			t.Errorf("%s implements kernel.Closer and nothing would ever call it: %s", scope, root.why)
+		}
+	}
+
+	for scope := range closers {
+		if !known(scopes, scope) {
+			t.Errorf("closers names %q, which is no longer a view", scope)
+		}
+	}
+	for scope := range parked {
+		if !known(scopes, scope) {
+			t.Errorf("parked names %q, which is no longer a view", scope)
+		}
+	}
+}
+
 // seed is the row a list would have handed over: a key and nothing else, which
 // is all these panes need to be built.
 func seed() jira.Issue {

--- a/internal/ui/onboarding/commands.go
+++ b/internal/ui/onboarding/commands.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/varijkapil13/saral/internal/app"
 	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
 	"github.com/varijkapil13/saral/pkg/jira"
 )
 
@@ -137,10 +138,12 @@ func (m *Model) start(kind busy, run func(context.Context, int) tea.Msg) tea.Cmd
 	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
 	m.cancel, m.busy, m.last = cancel, kind, kind
 	m.problem, m.note = "", ""
-	return tea.Batch(m.spin.Tick, func() tea.Msg {
+	// The spinner's tick is left where it is: it belongs to whoever is on screen.
+	// The call itself is this view's own answer and is addressed to it.
+	return tea.Batch(m.spin.Tick, kernel.Reply(func() tea.Msg {
 		defer cancel()
 		return run(ctx, seq)
-	})
+	}, m.addr))
 }
 
 func (m *Model) verify() tea.Cmd {
@@ -217,14 +220,14 @@ func (m *Model) suggest() tea.Cmd {
 	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
 	m.cancelBg = cancel
 	m.looking, m.suggested, m.lookup = true, nil, ""
-	return func() tea.Msg {
+	return kernel.Reply(func() tea.Msg {
 		defer cancel()
 		keys, err := recentProjects(ctx, search)
 		if err != nil {
 			return projectsUnknownMsg{seq: seq, err: err}
 		}
 		return projectsFoundMsg{seq: seq, keys: keys}
-	}
+	}, m.addr)
 }
 
 // suggestionLimit is how many issues the picker reads to find project keys. It

--- a/internal/ui/onboarding/commands.go
+++ b/internal/ui/onboarding/commands.go
@@ -111,9 +111,9 @@ func (m *Model) configLoaded(msg configLoadedMsg) tea.Cmd {
 	return nil
 }
 
-// stop cancels whatever is in the air, which is what closing or looking away
-// from this view has to do: a verification the user has walked away from must
-// not still be running.
+// stop cancels whatever is in the air. It is what starting the next question
+// does, and not what losing the keyboard does: a palette opened over a token
+// being checked must not cancel the check.
 func (m *Model) stop() {
 	if m.cancel != nil {
 		m.cancel()

--- a/internal/ui/onboarding/harness_test.go
+++ b/internal/ui/onboarding/harness_test.go
@@ -110,6 +110,10 @@ func (d *driver) run(cmd tea.Cmd) {
 		for _, c := range msg {
 			d.run(c)
 		}
+	// The kernel takes the envelope off a view's own answer and hands the message
+	// inside to the view the address names. There is one view here.
+	case kernel.ReplyMsg:
+		d.send(msg.Msg)
 	case spinner.TickMsg:
 	case tea.QuitMsg:
 		d.quit = true

--- a/internal/ui/onboarding/kernel_test.go
+++ b/internal/ui/onboarding/kernel_test.go
@@ -216,6 +216,25 @@ type kernelDriver struct {
 	t      *testing.T
 	model  tea.Model
 	frames []string
+
+	// held keeps what a command answered with instead of delivering it. An
+	// answer that has already landed cannot be covered by anything, so this is
+	// the only way to arrange the case the palette makes: the check waits,
+	// something is pushed over this view, and only then does the kernel get the
+	// message and decide where it belongs.
+	holding bool
+	held    []tea.Msg
+}
+
+func (k *kernelDriver) hold() { k.holding = true }
+
+func (k *kernelDriver) release() {
+	k.t.Helper()
+	held := k.held
+	k.holding, k.held = false, nil
+	for _, msg := range held {
+		k.send(msg)
+	}
 }
 
 func (k *kernelDriver) send(msg tea.Msg) {
@@ -239,6 +258,10 @@ func (k *kernelDriver) run(cmd tea.Cmd) {
 		}
 	case spinner.TickMsg:
 	default:
+		if k.holding {
+			k.held = append(k.held, msg)
+			return
+		}
 		k.send(msg)
 	}
 }
@@ -259,4 +282,55 @@ func (k *kernelDriver) press(keys ...string) {
 
 func (k *kernelDriver) frame() string {
 	return ansi.Strip(k.model.(kernel.Model).Frame())
+}
+
+// cover stands in for the palette, which this package may not import. What
+// matters is that it is on top and answers for none of setup's messages.
+type cover struct{}
+
+func (cover) Init() tea.Cmd                         { return nil }
+func (cover) Update(tea.Msg) (kernel.View, tea.Cmd) { return cover{}, nil }
+func (cover) View() string                          { return "something else entirely" }
+
+// Setup is a root and is never discarded, but the palette opens over it like it
+// opens over anything else. A token being checked when that happens is an answer
+// this view still needs, and it belongs to this view rather than to whatever was
+// put on top of it.
+func TestKernel_AnAnswerLandingWhileSetupIsCoveredStillReachesIt(t *testing.T) {
+	keyring.MockInit()
+	t.Cleanup(keyring.MockInit)
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+
+	fake := testFake()
+	SetConnector(func(string, string, string) (jira.SessionClient, error) { return fake, nil })
+	t.Cleanup(func() { SetConnector(nil) })
+
+	root, err := kernel.New(testDeps(), kernel.WithSize(100, 30), kernel.WithInitialView(ViewID), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	k := &kernelDriver{t: t, model: root}
+	k.send(tea.WindowSizeMsg{Width: 100, Height: 30})
+	k.run(root.Init())
+	k.typeIn(testSite)
+	k.press("enter")
+	k.typeIn(testEmail)
+	k.press("enter")
+	k.typeIn(testToken)
+
+	k.hold()
+	k.press("enter")
+	k.send(kernel.PushMsg{ID: "cover", Title: "Cover", View: cover{}})
+	if !strings.Contains(k.frame(), "something else entirely") {
+		t.Fatalf("nothing was pushed over setup:\n%s", k.frame())
+	}
+
+	k.release()
+	k.send(kernel.PopMsg{})
+
+	// The token's own step says who it verified as, and nothing says that until
+	// the check has answered.
+	if !strings.Contains(k.frame(), "verified as Sam Tester") {
+		t.Errorf("the check that was in flight never reached setup:\n%s", k.frame())
+	}
 }

--- a/internal/ui/onboarding/onboarding.go
+++ b/internal/ui/onboarding/onboarding.go
@@ -172,7 +172,6 @@ func (m Model) Update(msg tea.Msg) (kernel.View, tea.Cmd) {
 
 	case kernel.FocusMsg:
 		if !msg.Focused {
-			m.stop()
 			m.blurField()
 			return m, nil
 		}

--- a/internal/ui/onboarding/onboarding.go
+++ b/internal/ui/onboarding/onboarding.go
@@ -77,6 +77,7 @@ func NewWith(d kernel.Deps, connect Connector) kernel.View {
 		connect: connect,
 		cfg:     config.Config{Mouse: true},
 		cache:   &renderCache{},
+		addr:    kernel.NewAddr(),
 	}
 	m.zones = widget.NewZoner(d.Zones)
 	m.restyle()
@@ -98,6 +99,8 @@ var _ kernel.View = Model{}
 var _ kernel.Blocker = Model{}
 
 var _ kernel.KeyCapturer = Model{}
+
+var _ kernel.Addressed = Model{}
 
 // Model is the onboarding view: a state machine over five text inputs and one
 // choice, with a verification between the steps that need one.
@@ -121,6 +124,7 @@ type Model struct {
 
 	cancel   context.CancelFunc
 	cancelBg context.CancelFunc
+	addr     kernel.Addr
 
 	problem string
 	note    string
@@ -158,7 +162,12 @@ func (m Model) WantsRawKeys() bool {
 // Init loads the config file that may already exist, because onboarding also
 // adds a profile to one, and because writing over a file this build cannot
 // parse would lose whatever is in it.
-func (m Model) Init() tea.Cmd { return loadConfig }
+func (m Model) Init() tea.Cmd { return kernel.Reply(loadConfig, m.addr) }
+
+// Addr is where the kernel delivers what this view asked the site for. It is a
+// root, so nothing discards it — but the palette opens over it, and a token
+// being checked while that is up is an answer this view still needs.
+func (m Model) Addr() kernel.Addr { return m.addr }
 
 // Update routes one message. Every outcome has its own message type, and each
 // carries the sequence number of the operation that produced it so that a

--- a/internal/ui/onboarding/onboarding_test.go
+++ b/internal/ui/onboarding/onboarding_test.go
@@ -547,7 +547,7 @@ func TestSave_NamesASecondProfileForTheSameSiteWithoutOverwritingTheFirst(t *tes
 	}
 }
 
-func TestFocus_CancelsWhatIsInTheAirWhenTheViewStopsBeingLookedAt(t *testing.T) {
+func TestStop_CancelsWhatIsInTheAir(t *testing.T) {
 	t.Parallel()
 
 	fake := testFake()
@@ -572,6 +572,33 @@ func TestFocus_CancelsWhatIsInTheAirWhenTheViewStopsBeingLookedAt(t *testing.T) 
 	}
 	if m.busy != busyNone {
 		t.Error("the view still thinks something is in the air")
+	}
+}
+
+// Losing the keyboard is not the same thing. This view is only ever a root, so
+// it is parked rather than discarded, and the palette opens over it: a token
+// being checked must survive both.
+func TestFocus_LosingTheKeyboardDoesNotCancelACheckInFlight(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t, testFake())
+	d.typeIn(testSite)
+	d.press("enter")
+	d.typeIn(testEmail)
+	d.press("enter")
+	d.typeIn(testToken)
+
+	m := d.model()
+	cancelled := false
+	m.busy, m.seq = busyProbe, 7
+	m.cancel = func() { cancelled = true }
+
+	blurred, _ := m.Update(kernel.FocusMsg{})
+	if cancelled {
+		t.Error("the check was cancelled by the view merely losing the keyboard")
+	}
+	if got := blurred.(Model).busy; got != busyProbe {
+		t.Errorf("the view says it is %d, want it to still be checking", got)
 	}
 }
 

--- a/internal/ui/reply_test.go
+++ b/internal/ui/reply_test.go
@@ -1,0 +1,319 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	zone "github.com/lrstanley/bubblezone/v2"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/internal/ui/list"
+	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
+	"github.com/varijkapil13/saral/pkg/jira/jiratest"
+)
+
+// program is the whole thing running: the kernel, every view this build
+// registered, and the real command palette on ctrl+k.
+//
+// Nothing here hands a view a message. Everything goes to the kernel and the
+// kernel decides where it belongs, which is the step these tests are about — the
+// step a test that delivers an answer to the view itself skips over.
+type program struct {
+	t *testing.T
+	m kernel.Model
+
+	// held keeps a view's own answers back instead of delivering them. An answer
+	// that has already landed cannot be covered by anything, so this is the only
+	// way to arrange the case: the answer waits, ctrl+k puts the palette over the
+	// view that asked, and only then is the kernel given the message.
+	//
+	// What the kernel acts on itself goes through, because those are the gestures
+	// that build the situation rather than the answers under test.
+	holding bool
+	held    []tea.Msg
+}
+
+func boot(t *testing.T, d kernel.Deps, root string, w, h int) *program {
+	t.Helper()
+
+	m, err := kernel.New(d, kernel.WithSize(w, h), kernel.WithInitialView(root), kernel.WithMouse(false))
+	if err != nil {
+		t.Fatalf("kernel.New: %v", err)
+	}
+	p := &program{t: t, m: m}
+	p.send(tea.WindowSizeMsg{Width: w, Height: h})
+	return p
+}
+
+func (p *program) hold() { p.holding = true }
+
+// release hands the kernel everything that was held, in the order it came back.
+func (p *program) release() {
+	p.t.Helper()
+
+	held := p.held
+	p.holding, p.held = false, nil
+	for _, msg := range held {
+		p.send(msg)
+	}
+}
+
+// gestures are what the kernel acts on rather than what a view is waiting for.
+// Holding a push would mean the view under test never opens.
+func gesture(msg tea.Msg) bool {
+	switch msg.(type) {
+	case kernel.PushMsg, kernel.PopMsg, kernel.OpenMsg, kernel.RunCommandMsg,
+		kernel.BroadcastMsg, kernel.StatusMsg:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *program) send(msg tea.Msg) {
+	p.t.Helper()
+
+	next, cmd := p.m.Update(msg)
+	m, ok := next.(kernel.Model)
+	if !ok {
+		p.t.Fatal("the kernel stopped returning its own model")
+	}
+	p.m = m
+	p.run(cmd)
+}
+
+func (p *program) run(cmd tea.Cmd) {
+	p.t.Helper()
+
+	queue := []tea.Cmd{cmd}
+	for steps := 0; len(queue) > 0; steps++ {
+		if steps > 8000 {
+			p.t.Fatal("commands never settled")
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		if p.holding && !gesture(msg) {
+			p.held = append(p.held, msg)
+			continue
+		}
+		updated, follow := p.m.Update(msg)
+		m, ok := updated.(kernel.Model)
+		if !ok {
+			p.t.Fatal("the kernel stopped returning its own model")
+		}
+		p.m = m
+		queue = append(queue, follow)
+	}
+}
+
+func (p *program) press(keys ...string) {
+	p.t.Helper()
+
+	for _, k := range keys {
+		p.send(stroke(k))
+	}
+}
+
+func (p *program) frame() string { return ansi.Strip(p.m.Frame()) }
+
+func stroke(s string) tea.KeyPressMsg {
+	switch s {
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "esc":
+		return tea.KeyPressMsg{Code: tea.KeyEscape}
+	case "ctrl+k":
+		return tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl}
+	default:
+		return tea.KeyPressMsg{Code: rune(s[0]), Text: s}
+	}
+}
+
+// replyFake is a project with a thread on the issue these tests open, so that
+// the sidebar has an answer of its own to wait for.
+func replyFake(t *testing.T) *jiratest.Fake {
+	t.Helper()
+
+	f := jiratest.New(
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithIssues(jiratest.Gen(12)),
+	)
+	body := adf.NewDoc(adf.NewNode("paragraph", adf.NewText(threadLine)))
+	if _, err := f.AddComment(t.Context(), "PROJ-12", body); err != nil {
+		t.Fatalf("seeding the thread: %v", err)
+	}
+	return f
+}
+
+// threadLine is what the sidebar draws once the thread's own read has landed,
+// and nothing draws before it.
+const threadLine = "The conversation you came for."
+
+func replyDeps(f *jiratest.Fake) kernel.Deps {
+	ok := jira.Capability{OK: true}
+	return kernel.Deps{
+		Jira: f,
+		Caps: jira.Capabilities{
+			Plans: ok, BulkMove: ok, Boards: ok, Attachments: ok,
+			DeleteIssues: ok, People: ok, TimeZone: time.UTC,
+		},
+		Project: "PROJ",
+		Theme:   kernel.NewTheme(kernel.ThemeNoColor, true, kernel.ASCIIGlyphs()),
+		Zones:   zone.New(),
+		Site:    "example.atlassian.net",
+		Now:     func() time.Time { return time.Date(2026, time.March, 5, 9, 0, 0, 0, time.UTC) },
+	}
+}
+
+// palettePrompt is what the palette draws where nothing has been typed, and how
+// these tests know it really is the palette that is covering the view.
+const palettePrompt = "what do you want to do"
+
+// A view's own answer, through the kernel and the real palette. Every one of
+// these views asks the site for something and can have ctrl+k pressed over it
+// while the answer is still out. The answer belongs to whichever view asked.
+//
+// arrive is driven while the answers are held, so the view opens with its read
+// genuinely in flight. Every case asserts the view has nothing yet, so that a
+// read which quietly completed early cannot make one of these pass.
+func TestReply_AnAnswerLandingUnderThePaletteStillReachesTheViewThatAskedForIt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// settle gets the program to where the gesture can be made, with every
+		// answer up to that point delivered.
+		settle func(*program)
+		arrive func(*program)
+		want   []string
+		gone   []string
+	}{
+		{
+			name:   "the issue list, which is a root and is covered where it stands",
+			settle: func(*program) {},
+			arrive: func(p *program) { p.run(p.m.Init()) },
+			want:   []string{"PROJ-12", "Retire the nightly export"},
+		},
+		{
+			name:   "the detail pane, pushed over the list",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.press("enter") },
+			want:   []string{"Filed against PROJ-12."},
+		},
+		{
+			name:   "the field editor, pushed over the pane",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.press("enter", "e") },
+			want:   []string{"2025-03-16"},
+			gone:   []string{"not read"},
+		},
+		{
+			name:   "the transition picker, pushed over the pane",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.press("enter", "t") },
+			want:   []string{"Move to Building"},
+		},
+		{
+			name:   "the filter picker, pushed over the list",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.press("f", "enter") },
+			want:   []string{"Ada Lovelace"},
+		},
+		{
+			name:   "the create form, pushed by a command",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.send(kernel.RunCommandMsg{ID: "issue.create"}) },
+			want:   []string{"Defect"},
+		},
+		{
+			// The thread the sidebar draws is a model inside the pane and never an
+			// entry on the stack, so the kernel cannot deliver to it at all. Its
+			// answer names the pane after itself, and the pane hands it on.
+			name:   "the comment thread the pane draws beside the description",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.press("enter") },
+			want:   []string{threadLine},
+		},
+		{
+			// The same thread, lent to the kernel for the whole screen. Now it is
+			// an entry, and the answer goes straight to it rather than through the
+			// pane underneath.
+			name:   "the comment thread lent to the kernel for the whole screen",
+			settle: func(p *program) { p.run(p.m.Init()) },
+			arrive: func(p *program) { p.press("enter", "C") },
+			want:   []string{threadLine},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sweepEnv(t)
+
+			p := boot(t, replyDeps(replyFake(t)), list.ViewID, 120, 40)
+			tc.settle(p)
+
+			p.hold()
+			tc.arrive(p)
+			mustLack(t, p.frame(), tc.want...)
+
+			p.press("ctrl+k")
+			mustHave(t, p.frame(), palettePrompt)
+
+			p.release()
+			p.press("esc")
+
+			mustHave(t, p.frame(), tc.want...)
+			mustLack(t, p.frame(), tc.gone...)
+		})
+	}
+}
+
+// The other half: an answer for a view that has been thrown away goes nowhere.
+// The kernel has no view to give it to, and handing it to whatever is on top is
+// what put an issue's fields into somebody else's pane.
+func TestReply_AnAnswerForAViewThatIsGoneIsDroppedRatherThanGivenToTheTop(t *testing.T) {
+	sweepEnv(t)
+
+	p := boot(t, replyDeps(replyFake(t)), list.ViewID, 120, 40)
+	p.run(p.m.Init())
+
+	p.hold()
+	p.press("enter", "t")
+	p.press("esc", "esc")
+	mustHave(t, p.frame(), "Retire the nightly export")
+
+	p.release()
+	mustLack(t, p.frame(), "Move to Building")
+	mustHave(t, p.frame(), "Retire the nightly export")
+}
+
+func mustHave(t *testing.T, frame string, want ...string) {
+	t.Helper()
+
+	for _, w := range want {
+		if !strings.Contains(frame, w) {
+			t.Errorf("the frame does not carry %q:\n%s", w, frame)
+		}
+	}
+}
+
+func mustLack(t *testing.T, frame string, gone ...string) {
+	t.Helper()
+
+	for _, g := range gone {
+		if strings.Contains(frame, g) {
+			t.Errorf("the frame still carries %q:\n%s", g, frame)
+		}
+	}
+}


### PR DESCRIPTION
Closes #124 and #125. The two halves have to ship together: **without the delivery fix, removing the
blur-cancel is a regression**, and the first version of this branch was one. That is written out
under *The stall this branch used to have* below.

## The gap

The kernel said one thing — `FocusMsg{Focused: false}` — in three situations that mean three
different things, and gave a view nothing to tell them apart:

| Gesture | What happened to the view | Told |
|---|---|---|
| something pushed over it | still there, underneath | `FocusMsg{false}` |
| a switch to another root | parked in `m.live`, comes back on its digit | `FocusMsg{false}` |
| popped | gone | `FocusMsg{false}` |

Cancelling a fetch on all three is how **opening the palette over a loading comment thread cancelled
the load**. Cancelling on none of them left every discarded view asking a rate-limited API for an
answer nothing would ever draw.

And underneath both: `Model.route`'s default is `forwardTop`, so an answer is delivered to whatever is
on top of the stack **when it lands**. A view is blurred by exactly the thing that makes it not the
top, so every answer arriving while the palette was up went to the palette and was dropped.

## Part one: `kernel.Closer`

```go
type Closer interface {
	Close()
}
```

The fourth optional interface, next to `KeyCapturer`, `Blocker` and `KeyReporter` — not a fourth
shape. `Blocker` refuses a close; `Closer` is told about the one that happened.

**A call and not a message.** `Update` hands back a `View` the kernel is about to drop, so anything a
discarded view records there is thrown away with it and the only effect it can have is one it
performs on the spot. And a message is broadcastable: `kernel.Broadcast(CloseMsg{})` would let any
view tell every other one it was finished. Whether a view is gone is the kernel's to say, and it says
it to that view alone.

Two paths call `Close` and no others: the entry a **pop** takes off, and every entry above index zero
a **root switch** throws away. Not a view pushed over (`TestClose_AViewPushedOverIsNotDiscarded`), not
a root parked in `live` (asserted by identity), not a project switch, and not quitting —
`TestClose_QuittingTellsNobody` pins that as a choice rather than an omission.

**`kernel.Lend` is the push that keeps the view.** The issue pane draws the comment thread in its
sidebar and `C` hands the kernel *that same model*. Closing it on `esc` would cancel a read the
sidebar is still waiting for. `PushMsg` grows a `Lent` flag; the kernel drops a lent entry without
closing it and the lender closes it in its own `Close`.

## Part two: `kernel.Reply` and `kernel.Addressed`

```go
type Addr uint64

func NewAddr() Addr
func Reply(cmd tea.Cmd, to ...Addr) tea.Cmd

type Addressed interface {
	Addr() Addr
}
```

A view mints an address for itself and wraps its own commands in it. The kernel takes the envelope
off and delivers the message to the view holding that address — anywhere on the stack, or parked in
`live` after a root switch — and **drops it when no address resolves**, because a discarded view has
no frame left to draw the answer into. The kernel never learns a view's message types.

Three decisions worth stating:

- **Opt-in, and narrow.** Everything unaddressed still goes to `forwardTop`, which is where every
  `bubbles` message belongs — a cursor blink, a spinner tick. Addressing those would blink every
  input in the program and walk the whole session under every tick.
  `TestReply_AMessageWithNoAddressStillGoesToTheTop` holds that path where it was.
- **The address is a number, not the `View`.** A view need not be a pointer — onboarding is a struct
  the kernel copies on every `Update` — and `==` on two interfaces holding the same non-comparable
  type panics rather than answering.
- **`To` is a list, most particular first.** The thread in the pane's sidebar is a model inside a
  view and never a stack entry, so the kernel cannot deliver to it at all. Its answer names itself
  and then the pane; the kernel takes the first address it can see — the thread while `C` has it lent
  to the whole screen, the pane otherwise, which forwards what it does not recognise. So the pane
  does not wrap on the thread's behalf, and the thread does not lose its answer when it is an entry
  in its own right. `TestReply_TheMostParticularAddressTheKernelCanSeeWins` covers both directions.

## The stall this branch used to have

`internal/ui/issue`'s detail pane had a hand-written recovery: on regaining focus, if it had nothing,
it read again. That recovered the answer the palette had eaten — which is why removing the
blur-cancel looked safe. The first version of this branch removed the cancel and guarded the recovery
with `!m.loadingIssue`, a flag cleared only by `loadedMsg` and `failedMsg` — **the very messages the
palette ate**. It stayed true for ever and the pane never asked again: `ctrl+k` over a loading issue,
then `esc`, left a pane with nothing, loading for as long as it was open.

Six green race runs did not catch it, because the tests handed the pane its own answer back — exactly
the step the kernel was not taking.

So: `loadingIssue` is **deleted** rather than renamed, and so is the refocus re-read. Nothing asks
twice, because nothing loses an answer. The editor, the transition picker and the create form never
had a recovery and no longer need one.

## Adopted, by name

| View | `Close` stops | `Addr` receives |
|---|---|---|
| `comment.Model` | the thread read, the paging, a send | all three, plus its holder's address when a pane draws it |
| `issue.Model` | the issue read, and the thread through `kernel.CloseView` | the issue read, and the split write |
| `issue.editModel` | the re-read and the field schema | both, the save, and what `$EDITOR` gives back |
| `issue.moveModel` | the transitions read and a move being applied | both |
| `form.Model` | the issue types and the create screen | those, the account, and the create |
| `filter.Model` | a vocabulary read and an account search | both |
| `list.Model` | — parked, never discarded | every page, and the poll tick |
| `onboarding.Model` | — parked, never discarded | the connect, the probe, the save, the project lookup |

The list's poll tick is addressed for a reason of its own: `pollArmed` is cleared by the tick
arriving and by nothing else, so one eaten by the palette stopped the poller for the rest of the
session. `list` and `onboarding` still implement no `Closer` — nothing pushes either — and are listed
as exempt with that reason. The command palette needs no address: everything it offers comes out of
the registry and the local index, inside the keystroke.

`internal/ui/livekeys_test.go` now holds three sweeps over the key registry — live keys, `Closer`,
`Addressed` — and a ninth view fails all of them until somebody decides which half it belongs in.

## The test that decides it

`internal/ui/reply_test.go` drives the **whole program**: the kernel, every registered view, and the
real palette on `ctrl+k`. Nothing hands a view a message; every message goes to the kernel and the
kernel decides where it belongs. The answers are held back until the palette is up, so the delivery
decision is genuinely made with the view underneath, and every case first asserts the view has
nothing — a read that quietly finished early cannot make one pass.

Eight cases: the issue list, the detail pane, the field editor, the transition picker, the filter
picker, the create form, and the sidebar thread in both the places it is drawn. Plus an answer for a
view that has been popped, which must go nowhere. `internal/ui/issue` and `internal/ui/onboarding`
have the same shape at kernel level for the pane and for setup.

Checked by mutation: removing the kernel's routing turns every case red; dropping the address from
any one view turns exactly that view's case red and no other; dropping the holder from the thread's
address turns the sidebar case red and leaves the full-screen one green.

## Existing tests changed, and why none of it is a lowered bar

- `TestIssue_LosingFocusStopsTheWorkAndGettingItBackStartsItAgain` asserted the palette bug. Replaced.
- `TestIssue_LosingTheKeyboardDoesNotGiveUpTheRead` used to hand the pane its own answer back. It now
  asserts the read survives the blur **and carries the pane's address**, and the delivery is asserted
  through the kernel where the kernel really does it.
- `TestMove_StopsReadingWhenThePaneIsClosed` said "closed" and drove a blur. It drives a real `Close`
  now, with a second test for the blur.
- `onboarding`'s `TestFocus_CancelsWhatIsInTheAir...` never sent a `FocusMsg` — it called `stop()`.
  Renamed to `TestStop_...`, assertions untouched, with a new test for the blur.
- Each package's test harness now takes the envelope off a reply before handing the message on, which
  is what the kernel does. The harnesses stand in for the kernel; they have to do what it does.

`make check` green, budgets green: no `TestBudget_*` number moved, and none needed to — an address is
a `uint64` on a path that runs once per network answer, not once per frame.
