### PR TITLE
feat(kernel): g then i jumps to an issue by key or URL

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -901,6 +901,31 @@ eight views are built against it and it is closed.
   Also #62's other half: the palette's *switch view* opens the same overlay, so the gesture has the
   three routes `docs/UX.md` principle 3 asks for.
 
+- [x] **K8 — The in-session half of jumping to an issue** ·
+  [#62](https://github.com/varijkapil13/saral/issues/62) ·
+  **owns** `internal/ui/kernel/keys.go` (the `Jump` binding), the `Jump` case in
+  `internal/ui/kernel/kernel.go`'s prefix resolution and `liveGlobals`, the `Jump` row in
+  `internal/ui/kernel/destinations.go`'s `destFooterActs`, `internal/ui/palette/{jump,jump_test}.go`,
+  the `search` function in `internal/ui/palette/issues.go`, `docs/{UX,ROADMAP}.md`
+  K5 built the CLI half: `app.ParseKey` and `app.ParseIssueURL` read a key or a pasted browse, board
+  or backlog URL, and `saral PROJ-142` opens it with a fetch. What it deliberately left was the
+  in-session gesture, because `g` had just become the view-slot prefix and nothing had decided what
+  completes it for a key.
+  **`g` then `i` opens the palette**, exactly as `ctrl+k` does — a third route to the place #85 already
+  built rather than a fourth place that reads a key on its own. Not `k` or `j`: K7 landed in the same
+  batch and had already spent both, and `up`/`down`, on moving the destinations overlay's own cursor,
+  so `i` is what completes the prefix for a key without shadowing them. The palette's own filter is
+  where the reading happens: `jumpHit` runs the same two parsers against what was typed, on every
+  keystroke, alongside the fuzzy index #85 wired up. A key already cached is still found by the index
+  as before and is never offered twice; a key or a URL that parses but is not cached is offered
+  anyway, seeded with nothing but its key — the same seed the CLI argument opens with — so selecting
+  it fetches fresh rather than requiring a prior read to have cached it. A URL for another site is
+  named as the mistake it is, in the same words the CLI argument answers with, and offers nothing
+  rather than opening against this one.
+  **Ordinary filter text is never mistaken for a key**: `app.ParseKey` and `app.ParseIssueURL` both
+  refuse anything that is not their shape, so typing a few words of a title still only reaches the
+  fuzzy index.
+
 ## W1 · the seam Batches 4 to 8 code against
 
 Three batches reach for the same three things — attachments, versions, sprints — and eight packets

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -359,15 +359,20 @@ reasons that directory already holds them: a pane width belongs to the terminal 
 account, so two profiles on one machine want one answer and a `config.toml` handed to somebody else
 should not carry your proportions.
 
-Jumping to an issue by key is half built. **From the command line it works**: `saral PROJ-142` opens
-that issue over whichever root would have opened, and so does a pasted browse, board or backlog URL —
-a URL for another site is named as a mistake rather than read against this one, because the same key
-usually exists on both. **Inside a running session there is still no gesture**, because `g` is now the
-prefix the view slots sit behind and what completes it for a key has not been decided:
-[#62](https://github.com/varijkapil13/saral/issues/62) holds that half, and `app.ParseKey` and
-`app.ParseIssueURL` are what it will read with. The parse is a **shape** and never a claim the issue
-exists — the project key charset is per-instance — so what is not there comes back from the site,
-in the site's words.
+Jumping to an issue by key has all three of principle 3's routes now. **From the command line**:
+`saral PROJ-142` opens that issue over whichever root would have opened, and so does a pasted browse,
+board or backlog URL — a URL for another site is named as a mistake rather than read against this
+one, because the same key usually exists on both. **`g` then `i`, from anywhere in a running
+session**, opens the palette already armed to read what gets typed next as a key or a URL, the same
+way `ctrl+k` does — `g` is the prefix the view slots sit behind, and `i` is what completes it for a
+key. Not `k` or `j`: the destinations overlay this same prefix opens already spends both, and
+`up`/`down`, moving its own cursor. **From the palette itself**, typing or pasting either is read the
+same way as it is typed, whether or not the issue has ever been cached: a key already on disk is
+found by the fuzzy index as before, and a key or a URL that parses but is not cached is offered
+anyway, seeded with nothing but its key, so opening it fetches it fresh the way the CLI argument
+does. `app.ParseKey` and `app.ParseIssueURL` are what all three routes read with, and the parse is a
+**shape** and never a claim the issue exists — the project key charset is per-instance — so what is
+not there comes back from the site, in the site's words.
 
 ## Mouse
 

--- a/internal/ui/kernel/destinations.go
+++ b/internal/ui/kernel/destinations.go
@@ -177,6 +177,7 @@ func (m Model) destMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 func (m Model) destFooterActs() []Binding {
 	return []Binding{
 		Bind(m.keys.Slot.Keys(), "1-9", "switch view"),
+		Bind(m.keys.Jump.Keys(), m.keys.Jump.Keys()[0], m.keys.Jump.Help().Desc),
 		destDown,
 		destChoose,
 		Bind(m.keys.Back.Keys(), "esc", "cancel"),

--- a/internal/ui/kernel/kernel.go
+++ b/internal/ui/kernel/kernel.go
@@ -801,6 +801,8 @@ func (m Model) resolvePrefix(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if slot, err := strconv.Atoi(msg.String()); err == nil {
 			return m.openSlot(slot)
 		}
+	case Matches(msg, m.keys.Jump):
+		return m.openPalette()
 	}
 	first, cmd := m.forwardTop(buffered)
 	model, ok := first.(Model)
@@ -1805,7 +1807,7 @@ func (m Model) liveGlobals() KeySet {
 	} else {
 		set.Short = append(set.Short, g.Quit)
 	}
-	set.Full = [][]Binding{{g.Saved, g.Go, g.Slot, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}}
+	set.Full = [][]Binding{{g.Saved, g.Go, g.Slot, g.Jump, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}}
 	if len(bound) > 0 {
 		set.Full = append([][]Binding{bound}, set.Full...)
 	}

--- a/internal/ui/kernel/keys.go
+++ b/internal/ui/kernel/keys.go
@@ -54,6 +54,13 @@ type GlobalKeys struct {
 	// Saved runs the query bound to a number key. Same nine digits, pressed
 	// alone, and only in a root view.
 	Saved Binding
+	// Jump completes the g prefix the way Slot completes it for a digit: it
+	// opens the palette already armed with what gets typed next, so a key or a
+	// pasted URL is a third route to the same place ctrl+k and the CLI
+	// argument reach, per docs/UX.md principle 3. Its key is i rather than the
+	// more obvious k or j: the destinations overlay this prefix now opens
+	// already spends both, and up/down, on moving its own cursor.
+	Jump Binding
 }
 
 // DefaultGlobalKeys is the keymap from docs/UX.md. Vim keys and arrows are both
@@ -69,6 +76,7 @@ func DefaultGlobalKeys() GlobalKeys {
 		Go:      Bind([]string{"g"}, "g", "where to go"),
 		Slot:    Bind(digits, "g 1-9", "switch view"),
 		Saved:   Bind(digits, "1-9", "saved query"),
+		Jump:    Bind([]string{"i"}, "g i", "jump to an issue"),
 	}
 }
 
@@ -78,7 +86,7 @@ var digits = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}
 func (g GlobalKeys) KeySet() KeySet {
 	return KeySet{
 		Short: []Binding{g.Help, g.Palette, g.Quit},
-		Full:  [][]Binding{{g.Saved, g.Go, g.Slot, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}},
+		Full:  [][]Binding{{g.Saved, g.Go, g.Slot, g.Jump, g.Back, g.Refresh, g.Purge}, {g.Palette, g.Help, g.Quit}},
 	}
 }
 

--- a/internal/ui/kernel/palette_test.go
+++ b/internal/ui/kernel/palette_test.go
@@ -32,6 +32,22 @@ func TestPalette_CtrlKPushesOverTheViewYouWereInRatherThanReplacingIt(t *testing
 	}
 }
 
+func TestGoPrefix_IOpensThePaletteJustLikeCtrlK(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	RegisterView(spec("board", 1, "", &stubView{id: "board"}))
+	RegisterView(spec(PaletteViewID, 0, "", &stubView{id: PaletteViewID}))
+
+	m := newAt(t, testDeps(), 120, 30)
+	m, _ = press(m, "g", "i")
+	if got := ansi.Strip(m.Frame()); !strings.Contains(got, "palette body") {
+		t.Fatalf("g i did not open the palette:\n%s", got)
+	}
+	if len(m.stack) != 2 {
+		t.Errorf("the stack is %d deep after g i, want 2", len(m.stack))
+	}
+}
+
 func TestPalette_IsBuiltFreshOnEveryCtrlK(t *testing.T) {
 	resetRegistry()
 	t.Cleanup(resetRegistry)

--- a/internal/ui/kernel/testdata/destinations_120x38.golden
+++ b/internal/ui/kernel/testdata/destinations_120x38.golden
@@ -35,4 +35,4 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- Issues  1-9 switch view  up/down choose  enter go there  esc cancel
+ Issues  1-9 switch view  i jump to an issue  up/down choose  enter go there  esc cancel

--- a/internal/ui/kernel/testdata/destinations_80x20.golden
+++ b/internal/ui/kernel/testdata/destinations_80x20.golden
@@ -17,4 +17,4 @@
                                                                                 
                                                                                 
                                                                                 
- Issues  1-9 switch view  up/down choose  enter go there  esc cancel
+ Issues  1-9 switch view  i jump to an issue  up/down choose  enter go there  +1

--- a/internal/ui/kernel/testdata/help_filtering.golden
+++ b/internal/ui/kernel/testdata/help_filtering.golden
@@ -2,10 +2,10 @@
 enter keep filter     1-9   saved query           ctrl+k commands                                                       
 esc   clear filter    g     where to go           ?      help                                                           
                       g 1-9 switch view           q      quit                                                           
+                      g i   jump to an issue                                                                            
                       esc   back                                                                                        
                       r     refresh                                                                                     
                       R     refetch everything                                                                          
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/internal/ui/kernel/testdata/help_resting.golden
+++ b/internal/ui/kernel/testdata/help_resting.golden
@@ -2,10 +2,10 @@
 enter open the row under the cursor    ↓/j down    1-9   saved query           ctrl+k commands                          
 /     filter these rows                ↑/k up      g     where to go           ?      help                              
                                                    g 1-9 switch view           q      quit                              
+                                                   g i   jump to an issue                                               
                                                    esc   back                                                           
                                                    r     refresh                                                        
                                                    R     refetch everything                                             
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/internal/ui/palette/issues.go
+++ b/internal/ui/palette/issues.go
@@ -49,17 +49,25 @@ func (m *Model) search(text string, now time.Time) tea.Cmd {
 	for i := range found {
 		m.hits = append(m.hits, newHit(found[i], now))
 	}
+	jump, warn := m.jumpHit(text)
+	if jump != nil && !m.alreadyFound(jump.key) {
+		m.hits = append([]hit{*jump}, m.hits...)
+	}
 	for i := range m.hits {
 		m.shown = append(m.shown, entry{issue: true, at: i})
 	}
+	var cmds []tea.Cmd
+	if warn != nil {
+		cmds = append(cmds, warn)
+	}
 	if err != nil {
-		return kernel.Warn("the cache on this machine could not be walked: " + err.Error())
+		cmds = append(cmds, kernel.Warn("the cache on this machine could not be walked: "+err.Error()))
 	}
 	if n := m.index.Dropped(); n > 0 && n != m.said {
 		m.said = n
-		return kernel.Warn(dropped(n))
+		cmds = append(cmds, kernel.Warn(dropped(n)))
 	}
-	return nil
+	return tea.Batch(cmds...)
 }
 
 // dropped says how much of the cache went unread, because a palette that offers

--- a/internal/ui/palette/jump.go
+++ b/internal/ui/palette/jump.go
@@ -1,0 +1,51 @@
+package palette
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/varijkapil13/saral/internal/app"
+	"github.com/varijkapil13/saral/internal/config"
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+)
+
+// jumpLabel marks a hit this session has not read, so it never reads like a
+// cached issue whose age happened to come back blank.
+const jumpLabel = "not cached — opens with a fetch"
+
+// jumpHit resolves what was typed as an issue key or a Jira URL — the two
+// shapes docs/UX.md promises reach an issue with no round trip — using the
+// same two parsers K5 gave the CLI argument. It is what g then k answers to:
+// opening the palette already armed with what gets typed, rather than a
+// fourth place that reads a key, and it is why a key search does not need to
+// already be cached to be offered here.
+//
+// A URL for another site is named as the mistake it is, in the same words the
+// CLI argument answers with, rather than read against this profile's site.
+func (m *Model) jumpHit(text string) (h *hit, warn tea.Cmd) {
+	if key, ok := app.ParseKey(text); ok {
+		return &hit{key: key, text: key + "  " + jumpLabel}, nil
+	}
+	key, host, ok := app.ParseIssueURL(text)
+	if !ok {
+		return nil, nil
+	}
+	if here, err := config.NormalizeSite(m.deps.Site); err == nil && !strings.EqualFold(here, host) {
+		return nil, kernel.Warn(fmt.Sprintf("%s is on %s and this profile is on %s, so it was not opened", key, host, here))
+	}
+	return &hit{key: key, text: key + "  " + jumpLabel}, nil
+}
+
+// alreadyFound reports whether a cache hit already answers this key, so a
+// valid key already ranked by the index is not offered a second time under a
+// different row.
+func (m *Model) alreadyFound(key string) bool {
+	for i := range m.hits {
+		if strings.EqualFold(m.hits[i].key, key) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ui/palette/jump_test.go
+++ b/internal/ui/palette/jump_test.go
@@ -1,0 +1,113 @@
+package palette
+
+import (
+	"strings"
+	"testing"
+)
+
+// The whole reason a key needs a route besides the cache index: an issue
+// nothing has been cached on this machine yet still has to open, with the
+// fetch the CLI argument already does for it.
+func TestPalette_TypingAnUncachedKeyOffersToOpenItWithAFetch(t *testing.T) {
+	t.Parallel()
+
+	d := paletteDeps()
+	p := fly(t, d, sample(), memoryTable(), 120, 24)
+	p.typeText("PROJ-999")
+
+	if got := p.keys(); len(got) != 1 || got[0] != "PROJ-999" {
+		t.Fatalf("typing a key nothing has cached offers %v, want [PROJ-999]", got)
+	}
+	p.press("enter")
+	if got := p.pushed(); len(got) != 1 || got[0] != "issue:PROJ-999" {
+		t.Fatalf("enter over an uncached key pushed %v, want the detail pane for PROJ-999", got)
+	}
+}
+
+// A key already ranked by the index is not offered a second time under a row
+// that would look like a different issue.
+func TestPalette_TypingAKeyAlreadyCachedDoesNotDuplicateTheRow(t *testing.T) {
+	t.Parallel()
+
+	d, _ := cachedDeps()
+	p := fly(t, d, sample(), memoryTable(), 120, 24)
+	p.typeText("PROJ-142")
+
+	if got := p.keys(); len(got) != 1 || got[0] != "PROJ-142" {
+		t.Fatalf("a cached key typed exactly offers %v, want it once", got)
+	}
+}
+
+// A pasted browse URL for this profile's own site reaches the issue it names,
+// the way it reaches the CLI argument's parser.
+func TestPalette_PastingABrowseURLOffersTheIssueItNames(t *testing.T) {
+	t.Parallel()
+
+	d := paletteDeps()
+	p := fly(t, d, sample(), memoryTable(), 120, 24)
+	p.typeText("https://example.atlassian.net/browse/PROJ-77")
+
+	if got := p.keys(); len(got) != 1 || got[0] != "PROJ-77" {
+		t.Fatalf("pasting a browse URL for this site offers %v, want [PROJ-77]", got)
+	}
+	p.press("enter")
+	if got := p.pushed(); len(got) != 1 || got[0] != "issue:PROJ-77" {
+		t.Fatalf("enter over a pasted URL pushed %v, want the detail pane for PROJ-77", got)
+	}
+}
+
+// A board or backlog URL carries the key in ?selectedIssue= rather than the
+// path, which is the shape /browse/ does not have.
+func TestPalette_PastingABoardURLReadsSelectedIssueFromTheQuery(t *testing.T) {
+	t.Parallel()
+
+	d := paletteDeps()
+	p := fly(t, d, sample(), memoryTable(), 120, 24)
+	p.typeText("https://example.atlassian.net/jira/software/projects/PROJ/boards/3?selectedIssue=PROJ-77")
+
+	if got := p.keys(); len(got) != 1 || got[0] != "PROJ-77" {
+		t.Fatalf("pasting a board URL offers %v, want [PROJ-77]", got)
+	}
+}
+
+// A URL for another site is named as the mistake it is, in the same words the
+// CLI argument answers with, rather than read against this profile's site.
+func TestPalette_PastingAURLForAnotherSiteNamesTheMismatchRatherThanOpeningIt(t *testing.T) {
+	t.Parallel()
+
+	d := paletteDeps()
+	p := fly(t, d, sample(), memoryTable(), 120, 24)
+	p.typeText("https://other.atlassian.net/browse/PROJ-77")
+
+	if got := p.keys(); len(got) != 0 {
+		t.Fatalf("a URL for another site offered %v, want nothing opened against this one", got)
+	}
+	// Every stroke of the paste re-evaluates, and a prefix like .../PROJ-7 is
+	// already a valid key shape on the wrong site — so more than one warning is
+	// expected here. It is the last one, over the whole pasted key, that has to
+	// name both sites.
+	got := p.statuses()
+	if len(got) == 0 {
+		t.Fatal("pasting a URL for another site said nothing")
+	}
+	last := got[len(got)-1]
+	if !strings.Contains(last, "PROJ-77") || !strings.Contains(last, "other.atlassian.net") || !strings.Contains(last, "example.atlassian.net") {
+		t.Fatalf("the last warning read %q, want it to name the key and both sites", last)
+	}
+}
+
+// Text that is neither a key nor a URL is ordinary filter text: it must not be
+// offered as something to jump to.
+func TestPalette_OrdinaryTextIsNotOfferedAsAJumpTarget(t *testing.T) {
+	t.Parallel()
+
+	d, _ := cachedDeps()
+	p := fly(t, d, sample(), memoryTable(), 120, 24)
+	p.typeText("login")
+
+	for _, key := range p.keys() {
+		if key == "login" {
+			t.Fatalf("plain filter text was offered as a key to jump to: %v", p.keys())
+		}
+	}
+}

--- a/internal/ui/testdata/destinations_everything_within_reach_at_120_120x38.golden
+++ b/internal/ui/testdata/destinations_everything_within_reach_at_120_120x38.golden
@@ -35,4 +35,4 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- Issues  1-9 switch view  up/down choose  enter go there  esc cancel
+ Issues  1-9 switch view  i jump to an issue  up/down choose  enter go there  esc cancel

--- a/internal/ui/testdata/destinations_everything_within_reach_at_80_80x20.golden
+++ b/internal/ui/testdata/destinations_everything_within_reach_at_80_80x20.golden
@@ -17,4 +17,4 @@
                                                                                 
                                                                                 
                                                                                 
- Issues  1-9 switch view  up/down choose  enter go there  esc cancel
+ Issues  1-9 switch view  i jump to an issue  up/down choose  enter go there  +1

--- a/internal/ui/testdata/destinations_nothing_probed_yet_at_120_120x38.golden
+++ b/internal/ui/testdata/destinations_nothing_probed_yet_at_120_120x38.golden
@@ -35,4 +35,4 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- Issues  1-9 switch view  up/down choose  enter go there  esc cancel
+ Issues  1-9 switch view  i jump to an issue  up/down choose  enter go there  esc cancel

--- a/internal/ui/testdata/destinations_the_boards_out_of_reach_at_80_80x20.golden
+++ b/internal/ui/testdata/destinations_the_boards_out_of_reach_at_80_80x20.golden
@@ -17,4 +17,4 @@
                                                                                 
                                                                                 
                                                                                 
- Issues  1-9 switch view  up/down choose  enter go there  esc cancel
+ Issues  1-9 switch view  i jump to an issue  up/down choose  enter go there  +1

--- a/internal/ui/testdata/overlay_120x38.golden
+++ b/internal/ui/testdata/overlay_120x38.golden
@@ -2,6 +2,7 @@ attach
 1-9   saved query           ctrl+k commands
 g     where to go           ?      help
 g 1-9 switch view           q      quit
+g i   jump to an issue
 esc   back
 r     refresh
 R     refetch everything
@@ -22,23 +23,26 @@ comment
 a write a comment    ↓/j  down         ctrl+d  half page down    1-9   saved query           ctrl+k commands
 e edit this one      ↑/k  up           ctrl+u  half page up      g     where to go           ?      help
 d delete this one    pgdn page down    g g     oldest            g 1-9 switch view           q      quit
-                     pgup page up      G / g e newest            esc   back
-                                       ←/h     pan left          r     refresh
-                                       →/l     pan right         R     refetch everything
+                     pgup page up      G / g e newest            g i   jump to an issue
+                                       ←/h     pan left          esc   back
+                                       →/l     pan right         r     refresh
+                                                                 R     refetch everything
 
 filter
 enter choose what to filter by    ↓/j  down         1-9   saved query           ctrl+k commands
                                   ↑/k  up           g     where to go           ?      help
                                   pgdn page down    g 1-9 switch view           q      quit
-                                  pgup page up      esc   back
-                                  home first row    r     refresh
-                                  end  last row     R     refetch everything
+                                  pgup page up      g i   jump to an issue
+                                  home first row    esc   back
+                                  end  last row     r     refresh
+                                                    R     refetch everything
 
 form
 enter use this issue type    ↓/j  down         1-9   saved query           ctrl+k commands
                              ↑/k  up           g     where to go           ?      help
                              home first row    g 1-9 switch view           q      quit
-                             end  last row     esc   back
+                             end  last row     g i   jump to an issue
+                                               esc   back
                                                r     refresh
                                                R     refetch everything
 
@@ -46,10 +50,10 @@ issue
 tab next pane        ↓/j    down         d/ctrl+d  half page down        1-9   saved query           ctrl+k commands
 e   edit fields      ↑/k    up           u/ctrl+u  half page up          g     where to go           ?      help
 t   change status    f/pgdn page down    g g       top                   g 1-9 switch view           q      quit
-C   comment          b/pgup page up      G / g e   bottom                esc   back
-                     →/l    pan right    shift+tab previous pane         r     refresh
-                     ←/h    pan left     z         expand or collapse    R     refetch everything
-                                         <         wider sidebar
+C   comment          b/pgup page up      G / g e   bottom                g i   jump to an issue
+                     →/l    pan right    shift+tab previous pane         esc   back
+                     ←/h    pan left     z         expand or collapse    r     refresh
+                                         <         wider sidebar         R     refetch everything
                                          >         wider description
                                          =         reset the split
 
@@ -57,7 +61,8 @@ issue.edit
 enter  change this field    ↓/j down    ←/h previous value    1-9   saved query           ctrl+k commands
 del    empty this field     ↑/k up      →/l next value        g     where to go           ?      help
 ctrl+s save                                                   g 1-9 switch view           q      quit
-X      discard changes                                        esc   back
+X      discard changes                                        g i   jump to an issue
+                                                              esc   back
                                                               r     refresh
                                                               R     refetch everything
 
@@ -65,6 +70,7 @@ issue.move
 enter choose    ↓/j down    1-9   saved query           ctrl+k commands
                 ↑/k up      g     where to go           ?      help
                             g 1-9 switch view           q      quit
+                            g i   jump to an issue
                             esc   back
                             r     refresh
                             R     refetch everything
@@ -73,30 +79,34 @@ list
 enter open                                     ↓/j  down         ctrl+d  half page down    1-9   saved query        ...
 f     filter by a person, a status, a label    ↑/k  up           ctrl+u  half page up      g     where to go
 /     filter                                   pgdn page down    g g     first row         g 1-9 switch view
-a     all issues                               pgup page up      G / g e last row          esc   back
-e     edit this search                                                                     r     refresh
-s     save this query to a key                                                             R     refetch everything
+a     all issues                               pgup page up      G / g e last row          g i   jump to an issue
+e     edit this search                                                                     esc   back
+s     save this query to a key                                                             r     refresh
+                                                                                           R     refetch everything
 
 move
 enter use the project under the cursor    ↓/j  down         1-9   saved query           ctrl+k commands
 i     type a project key                  ↑/k  up           g     where to go           ?      help
                                           pgdn page down    g 1-9 switch view           q      quit
-                                          pgup page up      esc   back
-                                          home first row    r     refresh
-                                          end  last row     R     refetch everything
+                                          pgup page up      g i   jump to an issue
+                                          home first row    esc   back
+                                          end  last row     r     refresh
+                                                            R     refetch everything
 
 plans
 enter show what this plan is made of    ↓/j  down          1-9   saved query           ctrl+k commands
                                         ↑/k  up            g     where to go           ?      help
                                         pgdn page down     g 1-9 switch view           q      quit
-                                        pgup page up       esc   back
-                                        home first plan    r     refresh
-                                        end  last plan     R     refetch everything
+                                        pgup page up       g i   jump to an issue
+                                        home first plan    esc   back
+                                        end  last plan     r     refresh
+                                                           R     refetch everything
 
 release.flow
 enter choose what happens to the open issues    ↓/j down    1-9   saved query           ctrl+k commands
                                                 ↑/k up      g     where to go           ?      help
                                                             g 1-9 switch view           q      quit
+                                                            g i   jump to an issue
                                                             esc   back
                                                             r     refresh
                                                             R     refetch everything
@@ -105,14 +115,16 @@ releases
 enter release this version       ↓/j  down             1-9   saved query           ctrl+k commands
 n     new version                ↑/k  up               g     where to go           ?      help
 e     edit this version          pgdn page down        g 1-9 switch view           q      quit
-A     archive or unarchive it    pgup page up          esc   back
-                                 g g  first version    r     refresh
-                                 G    last version     R     refetch everything
+A     archive or unarchive it    pgup page up          g i   jump to an issue
+                                 g g  first version    esc   back
+                                 G    last version     r     refresh
+                                                       R     refetch everything
 
 sprints
 o show or hide closed sprints    1-9   saved query           ctrl+k commands
                                  g     where to go           ?      help
                                  g 1-9 switch view           q      quit
+                                 g i   jump to an issue
                                  esc   back
                                  r     refresh
                                  R     refetch everything
@@ -121,6 +133,7 @@ timeline
 n where these dates came from    1-9   saved query           ctrl+k commands
                                  g     where to go           ?      help
                                  g 1-9 switch view           q      quit
+                                 g i   jump to an issue
                                  esc   back
                                  r     refresh
                                  R     refetch everything


### PR DESCRIPTION
Closes #62.

## Summary
- `docs/UX.md` promised three routes to an issue key — the CLI argument, an in-session gesture, and the palette — and only the first existed. K5 (#63, filed against #62) built `app.ParseKey`/`app.ParseIssueURL` for the CLI half and deliberately left the in-session gesture open, since `g` had just become the view-slot prefix and nothing had decided what completes it for a key.
- `g` then `i` opens the palette, exactly as `ctrl+k` does — a third route to the place #85 already built (the palette's fuzzy index over cached issues) rather than a fourth place that reads a key on its own. Not `k` or `j`: #133 (K7, merged in this same batch) had already spent both, and `up`/`down`, on moving the destinations overlay's own cursor — `k`/`j` are intercepted by that overlay before this branch's own `resolvePrefix` case is ever reached, so `i` is what completes the prefix without silently shadowing them. (Original PR used `k`; renamed after rebasing onto #133 exposed the collision — see commit history.)
- The palette's filter now also runs `jumpHit`, using the same two parsers K5 gave the CLI argument, alongside the fuzzy index, on every keystroke:
  - A key already cached is still found by the index as before and is never offered twice.
  - A key or a URL that parses but is **not** cached is offered anyway, seeded with nothing but its key — the same seed the CLI argument opens with — so selecting it fetches fresh rather than requiring a prior read to have cached it.
  - A URL for another site is named as the mistake it is, in the same words the CLI argument answers with, and offers nothing rather than opening against this one.
  - Ordinary filter text is never mistaken for a key: both parsers refuse anything that is not their shape.
- The destinations overlay's own footer row (`destFooterActs`) now also teaches `i jump to an issue`, alongside `1-9 switch view`.
- `docs/{UX,ROADMAP}.md` updated (added packet K8).

## Test plan
- [x] `make check` (tidy, lint, race) green, rebased onto main after #133 and #134 merged
- [x] New tests in `internal/ui/palette/jump_test.go`: uncached key opens with a fetch, a cached key is not duplicated, a browse URL and a board/backlog `?selectedIssue=` URL both resolve, a URL for another site is refused and named, plain filter text is never offered as a key
- [x] New kernel test `TestGoPrefix_IOpensThePaletteJustLikeCtrlK`
- [x] `?` help-overlay and destinations-overlay goldens regenerated and reviewed by hand for every view and every affected package — no line-wrapping regression

https://claude.ai/code/session_015SMw7ryvux5CExuhTATVdw