### PR TITLE
fix(release): the homebrew cask token needs the bare Env form

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,7 @@ homebrew_casks:
     repository:
       owner: varijkapil13
       name: homebrew-tap
-      token: '{{ index .Env "HOMEBREW_TAP_TOKEN" }}'
+      token: '{{ .Env.HOMEBREW_TAP_TOKEN }}'
     # Without a tap to push to, publishing the release still has to succeed.
     skip_upload: '{{ if index .Env "HOMEBREW_TAP_TOKEN" }}false{{ else }}true{{ end }}'
     homepage: https://github.com/varijkapil13/saral

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -133,3 +133,12 @@ happens to measure, so the budget is guarded at its worst case — sits at 88% o
 - **The binaries are unsigned.** The cask's `postflight` clears the quarantine attribute, which is why
   a `brew install`ed binary runs on macOS. Signing and notarizing needs an Apple Developer account
   and is not set up.
+- **`repository.token` takes only the bare `{{ .Env.VAR_NAME }}` form.** `homebrew_casks[].repository`
+  is a `repository` block, and GoReleaser refuses any other templating on its `token` — `{{ index .Env
+  "HOMEBREW_TAP_TOKEN" }}` fails at publish time with "expected `{{ .Env.VAR_NAME }}` only", which
+  `goreleaser check` and a `--skip=publish` dry run both pass, because neither resolves `token` at all.
+  `v0.2.0` shipped its four archives and no cask over exactly this: the release step has already
+  published by the time this error surfaces, and GoReleaser does not rewind it — see "The thing to
+  understand first" above. `skip_upload` is a different field with no such restriction and keeps its
+  `index .Env` form, which is there on purpose so an absent variable reads as empty rather than as a
+  template error.


### PR DESCRIPTION
## Summary
- `v0.2.0` published its four archives and no Homebrew cask: `homebrew_casks[].repository.token` used `{{ index .Env "HOMEBREW_TAP_TOKEN" }}`, and GoReleaser accepts only the bare `{{ .Env.VAR_NAME }}` form on a `repository.token` field — confirmed against GoReleaser's own docs, which show only that exact form for this field (e.g. `token: "{{ .Env.RELEASE_GITHUB_TOKEN }}"`). It failed at publish time with `expected {{ .Env.VAR_NAME }} only (no plain-text or other interpolation)`.
- `goreleaser check` and a `--skip=publish` dry run both pass regardless — neither resolves `repository.token`, only an actual publish does, and by then the GitHub release has already gone out with no rollback (see `docs/RELEASING.md`'s own "thing to understand first").
- `skip_upload` keeps its `index .Env` form on purpose (documented already) — that field has no such restriction, and the form there exists so an absent variable reads as empty rather than a template error.
- `docs/RELEASING.md` updated with this failure mode.

## Test plan
- [x] `goreleaser check` passes
- [x] Fix matches GoReleaser's documented canonical form for `repository.token` exactly
- [ ] Confirmed by an actual release once this merges (v0.1.0/v0.2.0 couldn't catch this locally, which is the whole point of the note added)

https://claude.ai/code/session_015SMw7ryvux5CExuhTATVdw