### PR TITLE
feat(kernel): configurable colour schemes, and category colour two views already computed

### DIFF
--- a/cmd/saral/main.go
+++ b/cmd/saral/main.go
@@ -67,6 +67,7 @@ type options struct {
 	// arg is the positional argument, which names a view, an issue or a Jira URL.
 	arg        string
 	theme      string
+	scheme     string
 	poll       time.Duration
 	mouse      bool
 	mouseSet   bool
@@ -81,6 +82,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fs.StringVar(&opt.project, "project", "", "project key to scope the session to; several capabilities are per-project")
 	fs.StringVar(&opt.profile, "profile", "", "profile to use (default: the active one)")
 	fs.StringVar(&opt.theme, "theme", "", "auto, dark, light or no-color")
+	fs.StringVar(&opt.scheme, "scheme", "", "default, nord, dracula, solarized or gruvbox")
 	fs.DurationVar(&opt.poll, "poll", 0, "re-read the focused view this often; off by default, and pauses when Jira rate-limits")
 	fs.BoolVar(&opt.mouse, "mouse", true, "enable mouse reporting")
 	fs.BoolVar(&opt.benchPaint, "bench-first-paint", false, "render one frame, print how long it took, and exit")
@@ -208,7 +210,15 @@ func build(opt options) (deps kernel.Deps, kopts []kernel.Option, notice string,
 		theme = profile.Theme
 	}
 	mode := kernel.ThemeModeFromEnv(os.Environ(), theme)
-	deps.Theme = kernel.NewTheme(mode, true, kernel.GlyphsFor(profile.Glyphs))
+	scheme := opt.scheme
+	if scheme == "" {
+		scheme = profile.Scheme
+	}
+	// An unrecognised scheme falls back to the default the same way an
+	// unrecognised theme falls back to auto: silently, at the flag, with the
+	// error surfaced instead when a profile tries to save one.
+	resolvedScheme, _ := kernel.ParseScheme(scheme)
+	deps.Theme = kernel.NewTheme(mode, true, kernel.GlyphsFor(profile.Glyphs), kernel.WithScheme(resolvedScheme))
 
 	mouse := cfg.Mouse
 	if opt.mouseSet {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1093,6 +1093,38 @@ are guesses.
   **What this does not cover:** the backlog view (`internal/ui/backlog`) draws on the same board and
   could offer the same quick filters and the same picker; that is a separate packet.
 
+- [x] **P6.5 — Configurable colour schemes, and the category colour two views already computed and
+  never drew** · [#139](https://github.com/varijkapil13/saral/issues/139) ·
+  **owns** `internal/ui/kernel/scheme*.go`, the `Theme.Scheme`/`WithScheme` addition in
+  `internal/ui/kernel/theme.go`, the `Scheme` field and its validation in `internal/config/config.go`,
+  the `-scheme` flag in `cmd/saral/main.go`, the category-colour wiring in `internal/ui/board/render.go`
+  and `internal/ui/issue/render.go`
+  Requested directly, not picked off the roadmap in advance — recorded here after the fact, the way
+  #136 was. `kernel.Scheme` is nine semantic roles (`fg, muted, accent, danger, warning, success,
+  surface, selected, onAccent`), each resolved separately for light and dark, never a `lipgloss.Color`
+  hardcoded at a call site; five named presets ship (default, Nord, Dracula, Solarized, Gruvbox).
+  `NewTheme` took a variadic `...ThemeOption` rather than a new required parameter, so none of its
+  roughly seventy existing call sites had to change. `internal/config` cannot import
+  `internal/ui/kernel` — the kernel already imports `config` for save/load, and the reverse would
+  cycle — so its `schemes` validation list is a hand-kept mirror of `kernel.Schemes`, the same
+  precedent `themes` already set for `kernel.ThemeMode`. Switchable at runtime from the command
+  palette (one command per scheme, in an "Appearance" group), via `-scheme`, or via a profile's
+  `scheme = "..."` key, independent of `-theme`: light/dark and which colours stays two separate axes.
+  **The rest of the packet is two colour gaps that were already half-built and never wired up**, not
+  new colour: the board's own `categories [4]lipgloss.Style` was computed every theme generation and
+  never rendered anywhere, so a resting card's key now carries its status category's colour the way
+  its column caption already implies it. The issue detail pane coloured a *related* issue's status by
+  category already; its own header did not, for no reason the diff could find, so it does now — each
+  fact in the header line renders with its own style now rather than the whole line once, since
+  nesting a coloured substring inside one outer `Render()` call risks the outer style's reset code
+  cutting the inner colour off partway through rather than closing cleanly at the fact's own end.
+  **What this does not cover:** priority and issue-type colouring. Both are per-instance configurable
+  on a real Jira site — names, and for priority the severity order too — so colouring by name match
+  would be exactly the instance-specific hardcoding this file's own working agreement calls out as the
+  most common way a PR gets rejected here. The instance-safe version, deriving relative severity from
+  the site's own priority order via `Priorities(ctx)`, needs a session-level priority-order cache
+  nothing in the codebase keeps yet; left for a follow-up rather than folded in here.
+
 ## Batch 7 — Cross-project move · parallel ×1
 
 - [x] **P7.1 — Move wizard** · [#25](https://github.com/varijkapil13/saral/issues/25) · **owns** `pkg/jira/cloud/bulkmove.go`, `internal/ui/move/**`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,7 +56,11 @@ type Profile struct {
 	Token    TokenSource
 	Timeline Timeline
 	Theme    string
-	Glyphs   string
+	// Scheme is which named set of colours the theme draws from — Theme is
+	// light or dark, Scheme is which colours mean accent, danger and the rest.
+	// The two are independent: any scheme works in either mode.
+	Scheme string
+	Glyphs string
 	// Queries are the searches this profile keeps, each optionally bound to a
 	// number key. They are app's own type, validated by app's own rules, so that
 	// a file and a keypress cannot disagree about what a saved query is; the
@@ -79,7 +83,12 @@ type Timeline struct {
 }
 
 var (
-	themes    = []string{"", "dark", "light", "no-color"}
+	themes = []string{"", "dark", "light", "no-color"}
+	// schemes mirrors kernel.Schemes by name. It cannot read that list directly
+	// — kernel already imports this package for where a theme choice is saved,
+	// so the reverse import would cycle — the same reason themes above is its
+	// own hand-kept list rather than reading ThemeMode's.
+	schemes   = []string{"", "default", "nord", "dracula", "solarized", "gruvbox"}
 	glyphSets = []string{"", "unicode", "ascii"}
 
 	secretKeys = []string{"token", "value", "secret", "password", "api_token", "api-token", "apitoken"}
@@ -160,6 +169,7 @@ type fileProfile struct {
 	Token    toml.Primitive `toml:"token"`
 	Timeline Timeline       `toml:"timeline"`
 	Theme    string         `toml:"theme"`
+	Scheme   string         `toml:"scheme"`
 	Glyphs   string         `toml:"glyphs"`
 	Queries  []fileQuery    `toml:"queries"`
 }
@@ -247,6 +257,7 @@ func decodeProfile(md *toml.MetaData, name string, fp fileProfile) (Profile, err
 		Token:    token,
 		Timeline: fp.Timeline,
 		Theme:    strings.TrimSpace(fp.Theme),
+		Scheme:   strings.TrimSpace(fp.Scheme),
 		Glyphs:   strings.TrimSpace(fp.Glyphs),
 		Queries:  decodeQueries(fp.Queries),
 	}
@@ -413,6 +424,9 @@ func (p Profile) Validate() error {
 	}
 	if !slices.Contains(themes, p.Theme) {
 		return fmt.Errorf("profile %q: theme %q is not one of %s", p.Name, p.Theme, strings.Join(themes[1:], ", "))
+	}
+	if !slices.Contains(schemes, p.Scheme) {
+		return fmt.Errorf("profile %q: scheme %q is not one of %s", p.Name, p.Scheme, strings.Join(schemes[1:], ", "))
 	}
 	if !slices.Contains(glyphSets, p.Glyphs) {
 		return fmt.Errorf("profile %q: glyphs %q is not one of %s", p.Name, p.Glyphs, strings.Join(glyphSets[1:], ", "))
@@ -586,6 +600,9 @@ func (c Config) encode() ([]byte, error) {
 		}
 		if p.Theme != "" {
 			pairs = append(pairs, [2]string{"theme", quote(p.Theme)})
+		}
+		if p.Scheme != "" {
+			pairs = append(pairs, [2]string{"scheme", quote(p.Scheme)})
 		}
 		if p.Glyphs != "" {
 			pairs = append(pairs, [2]string{"glyphs", quote(p.Glyphs)})

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -79,3 +79,29 @@ func TestValidate_RefusesAProjectThatIsNotAKey(t *testing.T) {
 		t.Errorf("error %q does not quote the offending value", err)
 	}
 }
+
+func TestValidate_AcceptsEveryKnownSchemeAndRefusesAnythingElse(t *testing.T) {
+	t.Parallel()
+
+	base := Profile{
+		Name: "work", Site: "example.atlassian.net", Email: "you@example.com",
+		Token: TokenSource{Env: "JIRA_TOKEN"},
+	}
+	for _, scheme := range []string{"", "default", "nord", "dracula", "solarized", "gruvbox"} {
+		p := base
+		p.Scheme = scheme
+		if err := p.Validate(); err != nil {
+			t.Errorf("scheme %q was refused: %v", scheme, err)
+		}
+	}
+
+	p := base
+	p.Scheme = "monokai"
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("an unknown colour scheme was accepted")
+	}
+	if !strings.Contains(err.Error(), "monokai") {
+		t.Errorf("error %q does not quote the offending value", err)
+	}
+}

--- a/internal/ui/board/budget_test.go
+++ b/internal/ui/board/budget_test.go
@@ -52,12 +52,15 @@ func TestBudget_BoardColumnsAreVirtualizedAsWellAsItsRows(t *testing.T) {
 // construction, which is what says the miss itself is bounded: two lines are
 // rebuilt and two cards with them, not a screen of either.
 //
-// 61 on an M2 Pro and 63 compiled for amd64, every run of each.
+// 93 on an M2 Pro, every run: the ceiling moved from 72 when a card's key
+// picked up the status category colour a column caption already carries —
+// one more Style.Render per resting card, the same call list.go's own status
+// cell already makes and already budgets for.
 func TestBudget_ABoardMemoMissCostsTwoLinesAndNotAScreen(t *testing.T) {
 	got := testing.Benchmark(BenchmarkBoardWalk10k).AllocsPerOp()
-	t.Logf("a frame that moves the cursor one card: %d allocations, ceiling 72", got)
-	if got > 72 {
-		t.Errorf("moving the cursor one card allocates %d times, over the ceiling of 72; it measured 61 "+
+	t.Logf("a frame that moves the cursor one card: %d allocations, ceiling 105", got)
+	if got > 105 {
+		t.Errorf("moving the cursor one card allocates %d times, over the ceiling of 105; it measured 93 "+
 			"when the ceiling was set, and a screen of thirty-six lines would be an order of magnitude more", got)
 	}
 }

--- a/internal/ui/board/render.go
+++ b/internal/ui/board/render.go
@@ -316,8 +316,19 @@ func renderCard(iss *jira.Issue, cell int, selected, inHand bool, st *styles, t 
 	if left := room - ansi.StringWidth(estimate); left < minSummary {
 		estimate = ""
 	}
-	body := iss.Key
-	if left := room - ansi.StringWidth(estimate) - ansi.StringWidth(body) - 1; left > 0 {
+	key := iss.Key
+	// The key carries the status category's colour while the card is resting:
+	// a column already says which status something is in, so this is which
+	// kind of status. Selected and held both invert the whole card, which a
+	// second colour on the key would only fight, so neither applies it — and
+	// it goes on before truncation, never after, so a narrow cell cutting the
+	// key cannot separate the colour from what it was coloring.
+	renderedKey := key
+	if !selected && !inHand {
+		renderedKey = st.categories[categoryIndex(iss.Status.Category)].Render(key)
+	}
+	body := renderedKey
+	if left := room - ansi.StringWidth(estimate) - ansi.StringWidth(key) - 1; left > 0 {
 		body += " " + ansi.Truncate(iss.Summary, left, ell)
 	}
 	out := mark + padTruncate(body, max(room-ansi.StringWidth(estimate), 0), ell) + estimate
@@ -712,3 +723,13 @@ func padTruncate(s string, width int, ellipsis string) string {
 // board measuring in points holds 3 far more often than 3.5, and "3.0" in every
 // cell of a narrow column is a column of noise.
 func trimNumber(n float64) string { return strconv.FormatFloat(n, 'f', -1, 64) }
+
+// categoryIndex is the position a status's category indexes styles.categories
+// at, with anything outside the four the site can answer read as unknown
+// rather than indexed out of bounds.
+func categoryIndex(c jira.StatusCategory) int {
+	if c < jira.CategoryUnknown || c > jira.CategoryDone {
+		return int(jira.CategoryUnknown)
+	}
+	return int(c)
+}

--- a/internal/ui/board/render_test.go
+++ b/internal/ui/board/render_test.go
@@ -210,3 +210,37 @@ func TestBoardRender_ABoardThatDoesNotEstimateDrawsNoNumbers(t *testing.T) {
 	mustNotContain(t, plain.view(), "8")
 	mustContain(t, counted.view(), "8")
 }
+
+// A resting card's key carries its status category's colour — a column
+// already says which status something is in, so this is which kind of
+// status — and selecting or holding the card, which inverts the whole thing,
+// does not layer a second colour on top of that.
+func TestRenderCard_TheKeyCarriesItsStatusCategorysColourWhileResting(t *testing.T) {
+	t.Parallel()
+	th := kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs())
+	st := newStyles(th)
+	p := plan{}
+
+	// Same key and summary, only the category differs, so any difference in
+	// what renderCard answers with is the category's colour and nothing else.
+	toDo := &jira.Issue{Key: "PROJ-1", Summary: "one", Status: jira.Status{Category: jira.CategoryToDo}}
+	done := &jira.Issue{Key: "PROJ-1", Summary: "one", Status: jira.Status{Category: jira.CategoryDone}}
+
+	restingToDo := renderCard(toDo, 30, false, false, st, th, p)
+	if restingToDo == ansi.Strip(restingToDo) {
+		t.Fatal("a resting card built from a colour theme carries no colour at all, so this test proves nothing")
+	}
+	if restingDone := renderCard(done, 30, false, false, st, th, p); restingDone == restingToDo {
+		t.Error("two resting cards in different categories rendered identically")
+	}
+	if sameAgain := renderCard(toDo, 30, false, false, st, th, p); sameAgain != restingToDo {
+		t.Errorf("the same card rendered twice differs: %q vs %q", sameAgain, restingToDo)
+	}
+
+	if selected := renderCard(toDo, 30, true, false, st, th, p); selected != renderCard(done, 30, true, false, st, th, p) {
+		t.Error("two selected cards still differ by category, so a second colour is fighting the selection style")
+	}
+	if held := renderCard(toDo, 30, false, true, st, th, p); held != renderCard(done, 30, false, true, st, th, p) {
+		t.Error("two held cards still differ by category, so a second colour is fighting the held style")
+	}
+}

--- a/internal/ui/issue/render.go
+++ b/internal/ui/issue/render.go
@@ -121,21 +121,25 @@ func (m *Model) header() string {
 	room := max(m.width-ansi.StringWidth(m.issue.Key)-2, 1)
 	title := m.styles.title.Render(ansi.Truncate(m.issue.Summary, room, ell))
 
+	// Each fact is styled on its own rather than the joined line being styled
+	// once: the status carries its category's colour, the way a related
+	// issue's already does, and nesting that inside one outer muted.Render
+	// would have the outer reset code cut the colour off partway through
+	// rather than stopping cleanly at the status.
 	facts := make([]string, 0, 5)
-	for _, s := range [...]string{
-		m.issue.Type.Name,
-		statusLabel(m.issue.Status),
-		priorityName(m.issue),
-		assigneeName(m.issue, "unassigned"),
-	} {
+	addFact := func(s string, style lipgloss.Style) {
 		if s != "" {
-			facts = append(facts, s)
+			facts = append(facts, style.Render(s))
 		}
 	}
+	addFact(m.issue.Type.Name, m.styles.muted)
+	addFact(statusLabel(m.issue.Status), m.styles.category(m.issue.Status.Category))
+	addFact(priorityName(m.issue), m.styles.muted)
+	addFact(assigneeName(m.issue, "unassigned"), m.styles.muted)
 	if when := formatWhen(m.issue.Updated, m.location()); when != "" {
-		facts = append(facts, "updated "+when)
+		addFact("updated "+when, m.styles.muted)
 	}
-	meta := m.styles.muted.Render(ansi.Truncate(strings.Join(facts, sep), m.width, ell))
+	meta := ansi.Truncate(strings.Join(facts, m.styles.muted.Render(sep)), m.width, ell)
 
 	return key + "  " + title + "\n" + meta + "\n" +
 		m.styles.rule.Render(strings.Repeat(t.Glyphs.HLine, max(m.width, 1)))

--- a/internal/ui/issue/render_test.go
+++ b/internal/ui/issue/render_test.go
@@ -1,0 +1,37 @@
+package issue
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/varijkapil13/saral/internal/ui/kernel"
+	"github.com/varijkapil13/saral/pkg/jira"
+)
+
+// The status fact in the header carries its category's colour, the way a
+// resting board card's key already does, rather than the one uniform muted
+// colour every other fact still uses.
+func TestHeader_TheStatusFactCarriesItsCategorysColour(t *testing.T) {
+	t.Parallel()
+	d := testDeps(nil)
+	d.Theme = kernel.NewTheme(kernel.ThemeDark, true, kernel.UnicodeGlyphs())
+
+	seed := jira.Issue{Key: "PROJ-1", Summary: "one", Status: jira.Status{Name: "Done", Category: jira.CategoryDone}}
+	dr := newDriver(t, d, seed, 80, 24)
+
+	raw := dr.m.header()
+	if raw == ansi.Strip(raw) {
+		t.Fatal("a header built from a colour theme carries no colour at all, so this test proves nothing")
+	}
+
+	want := dr.m.styles.category(jira.CategoryDone).Render(statusLabel(seed.Status))
+	if !strings.Contains(raw, want) {
+		t.Errorf("header %q does not contain the status rendered in its category colour %q", raw, want)
+	}
+
+	if mutedStatus := dr.m.styles.muted.Render(statusLabel(seed.Status)); mutedStatus != want && strings.Contains(raw, mutedStatus) {
+		t.Error("the status is still rendered in the muted colour rather than its category's")
+	}
+}

--- a/internal/ui/kernel/scheme.go
+++ b/internal/ui/kernel/scheme.go
@@ -1,0 +1,205 @@
+package kernel
+
+import (
+	"errors"
+	"fmt"
+	"image/color"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/varijkapil13/saral/internal/config"
+)
+
+// Scheme is a named set of the colours every themed style draws from — the
+// same nine roles Theme's colored() has always built from literals, now
+// swappable as a whole rather than fixed to the one this program shipped
+// with. It is a colour scheme and deliberately never called a "palette" in
+// code or in anything this program says: that word already means the command
+// palette everywhere else here, and a second meaning for it would be read as
+// the first one.
+type Scheme struct {
+	id, title   string
+	light, dark schemeColors
+}
+
+// schemeColors is the nine roles every themed style is built from, resolved
+// for one of light or dark. Nine rather than one per Theme field, because a
+// Header's background and a Badge's background are both surface, and giving
+// every style its own literal would let two things meant to match drift apart
+// one scheme edit at a time.
+type schemeColors struct {
+	fg, muted, accent, danger, warning, success, surface, selected, onAccent color.Color
+}
+
+func (s Scheme) colors(dark bool) schemeColors {
+	if dark {
+		return s.dark
+	}
+	return s.light
+}
+
+// ID is the name a config file, a flag or the command palette names this
+// scheme by.
+func (s Scheme) ID() string { return s.id }
+
+// Title is the sentence the command palette offers this scheme with.
+func (s Scheme) Title() string { return s.title }
+
+// hexColors builds a schemeColors from nine hex strings in field order, so a
+// scheme's table reads as the colours it names rather than as nine calls to
+// lipgloss.Color repeated for every one of five schemes and two modes.
+func hexColors(fg, muted, accent, danger, warning, success, surface, selected, onAccent string) schemeColors {
+	return schemeColors{
+		fg: lipgloss.Color(fg), muted: lipgloss.Color(muted), accent: lipgloss.Color(accent),
+		danger: lipgloss.Color(danger), warning: lipgloss.Color(warning), success: lipgloss.Color(success),
+		surface: lipgloss.Color(surface), selected: lipgloss.Color(selected), onAccent: lipgloss.Color(onAccent),
+	}
+}
+
+// DefaultScheme is what a session starts in when nothing configured
+// otherwise, and is the colours this program has always drawn: every other
+// scheme is additive, not a replacement of what colour meant before it
+// existed.
+var DefaultScheme = Scheme{
+	id: "default", title: "Use the default colours",
+	light: hexColors("#1f2328", "#6e7781", "#0550ae", "#cf222e", "#9a6700", "#1a7f37", "#eaeef2", "#ddf4ff", "#0a3069"),
+	dark:  hexColors("#e6edf3", "#8b949e", "#79c0ff", "#ff7b72", "#d29922", "#3fb950", "#161b22", "#1f6feb", "#f0f6fc"),
+}
+
+var nordScheme = Scheme{
+	id: "nord", title: "Use the Nord colour scheme",
+	dark:  hexColors("#eceff4", "#4c566a", "#88c0d0", "#bf616a", "#ebcb8b", "#a3be8c", "#3b4252", "#5e81ac", "#eceff4"),
+	light: hexColors("#2e3440", "#4c566a", "#5e81ac", "#bf616a", "#b48111", "#4c7a3d", "#e5e9f0", "#88c0d0", "#2e3440"),
+}
+
+var draculaScheme = Scheme{
+	id: "dracula", title: "Use the Dracula colour scheme",
+	dark:  hexColors("#f8f8f2", "#6272a4", "#bd93f9", "#ff5555", "#f1fa8c", "#50fa7b", "#44475a", "#6272a4", "#282a36"),
+	light: hexColors("#282a36", "#6272a4", "#6b46c1", "#d63031", "#b8860b", "#2e7d32", "#f4f4f8", "#e0d4f7", "#282a36"),
+}
+
+var solarizedScheme = Scheme{
+	id: "solarized", title: "Use the Solarized colour scheme",
+	dark:  hexColors("#839496", "#586e75", "#268bd2", "#dc322f", "#b58900", "#859900", "#073642", "#268bd2", "#fdf6e3"),
+	light: hexColors("#657b83", "#93a1a1", "#268bd2", "#dc322f", "#b58900", "#859900", "#eee8d5", "#268bd2", "#fdf6e3"),
+}
+
+var gruvboxScheme = Scheme{
+	id: "gruvbox", title: "Use the Gruvbox colour scheme",
+	dark:  hexColors("#ebdbb2", "#928374", "#83a598", "#fb4934", "#fabd2f", "#b8bb26", "#3c3836", "#458588", "#282828"),
+	light: hexColors("#3c3836", "#928374", "#458588", "#cc241d", "#d79921", "#98971a", "#ebdbb2", "#83a598", "#fbf1c7"),
+}
+
+// Schemes is every scheme this build offers, in the order the command palette
+// and an unknown-scheme error list them in.
+var Schemes = []Scheme{DefaultScheme, nordScheme, draculaScheme, solarizedScheme, gruvboxScheme}
+
+// ParseScheme resolves a scheme by the name a config file or a flag gives it.
+// Empty means the default, the same way an unset theme means auto.
+func ParseScheme(s string) (Scheme, error) {
+	name := strings.ToLower(strings.TrimSpace(s))
+	if name == "" || name == "default" {
+		return DefaultScheme, nil
+	}
+	for i := range Schemes {
+		if Schemes[i].id == name {
+			return Schemes[i], nil
+		}
+	}
+	names := make([]string, len(Schemes))
+	for i := range Schemes {
+		names[i] = Schemes[i].id
+	}
+	return DefaultScheme, fmt.Errorf("kernel: unknown colour scheme %q, want one of %s", s, strings.Join(names, ", "))
+}
+
+// The scheme is switchable while the program runs, registered as commands for
+// the same reason the theme's modes are — there is no letter left that would
+// not also be a letter somebody types into a field.
+func init() { registerSchemeCommands() }
+
+func registerSchemeCommands() {
+	for i := range Schemes {
+		RegisterCommand(Command{
+			ID:    "scheme." + Schemes[i].id,
+			Title: Schemes[i].title,
+			Group: "Appearance",
+			Run:   func(d Deps) tea.Cmd { return SwitchScheme(d, Schemes[i]) },
+		})
+	}
+}
+
+// SwitchScheme rebuilds the styles in a new scheme and keeps the choice. The
+// mode and the glyph set both come along unchanged: a scheme answers a
+// question about which colours, not about light, dark or the font.
+func SwitchScheme(d Deps, s Scheme) tea.Cmd {
+	mode, dark, glyphs := ThemeAuto, true, UnicodeGlyphs()
+	if d.Theme != nil {
+		mode, dark, glyphs = d.Theme.Mode, d.Theme.Dark, d.Theme.Glyphs
+	}
+	next := NewTheme(mode, dark, glyphs, WithScheme(s))
+	return tea.Batch(
+		func() tea.Msg { return ThemeMsg{Theme: next} },
+		saveScheme(d.Site, s),
+	)
+}
+
+// saveScheme writes the scheme into the profile it came from. The scheme has
+// already changed by the time this runs, so a failure is reported rather than
+// undoing the switch — the same shape saveTheme already answers in.
+func saveScheme(site string, s Scheme) tea.Cmd {
+	return func() tea.Msg {
+		switch err := writeScheme(site, s); {
+		case err == nil:
+			return nil
+		case errors.Is(err, config.ErrNoConfig), errors.Is(err, config.ErrNoProfile):
+			return StatusMsg{
+				Text:  "the colour scheme changed for this session; there is no profile to save it to",
+				Level: LevelInfo,
+			}
+		default:
+			return StatusMsg{
+				Text:  "the colour scheme changed for this session, but saving it failed: " + err.Error(),
+				Level: LevelWarn,
+			}
+		}
+	}
+}
+
+// writeScheme reads the whole file and writes it back with one field changed,
+// for the reason writeTheme already does: Save writes the profile it is
+// handed and nothing else, so a fresh Profile built from what is on screen
+// would drop the saved queries, the timeline field names and the glyph set.
+func writeScheme(site string, s Scheme) error {
+	path, err := config.Path()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		return err
+	}
+	profile, err := cfg.Current()
+	if err != nil {
+		return err
+	}
+	if site != "" && profile.Site != site {
+		return fmt.Errorf("this session is on %s and the active profile %q is on %s, so nothing was written",
+			site, profile.Name, profile.Site)
+	}
+	// Default is the absence of a scheme in the file rather than a value, so
+	// that a profile that never chose and a profile that chose default read
+	// the same.
+	value := s.id
+	if s.id == DefaultScheme.id {
+		value = ""
+	}
+	if profile.Scheme == value {
+		return nil
+	}
+	profile.Scheme = value
+	cfg.Profiles[profile.Name] = profile
+	return cfg.Save(path)
+}

--- a/internal/ui/kernel/scheme_test.go
+++ b/internal/ui/kernel/scheme_test.go
@@ -1,0 +1,184 @@
+package kernel
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/varijkapil13/saral/internal/config"
+)
+
+func TestParseScheme(t *testing.T) {
+	t.Parallel()
+	for in, want := range map[string]string{
+		"": "default", "default": "default", "Nord": "nord", "dracula": "dracula",
+		"SOLARIZED": "solarized", "gruvbox": "gruvbox",
+	} {
+		got, err := ParseScheme(in)
+		if err != nil {
+			t.Errorf("%q: %v", in, err)
+		}
+		if got.ID() != want {
+			t.Errorf("%q: got %v want %v", in, got.ID(), want)
+		}
+	}
+	if got, err := ParseScheme("  nord\t"); err != nil || got.ID() != "nord" {
+		t.Errorf("surrounding whitespace was not trimmed: %v %v", got, err)
+	}
+	if _, err := ParseScheme("monokai"); err == nil {
+		t.Error("an unknown scheme name was accepted")
+	}
+}
+
+// Every scheme this build offers has both a light and a dark half, or a
+// scheme picked in one mode would silently fall back to the zero colour.
+func TestSchemes_EveryOneHasBothLightAndDark(t *testing.T) {
+	t.Parallel()
+	for _, sc := range Schemes {
+		for _, dark := range []bool{true, false} {
+			c := sc.colors(dark)
+			if c.fg == nil || c.accent == nil || c.danger == nil || c.warning == nil ||
+				c.success == nil || c.muted == nil || c.surface == nil || c.selected == nil || c.onAccent == nil {
+				t.Errorf("%s (dark=%v) leaves a role with no colour: %+v", sc.id, dark, c)
+			}
+		}
+	}
+}
+
+func TestNewTheme_SchemesDiffer(t *testing.T) {
+	t.Parallel()
+	def := NewTheme(ThemeDark, true, UnicodeGlyphs())
+	nord := NewTheme(ThemeDark, true, UnicodeGlyphs(), WithScheme(nordScheme))
+	if def.Accent.Render("x") == nord.Accent.Render("x") {
+		t.Error("the default scheme and Nord render the accent identically")
+	}
+	if !hasColour(nord.Accent.Render("x")) {
+		t.Error("a coloured theme with a scheme set emitted no colour")
+	}
+	if nord.Scheme.ID() != "nord" {
+		t.Errorf("the theme reports scheme %q, want nord", nord.Scheme.ID())
+	}
+	if def.Scheme.ID() != DefaultScheme.ID() {
+		t.Errorf("a theme built with no WithScheme reports %q, want the default", def.Scheme.ID())
+	}
+}
+
+func TestSchemeCommands_AreInThePaletteOnePerScheme(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+	registerSchemeCommands()
+
+	want := make(map[string]bool, len(Schemes))
+	for _, sc := range Schemes {
+		want["scheme."+sc.id] = false
+	}
+	for _, cmd := range Commands() {
+		if _, ours := want[cmd.ID]; !ours {
+			continue
+		}
+		want[cmd.ID] = true
+		if cmd.Title == "" || cmd.Run == nil {
+			t.Errorf("%s is registered with nothing to show or nothing to run", cmd.ID)
+		}
+		if len(cmd.Keys) != 0 {
+			t.Errorf("%s teaches keys %v; no view shows a key for the scheme, so the palette must not claim one",
+				cmd.ID, cmd.Keys)
+		}
+	}
+	for id, found := range want {
+		if !found {
+			t.Errorf("%s is not registered, so the palette cannot reach it", id)
+		}
+	}
+}
+
+func TestSwitchScheme_RebuildsTheStylesAndKeepsModeAndGlyphs(t *testing.T) {
+	colourfulEnv(t)
+	writeConfig(t, profileWithEverything)
+
+	d := Deps{Theme: NewTheme(ThemeLight, false, ASCIIGlyphs()), Site: "example.atlassian.net"}
+	msg := firstMsgOfType[ThemeMsg](t, SwitchScheme(d, nordScheme))
+	switch {
+	case msg.Theme == nil:
+		t.Fatal("no theme came back")
+	case msg.Theme.Scheme.ID() != "nord":
+		t.Errorf("got scheme %q want nord", msg.Theme.Scheme.ID())
+	case msg.Theme.Mode != ThemeLight:
+		t.Errorf("the mode changed to %v; a scheme switch answers a question about colour, not about light or dark", msg.Theme.Mode)
+	case msg.Theme.Dark:
+		t.Error("a light theme reports itself dark after only its scheme changed")
+	case msg.Theme.Glyphs.Bullet != ASCIIGlyphs().Bullet:
+		t.Error("the glyph set was replaced; a scheme switch answers a question about colour, not about the font")
+	case !hasColour(msg.Theme.Accent.Render("x")):
+		t.Error("switching scheme left the styles colourless")
+	}
+}
+
+func TestWriteScheme_ChangesTheSchemeAndNothingElseInTheProfile(t *testing.T) {
+	path := writeConfig(t, profileWithEverything)
+
+	if err := writeScheme("example.atlassian.net", nordScheme); err != nil {
+		t.Fatalf("writeScheme: %v", err)
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := cfg.Get("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch {
+	case got.Scheme != "nord":
+		t.Errorf("scheme is %q, want nord", got.Scheme)
+	case got.Glyphs != "ascii":
+		t.Errorf("the glyph set went from ascii to %q", got.Glyphs)
+	case len(got.Queries) != 1 || got.Queries[0].Slot != 2:
+		t.Errorf("the saved queries did not survive: %+v", got.Queries)
+	case len(got.Timeline.Start) != 1 || len(got.Timeline.End) != 1:
+		t.Errorf("the timeline fields did not survive: %+v", got.Timeline)
+	case got.Token.Env != "JIRA_TOKEN":
+		t.Errorf("the token source changed to %+v", got.Token)
+	case cfg.Active != "work" || !cfg.Mouse:
+		t.Errorf("the file's own settings changed: active=%q mouse=%v", cfg.Active, cfg.Mouse)
+	}
+}
+
+func TestWriteScheme_WritesDefaultAsNoSchemeAtAll(t *testing.T) {
+	path := writeConfig(t, strings.Replace(profileWithEverything, `glyphs = "ascii"`, `scheme = "nord"`, 1))
+
+	if err := writeScheme("example.atlassian.net", DefaultScheme); err != nil {
+		t.Fatalf("writeScheme: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "scheme") {
+		t.Errorf("default was written as a value rather than as an absence:\n%s", body)
+	}
+}
+
+func TestWriteScheme_RefusesWhenTheSessionIsNotOnTheActiveProfilesSite(t *testing.T) {
+	writeConfig(t, profileWithEverything)
+
+	err := writeScheme("other.atlassian.net", nordScheme)
+	if err == nil {
+		t.Fatal("the scheme was written onto a profile this session is not running as")
+	}
+	if !strings.Contains(err.Error(), "other.atlassian.net") || !strings.Contains(err.Error(), "work") {
+		t.Errorf("the refusal does not say which session and which profile: %v", err)
+	}
+}
+
+func TestSaveScheme_SaysSoWhenThereIsNoProfileToSaveTo(t *testing.T) {
+	t.Setenv("SARAL_CONFIG_DIR", t.TempDir())
+
+	status := firstMsgOfType[StatusMsg](t, saveScheme("example.atlassian.net", nordScheme))
+	if !strings.Contains(status.Text, "no profile") {
+		t.Errorf("unhelpful message with nowhere to save: %q", status.Text)
+	}
+	if status.Level != LevelInfo {
+		t.Errorf("a first run with no profile is reported at level %v, which reads as a failure", status.Level)
+	}
+}

--- a/internal/ui/kernel/theme.go
+++ b/internal/ui/kernel/theme.go
@@ -140,6 +140,11 @@ type Theme struct {
 	Dark   bool
 	Color  bool
 	Glyphs Glyphs
+	// Scheme is which set of colours Base through Overlay below were built
+	// from. It travels with the theme so that switching mode (SwitchTheme)
+	// without being told a scheme keeps the one already in force, the same way
+	// switching scheme keeps the mode.
+	Scheme Scheme
 
 	Base       lipgloss.Style
 	Muted      lipgloss.Style
@@ -172,15 +177,36 @@ type Theme struct {
 
 var themeGen atomic.Int64
 
+// ThemeOption configures NewTheme beyond mode, dark and glyphs. It exists so
+// that the scheme is optional at every one of NewTheme's existing call
+// sites — a caller that never heard of one still gets DefaultScheme, which is
+// the colours this program always drew.
+type ThemeOption func(*themeConfig)
+
+type themeConfig struct {
+	scheme Scheme
+}
+
+// WithScheme sets which named set of colours the theme is built from. Not
+// given, a theme is built from DefaultScheme.
+func WithScheme(s Scheme) ThemeOption {
+	return func(c *themeConfig) { c.scheme = s }
+}
+
 // NewTheme builds the styles for a mode. dark is only consulted when the mode
 // is Auto; it comes from the terminal's reported background colour.
-func NewTheme(mode ThemeMode, dark bool, glyphs Glyphs) *Theme {
+func NewTheme(mode ThemeMode, dark bool, glyphs Glyphs, opts ...ThemeOption) *Theme {
+	cfg := themeConfig{scheme: DefaultScheme}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	t := &Theme{
 		Gen:    int(themeGen.Add(1)),
 		Mode:   mode,
 		Dark:   dark,
 		Color:  mode != ThemeNoColor,
 		Glyphs: glyphs,
+		Scheme: cfg.scheme,
 	}
 	switch mode {
 	case ThemeDark:
@@ -190,7 +216,7 @@ func NewTheme(mode ThemeMode, dark bool, glyphs Glyphs) *Theme {
 	case ThemeAuto, ThemeNoColor:
 	}
 	if t.Color {
-		t.colored()
+		t.colored(cfg.scheme.colors(t.Dark))
 	} else {
 		t.plain()
 	}
@@ -238,19 +264,13 @@ func (t *Theme) plain() {
 	}
 }
 
-func (t *Theme) colored() {
-	pick := lipgloss.LightDark(t.Dark)
-	var (
-		fg       = pick(lipgloss.Color("#1f2328"), lipgloss.Color("#e6edf3"))
-		muted    = pick(lipgloss.Color("#6e7781"), lipgloss.Color("#8b949e"))
-		accent   = pick(lipgloss.Color("#0550ae"), lipgloss.Color("#79c0ff"))
-		danger   = pick(lipgloss.Color("#cf222e"), lipgloss.Color("#ff7b72"))
-		warning  = pick(lipgloss.Color("#9a6700"), lipgloss.Color("#d29922"))
-		success  = pick(lipgloss.Color("#1a7f37"), lipgloss.Color("#3fb950"))
-		surface  = pick(lipgloss.Color("#eaeef2"), lipgloss.Color("#161b22"))
-		selected = pick(lipgloss.Color("#ddf4ff"), lipgloss.Color("#1f6feb"))
-		onAccent = pick(lipgloss.Color("#0a3069"), lipgloss.Color("#f0f6fc"))
-	)
+// colored builds the styles from one scheme's nine roles, already resolved
+// for this theme's mode by the caller — colored itself never asks whether it
+// is drawing light or dark, so a scheme with the two reversed cannot make it
+// draw the wrong one.
+func (t *Theme) colored(c schemeColors) {
+	fg, muted, accent, danger, warning, success, surface, selected, onAccent :=
+		c.fg, c.muted, c.accent, c.danger, c.warning, c.success, c.surface, c.selected, c.onAccent
 	base := lipgloss.NewStyle().Foreground(fg)
 	t.Base = base
 	t.Muted = lipgloss.NewStyle().Foreground(muted)

--- a/internal/ui/palette/testdata/session_120x30.golden
+++ b/internal/ui/palette/testdata/session_120x30.golden
@@ -1,9 +1,14 @@
  saral | Commands                                                                          PROJ | example.atlassian.net 
 > what do you want to do?                                                                                               
------------------------------------------------------------------------------------------------------------- 28 commands
+------------------------------------------------------------------------------------------------------------ 33 commands
 > Follow the terminal's own colours             Appearance                                                              
   Turn colour off                               Appearance                                                              
+  Use the Dracula colour scheme                 Appearance                                                              
+  Use the Gruvbox colour scheme                 Appearance                                                              
+  Use the Nord colour scheme                    Appearance                                                              
+  Use the Solarized colour scheme               Appearance                                                              
   Use the dark theme                            Appearance                                                              
+  Use the default colours                       Appearance                                                              
   Use the light theme                           Appearance                                                              
   Delete the comment you are on                 Comments                                                               d
   Edit the comment you are on                   Comments                                                               e
@@ -22,9 +27,4 @@
   Every issue in this project                   Search                                                                 a
   Filter by this row's assignee                 Search                                                                  
   Filter by this row's status                   Search                                                                  
-  Filter by this row's type                     Search                                                                  
-  Filter these issues by a person, a status...  Search                                                                 f
-  Issues I reported                             Search                                                                  
-  My issues                                     Search                                                                  
-  Save this query to a number key               Search                                                                 s
  Issues  enter run it  esc close                                                                                  ctrl+k


### PR DESCRIPTION
Stacked on #137 — base is `feat/board-quick-filters`, not `main`, because it shares files (`board/render.go`, `board/budget_test.go`) with that still-open PR. Retarget to `main` once #137 merges.

## Summary
- `kernel.Scheme`: nine semantic colour roles (fg, muted, accent, danger, warning, success, surface, selected, onAccent), resolved separately for light/dark. Five named presets: default, Nord, Dracula, Solarized, Gruvbox.
- Switchable at runtime from the command palette (one command per scheme), via `-scheme`, or a profile's `scheme = "..."` config key — independent of `-theme` (light/dark stays its own axis).
- `NewTheme` took a variadic `...ThemeOption` rather than a new required parameter, so its ~70 existing call sites needed no changes.
- Two colour gaps that were already computed and never drawn: the board's `categories [4]lipgloss.Style` array now colours a resting card's key; the issue pane's own status now gets the category colour a related issue's status already had.
- Deliberately **not** covered: priority/issue-type colouring, both per-instance configurable on a real site, so name-matching would be exactly the hardcoding CLAUDE.md flags as the most common way a PR gets rejected here. Left as a follow-up (needs a session-level priority-order cache that doesn't exist yet).

Closes #139.

## Test plan
- [x] `go build ./...`
- [x] `go test -p 1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `go mod tidy && git diff --exit-code`
- [x] `golangci-lint run` — 0 issues
- [x] Board budget ceiling reviewed and bumped with a measured, justified number (61→93, ceiling set to 105)
- [x] Golden files regenerated and hand-reviewed (command palette's Appearance group)

https://claude.ai/code/session_015SMw7ryvux5CExuhTATVdw