### PR TITLE
feat(port): the seam Batches 4 to 8 code against, and a gate that does not lie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 coverage.*
 .DS_Store
 /testdata/live/
+**/testdata/live/
 pkg/jira/jiratest/fixtures/*.raw
 /.claude/

--- a/cmd/saral/main_test.go
+++ b/cmd/saral/main_test.go
@@ -532,7 +532,7 @@ func TestFirstPaint_DrawsRowsOutOfTheRealCacheFile(t *testing.T) {
 	}
 	defer releaseCache()
 
-	took, frame, err := kernel.FirstPaint(deps, 120, 40, opts...)
+	_, frame, err := kernel.FirstPaint(deps, 120, 40, opts...)
 	if err != nil {
 		t.Fatalf("FirstPaint: %v", err)
 	}
@@ -543,8 +543,5 @@ func TestFirstPaint_DrawsRowsOutOfTheRealCacheFile(t *testing.T) {
 		if !strings.Contains(frame, rows[i].Summary) {
 			t.Errorf("%s was drawn without its summary", rows[i].Key)
 		}
-	}
-	if took > 60*time.Millisecond {
-		t.Errorf("the first paint took %s, want under the 60ms in docs/PERFORMANCE.md", took)
 	}
 }

--- a/docs/API-NOTES.md
+++ b/docs/API-NOTES.md
@@ -12,6 +12,10 @@ find out. Read it before writing an adapter method.
   German and back.
 - `schema` — taken from Atlassian's published OpenAPI and JSON schemas. Nobody has watched a real
   site do it.
+- `assumed` — weaker than both: the shape a fixture was written to, reasoned from the endpoint's
+  documented behaviour and the shapes either side of it by somebody with no site to check against.
+  An adapter may be built on one; a product decision may not. The first capture that touches the
+  endpoint either promotes the row or deletes it.
 
 A `live` row is enough to disprove a schema claim and not enough to prove a shape universal: one
 site is one site, and two rows below record a site disagreeing with *itself*. When you verify a
@@ -46,7 +50,7 @@ nobody had checked, so the marker is the point, not decoration.
 | live | On the queue body, `failedAccessibleIssues` and `invalidOrInaccessibleIssueCount` are **absent when zero** | Absent is not a zero with a key on it. A decoder that requires them fails on a clean run. |
 | live | A task's `description` is not reliable prose — it reported zero issues for a run of sixty — and its `message` is sometimes an unresolved i18n key | Report progress from the counts. Neither of those two strings is safe to show a user. |
 | live | A task's `result` is an object for a bulk operation, and its clock — `submitted`, `started`, `lastUpdate`, `finished`, `progress` — is **epoch millis** | Keep `result` as `json.RawMessage` and decode per operation. The Connect variant `TaskProgress` sends those same fields as RFC 3339 strings: two shapes, one name. |
-| schema | The task status enum has **seven** values: `ENQUEUED`, `RUNNING`, `COMPLETE`, `FAILED`, `CANCEL_REQUESTED`, `CANCELLED`, `DEAD` | A cancelled task reads as `CANCEL_REQUESTED` for as long as it takes to stop, so a poller sees it. `jira.TaskState` is missing that one ([#59](https://github.com/varijkapil13/saral/issues/59)). |
+| schema | The task status enum has **seven** values: `ENQUEUED`, `RUNNING`, `COMPLETE`, `FAILED`, `CANCEL_REQUESTED`, `CANCELLED`, `DEAD` | A cancelled task reads as `CANCEL_REQUESTED` for as long as it takes to stop, so a poller sees it. `jira.TaskState` carries all seven, and `Done()` deliberately reports `CANCEL_REQUESTED` as still running. |
 | schema | Dynamic webhooks (`POST /rest/api/3/webhook`) are **Connect / OAuth 2.0 apps only** | No push channel for an API-token client. Poll, scoped and backing off. |
 | schema | The Plans API requires **Administer Jira** on every endpoint, is experimental, and lives at `/rest/api/3/plans/plan` — the doubled segment is correct | Per-plan rights in the UI do not grant API access. `GET /rest/api/3/plans` does not exist. Fall back to locally defined plans. |
 | schema | There is **no release-notes API**. `ReleaseNote.jspa` is a rendered web page | Out of scope by decision. |
@@ -287,13 +291,36 @@ and two story-point fields on one site are all normal answers this client has to
 | Source | Fact | Consequence |
 |---|---|---|
 | live | **No version read reports the unresolved count** — not `GET /version/{id}`, not with `expand=issuesstatus`, not the paged project endpoint. It lives on `GET /rest/api/3/version/{id}/unresolvedIssueCount`, and the key there is spelled `issuesUnresolvedCount` | `jira.Version.Unresolved` can only be filled by that extra call, one per version. So the pre-release gate costs a round trip, and a version list cannot show the number for free — which is fine, because the number is only needed at the moment of releasing. |
-| live | `overdue` is emitted with an explicit **`false`** on an unreleased version and is **absent on a released one** | Absence is not "false", it is "released". Detecting overdue by key presence gets it backwards. Do not round-trip the key. |
+| live | `overdue` is emitted with an explicit **`false`** on an unreleased version and is **absent on a released one** | Read `released` for whether it shipped. `overdue` is documented only as *is this version overdue*, so its presence is not a second way of saying unreleased: a version trimmed into an issue read or a createmeta answer omits the key whatever its state. Do not round-trip it. |
 | live | `expand=issuesstatus` is per-request, not per-version | Either every version in the page has `issuesStatusForFixVersion` or none does. Its absence never means "no issues". |
 | live | `issuesStatusForFixVersion` buckets by **status category**; the unresolved count counts by **resolution** | They disagree — an issue can be in the Done category with no resolution. Only the count is the gate. |
 | live | Archived versions are filtered out of createmeta allowed values but present in the paged version list | A fix-version picker fed from the version list offers archived versions, so filter the list rather than swapping the source: an issue can already carry an archived version, and a detail view has to render it whatever a create screen would offer. |
 | schema | `/project/{key}/versions` returns a **bare array**; `/project/{key}/version` returns a **paged envelope** | One letter apart, different top-level JSON type. Use the paged one — a project accumulates hundreds of versions. |
+| schema | `Version.projectId` is a JSON **number** (`integer(int64)`), while `jira.Version.ProjectID` is a Go **string** | Convert at the boundary — a `json.Number` or an int64 intermediate. Decoding a version straight into the port type fails with *cannot unmarshal number into Go struct field … of type string*. Both version fixtures send the number a site sends; do not "fix" them. Same trap as `location.projectId` on a board, above. |
 | schema | `userStartDate` / `userReleaseDate` are locale display strings | Render `startDate` / `releaseDate` yourself. |
 | schema | Plans `id` is a **string** in the list response while the get-plan example shows a number | Decode leniently. `issueSources[].value` is a numeric project **id**, never a key. |
+
+## Attachments, versions and sprint writes, as the fixtures answer them
+
+These rows are what `pkg/jira/jiratest/fixtures/**` and the fixture server's routes were written to,
+so that Batch 4-8 has something to test an adapter against. The marker on each says how far that
+goes: a `schema` row is Atlassian's published shape, an `assumed` row is somebody reasoning with no
+site to check against. Nothing here is `live`.
+
+| Source | Fact | Consequence |
+|---|---|---|
+| assumed | The attachment array on an **issue read** spells `id` as a **string**, the way the upload's answer does and unlike `GET /attachment/{id}` (the `live` id-type row in Hard constraints has the other two) | Normalise to a string at the boundary; nothing may compare an id from two reads raw. |
+| assumed | An entry in the upload's answer **omits `thumbnail` entirely** for a file the site could not thumbnail, and sends it beside `content` for one it could | Branch on the key's presence. A struct that expects it everywhere reads an empty string as a URL and a preview pane then fetches nothing, twice. |
+| assumed | With `?redirect=false` Jira honours `Range` **itself**: `bytes=N-` answers **206** with `Content-Range: bytes N-<last>/<length>`, and a start past the end answers **416** | `DownloadOptions.From` is a real resume rather than a re-read with the front thrown away. The `live` row above covers the redirect and where an unqualified 206 comes from. `jiratest.AttachmentContent` is the payload the fixture server streams, and its `/media/` route stands in for the host a redirect points at. |
+| assumed | A site with attachments switched off refuses the upload in the **classic envelope** — a sentence in `errorMessages`, `errors` empty | It is a Jira handler saying no, so it is not one of the two shapes the same endpoint answers a bad request in. `attachment_disabled.json` is that body. |
+| schema | `GET /rest/api/3/version/{id}/unresolvedIssueCount` answers three keys and no more: `self`, `issuesUnresolvedCount` and `issuesCount` (`VersionUnresolvedIssuesCount`) | The total arrives beside the count, so a release gate can say "8 of 14" from one request. Only the unresolved half is the gate. |
+| schema | `POST /rest/api/3/version` answers **201** with the whole version, and `PUT /rest/api/3/version/{id}` answers **200** with it | Neither write needs a confirming read. |
+| assumed | `GET /rest/agile/1.0/sprint/{id}` answers the same object an entry of `/board/{id}/sprint` carries, dates included | It is what `jira.Client.Sprint` calls, so a timeline resolves an issue's sprint id without walking every board of the project. A sprint answers with no dates until they are **set**, whatever its state — `sprint_page.json`'s sprint 43 has none and `sprint_created.json` is a future sprint with both — so a missing date is nothing to draw rather than a failed read. |
+| schema | `POST /rest/agile/1.0/sprint` answers **201** with the created sprint | The new sprint's id arrives with it, so a create needs no confirming read. It is the only one of the four sprint writes whose status is documented; the three below are reasoned. |
+| assumed | `POST /rest/agile/1.0/sprint/{id}` answers **200** with the whole sprint as it stands after the patch | The partial update is both the safe call and the one that answers enough to redraw the row. It answers the state the transition left, so `sprint_updated.json` is mid-life: only `CompleteSprint` gets a `completeDate` back, and a test for that one overrides the route with `sprint_one.json`. |
+| assumed | `POST /rest/agile/1.0/sprint/{id}/issue` and `POST /rest/agile/1.0/backlog/issue` answer **204 with no body** | There is nothing to decode, so a move is reported from the status and the 50-issue cap above is the only thing to chunk for. |
+| assumed | A `CANCEL_REQUESTED` task carries **no `finished` and no `result`**, exactly as a `RUNNING` one does | The state is not an ending, and the body agrees with `TaskState.Done()` rather than needing a special case. `task_cancel_requested.json` is that body. |
+| schema | The bulk queue's `status` is the **same seven-value enum** as the generic task endpoint's, `CANCEL_REQUESTED` included (`BulkOperationProgress.status`) | A move poller needs every case a task poller needs. There is no `bulkmove_task_cancel_requested.json`, and that is a gap in the fixture set rather than a state the endpoint cannot report. |
 
 ## Writes that do not read back at once
 
@@ -324,6 +351,11 @@ any poller on the first 429. Cost-based limits mean a burst of narrow requests b
   exercised it.
 - Bulk **move** in particular. Only bulk transition was run; the two share a queue, so the progress
   bodies above are trustworthy and the move's own caps, permissions and failure detail are not.
+- Every row marked `assumed` under *Attachments, versions and sprint writes* above: the shape of
+  `GET /rest/agile/1.0/sprint/{id}`, the statuses the three sprint writes other than the create
+  answer, whether the attachment content endpoint really answers 206 and 416 the way the fixture
+  server does, which keys an upload's answer drops, and whether a `CANCEL_REQUESTED` body omits
+  `result`.
 - Whether `Retry-After` ever arrives as an HTTP-date. No 429 was provoked.
 - Whether `isAvailable` on a transition is ever `false` without asking for unavailable ones.
 - What `/user/search` answers a token that lacks **Browse users and groups**. The testbed account

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -15,10 +15,10 @@ today; comparing a run against a baseline is P9.2
 |---|---|---|
 | Cold start → first paint (no cache) | **< 250 ms** | `ci.yml`, best of five `saral --bench-first-paint` runs against an empty cache directory |
 | Cold start → first paint (warm cache) | < 60 ms | *measured, not guarded.* `hyperfine` on `saral --bench-first-paint`. Warming the cache needs a site, so CI cannot; the in-process half is `TestBudget_FirstPaintFromCache` |
-| Keystroke → frame, steady state | **mean < 16 ms** at 10k rows | asserted in every view that takes a keystroke — list, issue, comment, filter and the kernel chrome. The budget used to read *p99*; a benchmark reports a mean and keeps no distribution, so p99 waits on #30 |
+| Keystroke → frame, steady state | **mean < 16 ms** at 10k rows | asserted in every view that takes a keystroke — list, issue, comment, filter, the palette, the form and the kernel chrome. The budget used to read *p99*; a benchmark reports a mean and keeps no distribution, so p99 waits on #30 |
 | Scroll a 10k-row list | 1 allocation a frame | the frame string `View` returns, and nothing behind it. Asserted with the mouse on, under a kept filter and under terms in force |
 | Frame allocations at 200×60 | ceilings in `internal/ui/kernel/budget_test.go` | 297 for a frame, 310 for a keystroke and its frame, 324 with the mouse on, each held to a ceiling about a tenth above |
-| Full redraw at 200×60 | < 4 ms | asserted in list, issue, comment, filter and the kernel chrome |
+| Full redraw at 200×60 | < 4 ms | asserted in list, issue, comment, filter, the form and the kernel chrome |
 | RSS with 10k issues cached | < 60 MB | *measured, not guarded.* Nothing reads the number; the harness that would is #30 |
 | Stripped binary | **< 15 MiB** | `ci.yml`'s size step |
 | Cache read for a view's first paint | < 5 ms | `BenchmarkCacheReadFirstPaint` |
@@ -42,7 +42,11 @@ with. Four things make one of them worth trusting, and each was got wrong once h
   is therefore built `//go:build !race` — and a `!race` tag on its own means a test that runs
   *nowhere*, because the only suite CI ran was the race one. The `budgets` job exists to close that:
   it runs the guards without the detector, inside the same loopback-only namespace the race suite
-  uses, and proves the namespace isolates before it trusts it.
+  uses, and proves the namespace isolates before it trusts it. What the job cannot see is a
+  wall-clock assertion that never became a guard at all: three in the palette, two in the form and
+  one in `cmd/saral` sat in an untagged file, ran under the detector, and failed on whichever run
+  lost the lottery — about half of them. `TestBudget_EveryWallClockAssertionSitsInAGuard` is why
+  that shape now fails the build instead of the suite.
 - **It is not parallel.** An allocation count comes from process-wide `MemStats`, so a benchmark run
   beside another test is handed that test's allocations divided by its own iteration count. Measured
   here: a scroll that costs 1 allocation a frame reports **733** when one neighbouring parallel test
@@ -78,6 +82,7 @@ table, which is the same thing as writing down that the budget is no longer held
 |---|---|
 | `internal/app` | `TestBudget_CacheReadForAViewsFirstPaint` |
 | `internal/app` | `TestBudget_CIRunsTheGuardsWithoutTheDetector` |
+| `internal/app` | `TestBudget_EveryWallClockAssertionSitsInAGuard` |
 | `internal/app` | `TestBudget_IndexRebuildAtTenThousandIssues` |
 | `internal/app` | `TestBudget_IndexSearchAllocatesOnlyTheAnswerItHandsBack` |
 | `internal/app` | `TestBudget_IndexSearchAtTenThousandIssues` |
@@ -90,6 +95,8 @@ table, which is the same thing as writing down that the budget is no longer held
 | `internal/ui/filter` | `TestBudget_PickerRowsAreMemoizedSoAFrameCostsNothingToRedraw` |
 | `internal/ui/filter` | `TestBudget_PickerScrollingCostsTheSameOnTwoThousandRowsAsOnTwenty` |
 | `internal/ui/filter` | `TestBudget_RankingReusesItsBuffers` |
+| `internal/ui/form` | `TestBudget_FormFullRedrawAt200x60` |
+| `internal/ui/form` | `TestBudget_FormKeystrokeToFrameOnALongScreen` |
 | `internal/ui/issue` | `TestBudget_DragCostsAFrameWhileHeldAndAResizeWhileMoving` |
 | `internal/ui/issue` | `TestBudget_FullRedrawAt200x60` |
 | `internal/ui/issue` | `TestBudget_KeystrokeToFrame` |
@@ -107,6 +114,9 @@ table, which is the same thing as writing down that the budget is no longer held
 | `internal/ui/list` | `TestBudget_ScrollingCostsTheSameUnderTermsInForce` |
 | `internal/ui/list` | `TestBudget_ScrollingCostsTheSameWithTheMouseOn` |
 | `internal/ui/list` | `TestBudget_AMemoMissCostsOneRowAndNotAWindow` |
+| `internal/ui/palette` | `TestBudget_PaletteKeystrokeOverEveryCachedIssue` |
+| `internal/ui/palette` | `TestBudget_PaletteKeystrokeOverTwoThousandCommands` |
+| `internal/ui/palette` | `TestBudget_PaletteOpeningIsOnTheKeystrokeBudget` |
 | `internal/ui/richtext` | `TestBudget_Render` |
 | `internal/ui/richtext` | `TestBudget_ScalesWithTheDocument` |
 | `internal/ui/richtext` | `TestBudget_Summary` |
@@ -122,8 +132,8 @@ is as visible as the list of what is:
 - **Cold start with a warm cache.** The cache has to be filled from a site first.
 - **p99 of anything.** `testing.Benchmark` reports a mean over its iterations and throws the
   distribution away.
-- **Every benchmark outside the table** — `pkg/adf`, `pkg/jira/cloud`'s decode, the palette and the
-  form — which are watched by eye and by #30 when it lands.
+- **Every benchmark outside the table** — `pkg/adf`, `pkg/jira/cloud`'s decode and the onboarding
+  view — which are watched by eye and by #30 when it lands.
 
 ## Where the time actually goes
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -755,6 +755,47 @@ three situations that mean three different things, and every view had to guess w
   underneath. Every guard was checked by mutation: removing the kernel's routing, and dropping the
   address from any one view, turns exactly that view's case red.
 
+## W1 · the seam Batches 4 to 8 code against
+
+Three batches reach for the same three things — attachments, versions, sprints — and eight packets
+would each have invented their own fixtures, their own role interface and their own guess at a body
+for them. This wave lands the seam once so a packet arrives to something it can test against on a
+machine with no Jira site, and so the guesses are written down in one place with a marker saying they
+are guesses.
+
+- [x] **W1 — Role interfaces, one sprint read, and the fixtures for three batches** ·
+  [#38](https://github.com/varijkapil13/saral/issues/38) ·
+  [#59](https://github.com/varijkapil13/saral/issues/59) ·
+  [#60](https://github.com/varijkapil13/saral/issues/60) ·
+  **owns** `pkg/jira/{port,roles,types}.go`, `pkg/jira/types_test.go`, `pkg/jira/jiratest/**`,
+  `docs/{API-NOTES,ROADMAP}.md`, `.gitignore`
+  Ten role interfaces — `AttachmentReader`/`Attacher`, `VersionReader`/`Releaser`, `BoardReader`,
+  `SprintReader`/`SprintManager`, `TaskWatcher`, `Relocator`, `PlanReader` — so a view holds the
+  narrowest thing it needs rather than the whole `Client`, and `*Fake` asserts every one of them at
+  compile time. `Client` grows `Sprint(ctx, id)`
+  ([#38](https://github.com/varijkapil13/saral/issues/38)): an issue's sprint value carries an id and
+  a name and no dates, so a timeline has no board to reach the sprint through and walking every board
+  of the project was the alternative. `jira.TaskState` gains the seventh state the schema has always
+  had, `TaskCancelRequested` ([#59](https://github.com/varijkapil13/saral/issues/59)), and `Done()`
+  deliberately reports it as **still running** — a poller sees it several times before `CANCELLED`.
+  The fake's `BulkMove` now hands back a `/rest/api/3/bulk/queue/{id}` URL
+  ([#60](https://github.com/varijkapil13/saral/issues/60)); it pointed at `/rest/api/3/task/{id}`,
+  which is a different registry answering a body that does not decode as the queue's.
+  Eleven fixtures and fourteen routes for the three batches: the three shapes an attachment answers
+  in and its content as streamed bytes over a `/media/` route standing in for the host the redirect
+  points at, the version read / create / release / unresolved-count set, and one sprint per state a
+  write can leave. **There is deliberately no `PUT /rest/agile/1.0/sprint/{id}` route** and a test
+  holds it that way, so P6.2 cannot reach the full replace even by accident.
+  Every guess is an `assumed` or `schema` row in `docs/API-NOTES.md` under *Attachments, versions and
+  sprint writes*, with the legend saying what those markers are worth; the first capture that touches
+  one of those endpoints promotes the row or deletes it.
+  **The capture ignore rule had a hole and it is closed here.** `/testdata/live/` was root-anchored
+  while an unignored `pkg/jira/jiratest/fixtures/testdata/live/` chain existed **inside the
+  `//go:embed fixtures` tree**, so a capture written there was both committable by `git add -A` and
+  compiled into the binary, with every half of `checkleak.py` that CI runs reporting clean. The rule
+  now reads `/testdata/live/` **and** `**/testdata/live/`, and the empty chain is gone. That is why
+  `.gitignore` is in this packet's owned paths.
+
 ## Batch 4 — Attachments · parallel ×3
 
 - [ ] **P4.1 — List and download** · [#17](https://github.com/varijkapil13/saral/issues/17) · **owns** `pkg/jira/cloud/attachment.go`

--- a/internal/app/budget_ci_test.go
+++ b/internal/app/budget_ci_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-// These two keep docs/PERFORMANCE.md's promise about the budgets mechanical
+// These three keep docs/PERFORMANCE.md's promise about the budgets mechanical
 // rather than honour-system. They are the only budget tests built with the race
 // detector, because they measure nothing: they read the tree.
 
@@ -25,7 +25,18 @@ const (
 		"that a budget is no longer held"
 )
 
-var guardDecl = regexp.MustCompile(`(?m)^func (TestBudget_\w+)\(`)
+var (
+	guardDecl  = regexp.MustCompile(`(?m)^func (TestBudget_\w+)\(`)
+	testDecl   = regexp.MustCompile(`(?m)^func (Test\w*)\(`)
+	noDetector = regexp.MustCompile(`(?m)^//go:build [^\n]*!race`)
+
+	// The two shapes a wall-clock budget takes here. A relational operator
+	// against a fixed duration is the giveaway: the corpus compares durations
+	// for correctness with == and !=, passes timeouts as arguments, and bounds
+	// a polling loop with a deadline and After.
+	perOp      = regexp.MustCompile(`\bNsPerOp\(\)`)
+	clockBound = regexp.MustCompile(`[<>]=?[^=<>]*\btime\.(?:Nanosecond|Microsecond|Millisecond|Second|Minute|Hour)\b`)
+)
 
 type guard struct{ pkg, test string }
 
@@ -217,5 +228,84 @@ func repoRoot(t *testing.T) string {
 			t.Fatalf("no go.mod in any parent of the working directory")
 		}
 		dir = parent
+	}
+}
+
+// A wall-clock assertion outside a budget file is the hole the other two guards
+// leave open: the race suite builds it, the detector inflates what it measures
+// about twentyfold, and because the name is not TestBudget_ the table above
+// never misses it. Three palette assertions, two form ones and cmd/saral's
+// first paint sat in that hole and were the whole of a suite that failed about
+// half the time, each run on a different one of them.
+func TestBudget_EveryWallClockAssertionSitsInAGuard(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case d.IsDir() && skipWalk(d.Name()):
+			return fs.SkipDir
+		case d.IsDir() || !strings.HasSuffix(d.Name(), "_test.go"):
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		holdOneFile(t, filepath.ToSlash(rel), string(content))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree for wall-clock assertions: %v", err)
+	}
+}
+
+// holdOneFile checks the two halves of the mechanism on one test file: a
+// wall-clock assertion belongs in a budget file, and a test in a budget file has
+// to carry the name the only lane that runs one selects on.
+func holdOneFile(t *testing.T, rel, content string) {
+	t.Helper()
+
+	named := strings.HasSuffix(rel, "budget_test.go")
+	tagged := noDetector.MatchString(content)
+
+	if named && tagged {
+		for _, m := range testDecl.FindAllStringSubmatch(content, -1) {
+			if !strings.HasPrefix(m[1], "TestBudget_") {
+				t.Errorf("%s is built without the detector and defines %s. The budget lane selects "+
+					"%s and the race suite does not build this file, so it runs in neither: rename it",
+					rel, m[1], "'^TestBudget_'")
+			}
+		}
+		return
+	}
+
+	for i, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		var what string
+		switch {
+		case perOp.MatchString(line):
+			what = "reads a benchmark's ns/op"
+		case clockBound.MatchString(line):
+			what = "compares a duration against a fixed bound"
+		default:
+			continue
+		}
+		fix := "move it to a budget_test.go beside it, built without the detector, as a TestBudget_"
+		if named {
+			fix = "add the !race build constraint to this file"
+		}
+		t.Errorf("%s:%d %s, which makes it a wall-clock budget, and this file is built with the race "+
+			"detector. The detector puts about twenty times the cost on the paths these measure, so "+
+			"what the assertion reads is the instrumentation and it fails on whichever run loses the "+
+			"lottery: %s, and %s\n\t%s", rel, i+1, what, fix, guardsAnswer, strings.TrimSpace(line))
 	}
 }

--- a/internal/ui/form/bench_test.go
+++ b/internal/ui/form/bench_test.go
@@ -155,21 +155,3 @@ func TestFieldRendering_CostsNothingOnceMemoized(t *testing.T) {
 		t.Errorf("a memoized row allocates %.1f times, want none", got)
 	}
 }
-
-func TestKeystrokeToFrame_StaysUnderTheBudgetOnALongScreen(t *testing.T) {
-	t.Parallel()
-
-	res := testing.Benchmark(BenchmarkFormWalk200)
-	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
-		t.Errorf("keystroke to frame took %s on a 200-field screen, want under 16ms", per)
-	}
-}
-
-func TestFullRedraw_StaysUnderTheBudgetAt200x60(t *testing.T) {
-	t.Parallel()
-
-	res := testing.Benchmark(BenchmarkFormRedraw200x60)
-	if per := time.Duration(res.NsPerOp()); per > 4*time.Millisecond {
-		t.Errorf("a full redraw at 200x60 took %s, want under 4ms", per)
-	}
-}

--- a/internal/ui/form/budget_test.go
+++ b/internal/ui/form/budget_test.go
@@ -1,0 +1,32 @@
+//go:build !race
+
+package form
+
+import (
+	"testing"
+	"time"
+)
+
+// A create screen carries whatever custom fields a long-lived project has
+// accumulated, so both budgets in docs/PERFORMANCE.md are held at 200 fields
+// rather than at the eight a small project shows.
+//
+// The race detector puts about twenty times the cost on these paths, so the tag
+// is what keeps the numbers the binary's; ci.yml's budgets job is what keeps the
+// tag from meaning they run nowhere. Neither may be parallel: an allocation
+// count comes from process-wide MemStats, and a benchmark run beside another
+// test is handed that test's allocations divided by its own iteration count.
+
+func TestBudget_FormKeystrokeToFrameOnALongScreen(t *testing.T) {
+	res := testing.Benchmark(BenchmarkFormWalk200)
+	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
+		t.Errorf("keystroke to frame took %s on a 200-field screen, want under the 16ms in docs/PERFORMANCE.md", per)
+	}
+}
+
+func TestBudget_FormFullRedrawAt200x60(t *testing.T) {
+	res := testing.Benchmark(BenchmarkFormRedraw200x60)
+	if per := time.Duration(res.NsPerOp()); per > 4*time.Millisecond {
+		t.Errorf("a full redraw at 200x60 took %s, want under the 4ms in docs/PERFORMANCE.md", per)
+	}
+}

--- a/internal/ui/list/cache_test.go
+++ b/internal/ui/list/cache_test.go
@@ -159,7 +159,7 @@ func TestFirstPaint_DrawsStoredRowsWithNothingReachable(t *testing.T) {
 	rows := storedRows(6)
 	cache.hold(jql, rows, false, false)
 
-	took, frame, err := kernel.FirstPaint(deps, 120, 40)
+	_, frame, err := kernel.FirstPaint(deps, 120, 40)
 	if err != nil {
 		t.Fatalf("FirstPaint: %v", err)
 	}
@@ -168,9 +168,6 @@ func TestFirstPaint_DrawsStoredRowsWithNothingReachable(t *testing.T) {
 	}
 	if calls := f.Calls(); len(calls) != 0 {
 		t.Errorf("the first paint made %v", calls)
-	}
-	if took > 60*time.Millisecond {
-		t.Errorf("the first paint from the cache took %s, want under the 60ms in docs/PERFORMANCE.md", took)
 	}
 }
 

--- a/internal/ui/palette/bench_test.go
+++ b/internal/ui/palette/bench_test.go
@@ -171,37 +171,6 @@ func TestDrawing_CostsTheSameOnTwoThousandCommandsAsOnTwenty(t *testing.T) {
 	}
 }
 
-func TestKeystrokeToFrame_StaysUnderTheBudget(t *testing.T) {
-	t.Parallel()
-
-	res := testing.Benchmark(BenchmarkPaletteKeystroke2000)
-	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
-		t.Errorf("a keystroke into the filter took %s over 2000 commands, want under 16ms", per)
-	}
-}
-
-// The cache half of the palette is on the same budget as the command half, and
-// it is the half that grows with what the session has read.
-func TestKeystrokeOverEveryCachedIssue_StaysUnderTheBudget(t *testing.T) {
-	t.Parallel()
-
-	res := testing.Benchmark(BenchmarkPaletteKeystrokeCached)
-	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
-		t.Errorf("a keystroke over %d cached issues took %s, want under 16ms", app.DefaultIssueBound, per)
-	}
-}
-
-// ctrl+k builds the palette from scratch, so opening it is on the keystroke
-// budget too rather than on a start-up one.
-func TestOpening_StaysUnderTheKeystrokeBudget(t *testing.T) {
-	t.Parallel()
-
-	res := testing.Benchmark(BenchmarkPaletteOpen64)
-	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
-		t.Errorf("building the palette over 64 commands took %s, want under 16ms", per)
-	}
-}
-
 func TestRowRendering_CostsNothingOnceMemoized(t *testing.T) {
 	m := opened(t, 2000, 120, 40)
 	if got := testing.AllocsPerRun(200, func() { _ = m.row(0) }); got != 0 {

--- a/internal/ui/palette/budget_test.go
+++ b/internal/ui/palette/budget_test.go
@@ -1,0 +1,44 @@
+//go:build !race
+
+package palette
+
+import (
+	"testing"
+	"time"
+
+	"github.com/varijkapil13/saral/internal/app"
+)
+
+// ctrl+k builds the palette from scratch and every keystroke re-ranks both
+// halves of the list, so all three of these are on the 16ms keystroke budget in
+// docs/PERFORMANCE.md rather than on a start-up one.
+//
+// The race detector puts about twenty times the cost on these paths, so the tag
+// is what keeps the numbers the binary's; ci.yml's budgets job is what keeps the
+// tag from meaning they run nowhere. None may be parallel: an allocation count
+// comes from process-wide MemStats, and a benchmark run beside another test is
+// handed that test's allocations divided by its own iteration count.
+
+func TestBudget_PaletteKeystrokeOverTwoThousandCommands(t *testing.T) {
+	res := testing.Benchmark(BenchmarkPaletteKeystroke2000)
+	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
+		t.Errorf("a keystroke into the filter took %s over 2000 commands, want under the 16ms in docs/PERFORMANCE.md", per)
+	}
+}
+
+// The cache half of the palette is on the same budget as the command half, and
+// it is the half that grows with what the session has read.
+func TestBudget_PaletteKeystrokeOverEveryCachedIssue(t *testing.T) {
+	res := testing.Benchmark(BenchmarkPaletteKeystrokeCached)
+	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
+		t.Errorf("a keystroke over %d cached issues took %s, want under the 16ms in docs/PERFORMANCE.md",
+			app.DefaultIssueBound, per)
+	}
+}
+
+func TestBudget_PaletteOpeningIsOnTheKeystrokeBudget(t *testing.T) {
+	res := testing.Benchmark(BenchmarkPaletteOpen64)
+	if per := time.Duration(res.NsPerOp()); per > 16*time.Millisecond {
+		t.Errorf("building the palette over 64 commands took %s, want under the 16ms in docs/PERFORMANCE.md", per)
+	}
+}

--- a/pkg/jira/cloud/client.go
+++ b/pkg/jira/cloud/client.go
@@ -58,6 +58,12 @@ type Client struct {
 	concurrency int
 	gate        chan struct{}
 	flight      *singleflight.Group
+
+	// joined, when set, is called once per caller that has been registered with
+	// the flight for a key. A test coalescing N callers cannot otherwise know
+	// they have all attached, and releasing the leader before they have makes a
+	// correct second request look like a coalescer that failed to collapse one.
+	joined func()
 }
 
 // Option configures a Client at construction.
@@ -635,6 +641,9 @@ func (c *Client) coalesce(ctx context.Context, key string, fn func(context.Conte
 			}
 			return resp, err
 		})
+		if c.joined != nil {
+			c.joined()
+		}
 		select {
 		case <-ctx.Done():
 			// This caller is leaving. Forget the key so that whoever comes next

--- a/pkg/jira/cloud/client_test.go
+++ b/pkg/jira/cloud/client_test.go
@@ -581,6 +581,13 @@ func TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce(t *testing.T) {
 	r := fieldRequest()
 
 	const callers = 5
+	// Counted at the coalescer rather than at the server: a follower still on
+	// its way to the flight has not been collapsed into it yet, and the second
+	// request it then makes is correct behaviour that would read here as a
+	// coalescer which failed.
+	var attached atomic.Int64
+	c.joined = func() { attached.Add(1) }
+
 	results := make(chan error, callers)
 	for range callers {
 		go func() {
@@ -590,10 +597,8 @@ func TestDo_CoalescesIdenticalRequestsThatAreInFlightAtOnce(t *testing.T) {
 	}
 
 	receive(t, "the one request to reach the site", arrived)
-	// Give the four followers time to reach the coalescer; if they had not, the
-	// site would see more than one request and the assertion below would say so.
-	waitUntil(t, "every caller to be waiting on the one call in flight", func() bool {
-		return runtime.NumGoroutine() > 0 && len(s.Requests()) == 1
+	waitUntil(t, "every caller to be registered with the one call in flight", func() bool {
+		return attached.Load() == callers
 	})
 	letGo()
 	for range callers {

--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -684,6 +684,23 @@ func (f *Fake) Sprints(ctx context.Context, boardID int64, states ...jira.Sprint
 	})
 }
 
+// Sprint fetches one sprint by id.
+func (f *Fake) Sprint(ctx context.Context, id int64) (jira.Sprint, error) {
+	if err := f.fakeBegin(ctx, "Sprint"); err != nil {
+		return jira.Sprint{}, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.caps.Require(jira.CapBoards); err != nil {
+		return jira.Sprint{}, err
+	}
+	sp, ok := f.sprints[id]
+	if !ok {
+		return jira.Sprint{}, fakeNotFound("sprint", strconv.FormatInt(id, 10))
+	}
+	return fakeCloneSprint(*sp), nil
+}
+
 // CreateSprint creates a future sprint on a board.
 func (f *Fake) CreateSprint(ctx context.Context, in jira.SprintInput) (jira.Sprint, error) {
 	if err := f.fakeBegin(ctx, "CreateSprint"); err != nil {
@@ -917,7 +934,7 @@ func (f *Fake) BulkMove(ctx context.Context, in jira.MoveRequest) (jira.TaskRef,
 	}
 
 	id := f.fakeNextID("task")
-	ref := jira.TaskRef{ID: id, URL: fakeBaseURL + "/rest/api/3/task/" + id}
+	ref := jira.TaskRef{ID: id, URL: fakeBaseURL + "/rest/api/3/bulk/queue/" + id}
 	f.tasks[id] = &fakeTask{ref: ref, req: in, fails: f.failTask}
 	f.failTask = false
 	return ref, nil

--- a/pkg/jira/jiratest/fake_test.go
+++ b/pkg/jira/jiratest/fake_test.go
@@ -660,6 +660,8 @@ func TestCapabilities_GateTheMethodsThatDependOnThem(t *testing.T) {
 			func(ctx context.Context, c *jiratest.Fake) error { _, err := c.BoardConfig(ctx, 1); return err }},
 		{"Sprints with no board", jiratest.NoBoards, jira.CapBoards,
 			func(ctx context.Context, c *jiratest.Fake) error { _, err := c.Sprints(ctx, 1); return err }},
+		{"Sprint with no board", jiratest.NoBoards, jira.CapBoards,
+			func(ctx context.Context, c *jiratest.Fake) error { _, err := c.Sprint(ctx, 1); return err }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -789,6 +791,7 @@ func TestEveryCall_ShortCircuitsOnAContextThatIsAlreadyDone(t *testing.T) {
 		"UpdateIssue": func() error { return c.UpdateIssue(ctx, "PROJ-1", jira.IssuePatch{}) },
 		"Comments":    func() error { _, err := c.Comments(ctx, "PROJ-1"); return err },
 		"Sprints":     func() error { _, err := c.Sprints(ctx, 1); return err },
+		"Sprint":      func() error { _, err := c.Sprint(ctx, 1); return err },
 		"Download":    func() error { return c.Download(ctx, "att-1", io.Discard, jira.DownloadOptions{}) },
 		"Me":          func() error { _, err := c.Me(ctx); return err },
 	}
@@ -807,6 +810,8 @@ func TestFake_IsSafeForConcurrentUse(t *testing.T) {
 	c := fakeNewWithIssues(t, 60, jiratest.WithPageSize(20))
 	ctx := t.Context()
 	board := fakeBoard(t, c)
+	sprint := fakeSprintsOf(t, c, board.ID)[0]
+	goal := "concurrent"
 
 	work := []func() error{
 		func() error { _, err := c.Issue(ctx, "PROJ-3"); return err },
@@ -817,6 +822,16 @@ func TestFake_IsSafeForConcurrentUse(t *testing.T) {
 		func() error { return c.UpdateIssue(ctx, "PROJ-4", jira.IssuePatch{Labels: &[]string{"hot"}}) },
 		func() error { _, err := c.AddComment(ctx, "PROJ-5", adf.NewDoc()); return err },
 		func() error { _, err := c.Sprints(ctx, board.ID); return err },
+		// The writers below are what the read races against; reads alone cannot.
+		func() error { _, err := c.Sprint(ctx, sprint.ID); return err },
+		func() error {
+			_, err := c.CreateSprint(ctx, jira.SprintInput{BoardID: board.ID, Name: "concurrent"})
+			return err
+		},
+		func() error {
+			_, err := c.UpdateSprint(ctx, sprint.ID, jira.SprintPatch{Goal: &goal})
+			return err
+		},
 		func() error { _, err := c.Capabilities(ctx, "PROJ"); return err },
 		func() error {
 			_, err := c.CreateIssue(ctx, jira.IssueInput{ProjectKey: "PROJ", IssueTypeID: "10301", Summary: "concurrent"})
@@ -844,6 +859,91 @@ func TestFake_IsSafeForConcurrentUse(t *testing.T) {
 	}
 	if got := len(c.Calls()); got < len(work)*8 {
 		t.Errorf("want at least %d recorded calls, got %d", len(work)*8, got)
+	}
+}
+
+func TestSprint_ReadsOneByIdAndRefusesAnIdNoBoardHolds(t *testing.T) {
+	t.Parallel()
+	c := fakeNewWithIssues(t, 2)
+	ctx := t.Context()
+	board := fakeBoard(t, c)
+
+	sprints := fakeSprintsOf(t, c, board.ID)
+	want := sprints[1]
+	if want.Start == nil || want.End == nil || want.Goal == "" {
+		t.Fatalf("the sprint read by id has to be one carrying dates, got %+v", want)
+	}
+
+	got, err := c.Sprint(ctx, want.ID)
+	if err != nil {
+		t.Fatalf("Sprint(%d): %v", want.ID, err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Sprint(%d) = %+v, want the same sprint the board lists: %+v", want.ID, got, want)
+	}
+
+	var unknown int64 = 1
+	for _, sp := range sprints {
+		unknown += sp.ID
+	}
+	_, err = c.Sprint(ctx, unknown)
+	var missing *jira.NotFoundError
+	if !errors.As(err, &missing) {
+		t.Fatalf("Sprint(%d) = %v, want a *jira.NotFoundError for an id no board holds", unknown, err)
+	}
+	if missing.ID != strconv.FormatInt(unknown, 10) {
+		t.Errorf("the error names %q, want the id that was asked for", missing.ID)
+	}
+}
+
+// The seeded sprints share the time values behind their date pointers.
+func TestSprint_HandsBackACopyNoCallerCanWriteThrough(t *testing.T) {
+	t.Parallel()
+
+	moved := time.Date(1999, time.December, 31, 23, 59, 59, 0, time.UTC)
+	cases := []struct {
+		name string
+		date func(jira.Sprint) *time.Time
+	}{
+		{"start", func(sp jira.Sprint) *time.Time { return sp.Start }},
+		{"end", func(sp jira.Sprint) *time.Time { return sp.End }},
+		{"complete", func(sp jira.Sprint) *time.Time { return sp.Complete }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := fakeNewWithIssues(t, 1)
+			ctx := t.Context()
+			board := fakeBoard(t, c)
+			closed := fakeSprintsOf(t, c, board.ID)[0]
+
+			first, err := c.Sprint(ctx, closed.ID)
+			if err != nil {
+				t.Fatalf("Sprint(%d): %v", closed.ID, err)
+			}
+			at := tc.date(first)
+			if at == nil {
+				t.Fatalf("the closed sprint must carry a %s date, got %+v", tc.name, first)
+			}
+			was := *at
+			if was.Equal(moved) {
+				t.Fatalf("the fixture already sits at %v, so writing it proves nothing", moved)
+			}
+			*at = moved
+
+			second, err := c.Sprint(ctx, closed.ID)
+			if err != nil {
+				t.Fatalf("Sprint(%d) again: %v", closed.ID, err)
+			}
+			again := tc.date(second)
+			if again == nil {
+				t.Fatalf("the second read lost the %s date entirely", tc.name)
+			}
+			if !again.Equal(was) {
+				t.Errorf("%s = %v after a caller wrote through the sprint it was handed, want the stored %v", tc.name, *again, was)
+			}
+		})
 	}
 }
 
@@ -1452,6 +1552,26 @@ func TestBulkMove_WalksItsTaskToCompletionAndThenMovesTheIssues(t *testing.T) {
 	}
 	if moved.Project.Key != "OTHER" || moved.Type.ID != "10303" {
 		t.Errorf("want the issue in OTHER as the target type, got %s / %s", moved.Project.Key, moved.Type.Name)
+	}
+}
+
+func TestBulkMove_ReferencesTheBulkQueueAndNotTheGenericTaskEndpoint(t *testing.T) {
+	t.Parallel()
+	c := jiratest.New(
+		jiratest.WithProject("PROJ", jiratest.Scrum),
+		jiratest.WithProject("OTHER", jiratest.Kanban),
+		jiratest.WithIssues(jiratest.Gen(2)),
+	)
+
+	ref, err := c.BulkMove(t.Context(), jira.MoveRequest{Keys: []string{"PROJ-1"}, TargetProjectKey: "OTHER", TargetIssueTypeID: "10303"})
+	if err != nil {
+		t.Fatalf("BulkMove: %v", err)
+	}
+	if want := "/rest/api/3/bulk/queue/" + ref.ID; !strings.HasSuffix(ref.URL, want) {
+		t.Errorf("URL = %q, want a reference ending in %q", ref.URL, want)
+	}
+	if strings.Contains(ref.URL, "/rest/api/3/task/") {
+		t.Errorf("URL = %q, which is the generic task endpoint and answers a different shape", ref.URL)
 	}
 }
 

--- a/pkg/jira/jiratest/fixtures/README.md
+++ b/pkg/jira/jiratest/fixtures/README.md
@@ -22,13 +22,21 @@ Deliberately not Jira's stock vocabulary: the statuses are `Backlog` / `In Revie
 code that hardcodes `"In Progress"` fails here rather than in front of a user.
 
 Hand-authored (cannot be captured): `rate_limited.json` (429 with `Retry-After`),
-`bulkmove_task_*.json` (one per task state), `task_*.json` (the same four states on the generic task
-endpoint, which answers a different shape), `validation_error.json` (400 with per-field errors).
+`bulkmove_task_*.json` (one per task state), `task_*.json` (five states on the generic task
+endpoint, which answers a different shape), `validation_error.json` (400 with per-field errors),
+`attachment_disabled.json` (the 403 a site with attachments switched off answers an upload with).
 
 The `task_*.json` set describes one run of the operation Atlassian's docs point at this endpoint from:
 replacing a custom-field select option across issues. It reuses the invented `Rollout Phase` field and
 its options from `createmeta_task.json`, and numbers its task differently from the bulk-move one —
 they are separate registries, and a shared id would read as one task answering at both endpoints.
+
+`task_cancel_requested.json` is the fifth state and the reason the set is not four: a cancelled task
+reads `CANCEL_REQUESTED` for as long as it takes to stop, so it is a state a poller sees rather than
+an end state. It carries no `finished` and no `result`, because the task has not stopped. The
+bulk queue reports the same seven names, so there is nothing special about the generic endpoint here:
+the missing `bulkmove_task_cancel_requested.json` is a gap in this set, not a state that queue cannot
+report.
 
 ## The Agile API pages three different ways
 
@@ -82,3 +90,65 @@ names translated, `untranslatedName` not, one field spelling it as a single run-
 matches neither the translated name nor the English one, two fields whose display names have collapsed
 into a single string, and a field with an empty `clauseNames`, which is the site saying it cannot be
 named in JQL at all.
+
+## Attachments answer in three JSON shapes, and the content in none of them
+
+| fixture | shape | what it is there to catch |
+|---|---|---|
+| `attachment_meta.json` | one object, `id` a **JSON number** | the same identifier is a **string** on the issue read and in the upload's answer, so nothing may compare one against another without normalising first |
+| `attachment_upload.json` | a **bare array** of attachment objects | a two-file upload answers two rows and no envelope; the non-image row carries **no `thumbnail` key**, which the image row does |
+| `attachment_disabled.json` | the classic `errorMessages` envelope | a site with attachments switched off refuses in the shape a Jira handler writes, not in RFC 7807 — that one answers a malformed multipart instead |
+
+The content of an attachment is not a fixture at all: `GET /rest/api/3/attachment/content/{id}`
+streams bytes and honours `Range`, so the server answers it from a handler over
+`jiratest.AttachmentContent`. It 303-redirects to a signed media URL unless the request carries
+`redirect=false`, and it redirects a `Range` request just the same — the `206` comes from the host the
+redirect points at, which the server stands in for on a `/media/` route of its own. The upload route
+enforces the two things a real site enforces before it reads a byte: the `X-Atlassian-Token: no-check`
+header, whose absence is a **404 with a plain-text body**, and a part named exactly `file`, whose
+absence is an RFC 7807 400.
+
+## Versions: the number a release turns on is a second request
+
+`version_unresolved_count.json` is the only fixture that carries `issuesUnresolvedCount`, because no
+version read carries it — not the paged list, not a single-version read, not the answer to a write.
+It counts by **resolution** while `issuesStatusForFixVersion` in `versions.json` buckets by **status
+category**, and the two deliberately disagree: an issue can sit in the done bucket with no resolution,
+so only the count is the gate.
+
+Three fixtures are the same version at three moments, so an adapter test can list, read and release
+without the id changing state under it: `versions.json` and `version_one.json` hold 10100 unreleased —
+the paged list with its status buckets, the single read without them — and `version_released.json` is
+that same 10100 after the `PUT` that shipped it. `version_created.json` is a different version, 10101,
+because a create answers an id the list has never seen.
+
+The four also differ on a key that is not `released`: `overdue` is sent explicitly as `false` on an
+unreleased version and is **absent** from a released one. Read `released` for whether it shipped —
+absence of `overdue` is not a second way of saying so, and a version trimmed into an issue read or a
+createmeta answer omits the key whatever its state.
+`TestFixtures_EveryVersionSaysWhetherItShippedTheWayASiteDoes` sweeps every version object in every
+fixture for both rules, and for `projectId` being the JSON **number** a site sends.
+
+## Sprints, and the date spelling that moves between two endpoints
+
+`sprint_one.json` is one sprint at `GET /rest/agile/1.0/sprint/{id}` — the endpoint a timeline
+resolves an issue's sprint id through, having no board to reach it by. It is the same sprint the
+board's page lists, with the same dates written the same way.
+
+`sprint_updated.json` is what the partial update answers: `POST /rest/agile/1.0/sprint/{id}` sends
+back the sprint as the transition left it, so the default route answers a sprint **mid-life** —
+active, dated, with no `completeDate`. Only `CompleteSprint` gets a terminal sprint back, and a test
+for that one overrides the route:
+
+    WithFixture(http.MethodPost, "/rest/agile/1.0/sprint/{id}", "sprint_one.json")
+
+`sprint_created.json` writes its dates the other way a site sends them: UTC-normalised with a `Z`,
+which is what a write answers whatever offset it was given. Both spellings are here on purpose,
+because a decoder holding one layout constant parses one of them and reads the other as a zero time.
+Neither parses with the platform layout that has no colon in its offset; a sprint boundary needs
+`time.RFC3339`.
+
+There is **no route for `PUT /rest/agile/1.0/sprint/{id}`**, and a test holds it that way. That call
+is the full replace: it nulls every field the request omits, which is why the port exposes
+`UpdateSprint`, `StartSprint` and `CompleteSprint` instead. An adapter reaching for it finds no
+endpoint here rather than a success it will not get from a site.

--- a/pkg/jira/jiratest/fixtures/attachment_disabled.json
+++ b/pkg/jira/jiratest/fixtures/attachment_disabled.json
@@ -1,0 +1,6 @@
+{
+  "errorMessages": [
+    "Attachments are switched off on this site, so no file can be added to an issue."
+  ],
+  "errors": {}
+}

--- a/pkg/jira/jiratest/fixtures/attachment_meta.json
+++ b/pkg/jira/jiratest/fixtures/attachment_meta.json
@@ -1,0 +1,19 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/attachment/10502",
+  "id": 10502,
+  "filename": "checkout-timeout.png",
+  "author": {
+    "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g",
+    "accountId": "5b10a2844c20165700ede21g",
+    "accountType": "atlassian",
+    "emailAddress": "user@example.com",
+    "displayName": "Example User",
+    "active": true,
+    "timeZone": "Europe/Berlin"
+  },
+  "created": "2026-02-11T09:12:44.000+0100",
+  "size": 34871,
+  "mimeType": "image/png",
+  "content": "https://example.atlassian.net/rest/api/3/attachment/content/10502",
+  "thumbnail": "https://example.atlassian.net/rest/api/3/attachment/thumbnail/10502"
+}

--- a/pkg/jira/jiratest/fixtures/attachment_upload.json
+++ b/pkg/jira/jiratest/fixtures/attachment_upload.json
@@ -1,0 +1,39 @@
+[
+  {
+    "self": "https://example.atlassian.net/rest/api/3/attachment/10503",
+    "id": "10503",
+    "filename": "rollout-notes.csv",
+    "author": {
+      "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g",
+      "accountId": "5b10a2844c20165700ede21g",
+      "accountType": "atlassian",
+      "emailAddress": "user@example.com",
+      "displayName": "Example User",
+      "active": true,
+      "timeZone": "Europe/Berlin"
+    },
+    "created": "2026-02-11T09:31:08.000+0100",
+    "size": 1904,
+    "mimeType": "text/csv",
+    "content": "https://example.atlassian.net/rest/api/3/attachment/content/10503"
+  },
+  {
+    "self": "https://example.atlassian.net/rest/api/3/attachment/10504",
+    "id": "10504",
+    "filename": "checkout-timeout-after.png",
+    "author": {
+      "self": "https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g",
+      "accountId": "5b10a2844c20165700ede21g",
+      "accountType": "atlassian",
+      "emailAddress": "user@example.com",
+      "displayName": "Example User",
+      "active": true,
+      "timeZone": "Europe/Berlin"
+    },
+    "created": "2026-02-11T09:31:09.000+0100",
+    "size": 41207,
+    "mimeType": "image/png",
+    "content": "https://example.atlassian.net/rest/api/3/attachment/content/10504",
+    "thumbnail": "https://example.atlassian.net/rest/api/3/attachment/thumbnail/10504"
+  }
+]

--- a/pkg/jira/jiratest/fixtures/sprint_created.json
+++ b/pkg/jira/jiratest/fixtures/sprint_created.json
@@ -1,0 +1,11 @@
+{
+  "id": 44,
+  "self": "https://example.atlassian.net/rest/agile/1.0/sprint/44",
+  "state": "future",
+  "name": "EX Sprint 10",
+  "startDate": "2026-02-02T08:00:00.000Z",
+  "endDate": "2026-02-16T08:00:00.000Z",
+  "createdDate": "2026-01-26T11:14:51.000Z",
+  "originBoardId": 10,
+  "goal": "Stream the attachment preview instead of buffering it."
+}

--- a/pkg/jira/jiratest/fixtures/sprint_one.json
+++ b/pkg/jira/jiratest/fixtures/sprint_one.json
@@ -1,0 +1,12 @@
+{
+  "id": 41,
+  "self": "https://example.atlassian.net/rest/agile/1.0/sprint/41",
+  "state": "closed",
+  "name": "EX Sprint 7",
+  "startDate": "2026-01-05T09:00:00.000+01:00",
+  "endDate": "2026-01-19T09:00:00.000+01:00",
+  "completeDate": "2026-01-19T14:12:38.000+01:00",
+  "createdDate": "2025-12-18T10:41:02.000+01:00",
+  "originBoardId": 10,
+  "goal": "Close out the checkout rewrite."
+}

--- a/pkg/jira/jiratest/fixtures/sprint_updated.json
+++ b/pkg/jira/jiratest/fixtures/sprint_updated.json
@@ -1,0 +1,11 @@
+{
+  "id": 42,
+  "self": "https://example.atlassian.net/rest/agile/1.0/sprint/42",
+  "state": "active",
+  "name": "EX Sprint 8",
+  "startDate": "2026-01-19T09:00:00.000+01:00",
+  "endDate": "2026-02-02T09:00:00.000+01:00",
+  "createdDate": "2026-01-05T09:02:17.000+01:00",
+  "originBoardId": 10,
+  "goal": "Ship the field cache."
+}

--- a/pkg/jira/jiratest/fixtures/task_cancel_requested.json
+++ b/pkg/jira/jiratest/fixtures/task_cancel_requested.json
@@ -1,0 +1,13 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/task/11072",
+  "id": "11072",
+  "description": "Deselect the Rollout Phase option Phase Three on EX issues and select Phase Two instead",
+  "status": "CANCEL_REQUESTED",
+  "message": "task.progress.cancellation.requested",
+  "progress": 60,
+  "elapsedRuntime": 21000,
+  "submitted": 1770814500000,
+  "started": 1770814503000,
+  "lastUpdate": 1770814524000,
+  "submittedBy": 11703
+}

--- a/pkg/jira/jiratest/fixtures/version_created.json
+++ b/pkg/jira/jiratest/fixtures/version_created.json
@@ -1,0 +1,14 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/version/10101",
+  "id": "10101",
+  "description": "Follow-ups the checkout rewrite did not fit.",
+  "name": "2026.4",
+  "archived": false,
+  "released": false,
+  "startDate": "2026-03-30",
+  "releaseDate": "2026-04-24",
+  "userStartDate": "30/Mar/26",
+  "userReleaseDate": "24/Apr/26",
+  "projectId": 10000,
+  "overdue": false
+}

--- a/pkg/jira/jiratest/fixtures/version_one.json
+++ b/pkg/jira/jiratest/fixtures/version_one.json
@@ -1,0 +1,13 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/version/10100",
+  "id": "10100",
+  "name": "2026.3",
+  "archived": false,
+  "released": false,
+  "startDate": "2026-03-02",
+  "releaseDate": "2026-03-27",
+  "userStartDate": "02/Mar/26",
+  "userReleaseDate": "27/Mar/26",
+  "projectId": 10000,
+  "overdue": false
+}

--- a/pkg/jira/jiratest/fixtures/version_released.json
+++ b/pkg/jira/jiratest/fixtures/version_released.json
@@ -1,0 +1,12 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/version/10100",
+  "id": "10100",
+  "name": "2026.3",
+  "archived": false,
+  "released": true,
+  "startDate": "2026-03-02",
+  "releaseDate": "2026-03-27",
+  "userStartDate": "02/Mar/26",
+  "userReleaseDate": "27/Mar/26",
+  "projectId": 10000
+}

--- a/pkg/jira/jiratest/fixtures/version_unresolved_count.json
+++ b/pkg/jira/jiratest/fixtures/version_unresolved_count.json
@@ -1,0 +1,5 @@
+{
+  "self": "https://example.atlassian.net/rest/api/3/version/10100",
+  "issuesUnresolvedCount": 8,
+  "issuesCount": 14
+}

--- a/pkg/jira/jiratest/fixtures/versions.json
+++ b/pkg/jira/jiratest/fixtures/versions.json
@@ -35,6 +35,7 @@
       "userStartDate": "02/Mar/26",
       "userReleaseDate": "27/Mar/26",
       "projectId": 10000,
+      "overdue": false,
       "issuesStatusForFixVersion": {
         "unmapped": 1,
         "toDo": 4,

--- a/pkg/jira/jiratest/fixtures_test.go
+++ b/pkg/jira/jiratest/fixtures_test.go
@@ -10,12 +10,15 @@ import (
 	"path"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/varijkapil13/saral/pkg/adf"
+	"github.com/varijkapil13/saral/pkg/jira"
 	"github.com/varijkapil13/saral/pkg/jira/jiratest"
 )
 
@@ -179,6 +182,9 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 
 	want := []string{
 		"approximate_count.json",
+		"attachment_disabled.json",
+		"attachment_meta.json",
+		"attachment_upload.json",
 		"board.json",
 		"board_config_estimation.json",
 		"board_config_no_estimation.json",
@@ -213,7 +219,11 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 		"rate_limited.json",
 		"search_page1.json",
 		"search_page2.json",
+		"sprint_created.json",
+		"sprint_one.json",
 		"sprint_page.json",
+		"sprint_updated.json",
+		"task_cancel_requested.json",
 		"task_complete.json",
 		"task_enqueued.json",
 		"task_failed.json",
@@ -224,6 +234,10 @@ func TestFixtures_CoverEveryResponseTheServerReplays(t *testing.T) {
 		"user_bulk_page2.json",
 		"user_search.json",
 		"validation_error.json",
+		"version_created.json",
+		"version_one.json",
+		"version_released.json",
+		"version_unresolved_count.json",
 		"versions.json",
 	}
 	got := slices.Sorted(maps.Keys(srvJSONFixtures(t)))
@@ -716,13 +730,20 @@ type srvBulkProgress struct {
 }
 
 var srvTaskStates = map[string]string{
-	"task_enqueued.json": "ENQUEUED",
-	"task_running.json":  "RUNNING",
-	"task_complete.json": "COMPLETE",
-	"task_failed.json":   "FAILED",
+	"task_enqueued.json":         "ENQUEUED",
+	"task_running.json":          "RUNNING",
+	"task_cancel_requested.json": "CANCEL_REQUESTED",
+	"task_complete.json":         "COMPLETE",
+	"task_failed.json":           "FAILED",
 }
 
 func srvTaskFixtureNames() []string { return slices.Sorted(maps.Keys(srvTaskStates)) }
+
+// srvTaskHasStopped is the port's own predicate, so a fixture and Done() cannot
+// drift apart. CANCEL_REQUESTED is deliberately on the running side of it.
+func srvTaskHasStopped(status string) bool {
+	return jira.TaskState(status).Done()
+}
 
 func srvDecodeStrict(t *testing.T, body []byte, into any) {
 	t.Helper()
@@ -838,8 +859,7 @@ func TestFixtures_GenericTaskFinishesOnlyWhenItHasStopped(t *testing.T) {
 			t.Parallel()
 			task := srvTask(t, name)
 
-			stopped := task.Status == "COMPLETE" || task.Status == "FAILED"
-			if stopped != (task.Finished != nil) {
+			if stopped := srvTaskHasStopped(task.Status); stopped != (task.Finished != nil) {
 				t.Errorf("status %s with finished set = %v", task.Status, task.Finished != nil)
 			}
 			if task.Finished != nil && *task.Finished != task.LastUpdate {
@@ -859,7 +879,7 @@ func TestFixtures_GenericTaskResultIsOnlyReadableAsRawJSON(t *testing.T) {
 			t.Parallel()
 			task := srvTask(t, name)
 
-			if task.Status == "ENQUEUED" || task.Status == "RUNNING" {
+			if !srvTaskHasStopped(task.Status) {
 				if task.Result != nil {
 					t.Errorf("a %s task already carries a result: %s", task.Status, task.Result)
 				}
@@ -944,6 +964,356 @@ func srvSharedKeys(t *testing.T, left, right []byte) map[string]struct{} {
 		}
 	}
 	return shared
+}
+
+func TestFixtures_CoverTheShapesAnAttachmentAnswersIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the metadata read is one object carrying every key the port maps from", func(t *testing.T) {
+		t.Parallel()
+		meta := srvDecode(t, srvFixture(t, "attachment_meta.json"))
+
+		for _, key := range []string{"self", "id", "filename", "mimeType", "size", "created", "author", "content", "thumbnail"} {
+			if _, ok := meta[key]; !ok {
+				t.Errorf("attachment_meta.json sends no %s", key)
+			}
+		}
+		author, ok := meta["author"].(map[string]any)
+		if !ok {
+			t.Fatalf("author = %v, want the account object every read carries", meta["author"])
+		}
+		for _, key := range []string{"accountId", "accountType", "displayName"} {
+			if _, ok := author[key]; !ok {
+				t.Errorf("the author sends no %s", key)
+			}
+		}
+	})
+
+	t.Run("the upload answers a bare array, so a two-file upload has two rows to decode", func(t *testing.T) {
+		t.Parallel()
+		rows := srvAttachments(t, "attachment_upload.json")
+
+		if len(rows) < 2 {
+			t.Fatalf("attachment_upload.json holds %d rows, want the several a multi-file upload answers", len(rows))
+		}
+		for _, row := range rows {
+			for _, key := range []string{"id", "filename", "mimeType", "size", "created", "author", "content"} {
+				if _, ok := row[key]; !ok {
+					t.Errorf("an uploaded attachment sends no %s", key)
+				}
+			}
+		}
+	})
+
+	t.Run("an id is a number on the metadata read and a string wherever else it appears", func(t *testing.T) {
+		t.Parallel()
+
+		if _, ok := srvDecode(t, srvFixture(t, "attachment_meta.json"))["id"].(float64); !ok {
+			t.Error("attachment_meta.json sends its id as something other than a JSON number")
+		}
+		for _, fixture := range []string{"attachment_upload.json", "issue_rich_adf.json"} {
+			for _, row := range srvAttachments(t, fixture) {
+				if _, ok := row["id"].(string); !ok {
+					t.Errorf("%s sends an attachment id as something other than a string: %v", fixture, row["id"])
+				}
+			}
+		}
+	})
+
+	t.Run("a thumbnail is there only for a file the site could make one of", func(t *testing.T) {
+		t.Parallel()
+
+		var withThumb, without int
+		for _, row := range srvAttachments(t, "attachment_upload.json") {
+			kind, _ := row["mimeType"].(string)
+			_, ok := row["thumbnail"]
+			switch {
+			case ok && strings.HasPrefix(kind, "image/"):
+				withThumb++
+			case !ok && !strings.HasPrefix(kind, "image/"):
+				without++
+			default:
+				t.Errorf("a %s attachment sends thumbnail = %v", kind, ok)
+			}
+		}
+		if withThumb == 0 || without == 0 {
+			t.Errorf("the upload answers %d thumbnailed and %d plain rows, and a renderer has to survive both", withThumb, without)
+		}
+	})
+
+	t.Run("attachments switched off refuse in the classic envelope", func(t *testing.T) {
+		t.Parallel()
+		body := srvDecode(t, srvFixture(t, "attachment_disabled.json"))
+
+		if msgs, _ := body["errorMessages"].([]any); len(msgs) == 0 {
+			t.Error("attachment_disabled.json carries no errorMessages, which is the only part that says anything")
+		}
+		if errs, ok := body["errors"].(map[string]any); !ok || len(errs) != 0 {
+			t.Errorf("errors = %v, want the empty object this endpoint sends beside the sentence", body["errors"])
+		}
+		for _, key := range []string{"type", "title", "status", "detail"} {
+			if _, ok := body[key]; ok {
+				t.Errorf("attachment_disabled.json carries %s, and the classic envelope does not", key)
+			}
+		}
+	})
+}
+
+func srvAttachments(t *testing.T, fixture string) []map[string]any {
+	t.Helper()
+
+	body := srvFixture(t, fixture)
+	var rows []map[string]any
+	if err := json.Unmarshal(body, &rows); err == nil {
+		return rows
+	}
+	var issue struct {
+		Fields struct {
+			Attachment []map[string]any `json:"attachment"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(body, &issue); err != nil {
+		t.Fatalf("%s is neither an array of attachments nor an issue carrying them: %v", fixture, err)
+	}
+	if len(issue.Fields.Attachment) == 0 {
+		t.Fatalf("%s carries no attachments", fixture)
+	}
+	return issue.Fields.Attachment
+}
+
+func TestFixtures_TheUnresolvedCountIsItsOwnCallAndOutrunsTheStatusBuckets(t *testing.T) {
+	t.Parallel()
+
+	count := srvDecode(t, srvFixture(t, "version_unresolved_count.json"))
+	unresolved, ok := count["issuesUnresolvedCount"].(float64)
+	if !ok {
+		t.Fatalf("issuesUnresolvedCount = %v, and that spelling is the whole reason this fixture exists", count["issuesUnresolvedCount"])
+	}
+	if _, ok := count["issuesCount"].(float64); !ok {
+		t.Errorf("issuesCount = %v, want the total the endpoint sends beside the unresolved one", count["issuesCount"])
+	}
+	if unresolved <= 0 {
+		t.Error("the count is zero, so nothing here reaches the decision a release gate exists to put in front of a user")
+	}
+	for _, name := range srvVersionEndpoints {
+		if strings.Contains(string(srvFixture(t, name)), "issuesUnresolvedCount") {
+			t.Errorf("%s carries the unresolved count, and no version read does", name)
+		}
+	}
+
+	// The buckets count by status category and the gate counts by resolution, so
+	// an issue can be done and unresolved at once and the two numbers differ.
+	self, _ := count["self"].(string)
+	buckets := srvVersionBuckets(t, self)
+	var open float64
+	for _, key := range []string{"unmapped", "toDo", "inProgress"} {
+		value, ok := buckets[key].(float64)
+		if !ok {
+			t.Fatalf("the version's %s bucket is %v", key, buckets[key])
+		}
+		open += value
+	}
+	if unresolved == open {
+		t.Errorf("the unresolved count and the open buckets both say %v, so nothing pins that only the count is the gate", open)
+	}
+}
+
+func srvVersionBuckets(t *testing.T, self string) map[string]any {
+	t.Helper()
+
+	var page struct {
+		Values []struct {
+			Self   string         `json:"self"`
+			Status map[string]any `json:"issuesStatusForFixVersion"`
+		} `json:"values"`
+	}
+	if err := json.Unmarshal(srvFixture(t, "versions.json"), &page); err != nil {
+		t.Fatalf("decoding versions.json: %v", err)
+	}
+	for _, v := range page.Values {
+		if v.Self == self && v.Status != nil {
+			return v.Status
+		}
+	}
+	t.Fatalf("versions.json lists no version %q with status buckets, so the count is for a version nothing else here holds", self)
+	return nil
+}
+
+// A version reached other than from a version endpoint — an issue's fixVersions,
+// a createmeta allowedValue — arrives trimmed, and the overdue rule below does
+// not hold for those.
+var srvVersionEndpoints = []string{"version_created.json", "version_one.json", "version_released.json", "versions.json"}
+
+func TestFixtures_EveryVersionSaysWhetherItShippedTheWayASiteDoes(t *testing.T) {
+	t.Parallel()
+
+	var released, unreleased, trimmed int
+	for _, name := range slices.Sorted(maps.Keys(srvJSONFixtures(t))) {
+		for _, found := range srvVersions(t, name) {
+			at := name + found.at
+			if id, ok := found.version["projectId"]; ok {
+				if _, number := id.(float64); !number {
+					t.Errorf("%s: projectId = %v, and a site sends a JSON number there whatever the port's field type is", at, id)
+				}
+			}
+			if _, ok := found.version["archived"].(bool); !ok {
+				t.Errorf("%s: archived = %v, want the bool every version carries", at, found.version["archived"])
+			}
+			shipped, ok := found.version["released"].(bool)
+			if !ok {
+				t.Errorf("%s: released = %v, want the bool every version carries", at, found.version["released"])
+				continue
+			}
+			_, overdue := found.version["overdue"]
+			switch {
+			case !slices.Contains(srvVersionEndpoints, name):
+				if overdue {
+					t.Errorf("%s: a version trimmed into another read carries overdue, which only a version endpoint sends", at)
+				}
+				trimmed++
+			case shipped && overdue:
+				t.Errorf("%s: a released version carries overdue, and a site drops the key", at)
+			case !shipped && !overdue:
+				t.Errorf("%s: an unreleased version sends no overdue, and a site sends it explicitly false", at)
+			case shipped:
+				released++
+			default:
+				unreleased++
+			}
+		}
+	}
+	if released == 0 || unreleased == 0 || trimmed == 0 {
+		t.Errorf("the sweep saw %d released, %d unreleased and %d trimmed versions, and it means nothing without all three", released, unreleased, trimmed)
+	}
+}
+
+type srvVersionAt struct {
+	at      string
+	version map[string]any
+}
+
+// Nothing but a version carries any of these, so one is enough to sweep an
+// incomplete version in rather than let it escape the walk.
+var srvVersionKeys = []string{
+	"archived",
+	"issuesStatusForFixVersion",
+	"overdue",
+	"releaseDate",
+	"released",
+	"userReleaseDate",
+	"userStartDate",
+}
+
+func srvVersions(t *testing.T, fixture string) []srvVersionAt {
+	t.Helper()
+
+	var body any
+	if err := json.Unmarshal(srvFixture(t, fixture), &body); err != nil {
+		t.Fatalf("decoding %s: %v", fixture, err)
+	}
+	var out []srvVersionAt
+	var walk func(node any, at string)
+	walk = func(node any, at string) {
+		switch node := node.(type) {
+		case map[string]any:
+			if slices.ContainsFunc(srvVersionKeys, func(key string) bool { _, ok := node[key]; return ok }) {
+				out = append(out, srvVersionAt{at: at, version: node})
+			}
+			for _, key := range slices.Sorted(maps.Keys(node)) {
+				walk(node[key], at+"."+key)
+			}
+		case []any:
+			for i, item := range node {
+				walk(item, at+"["+strconv.Itoa(i)+"]")
+			}
+		}
+	}
+	walk(body, "")
+	return out
+}
+
+// srvPlatformLayout is what parses a date-time on a platform field: an offset of
+// four digits with no colon in it.
+const srvPlatformLayout = "2006-01-02T15:04:05.000-0700"
+
+func TestFixtures_SprintDatesNeedRFC3339InBothSpellingsASiteSends(t *testing.T) {
+	t.Parallel()
+
+	if _, err := time.Parse(srvPlatformLayout, srvAttachmentCreated(t)); err != nil {
+		t.Fatalf("the platform layout no longer parses an attachment's created: %v", err)
+	}
+
+	zulu := make(map[bool][]string)
+	for _, fixture := range []string{"sprint_one.json", "sprint_created.json", "sprint_updated.json", "sprint_page.json"} {
+		for _, sprint := range srvSprints(t, fixture) {
+			for _, key := range []string{"startDate", "endDate", "completeDate", "createdDate"} {
+				raw, sent := sprint[key]
+				if !sent {
+					continue
+				}
+				at, ok := raw.(string)
+				if !ok {
+					t.Errorf("%s: %s = %v is a %T, and every Agile route spells a sprint date as a string; epoch millis is the generic task endpoint", fixture, key, raw, raw)
+					continue
+				}
+				if _, err := time.Parse(time.RFC3339, at); err != nil {
+					t.Errorf("%s: %s = %q does not parse as RFC 3339: %v", fixture, key, at, err)
+				}
+				if _, err := time.Parse(srvPlatformLayout, at); err == nil {
+					t.Errorf("%s: %s = %q parses with the platform layout, so it is not the Agile spelling", fixture, key, at)
+				}
+				spelling := strings.HasSuffix(at, "Z")
+				zulu[spelling] = append(zulu[spelling], fixture+" "+key)
+			}
+		}
+	}
+	if len(zulu[true]) == 0 || len(zulu[false]) == 0 {
+		t.Errorf("every sprint date is spelt one way — %d normalised to Z, %d with an offset — and a site sends both", len(zulu[true]), len(zulu[false]))
+	}
+}
+
+func srvAttachmentCreated(t *testing.T) string {
+	t.Helper()
+
+	created, _ := srvDecode(t, srvFixture(t, "attachment_meta.json"))["created"].(string)
+	if created == "" {
+		t.Fatal("attachment_meta.json carries no created")
+	}
+	return created
+}
+
+func srvSprints(t *testing.T, fixture string) []map[string]any {
+	t.Helper()
+
+	body := srvDecode(t, srvFixture(t, fixture))
+	values, ok := body["values"].([]any)
+	if !ok {
+		return []map[string]any{body}
+	}
+	out := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		sprint, ok := value.(map[string]any)
+		if !ok {
+			t.Fatalf("%s carries a sprint that is not an object: %v", fixture, value)
+		}
+		out = append(out, sprint)
+	}
+	return out
+}
+
+func TestFixtures_AGenericTaskMessageIsNotAlwaysASentence(t *testing.T) {
+	t.Parallel()
+
+	var keys int
+	for _, name := range srvTaskFixtureNames() {
+		message := srvTask(t, name).Message
+		if message != "" && !strings.Contains(message, " ") && strings.Contains(message, ".") {
+			keys++
+		}
+	}
+	if keys == 0 {
+		t.Error("every message reads as prose, and a live poll answered one with an unresolved i18n key that a view would print verbatim")
+	}
 }
 
 func TestServer_TaskRoutesServeTheTwoShapesSeparately(t *testing.T) {

--- a/pkg/jira/jiratest/jiratest.go
+++ b/pkg/jira/jiratest/jiratest.go
@@ -53,6 +53,17 @@ var (
 	_ jira.SessionClient  = (*Fake)(nil)
 
 	_ jira.FilterVocabulary = (*Fake)(nil)
+
+	_ jira.AttachmentReader = (*Fake)(nil)
+	_ jira.Attacher         = (*Fake)(nil)
+	_ jira.VersionReader    = (*Fake)(nil)
+	_ jira.Releaser         = (*Fake)(nil)
+	_ jira.BoardReader      = (*Fake)(nil)
+	_ jira.SprintReader     = (*Fake)(nil)
+	_ jira.SprintManager    = (*Fake)(nil)
+	_ jira.TaskWatcher      = (*Fake)(nil)
+	_ jira.Relocator        = (*Fake)(nil)
+	_ jira.PlanReader       = (*Fake)(nil)
 )
 
 // BoardKind is what WithProject builds alongside a project.

--- a/pkg/jira/jiratest/server.go
+++ b/pkg/jira/jiratest/server.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -214,6 +215,15 @@ var srvDefaultRoutes = []srvRoute{
 	{http.MethodGet, "/rest/api/3/issue/{key}", srvFixtureHandler(http.StatusOK, "issue_rich_adf.json")},
 	{http.MethodGet, "/rest/api/3/issue/{key}/comment", srvFixtureHandler(http.StatusOK, "comments.json")},
 	{http.MethodGet, "/rest/api/3/issue/{key}/transitions", srvFixtureHandler(http.StatusOK, "transitions.json")},
+	// An attachment id is a number on this route and a string in the upload's
+	// answer, which is one attachment answering in two JSON types.
+	{http.MethodGet, "/rest/api/3/attachment/{id}", srvFixtureHandler(http.StatusOK, "attachment_meta.json")},
+	{http.MethodPost, "/rest/api/3/issue/{key}/attachments", srvUpload},
+	{http.MethodDelete, "/rest/api/3/attachment/{id}", srvFixtureHandler(http.StatusNoContent, "")},
+	// The media route below is not a Jira endpoint: it stands in for the host
+	// the redirect points at, which is where a 206 really comes from.
+	{http.MethodGet, "/rest/api/3/attachment/content/{id}", srvAttachmentContent},
+	{http.MethodGet, srvMediaPath + "{id}", srvAttachmentBytes},
 	{http.MethodGet, "/rest/api/3/field", srvFixtureHandler(http.StatusOK, "field.json")},
 	{http.MethodGet, "/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes", srvFixtureHandler(http.StatusOK, "createmeta_issuetypes.json")},
 	{http.MethodGet, "/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}", srvCreateMeta},
@@ -232,9 +242,19 @@ var srvDefaultRoutes = []srvRoute{
 	// versions.json is a paged envelope, which is what the singular /version
 	// endpoint answers; the plural /versions answers a bare array and cannot page.
 	{http.MethodGet, "/rest/api/3/project/{key}/version", srvFixtureHandler(http.StatusOK, "versions.json")},
+	{http.MethodPost, "/rest/api/3/version", srvFixtureHandler(http.StatusCreated, "version_created.json")},
+	{http.MethodGet, "/rest/api/3/version/{id}", srvFixtureHandler(http.StatusOK, "version_one.json")},
+	{http.MethodGet, "/rest/api/3/version/{id}/unresolvedIssueCount", srvFixtureHandler(http.StatusOK, "version_unresolved_count.json")},
+	{http.MethodPut, "/rest/api/3/version/{id}", srvFixtureHandler(http.StatusOK, "version_released.json")},
 	{http.MethodGet, "/rest/agile/1.0/board", srvFixtureHandler(http.StatusOK, "board.json")},
 	{http.MethodGet, "/rest/agile/1.0/board/{id}/configuration", srvFixtureHandler(http.StatusOK, "board_config_estimation.json")},
 	{http.MethodGet, "/rest/agile/1.0/board/{id}/sprint", srvFixtureHandler(http.StatusOK, "sprint_page.json")},
+	{http.MethodGet, "/rest/agile/1.0/sprint/{id}", srvFixtureHandler(http.StatusOK, "sprint_one.json")},
+	{http.MethodPost, "/rest/agile/1.0/sprint", srvFixtureHandler(http.StatusCreated, "sprint_created.json")},
+	// There is deliberately no PUT route: it nulls every field the request omits.
+	{http.MethodPost, "/rest/agile/1.0/sprint/{id}", srvFixtureHandler(http.StatusOK, "sprint_updated.json")},
+	{http.MethodPost, "/rest/agile/1.0/sprint/{id}/issue", srvFixtureHandler(http.StatusNoContent, "")},
+	{http.MethodPost, "/rest/agile/1.0/backlog/issue", srvFixtureHandler(http.StatusNoContent, "")},
 	// Three Agile paging envelopes, one per shape: these two name their array
 	// issues and send no isLast, the epics send no total, and the sprints above
 	// send all four keys.
@@ -340,6 +360,49 @@ func srvStartAt(r *http.Request) int {
 		return 0
 	}
 	return at
+}
+
+// AttachmentContent is the payload the attachment content route streams.
+const AttachmentContent = "saral fixture attachment: deterministic bytes for a resumed download\n"
+
+// srvMediaPath stands in for the media host a real site redirects an attachment
+// download to.
+const srvMediaPath = "/media/attachment/content/"
+
+const srvUploadMemory = 1 << 20
+
+// srvUpload's two refusals are neither of them the classic error envelope a
+// decoder written for the rest of the API expects.
+func srvUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-Atlassian-Token") != "no-check" {
+		w.Header().Set("Content-Type", "text/plain;charset=UTF-8")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("XSRF check failed"))
+		return
+	}
+	if err := r.ParseMultipartForm(srvUploadMemory); err != nil {
+		srvWriteProblem(w, http.StatusBadRequest, "The request body could not be read as a multipart upload.", r.URL.Path)
+		return
+	}
+	if len(r.MultipartForm.File["file"]) == 0 {
+		srvWriteProblem(w, http.StatusBadRequest, `The multipart request carries no part named "file".`, r.URL.Path)
+		return
+	}
+	srvServeFixture(w, http.StatusOK, "attachment_upload.json")
+}
+
+func srvAttachmentContent(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("redirect") != "false" {
+		w.Header().Set("Location", srvMediaPath+r.PathValue("id")+"?token=fixture-signed-token&expires=1770814500")
+		w.WriteHeader(http.StatusSeeOther)
+		return
+	}
+	srvAttachmentBytes(w, r)
+}
+
+func srvAttachmentBytes(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/octet-stream")
+	http.ServeContent(w, r, "", time.Time{}, strings.NewReader(AttachmentContent))
 }
 
 func srvCreateMeta(w http.ResponseWriter, r *http.Request) {

--- a/pkg/jira/jiratest/server_test.go
+++ b/pkg/jira/jiratest/server_test.go
@@ -3,8 +3,11 @@ package jiratest_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -83,15 +86,23 @@ func TestServer_ServesEveryDefaultRouteWithItsFixture(t *testing.T) {
 		{"one issue", http.MethodGet, "/rest/api/3/issue/EX-1", http.StatusOK, "issue_rich_adf.json"},
 		{"issue comments", http.MethodGet, "/rest/api/3/issue/EX-1/comment", http.StatusOK, "comments.json"},
 		{"issue transitions", http.MethodGet, "/rest/api/3/issue/EX-1/transitions", http.StatusOK, "transitions.json"},
+		{"one attachment's metadata", http.MethodGet, "/rest/api/3/attachment/10502", http.StatusOK, "attachment_meta.json"},
 		{"field catalogue", http.MethodGet, "/rest/api/3/field", http.StatusOK, "field.json"},
 		{"create metadata", http.MethodGet, "/rest/api/3/issue/createmeta/EX/issuetypes/10001", http.StatusOK, "createmeta_task.json"},
 		{"the account", http.MethodGet, "/rest/api/3/myself", http.StatusOK, "myself.json"},
 		{"site configuration", http.MethodGet, "/rest/api/3/configuration", http.StatusOK, "configuration.json"},
 		{"permissions", http.MethodGet, "/rest/api/3/mypermissions?permissions=BULK_CHANGE", http.StatusOK, "mypermissions_admin.json"},
 		{"project versions", http.MethodGet, "/rest/api/3/project/EX/version", http.StatusOK, "versions.json"},
+		{"one version", http.MethodGet, "/rest/api/3/version/10100", http.StatusOK, "version_one.json"},
+		{"a version created", http.MethodPost, "/rest/api/3/version", http.StatusCreated, "version_created.json"},
+		{"a version's unresolved issues", http.MethodGet, "/rest/api/3/version/10100/unresolvedIssueCount", http.StatusOK, "version_unresolved_count.json"},
+		{"a version released", http.MethodPut, "/rest/api/3/version/10100", http.StatusOK, "version_released.json"},
 		{"boards", http.MethodGet, "/rest/agile/1.0/board?projectKeyOrId=EX", http.StatusOK, "board.json"},
 		{"board configuration", http.MethodGet, "/rest/agile/1.0/board/10/configuration", http.StatusOK, "board_config_estimation.json"},
 		{"board sprints", http.MethodGet, "/rest/agile/1.0/board/10/sprint", http.StatusOK, "sprint_page.json"},
+		{"one sprint", http.MethodGet, "/rest/agile/1.0/sprint/41", http.StatusOK, "sprint_one.json"},
+		{"a sprint created", http.MethodPost, "/rest/agile/1.0/sprint", http.StatusCreated, "sprint_created.json"},
+		{"a sprint updated in part", http.MethodPost, "/rest/agile/1.0/sprint/42", http.StatusOK, "sprint_updated.json"},
 		{"board issues", http.MethodGet, "/rest/agile/1.0/board/10/issue", http.StatusOK, "board_issues.json"},
 		{"board backlog", http.MethodGet, "/rest/agile/1.0/board/10/backlog", http.StatusOK, "board_issues.json"},
 		{"board epics", http.MethodGet, "/rest/agile/1.0/board/10/epic", http.StatusOK, "board_epics.json"},
@@ -340,6 +351,312 @@ func srvRequiredFields(t *testing.T, body []byte) []string {
 		}
 	}
 	return out
+}
+
+// srvGet never follows a redirect, which is the only way to see one.
+func srvGet(t *testing.T, s *jiratest.Server, target string, header http.Header) srvReply {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.URL()+target, http.NoBody)
+	if err != nil {
+		t.Fatalf("building GET %s: %v", target, err)
+	}
+	for key, values := range header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", target, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading GET %s: %v", target, err)
+	}
+	return srvReply{status: resp.StatusCode, header: resp.Header, body: got}
+}
+
+// An empty xsrf sends no X-Atlassian-Token at all.
+func srvPostFile(t *testing.T, s *jiratest.Server, target, part, xsrf string) srvReply {
+	t.Helper()
+
+	var body bytes.Buffer
+	mp := multipart.NewWriter(&body)
+	file, err := mp.CreateFormFile(part, "rollout-notes.csv")
+	if err != nil {
+		t.Fatalf("building the %q part: %v", part, err)
+	}
+	if _, err := file.Write([]byte("id,phase\n10001,two\n")); err != nil {
+		t.Fatalf("writing the %q part: %v", part, err)
+	}
+	if err := mp.Close(); err != nil {
+		t.Fatalf("closing the multipart body: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.URL()+target, &body)
+	if err != nil {
+		t.Fatalf("building the upload: %v", err)
+	}
+	req.Header.Set("Content-Type", mp.FormDataContentType())
+	if xsrf != "" {
+		req.Header.Set("X-Atlassian-Token", xsrf)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("posting the upload: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the upload's answer: %v", err)
+	}
+	return srvReply{status: resp.StatusCode, header: resp.Header, body: got}
+}
+
+func TestServer_AttachmentUploadNeedsTheXSRFHeaderAndAPartNamedFile(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t)
+	const target = "/rest/api/3/issue/EX-1/attachments"
+
+	for _, tc := range []struct {
+		name string
+		xsrf string
+	}{
+		{"without the header the answer is a 404 that is not JSON at all", ""},
+		{"a token that is not the site's own is refused just the same", "1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := srvPostFile(t, s, target, "file", tc.xsrf)
+
+			if got.status != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404", got.status)
+			}
+			if ct := got.header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+				t.Errorf("Content-Type = %q, want the plain-text body a JSON decode fails on", ct)
+			}
+			if !strings.Contains(string(got.body), "XSRF") {
+				t.Errorf("body = %q, want the site's own words for the guard", got.body)
+			}
+		})
+	}
+
+	t.Run("a part under any other name is RFC 7807", func(t *testing.T) {
+		t.Parallel()
+		got := srvPostFile(t, s, target, "attachment", "no-check")
+
+		if got.status != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", got.status)
+		}
+		if ct := got.header.Get("Content-Type"); ct != "application/problem+json" {
+			t.Fatalf("Content-Type = %q, want application/problem+json", ct)
+		}
+		body := srvDecode(t, got.body)
+		if detail, _ := body["detail"].(string); detail == "" {
+			t.Error("the refusal carries no detail, which is the only part that says anything")
+		}
+		if _, ok := body["errorMessages"]; ok {
+			t.Error("the refusal carries errorMessages, and a problem+json body does not")
+		}
+	})
+
+	t.Run("a part named file answers the array, not one object", func(t *testing.T) {
+		t.Parallel()
+		got := srvPostFile(t, s, target, "file", "no-check")
+
+		if got.status != http.StatusOK {
+			t.Fatalf("status = %d, want 200", got.status)
+		}
+		if !bytes.Equal(got.body, srvFixture(t, "attachment_upload.json")) {
+			t.Error("the upload is not serving attachment_upload.json verbatim")
+		}
+	})
+}
+
+func TestServer_AttachmentsSwitchedOffRefuseTheUploadInTheClassicEnvelope(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t, jiratest.WithStatus(http.MethodPost, "/rest/api/3/issue/{key}/attachments", http.StatusForbidden, "attachment_disabled.json"))
+
+	got := srvPostFile(t, s, "/rest/api/3/issue/EX-1/attachments", "file", "no-check")
+	if got.status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", got.status)
+	}
+	if !bytes.Equal(got.body, srvFixture(t, "attachment_disabled.json")) {
+		t.Error("body is not attachment_disabled.json verbatim")
+	}
+}
+
+func TestServer_DeletingAnAttachmentAnswersNoContentAndNoBody(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t)
+
+	got := srvDo(t, s, http.MethodDelete, "/rest/api/3/attachment/10502", "")
+	if got.status != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", got.status)
+	}
+	if len(got.body) != 0 {
+		t.Errorf("body = %q, want empty", got.body)
+	}
+}
+
+// srvMediaStandIn mirrors the unexported route the fake's redirect points at.
+const srvMediaStandIn = "/media/attachment/content/"
+
+func TestServer_AttachmentContentRedirectsUnlessAskedNotTo(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t)
+	const id = "10502"
+	const target = "/rest/api/3/attachment/content/" + id
+
+	t.Run("asked not to redirect, Jira answers the bytes itself", func(t *testing.T) {
+		t.Parallel()
+		got := srvGet(t, s, target+"?redirect=false", http.Header{})
+
+		if got.status != http.StatusOK {
+			t.Fatalf("status = %d, want 200", got.status)
+		}
+		if location := got.header.Get("Location"); location != "" {
+			t.Errorf("Location = %q, and a client that follows redirects cannot tell that apart from Jira serving the bytes", location)
+		}
+		if string(got.body) != jiratest.AttachmentContent {
+			t.Errorf("body = %q, want the payload", got.body)
+		}
+	})
+
+	for _, tc := range []struct {
+		name      string
+		byteRange string
+	}{
+		{"a plain read", ""},
+		{"a resumed read, which is redirected just the same", "bytes=10-"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			header := http.Header{}
+			if tc.byteRange != "" {
+				header.Set("Range", tc.byteRange)
+			}
+			got := srvGet(t, s, target, header)
+
+			if got.status != http.StatusSeeOther {
+				t.Fatalf("status = %d, want 303", got.status)
+			}
+			location := got.header.Get("Location")
+			if location == "" {
+				t.Fatal("the redirect carries no Location")
+			}
+			media, err := url.Parse(location)
+			if err != nil {
+				t.Fatalf("Location = %q does not parse: %v", location, err)
+			}
+			if strings.HasPrefix(media.Path, "/rest/") {
+				t.Errorf("Location = %q still sits on the Jira API, and the download really leaves it for a media host", location)
+			} else if media.Path != srvMediaStandIn+id {
+				t.Errorf("Location path = %q, want the media route %q", media.Path, srvMediaStandIn+id)
+			}
+			if len(got.body) != 0 {
+				t.Errorf("the redirect carries a body: %q", got.body)
+			}
+			followed := srvDo(t, s, http.MethodGet, location, "")
+			if followed.status != http.StatusOK {
+				t.Fatalf("following the redirect answered %d, want 200", followed.status)
+			}
+			if string(followed.body) != jiratest.AttachmentContent {
+				t.Errorf("the media URL answered %q, want the payload", followed.body)
+			}
+		})
+	}
+}
+
+func TestServer_AttachmentContentHonoursARangeSoADownloadCanResume(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t)
+	const target = "/rest/api/3/attachment/content/10502?redirect=false"
+	full := jiratest.AttachmentContent
+
+	t.Run("a suffix comes back as 206 saying which bytes it is", func(t *testing.T) {
+		t.Parallel()
+		const from = 40
+		got := srvGet(t, s, target, http.Header{"Range": {fmt.Sprintf("bytes=%d-", from)}})
+
+		if got.status != http.StatusPartialContent {
+			t.Fatalf("status = %d, want 206", got.status)
+		}
+		if string(got.body) != full[from:] {
+			t.Errorf("body = %q, want the payload from byte %d", got.body, from)
+		}
+		if want := fmt.Sprintf("bytes %d-%d/%d", from, len(full)-1, len(full)); got.header.Get("Content-Range") != want {
+			t.Errorf("Content-Range = %q, want %q", got.header.Get("Content-Range"), want)
+		}
+	})
+
+	t.Run("a start past the end is refused rather than answered short", func(t *testing.T) {
+		t.Parallel()
+		got := srvGet(t, s, target, http.Header{"Range": {fmt.Sprintf("bytes=%d-", len(full)+1)}})
+
+		if got.status != http.StatusRequestedRangeNotSatisfiable {
+			t.Fatalf("status = %d, want 416", got.status)
+		}
+	})
+
+	t.Run("a whole read says a range would have been served", func(t *testing.T) {
+		t.Parallel()
+		got := srvGet(t, s, target, http.Header{})
+
+		if got.status != http.StatusOK {
+			t.Fatalf("status = %d, want 200", got.status)
+		}
+		if string(got.body) != full {
+			t.Errorf("body = %q, want the whole payload", got.body)
+		}
+		if ranges := got.header.Get("Accept-Ranges"); ranges != "bytes" {
+			t.Errorf("Accept-Ranges = %q, want bytes, or nothing knows a resume is possible", ranges)
+		}
+	})
+}
+
+func TestServer_HasNoRouteForTheSprintPUTThatNullsOmittedFields(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t)
+	const target = "/rest/agile/1.0/sprint/42"
+
+	partial := srvDo(t, s, http.MethodPost, target, `{"goal":"Stream the preview."}`)
+	if partial.status != http.StatusOK {
+		t.Fatalf("the partial update answered %d, want 200", partial.status)
+	}
+
+	full := srvDo(t, s, http.MethodPut, target, `{"name":"EX Sprint 7","state":"closed"}`)
+	if full.status != http.StatusNotFound {
+		t.Fatalf("PUT answered %d; the destructive full replace must reach no route at all", full.status)
+	}
+	if ct := full.header.Get("Content-Type"); ct != "application/problem+json" {
+		t.Errorf("Content-Type = %q, want the answer an unrouted path gets", ct)
+	}
+	if detail, _ := srvDecode(t, full.body)["detail"].(string); !strings.Contains(detail, http.MethodPut) {
+		t.Errorf("detail = %q, want the method that reached no endpoint", detail)
+	}
+}
+
+func TestServer_MovingIssuesToASprintOrTheBacklogAnswersNoContent(t *testing.T) {
+	t.Parallel()
+	s := srvNewServer(t)
+
+	for _, target := range []string{"/rest/agile/1.0/sprint/42/issue", "/rest/agile/1.0/backlog/issue"} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			got := srvDo(t, s, http.MethodPost, target, `{"issues":["EX-1","EX-2"]}`)
+
+			if got.status != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", got.status)
+			}
+			if len(got.body) != 0 {
+				t.Errorf("body = %q, want empty", got.body)
+			}
+		})
+	}
 }
 
 func TestServer_RecordsMethodPathQueryBodyAndHeaders(t *testing.T) {

--- a/pkg/jira/port.go
+++ b/pkg/jira/port.go
@@ -91,6 +91,13 @@ type Client interface {
 	// state lists them all, which on a board with years of history is a walk
 	// nothing on a first-paint path should be doing.
 	Sprints(ctx context.Context, boardID int64, states ...SprintState) (Page[Sprint], error)
+	// Sprint fetches one sprint by id, including its dates.
+	//
+	// It exists because an issue's sprint value carries an id and a name and no
+	// dates: a timeline drawing a bar from sprint dates starts from that id and
+	// has no board to reach it through, and walking every board of the project
+	// to find one sprint is the alternative.
+	Sprint(ctx context.Context, id int64) (Sprint, error)
 	// CreateSprint creates a future sprint.
 	CreateSprint(ctx context.Context, in SprintInput) (Sprint, error)
 	// UpdateSprint changes only the fields the patch names.

--- a/pkg/jira/roles.go
+++ b/pkg/jira/roles.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"context"
+	"io"
 
 	"github.com/varijkapil13/saral/pkg/adf"
 )
@@ -126,3 +127,126 @@ type SessionClient interface {
 	PeopleFinder
 	FilterVocabulary
 }
+
+// AttachmentReader lists an issue's attachments and streams one out. It is
+// separate from Attacher because the preview pane shows files it has no
+// business replacing, and because attachments can be disabled site-wide: a
+// token that may read one may still not add one.
+type AttachmentReader interface {
+	Attachments(ctx context.Context, key string) ([]Attachment, error)
+	Download(ctx context.Context, id string, w io.Writer, opt DownloadOptions) error
+}
+
+// Attacher reads, adds and removes an issue's attachments.
+type Attacher interface {
+	AttachmentReader
+	Upload(ctx context.Context, key string, files []FileRef) ([]Attachment, error)
+	DeleteAttachment(ctx context.Context, id string) error
+}
+
+// VersionReader reads a project's versions and how many issues are still open
+// on one. The count is its own call and its own method because it is the fact a
+// release decision turns on, and asking for it on a list of forty versions is
+// forty requests — so a list is read without it and a release screen asks.
+type VersionReader interface {
+	Versions(ctx context.Context, projectKey string) ([]Version, error)
+	UnresolvedCount(ctx context.Context, versionID string) (int, error)
+}
+
+// Releaser reads, writes and releases versions. ReleaseVersion is the only way
+// to ship one: the raw PUT will release a version over the top of its open
+// issues without saying so, and ReleaseInput cannot be built without deciding
+// what happens to them.
+type Releaser interface {
+	VersionReader
+	SaveVersion(ctx context.Context, v VersionInput) (Version, error)
+	ReleaseVersion(ctx context.Context, id string, in ReleaseInput) (Version, error)
+}
+
+// BoardReader reads the boards on a project and the configuration of one.
+// Nothing about a board may be assumed: its columns, whether it estimates and
+// whether it ranks are all answers, and BoardConfig is where they come from.
+type BoardReader interface {
+	Boards(ctx context.Context, projectKey string) ([]Board, error)
+	BoardConfig(ctx context.Context, boardID int64) (BoardConfig, error)
+}
+
+// SprintReader lists a board's sprints. A backlog view holds only this: it
+// draws which sprint an issue sits in without being able to end one.
+type SprintReader interface {
+	Sprints(ctx context.Context, boardID int64, states ...SprintState) (Page[Sprint], error)
+	Sprint(ctx context.Context, id int64) (Sprint, error)
+}
+
+// SprintManager runs a board's sprints and moves issues in and out of them.
+//
+// The state machine is the port's, not the caller's: future to active to closed
+// and no other move, which is why there is a method per transition instead of a
+// state to set. Nothing here can null a field it was not given.
+type SprintManager interface {
+	SprintReader
+	CreateSprint(ctx context.Context, in SprintInput) (Sprint, error)
+	UpdateSprint(ctx context.Context, id int64, in SprintPatch) (Sprint, error)
+	StartSprint(ctx context.Context, id int64) (Sprint, error)
+	CompleteSprint(ctx context.Context, id int64) (Sprint, error)
+	MoveToSprint(ctx context.Context, sprintID int64, keys []string) error
+	MoveToBacklog(ctx context.Context, keys []string) error
+}
+
+// TaskWatcher reports on a long-running Jira task. It is its own role because
+// the thing that polls a task is not always the thing that started one, and a
+// TaskRef carries the endpoint to poll with it.
+type TaskWatcher interface {
+	Task(ctx context.Context, ref TaskRef) (TaskStatus, error)
+}
+
+// Relocator moves issues to another project and follows the task that does it.
+// The two halves are one role: BulkMove returns nothing but a TaskRef, so a
+// holder that cannot poll has submitted a change it cannot report on.
+type Relocator interface {
+	TaskWatcher
+	BulkMove(ctx context.Context, in MoveRequest) (TaskRef, error)
+}
+
+// PlanReader lists Advanced Roadmaps plans. Holding it is not permission to use
+// it: every Plans endpoint is gated on Administer Jira, and the per-plan rights
+// the web UI grants do not reach the API — so an ordinary token gets a
+// *CapabilityError naming CapPlans, and the plan view draws what config defines
+// locally instead.
+type PlanReader interface {
+	Plans(ctx context.Context) ([]Plan, error)
+}
+
+// Every role is a subset of Client, and this is what says so.
+//
+// The assertions in pkg/jira/jiratest point the other way: they prove the fake
+// carries at least what a role asks for. Neither of them notices a method
+// dropped from Client, because the fake still has it and the role still wants
+// it — so Client can shed a method and nothing stops compiling. Converting a
+// nil Client to each role closes that direction: a signature that drifts, or a
+// method deleted from the port, fails the build here.
+var (
+	_ Prober           = Client(nil)
+	_ Identifier       = Client(nil)
+	_ Searcher         = Client(nil)
+	_ FieldCatalogue   = Client(nil)
+	_ SchemaReader     = Client(nil)
+	_ IssueWriter      = Client(nil)
+	_ Mover            = Client(nil)
+	_ CommentReader    = Client(nil)
+	_ Commenter        = Client(nil)
+	_ PeopleFinder     = Client(nil)
+	_ FilterVocabulary = Client(nil)
+	_ SessionClient    = Client(nil)
+
+	_ AttachmentReader = Client(nil)
+	_ Attacher         = Client(nil)
+	_ VersionReader    = Client(nil)
+	_ Releaser         = Client(nil)
+	_ BoardReader      = Client(nil)
+	_ SprintReader     = Client(nil)
+	_ SprintManager    = Client(nil)
+	_ TaskWatcher      = Client(nil)
+	_ Relocator        = Client(nil)
+	_ PlanReader       = Client(nil)
+)

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -1025,12 +1025,15 @@ type TaskState string
 
 // The task states Jira reports.
 const (
-	TaskEnqueued  TaskState = "ENQUEUED"
-	TaskRunning   TaskState = "RUNNING"
-	TaskComplete  TaskState = "COMPLETE"
-	TaskFailed    TaskState = "FAILED"
-	TaskCancelled TaskState = "CANCELLED"
-	TaskDead      TaskState = "DEAD"
+	TaskEnqueued TaskState = "ENQUEUED"
+	TaskRunning  TaskState = "RUNNING"
+	TaskComplete TaskState = "COMPLETE"
+	TaskFailed   TaskState = "FAILED"
+	// Not a stopped task: a switch with no case for it reports a running task
+	// as finished.
+	TaskCancelRequested TaskState = "CANCEL_REQUESTED"
+	TaskCancelled       TaskState = "CANCELLED"
+	TaskDead            TaskState = "DEAD"
 )
 
 // Done reports whether the task has stopped, however it ended.

--- a/pkg/jira/types_test.go
+++ b/pkg/jira/types_test.go
@@ -944,6 +944,7 @@ func TestTaskState_DoneOnlyWhenTheTaskHasStopped(t *testing.T) {
 		{state: jira.TaskRunning, want: false},
 		{state: jira.TaskComplete, want: true},
 		{state: jira.TaskFailed, want: true},
+		{state: jira.TaskCancelRequested, want: false},
 		{state: jira.TaskCancelled, want: true},
 		{state: jira.TaskDead, want: true},
 		{state: jira.TaskState(""), want: false},


### PR DESCRIPTION
Wave 1 of the run that finishes Batches 4–9 and the correction backlog. It lands only the seams every
later wave codes against, so that six waves are not each blocked on the same three files.

## What this is

**Ten role interfaces** for the areas the Cloud adapters are about to fill — `AttachmentReader`/
`Attacher`, `VersionReader`/`Releaser`, `BoardReader`, `SprintReader`/`SprintManager`,
`TaskWatcher`/`Relocator`, `PlanReader`. `jira.SessionClient` is deliberately **not** widened: it
names what a view in this build actually calls, and no view calls these until the views land. Widening
it now would break `pkg/jira/cloud/assert.go`, which is the point of it being narrow.

**The roles are checked in both directions.** The existing assertions in `pkg/jira/jiratest` prove the
fake carries at least what a role asks for. Nothing proved `Client` still declares it — the fake has
the method and the role wants it, so `Client` could shed one silently. Deleting `Sprint` from
`jira.Client`, this PR's headline addition, passed `go build`, `go vet` and all twenty packages under
`-race`. `var _ SprintReader = Client(nil)` for all 22 roles closes that direction; the mutation now
fails the build.

**`Sprint(ctx, id)`** (#38). The issue offered two ways to give a timeline sprint dates and called one
cheaper: a lookup by id, rather than resolving dates at map time and paying on every search. This is
that one.

**`TaskCancelRequested`** (#59), with `Done()` reporting it as still running — it is the state a
poller reads several times *before* `CANCELLED`. Verified against the published schema that **both**
progress bodies share the seven-value enum; an `API-NOTES` row claiming the bulk queue used only four
names was false and is corrected.

**The fake's bulk-move `TaskRef`** now points at `/bulk/queue/{id}` (#60), which `types.go` already
documented as the right endpoint.

**Eleven fixtures and fourteen routes** for attachments, versions and sprint writes — attachments had
no fixture at all, so six adapter files had nothing to test against. Attachment content is a *handler*
rather than a fixture: it honours `Range` with a 206 from a stand-in media host, because that is where
the 206 really comes from. There is deliberately **no** route for the sprint `PUT` that nulls omitted
fields, and a test holds that absence.

## Two things found on the way that are not housekeeping

**A capture of a real instance was one wrong directory away from shipping.** `testdata/live/` was
ignored at the repo root only, while an unignored `pkg/jira/jiratest/fixtures/testdata/live/fixtures/`
chain had existed since 20 Aug, left by a script run from the wrong cwd. That path is inside
`//go:embed fixtures` — a capture written there was committable **and** would have been compiled into
every released binary. `checkleak.py` could not see it: it probes the root, and its fixture sweep asks
only that every absolute URL name the invented site, which a scrubbed capture satisfies while still
carrying ticket summaries, release names and board names. Now ignored at any depth, and the stray
chain is gone.

**The race suite was a coin flip** — it failed about half its runs, on a different test each time, and
it reproduced on clean `main`. Commit 9fcdaa6 built the right mechanism: a wall-clock budget is named
`TestBudget_*`, lives in a `//go:build !race` file, is inventoried in `docs/PERFORMANCE.md`, and runs
in a lane without the detector. But every check in that mechanism keys on the **name**, so an
assertion under any other name is invisible to the inventory *and* runs under the detector. Six had
escaped: three in the palette, two in the form, one in `cmd/saral`. `docs/PERFORMANCE.md` even listed
the palette and the form under *what is still only measured* while five tests measured them, flakily.
They are guards now, and `TestBudget_EveryWallClockAssertionSitsInAGuard` fails the build when a
wall-clock assertion is written outside one — enforcing a convention only on what opts into it was
half a mechanism.

## Testing

Every new fixture and route is exercised, and the tests were mutation-checked rather than trusted:
four separate cases were found that stayed green when the code they claimed to cover was broken
(`Fake.Sprint`'s whole body, `TaskState.Done()`'s new state, a redirect assertion using a
redirect-following client, and a version sweep an object could escape by being incomplete). All four
are falsifiable now, each proven by mutating and watching it go red.

- `go build`, `go vet`, `golangci-lint run` (v2.12.2, the pinned version): clean
- `go test -race -count=1 ./...`: **5 consecutive runs, 20/20 packages, no failures** (it was 2-in-4
  failing before)
- the budget lane as CI runs it (`-run '^TestBudget_'`, no detector): green, and it now includes the
  palette and form guards
- `checkleak.py` and `checkleak_test.py` (24 tests): clean

Closes #38, #59, #60.